### PR TITLE
[POC]: Http service: support add graphql handler

### DIFF
--- a/nomos-services/http/Cargo.toml
+++ b/nomos-services/http/Cargo.toml
@@ -13,6 +13,9 @@ required-features = ["http"]
 [dependencies]
 axum = { version = "0.6", optional = true }
 async-trait = "0.1"
+# async-graphql does not follow semver, so we pin the version
+async-graphql = { version = "=5.0.5", optional = true }
+async-graphql-axum = { version = "=5.0.5", optional = true }
 bytes = "1.3"
 clap = { version = "4", features = ["derive", "env"], optional = true }
 futures = "0.3"
@@ -38,3 +41,4 @@ metrics = { path = "../metrics", features = ["gql"] }
 [features]
 default = []
 http = ["clap", "axum", "serde_json", "parking_lot", "hyper"]
+gql = ["async-graphql"]

--- a/nomos-services/http/Cargo.toml
+++ b/nomos-services/http/Cargo.toml
@@ -8,6 +8,11 @@ name = "axum"
 path = "examples/axum.rs"
 required-features = ["http"]
 
+[[example]]
+name = "graphql"
+path = "examples/axum.rs"
+required-features = ["http", "gql"]
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -42,4 +47,4 @@ once_cell = "1.17"
 [features]
 default = []
 http = ["clap", "axum", "serde_json", "parking_lot", "hyper"]
-gql = ["async-graphql"]
+gql = ["async-graphql", "async-graphql-axum"]

--- a/nomos-services/http/Cargo.toml
+++ b/nomos-services/http/Cargo.toml
@@ -37,6 +37,7 @@ tower-service = "0.3.2"
 
 [dev-dependencies]
 metrics = { path = "../metrics", features = ["gql"] }
+once_cell = "1.17"
 
 [features]
 default = []

--- a/nomos-services/http/Cargo.toml
+++ b/nomos-services/http/Cargo.toml
@@ -10,7 +10,7 @@ required-features = ["http"]
 
 [[example]]
 name = "graphql"
-path = "examples/axum.rs"
+path = "examples/graphql.rs"
 required-features = ["http", "gql"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/nomos-services/http/Cargo.toml
+++ b/nomos-services/http/Cargo.toml
@@ -20,7 +20,6 @@ axum = { version = "0.6", optional = true }
 async-trait = "0.1"
 # async-graphql does not follow semver, so we pin the version
 async-graphql = { version = "=5.0.5", optional = true }
-async-graphql-axum = { version = "=5.0.5", optional = true }
 bytes = "1.3"
 clap = { version = "4", features = ["derive", "env"], optional = true }
 futures = "0.3"
@@ -46,5 +45,5 @@ once_cell = "1.17"
 
 [features]
 default = []
-http = ["clap", "axum", "serde_json", "parking_lot", "hyper"]
-gql = ["async-graphql", "async-graphql-axum"]
+http = ["clap", "axum", "serde_json", "parking_lot", "hyper", "tower"]
+gql = ["async-graphql"]

--- a/nomos-services/http/Cargo.toml
+++ b/nomos-services/http/Cargo.toml
@@ -32,6 +32,9 @@ tower-http = { version = "0.3", features = ["cors", "trace"] }
 tokio = { version = "1", features = ["sync", "macros"] }
 tower-service = "0.3.2"
 
+[dev-dependencies]
+metrics = { path = "../metrics", features = ["gql"] }
+
 [features]
 default = []
 http = ["clap", "axum", "serde_json", "parking_lot", "hyper"]

--- a/nomos-services/http/examples/README.md
+++ b/nomos-services/http/examples/README.md
@@ -1,0 +1,33 @@
+# Http service examples
+
+## Axum.rs
+A simple service to demonstrate how to register http handler for overwatch service.
+
+To run this example use:
+```bash
+cargo run --example axum --features http
+```
+
+A GET enpoint will be registered at `http://localhost:8080/dummy/`. An endpoint corresponds with the Service name.
+
+## Graphql.rs
+A demonstration of usage from within an overwatch service over the http.
+
+To run this example use:
+```bash
+cargo run --example graphql --features http,gql
+```
+
+An enpoint will be registered at `http://localhost:8080/dummygraphqlservice/`. An endpoint corresponds with the Service name.
+
+To query this endpoint use:
+```bash
+curl --location --request POST 'localhost:8080/dummygraphqlservice/' \
+--data-raw '{"query":"query {val}","variables":{}}'
+
+```
+
+Every response should increment the `val` variable.
+```json
+{"data":{"val":1}}
+```

--- a/nomos-services/http/examples/axum.rs
+++ b/nomos-services/http/examples/axum.rs
@@ -3,7 +3,9 @@ use std::sync::Arc;
 
 use clap::Parser;
 use nomos_http::backends::HttpBackend;
-use nomos_http::bridge::{build_http_bridge, HttpBridgeRunner, HttpBridgeService};
+use nomos_http::bridge::{
+    build_graphql_bridge, build_http_bridge, HttpBridgeRunner, HttpBridgeService,
+};
 use nomos_http::{
     backends::axum::{AxumBackend, AxumBackendSettings},
     http::*,
@@ -79,9 +81,10 @@ where
     B::Error: Error + Send + Sync + 'static,
 {
     Box::new(Box::pin(async move {
-        let (dummy, mut hello_res_rx) = build_http_bridge::<DummyService, B, _>(handle, "")
-            .await
-            .unwrap();
+        let (dummy, mut hello_res_rx) =
+            build_http_bridge::<DummyService, B, _>(handle, HttpMethod::GET, "")
+                .await
+                .unwrap();
 
         while let Some(HttpRequest { res_tx, .. }) = hello_res_rx.recv().await {
             let (sender, receiver) = oneshot::channel();
@@ -101,12 +104,96 @@ where
     }))
 }
 
+fn dummy_graphql_router<B>(
+    handle: overwatch_rs::overwatch::handle::OverwatchHandle,
+) -> HttpBridgeRunner
+where
+    B: HttpBackend + Send + Sync + 'static,
+    B::Error: Error + Send + Sync + 'static,
+{
+    Box::new(Box::pin(async move {
+        let (dummy, mut hello_res_rx) =
+            build_graphql_bridge::<DummyGraphqlService, B, _>(handle, "graphql")
+                .await
+                .unwrap();
+
+        while let Some(GraphqlRequest { res_tx, .. }) = hello_res_rx.recv().await {
+            let (sender, receiver) = oneshot::channel();
+            dummy
+                .send(DummyGraphqlMsg {
+                    reply_channel: sender,
+                })
+                .await
+                .unwrap();
+            let value = receiver.await.unwrap();
+            res_tx
+                .send(async_graphql::Response::new(
+                    async_graphql::InputType::to_value(&DummyGraphql { val: value }),
+                ))
+                .await
+                .unwrap();
+        }
+        Ok(())
+    }))
+}
+
+#[derive(Debug, Clone, Default, async_graphql::SimpleObject, async_graphql::InputObject)]
+pub struct DummyGraphql {
+    val: i32,
+}
+
+pub struct DummyGraphqlService {
+    counter: Arc<Mutex<i32>>,
+    service_state: ServiceStateHandle<Self>,
+}
+
+#[derive(Debug)]
+pub struct DummyGraphqlMsg {
+    reply_channel: oneshot::Sender<i32>,
+}
+
+impl RelayMessage for DummyGraphqlMsg {}
+
+impl ServiceData for DummyGraphqlService {
+    const SERVICE_ID: ServiceId = "DummyGraphqlService";
+    type Settings = ();
+    type State = NoState<()>;
+    type StateOperator = NoOperator<Self::State>;
+    type Message = DummyGraphqlMsg;
+}
+
+#[async_trait::async_trait]
+impl ServiceCore for DummyGraphqlService {
+    fn init(service_state: ServiceStateHandle<Self>) -> Result<Self, overwatch_rs::DynError> {
+        Ok(Self {
+            counter: Default::default(),
+            service_state,
+        })
+    }
+
+    async fn run(self) -> Result<(), overwatch_rs::DynError> {
+        let Self {
+            counter,
+            service_state: ServiceStateHandle {
+                mut inbound_relay, ..
+            },
+        } = self;
+
+        // Handle the http request to dummy service.
+        while let Some(msg) = inbound_relay.recv().await {
+            handle_hello(counter.clone(), msg.reply_channel).await;
+        }
+
+        Ok(())
+    }
+}
 
 #[derive(overwatch_derive::Services)]
 struct Services {
-    http: ServiceHandle<HttpService<AxumBackend>>,
+    http: ServiceHandle<HttpService<AxumBackend<DummyGraphql>>>,
     router: ServiceHandle<HttpBridgeService>,
     dummy: ServiceHandle<DummyService>,
+    dummy_graphql: ServiceHandle<DummyGraphqlService>,
 }
 
 #[derive(clap::Parser)]
@@ -125,9 +212,13 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                 backend: settings.http,
             },
             router: nomos_http::bridge::HttpBridgeSettings {
-                runners: vec![Arc::new(Box::new(dummy_router::<AxumBackend>))],
+                runners: vec![
+                    Arc::new(Box::new(dummy_router::<AxumBackend<DummyGraphql>>)),
+                    Arc::new(Box::new(dummy_graphql_router::<AxumBackend<DummyGraphql>>)),
+                ],
             },
             dummy: (),
+            dummy_graphql: (),
         },
         None,
     )?;

--- a/nomos-services/http/examples/axum.rs
+++ b/nomos-services/http/examples/axum.rs
@@ -101,6 +101,7 @@ where
     }))
 }
 
+
 #[derive(overwatch_derive::Services)]
 struct Services {
     http: ServiceHandle<HttpService<AxumBackend>>,

--- a/nomos-services/http/examples/axum.rs
+++ b/nomos-services/http/examples/axum.rs
@@ -3,9 +3,7 @@ use std::sync::Arc;
 
 use clap::Parser;
 use nomos_http::backends::HttpBackend;
-use nomos_http::bridge::{
-    build_graphql_bridge, build_http_bridge, HttpBridgeRunner, HttpBridgeService,
-};
+use nomos_http::bridge::{build_http_bridge, HttpBridgeRunner, HttpBridgeService};
 use nomos_http::{
     backends::axum::{AxumBackend, AxumBackendSettings},
     http::*,
@@ -104,113 +102,11 @@ where
     }))
 }
 
-fn dummy_graphql_router<B>(
-    handle: overwatch_rs::overwatch::handle::OverwatchHandle,
-) -> HttpBridgeRunner
-where
-    B: HttpBackend + Send + Sync + 'static,
-    B::Error: Error + Send + Sync + 'static,
-{
-    Box::new(Box::pin(async move {
-        let (dummy, mut hello_res_rx) =
-            build_graphql_bridge::<DummyGraphqlService, B, _>(handle, "graphql")
-                .await
-                .unwrap();
-
-        while let Some(GraphqlRequest { res_tx, req }) = hello_res_rx.recv().await {
-            let (sender, receiver) = oneshot::channel();
-            dummy
-                .send(DummyGraphqlMsg {
-                    req,
-                    reply_channel: sender,
-                })
-                .await
-                .unwrap();
-            let res = receiver.await.unwrap();
-            res_tx.send(res).await.unwrap();
-        }
-        Ok(())
-    }))
-}
-
-#[derive(Debug, Clone, Default)]
-pub struct DummyGraphql {
-    val: Arc<Mutex<i32>>,
-}
-
-#[async_graphql::Object]
-impl DummyGraphql {
-    async fn val(&self) -> i32 {
-        let mut val = self.val.lock();
-        *val += 1;
-        *val
-    }
-}
-
-pub struct DummyGraphqlService {
-    service_state: ServiceStateHandle<Self>,
-}
-
-#[derive(Debug)]
-pub struct DummyGraphqlMsg {
-    req: async_graphql::Request,
-    reply_channel: oneshot::Sender<async_graphql::Response>,
-}
-
-impl RelayMessage for DummyGraphqlMsg {}
-
-impl ServiceData for DummyGraphqlService {
-    const SERVICE_ID: ServiceId = "DummyGraphqlService";
-    type Settings = ();
-    type State = NoState<()>;
-    type StateOperator = NoOperator<Self::State>;
-    type Message = DummyGraphqlMsg;
-}
-
-#[async_trait::async_trait]
-impl ServiceCore for DummyGraphqlService {
-    fn init(service_state: ServiceStateHandle<Self>) -> Result<Self, overwatch_rs::DynError> {
-        Ok(Self { service_state })
-    }
-
-    async fn run(self) -> Result<(), overwatch_rs::DynError> {
-        let Self {
-            service_state: ServiceStateHandle {
-                mut inbound_relay, ..
-            },
-        } = self;
-
-        static SCHEMA: once_cell::sync::Lazy<
-            async_graphql::Schema<
-                DummyGraphql,
-                async_graphql::EmptyMutation,
-                async_graphql::EmptySubscription,
-            >,
-        > = once_cell::sync::Lazy::new(|| {
-            async_graphql::Schema::build(
-                DummyGraphql::default(),
-                async_graphql::EmptyMutation,
-                async_graphql::EmptySubscription,
-            )
-            .finish()
-        });
-
-        // Handle the http request to dummy service.
-        while let Some(msg) = inbound_relay.recv().await {
-            let res = SCHEMA.execute(msg.req).await;
-            msg.reply_channel.send(res).unwrap();
-        }
-
-        Ok(())
-    }
-}
-
 #[derive(overwatch_derive::Services)]
 struct Services {
     http: ServiceHandle<HttpService<AxumBackend>>,
     router: ServiceHandle<HttpBridgeService>,
     dummy: ServiceHandle<DummyService>,
-    dummy_graphql: ServiceHandle<DummyGraphqlService>,
 }
 
 #[derive(clap::Parser)]
@@ -229,13 +125,9 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                 backend: settings.http,
             },
             router: nomos_http::bridge::HttpBridgeSettings {
-                runners: vec![
-                    Arc::new(Box::new(dummy_router::<AxumBackend>)),
-                    Arc::new(Box::new(dummy_graphql_router::<AxumBackend>)),
-                ],
+                runners: vec![Arc::new(Box::new(dummy_router::<AxumBackend>))],
             },
             dummy: (),
-            dummy_graphql: (),
         },
         None,
     )?;

--- a/nomos-services/http/examples/graphql.rs
+++ b/nomos-services/http/examples/graphql.rs
@@ -1,0 +1,158 @@
+use std::error::Error;
+use std::sync::Arc;
+
+use clap::Parser;
+use nomos_http::backends::HttpBackend;
+use nomos_http::bridge::{
+    build_graphql_bridge, build_http_bridge, HttpBridgeRunner, HttpBridgeService,
+};
+use nomos_http::{
+    backends::axum::{AxumBackend, AxumBackendSettings},
+    http::*,
+};
+use overwatch_rs::services::relay::RelayMessage;
+use overwatch_rs::services::{
+    handle::ServiceStateHandle,
+    state::{NoOperator, NoState},
+    ServiceCore, ServiceData, ServiceId,
+};
+use overwatch_rs::{overwatch::OverwatchRunner, services::handle::ServiceHandle};
+use parking_lot::Mutex;
+use tokio::sync::oneshot;
+
+fn dummy_graphql_router<B>(
+    handle: overwatch_rs::overwatch::handle::OverwatchHandle,
+) -> HttpBridgeRunner
+where
+    B: HttpBackend + Send + Sync + 'static,
+    B::Error: Error + Send + Sync + 'static,
+{
+    Box::new(Box::pin(async move {
+        let (dummy, mut hello_res_rx) =
+            build_graphql_bridge::<DummyGraphqlService, B, _>(handle, "graphql")
+                .await
+                .unwrap();
+
+        while let Some(GraphqlRequest { res_tx, req }) = hello_res_rx.recv().await {
+            let (sender, receiver) = oneshot::channel();
+            dummy
+                .send(DummyGraphqlMsg {
+                    req,
+                    reply_channel: sender,
+                })
+                .await
+                .unwrap();
+            let res = receiver.await.unwrap();
+            res_tx.send(res).await.unwrap();
+        }
+        Ok(())
+    }))
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct DummyGraphql {
+    val: Arc<Mutex<i32>>,
+}
+
+#[async_graphql::Object]
+impl DummyGraphql {
+    async fn val(&self) -> i32 {
+        let mut val = self.val.lock();
+        *val += 1;
+        *val
+    }
+}
+
+pub struct DummyGraphqlService {
+    service_state: ServiceStateHandle<Self>,
+}
+
+#[derive(Debug)]
+pub struct DummyGraphqlMsg {
+    req: async_graphql::Request,
+    reply_channel: oneshot::Sender<async_graphql::Response>,
+}
+
+impl RelayMessage for DummyGraphqlMsg {}
+
+impl ServiceData for DummyGraphqlService {
+    const SERVICE_ID: ServiceId = "DummyGraphqlService";
+    type Settings = ();
+    type State = NoState<()>;
+    type StateOperator = NoOperator<Self::State>;
+    type Message = DummyGraphqlMsg;
+}
+
+#[async_trait::async_trait]
+impl ServiceCore for DummyGraphqlService {
+    fn init(service_state: ServiceStateHandle<Self>) -> Result<Self, overwatch_rs::DynError> {
+        Ok(Self { service_state })
+    }
+
+    async fn run(self) -> Result<(), overwatch_rs::DynError> {
+        let Self {
+            service_state: ServiceStateHandle {
+                mut inbound_relay, ..
+            },
+        } = self;
+
+        static SCHEMA: once_cell::sync::Lazy<
+            async_graphql::Schema<
+                DummyGraphql,
+                async_graphql::EmptyMutation,
+                async_graphql::EmptySubscription,
+            >,
+        > = once_cell::sync::Lazy::new(|| {
+            async_graphql::Schema::build(
+                DummyGraphql::default(),
+                async_graphql::EmptyMutation,
+                async_graphql::EmptySubscription,
+            )
+            .finish()
+        });
+
+        // Handle the http request to dummy service.
+        while let Some(msg) = inbound_relay.recv().await {
+            let res = SCHEMA.execute(msg.req).await;
+            msg.reply_channel.send(res).unwrap();
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(overwatch_derive::Services)]
+struct Services {
+    http: ServiceHandle<HttpService<AxumBackend>>,
+    router: ServiceHandle<HttpBridgeService>,
+    dummy_graphql: ServiceHandle<DummyGraphqlService>,
+}
+
+#[derive(clap::Parser)]
+pub struct Args {
+    #[clap(flatten)]
+    http: AxumBackendSettings,
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    tracing_subscriber::fmt::fmt().with_file(false).init();
+
+    let settings = Args::parse();
+    let app = OverwatchRunner::<Services>::run(
+        ServicesServiceSettings {
+            http: nomos_http::http::Config {
+                backend: settings.http,
+            },
+            router: nomos_http::bridge::HttpBridgeSettings {
+                runners: vec![Arc::new(Box::new(dummy_graphql_router::<AxumBackend>))],
+            },
+            dummy: (),
+            dummy_graphql: (),
+        },
+        None,
+    )?;
+
+    tracing::info!("overwatch ready");
+    app.wait_finished();
+    Ok(())
+}

--- a/nomos-services/http/src/backends/axum.rs
+++ b/nomos-services/http/src/backends/axum.rs
@@ -13,7 +13,7 @@ use axum::{
 
 use hyper::{
     header::{CONTENT_TYPE, USER_AGENT},
-    Request,
+    Body, Request,
 };
 use overwatch_rs::{services::state::NoState, DynError};
 use parking_lot::Mutex;

--- a/nomos-services/http/src/backends/axum.rs
+++ b/nomos-services/http/src/backends/axum.rs
@@ -166,7 +166,7 @@ async fn handle_req(
     {
         Ok(_) => {
             // Wait for a response, then pass or serialize it?
-            let res = rx.recv().await.ok_or("".into());
+            let res = rx.recv().await.ok_or_else(|| "".into());
             res
         }
         Err(_e) => Err(AxumBackendError::SendError(_e).to_string()),

--- a/nomos-services/http/src/backends/axum.rs
+++ b/nomos-services/http/src/backends/axum.rs
@@ -138,27 +138,22 @@ impl AxumBackend {
     }
 
     fn add_data_route(&self, method: HttpMethod, path: &str, req_stream: Sender<HttpRequest>) {
-        let handler = match method {
-            HttpMethod::POST => post(
-                |Query(query): Query<HashMap<String, String>>, payload: Option<Bytes>| async move {
-                    handle_req(req_stream, query, payload).await
-                },
-            ),
-            HttpMethod::PUT => put(
-                |Query(query): Query<HashMap<String, String>>, payload: Option<Bytes>| async move {
-                    handle_req(req_stream, query, payload).await
-                },
-            ),
-            HttpMethod::PATCH => patch(
-                |Query(query): Query<HashMap<String, String>>, payload: Option<Bytes>| async move {
-                    handle_req(req_stream, query, payload).await
-                },
-            ),
-            _ => unimplemented!(),
+        let handler_fn = |Query(query): Query<HashMap<String, String>>, payload: Option<Bytes>| async move {
+            handle_req(req_stream, query, payload).await
         };
 
+        let handlers = {
+            let mut handlers = HashMap::new();
+            handlers.insert(HttpMethod::POST, post(handler_fn.clone()));
+            handlers.insert(HttpMethod::PUT, put(handler_fn.clone()));
+            handlers.insert(HttpMethod::PATCH, patch(handler_fn));
+            handlers
+        };
+
+        let handler = handlers.get(&method).unwrap_or_else(|| unimplemented!());
+
         let mut router = self.router.lock();
-        *router = router.clone().route(path, handler)
+        *router = router.clone().route(path, handler.clone())
     }
 }
 

--- a/nomos-services/http/src/backends/axum.rs
+++ b/nomos-services/http/src/backends/axum.rs
@@ -167,7 +167,7 @@ async fn handle_req(
     req_stream: Sender<HttpRequest>,
     query: HashMap<String, String>,
     payload: Option<Bytes>,
-) -> Result<String, String> {
+) -> Result<Bytes, String> {
     let (tx, mut rx) = tokio::sync::mpsc::channel(1);
     // Write Self::Request type message to req_stream.
     // TODO: handle result in a more elegant way.
@@ -182,10 +182,8 @@ async fn handle_req(
     {
         Ok(_) => {
             // Wait for a response, then pass or serialize it?
-            match rx.recv().await {
-                Some(res) => Ok(serde_json::to_string(&res).unwrap()),
-                None => Ok("".into()),
-            }
+            let res = rx.recv().await.ok_or("".into());
+            res
         }
         Err(_e) => Err(AxnumBackendError::SendGraphqlError.to_string()),
     }

--- a/nomos-services/http/src/backends/axum.rs
+++ b/nomos-services/http/src/backends/axum.rs
@@ -7,7 +7,7 @@ use axum::{
     extract::Query,
     http::HeaderValue,
     routing::{get, post},
-    Extension, Router,
+    Router,
 };
 use hyper::{
     header::{CONTENT_TYPE, USER_AGENT},

--- a/nomos-services/http/src/backends/axum.rs
+++ b/nomos-services/http/src/backends/axum.rs
@@ -103,6 +103,7 @@ impl HttpBackend for AxumBackend {
         req_stream: Sender<HttpRequest>,
     ) {
         let path = format!("/{}/{}", service_id.to_lowercase(), route.path);
+        tracing::info!("Axum backend: adding route {}", path);
         match route.method {
             HttpMethod::GET => self.add_get_route(&path, req_stream),
             HttpMethod::POST | HttpMethod::PUT | HttpMethod::PATCH => {

--- a/nomos-services/http/src/backends/axum.rs
+++ b/nomos-services/http/src/backends/axum.rs
@@ -51,9 +51,6 @@ pub enum AxumBackendError {
     #[error("axum backend: send error: {0}")]
     SendError(#[from] tokio::sync::mpsc::error::SendError<HttpRequest>),
 
-    #[error("axum backend: send error graphql endpoint error")]
-    SendGraphqlError,
-
     #[error("axum backend: {0}")]
     Any(DynError),
 }
@@ -185,6 +182,6 @@ async fn handle_req(
             let res = rx.recv().await.ok_or("".into());
             res
         }
-        Err(_e) => Err(AxnumBackendError::SendGraphqlError.to_string()),
+        Err(_e) => Err(AxumBackendError::SendError(_e).to_string()),
     }
 }

--- a/nomos-services/http/src/backends/mod.rs
+++ b/nomos-services/http/src/backends/mod.rs
@@ -7,7 +7,7 @@ use overwatch_rs::services::{state::ServiceState, ServiceId};
 use serde::{de::DeserializeOwned, Serialize};
 use tokio::sync::mpsc::Sender;
 
-use crate::http::{GraphqlRequest, HttpRequest, Route};
+use crate::http::{HttpRequest, Route};
 
 pub type Payload = Box<dyn DeserializeOwned>;
 pub type Response = Box<dyn Serialize>;
@@ -17,23 +17,12 @@ pub trait HttpBackend {
     type Config: Clone + Debug + Send + Sync + 'static;
     type State: ServiceState<Settings = Self::Config> + Clone;
     type Error: std::fmt::Display;
-    // type GraphqlQuery: Default + async_graphql::ObjectType + 'static;
-    // TODO: add below
-    // type GraphqlConfig: Clone + Debug + Send + Sync + 'static;
 
     fn new(config: Self::Config) -> Result<Self, Self::Error>
     where
         Self: Sized;
 
     fn add_route(&self, service_id: ServiceId, route: Route, req_stream: Sender<HttpRequest>);
-
-    // TODO: add graphql configuration as a parameter?
-    fn add_graphql_endpoint(
-        &self,
-        service_id: ServiceId,
-        path: String,
-        req_stream: Sender<GraphqlRequest>,
-    );
 
     async fn run(&self) -> Result<(), overwatch_rs::DynError>;
 }

--- a/nomos-services/http/src/backends/mod.rs
+++ b/nomos-services/http/src/backends/mod.rs
@@ -7,7 +7,7 @@ use overwatch_rs::services::{state::ServiceState, ServiceId};
 use serde::{de::DeserializeOwned, Serialize};
 use tokio::sync::mpsc::Sender;
 
-use crate::http::{HttpRequest, Route};
+use crate::http::{GraphqlRequest, HttpRequest, Route};
 
 pub type Payload = Box<dyn DeserializeOwned>;
 pub type Response = Box<dyn Serialize>;
@@ -17,11 +17,23 @@ pub trait HttpBackend {
     type Config: Clone + Debug + Send + Sync + 'static;
     type State: ServiceState<Settings = Self::Config> + Clone;
     type Error: std::fmt::Display;
+    type GraphqlQuery: Default + async_graphql::ObjectType + 'static;
+    // TODO: add below
+    // type GraphqlConfig: Clone + Debug + Send + Sync + 'static;
 
     fn new(config: Self::Config) -> Result<Self, Self::Error>
     where
         Self: Sized;
 
     fn add_route(&self, service_id: ServiceId, route: Route, req_stream: Sender<HttpRequest>);
+
+    // TODO: add graphql configuration as a parameter?
+    fn add_graphql_endpoint(
+        &self,
+        service_id: ServiceId,
+        path: String,
+        req_stream: Sender<GraphqlRequest<Self::GraphqlQuery>>,
+    );
+
     async fn run(&self) -> Result<(), overwatch_rs::DynError>;
 }

--- a/nomos-services/http/src/backends/mod.rs
+++ b/nomos-services/http/src/backends/mod.rs
@@ -17,7 +17,7 @@ pub trait HttpBackend {
     type Config: Clone + Debug + Send + Sync + 'static;
     type State: ServiceState<Settings = Self::Config> + Clone;
     type Error: std::fmt::Display;
-    type GraphqlQuery: Default + async_graphql::ObjectType + 'static;
+    // type GraphqlQuery: Default + async_graphql::ObjectType + 'static;
     // TODO: add below
     // type GraphqlConfig: Clone + Debug + Send + Sync + 'static;
 
@@ -32,7 +32,7 @@ pub trait HttpBackend {
         &self,
         service_id: ServiceId,
         path: String,
-        req_stream: Sender<GraphqlRequest<Self::GraphqlQuery>>,
+        req_stream: Sender<GraphqlRequest>,
     );
 
     async fn run(&self) -> Result<(), overwatch_rs::DynError>;

--- a/nomos-services/http/src/bridge.rs
+++ b/nomos-services/http/src/bridge.rs
@@ -1,16 +1,20 @@
-use crate::backends::HttpBackend;
-use crate::http::{GraphqlRequest, HttpMethod, HttpMsg, HttpRequest, HttpService};
-use async_trait::async_trait;
-use overwatch_rs::services::handle::ServiceStateHandle;
-use overwatch_rs::services::relay::{NoMessage, OutboundRelay};
-use overwatch_rs::services::state::{NoOperator, NoState};
-use overwatch_rs::services::{ServiceCore, ServiceData, ServiceId};
-use overwatch_rs::DynError;
 use std::error::Error;
 use std::fmt::{Debug, Formatter};
 use std::future::Future;
 use std::sync::Arc;
+
+use async_trait::async_trait;
+use overwatch_rs::services::handle::ServiceStateHandle;
+use overwatch_rs::services::relay::{NoMessage, OutboundRelay};
+use overwatch_rs::services::{
+    state::{NoOperator, NoState},
+    ServiceCore, ServiceData, ServiceId,
+};
+use overwatch_rs::DynError;
 use tokio::sync::mpsc::{channel, Receiver};
+
+use crate::backends::HttpBackend;
+use crate::http::{HttpMethod, HttpMsg, HttpRequest, HttpService};
 
 pub type HttpBridgeRunner =
     Box<dyn Future<Output = Result<(), overwatch_rs::DynError>> + Send + Unpin + 'static>;
@@ -56,35 +60,6 @@ where
         .map_err(|(e, _)| e)?;
 
     Ok((service_relay, http_receiver))
-}
-
-pub async fn build_graphql_bridge<S, B, P>(
-    handle: overwatch_rs::overwatch::handle::OverwatchHandle,
-    path: P,
-) -> Result<(OutboundRelay<S::Message>, Receiver<GraphqlRequest>), overwatch_rs::DynError>
-where
-    S: ServiceCore + Send + Sync + 'static,
-    B: HttpBackend + Send + Sync + 'static,
-    B::Error: Error + Send + Sync + 'static,
-    P: Into<String> + Send + Sync + 'static,
-{
-    let http_relay = handle.clone().relay::<HttpService<B>>().connect().await?;
-
-    let service_relay = handle.clone().relay::<S>().connect().await?;
-
-    let (graphql_sender, graphql_receiver) = channel(1);
-
-    // Register on http service to receive GET requests.
-    http_relay
-        .send(HttpMsg::add_graphql_endpoint(
-            S::SERVICE_ID,
-            path,
-            graphql_sender,
-        ))
-        .await
-        .map_err(|(e, _)| e)?;
-
-    Ok((service_relay, graphql_receiver))
 }
 
 pub struct HttpBridgeService {

--- a/nomos-services/http/src/bridge.rs
+++ b/nomos-services/http/src/bridge.rs
@@ -46,7 +46,7 @@ where
 
     // Register on http service to receive GET requests.
     http_relay
-        .send(HttpMsg::<B::GraphqlQuery>::add_http_handler(
+        .send(HttpMsg::add_http_handler(
             method,
             S::SERVICE_ID,
             path,
@@ -61,13 +61,7 @@ where
 pub async fn build_graphql_bridge<S, B, P>(
     handle: overwatch_rs::overwatch::handle::OverwatchHandle,
     path: P,
-) -> Result<
-    (
-        OutboundRelay<S::Message>,
-        Receiver<GraphqlRequest<B::GraphqlQuery>>,
-    ),
-    overwatch_rs::DynError,
->
+) -> Result<(OutboundRelay<S::Message>, Receiver<GraphqlRequest>), overwatch_rs::DynError>
 where
     S: ServiceCore + Send + Sync + 'static,
     B: HttpBackend + Send + Sync + 'static,
@@ -82,7 +76,7 @@ where
 
     // Register on http service to receive GET requests.
     http_relay
-        .send(HttpMsg::<B::GraphqlQuery>::add_graphql_endpoint(
+        .send(HttpMsg::add_graphql_endpoint(
             S::SERVICE_ID,
             path,
             graphql_sender,

--- a/nomos-services/http/src/http.rs
+++ b/nomos-services/http/src/http.rs
@@ -78,6 +78,11 @@ pub enum HttpMsg {
         route: Route,
         req_stream: Sender<HttpRequest>,
     },
+    AddGraphqlEndpoint {
+        service_id: ServiceId,
+        path: String,
+        schema: Arc<async_graphql::Schema<()>>,
+    },
 }
 
 impl HttpMsg {
@@ -90,6 +95,21 @@ impl HttpMsg {
             service_id,
             route: Route {
                 method: HttpMethod::GET,
+                path: path.into(),
+            },
+            req_stream,
+        }
+    }
+
+    pub fn add_post_handler<P: Into<String>>(
+        service_id: ServiceId,
+        path: P,
+        req_stream: Sender<HttpRequest>,
+    ) -> Self {
+        Self::AddHandler {
+            service_id,
+            route: Route {
+                method: HttpMethod::POST,
                 path: path.into(),
             },
             req_stream,

--- a/nomos-services/http/src/http.rs
+++ b/nomos-services/http/src/http.rs
@@ -185,7 +185,7 @@ impl<B: HttpBackend> Clone for Config<B> {
 #[cfg(feature = "gql")]
 pub async fn handle_graphql_req<M, F>(
     payload: Option<Bytes>,
-    dummy: OutboundRelay<M>,
+    relay: OutboundRelay<M>,
     f: F,
 ) -> Result<String, overwatch_rs::DynError>
 where
@@ -200,7 +200,7 @@ where
         .into_single()?;
 
     let (sender, receiver) = oneshot::channel();
-    dummy.send(f(req, sender)?).await.map_err(|_| {
+    relay.send(f(req, sender)?).await.map_err(|_| {
         tracing::error!(err = "failed to send graphql request to the http service");
         "failed to send graphql request to the frontend"
     })?;

--- a/nomos-services/http/src/http.rs
+++ b/nomos-services/http/src/http.rs
@@ -61,19 +61,6 @@ impl core::fmt::Debug for Route {
     }
 }
 
-// pub trait GraphqlSchema: Sized + Send + Sync + 'static {
-//     type Query: async_graphql::ObjectType + 'static;
-//     type Mutation: async_graphql::ObjectType + 'static;
-//     type Subscription: async_graphql::SubscriptionType + 'static;
-
-//     fn new(query: Self::Query, mutation: Self::Mutation, subscription: Self::Subscription) -> GraphqlRequest<Self>;
-// }
-
-// pub struct GraphqlRequest {
-//     pub req: async_graphql::Request,
-//     pub res_tx: Sender<async_graphql::Response>,
-// }
-
 #[derive(Debug, Clone)]
 pub struct HttpRequest {
     pub query: HashMap<String, String>,
@@ -91,11 +78,6 @@ pub enum HttpMsg {
         route: Route,
         req_stream: Sender<HttpRequest>,
     },
-    //    AddGraphqlEndpoint {
-    //        service_id: ServiceId,
-    //        path: String,
-    //        req_stream: Sender<GraphqlRequest>,
-    //    },
 }
 
 impl HttpMsg {
@@ -129,18 +111,6 @@ impl HttpMsg {
             req_stream,
         }
     }
-
-    //    pub fn add_graphql_endpoint<P: Into<String>>(
-    //        service_id: ServiceId,
-    //        path: P,
-    //        req_stream: Sender<GraphqlRequest>,
-    //    ) -> Self {
-    //        Self::AddGraphqlEndpoint {
-    //            service_id,
-    //            path: path.into(),
-    //            req_stream,
-    //        }
-    //    }
 }
 
 impl RelayMessage for HttpMsg {}
@@ -157,15 +127,6 @@ impl Debug for HttpMsg {
                 "HttpMsg::AddHandler {{ sender: {:?}, route: {:?} }}",
                 service_id, route
             ),
-            //             Self::AddGraphqlEndpoint {
-            //                 service_id,
-            //                 path,
-            //                 req_stream: _,
-            //             } => write!(
-            //                 fmt,
-            //                 "HttpMsg::AddGraphqlEndpoint {{ sender: {:?}, path: {:?} }}",
-            //                 service_id, path
-            //             ),
         }
     }
 }
@@ -199,28 +160,21 @@ where
             async move {
                 loop {
                     tokio::select! {
-                                            Some(msg) = inbound_relay.recv() => {
-                                                match msg {
-                                                    HttpMsg::AddHandler {
-                                                        service_id,
-                                                        route,
-                                                        req_stream,
-                                                    } => {
-                                                        backend.add_route(service_id, route, req_stream);
-                                                    },
-                    //                                HttpMsg::AddGraphqlEndpoint {
-                    //                                    service_id,
-                    //                                    path,
-                    //                                    req_stream,
-                    //                                } => {
-                    //                                    backend.add_graphql_endpoint(service_id, path, req_stream);
-                    //                                }
-                                                }
-                                            }
-                                            _server_exit = &mut stop_rx => {
-                                                break;
-                                            }
-                                        }
+                        Some(msg) = inbound_relay.recv() => {
+                            match msg {
+                                HttpMsg::AddHandler {
+                                    service_id,
+                                    route,
+                                    req_stream,
+                                } => {
+                                    backend.add_route(service_id, route, req_stream);
+                                },
+                            }
+                        }
+                        _server_exit = &mut stop_rx => {
+                            break;
+                        }
+                    }
                 }
             }
         });

--- a/nomos-services/http/src/http.rs
+++ b/nomos-services/http/src/http.rs
@@ -97,21 +97,6 @@ impl HttpMsg {
             req_stream,
         }
     }
-
-    pub fn add_post_handler<P: Into<String>>(
-        service_id: ServiceId,
-        path: P,
-        req_stream: Sender<HttpRequest>,
-    ) -> Self {
-        Self::AddHandler {
-            service_id,
-            route: Route {
-                method: HttpMethod::POST,
-                path: path.into(),
-            },
-            req_stream,
-        }
-    }
 }
 
 impl RelayMessage for HttpMsg {}

--- a/nomos-services/http/src/http.rs
+++ b/nomos-services/http/src/http.rs
@@ -69,10 +69,10 @@ impl core::fmt::Debug for Route {
 //     fn new(query: Self::Query, mutation: Self::Mutation, subscription: Self::Subscription) -> GraphqlRequest<Self>;
 // }
 
-pub struct GraphqlRequest {
-    pub req: async_graphql::Request,
-    pub res_tx: Sender<async_graphql::Response>,
-}
+// pub struct GraphqlRequest {
+//     pub req: async_graphql::Request,
+//     pub res_tx: Sender<async_graphql::Response>,
+// }
 
 #[derive(Debug, Clone)]
 pub struct HttpRequest {
@@ -91,11 +91,11 @@ pub enum HttpMsg {
         route: Route,
         req_stream: Sender<HttpRequest>,
     },
-    AddGraphqlEndpoint {
-        service_id: ServiceId,
-        path: String,
-        req_stream: Sender<GraphqlRequest>,
-    },
+    //    AddGraphqlEndpoint {
+    //        service_id: ServiceId,
+    //        path: String,
+    //        req_stream: Sender<GraphqlRequest>,
+    //    },
 }
 
 impl HttpMsg {
@@ -130,17 +130,17 @@ impl HttpMsg {
         }
     }
 
-    pub fn add_graphql_endpoint<P: Into<String>>(
-        service_id: ServiceId,
-        path: P,
-        req_stream: Sender<GraphqlRequest>,
-    ) -> Self {
-        Self::AddGraphqlEndpoint {
-            service_id,
-            path: path.into(),
-            req_stream,
-        }
-    }
+    //    pub fn add_graphql_endpoint<P: Into<String>>(
+    //        service_id: ServiceId,
+    //        path: P,
+    //        req_stream: Sender<GraphqlRequest>,
+    //    ) -> Self {
+    //        Self::AddGraphqlEndpoint {
+    //            service_id,
+    //            path: path.into(),
+    //            req_stream,
+    //        }
+    //    }
 }
 
 impl RelayMessage for HttpMsg {}
@@ -157,15 +157,15 @@ impl Debug for HttpMsg {
                 "HttpMsg::AddHandler {{ sender: {:?}, route: {:?} }}",
                 service_id, route
             ),
-            Self::AddGraphqlEndpoint {
-                service_id,
-                path,
-                req_stream: _,
-            } => write!(
-                fmt,
-                "HttpMsg::AddGraphqlEndpoint {{ sender: {:?}, path: {:?} }}",
-                service_id, path
-            ),
+            //             Self::AddGraphqlEndpoint {
+            //                 service_id,
+            //                 path,
+            //                 req_stream: _,
+            //             } => write!(
+            //                 fmt,
+            //                 "HttpMsg::AddGraphqlEndpoint {{ sender: {:?}, path: {:?} }}",
+            //                 service_id, path
+            //             ),
         }
     }
 }
@@ -199,28 +199,28 @@ where
             async move {
                 loop {
                     tokio::select! {
-                        Some(msg) = inbound_relay.recv() => {
-                            match msg {
-                                HttpMsg::AddHandler {
-                                    service_id,
-                                    route,
-                                    req_stream,
-                                } => {
-                                    backend.add_route(service_id, route, req_stream);
-                                },
-                                HttpMsg::AddGraphqlEndpoint {
-                                    service_id,
-                                    path,
-                                    req_stream,
-                                } => {
-                                    backend.add_graphql_endpoint(service_id, path, req_stream);
-                                }
-                            }
-                        }
-                        _server_exit = &mut stop_rx => {
-                            break;
-                        }
-                    }
+                                            Some(msg) = inbound_relay.recv() => {
+                                                match msg {
+                                                    HttpMsg::AddHandler {
+                                                        service_id,
+                                                        route,
+                                                        req_stream,
+                                                    } => {
+                                                        backend.add_route(service_id, route, req_stream);
+                                                    },
+                    //                                HttpMsg::AddGraphqlEndpoint {
+                    //                                    service_id,
+                    //                                    path,
+                    //                                    req_stream,
+                    //                                } => {
+                    //                                    backend.add_graphql_endpoint(service_id, path, req_stream);
+                    //                                }
+                                                }
+                                            }
+                                            _server_exit = &mut stop_rx => {
+                                                break;
+                                            }
+                                        }
                 }
             }
         });

--- a/nomos-services/metrics/Cargo.toml
+++ b/nomos-services/metrics/Cargo.toml
@@ -15,6 +15,7 @@ async-graphql-axum = { version = "5", optional = true }
 async-trait = "0.1"
 bytes = "1.3"
 clap = { version = "4", features = ["derive", "env"], optional = true }
+nomos-http = { path = "../http", optional = true }
 overwatch-rs = { git = "https://github.com/logos-co/Overwatch", branch = "main" }
 overwatch-derive = { git = "https://github.com/logos-co/Overwatch", branch = "main" }
 once_cell = "1.16"
@@ -33,4 +34,4 @@ futures = "0.3"
 
 [features]
 default = []
-gql = ["clap", "axum", "async-graphql", "async-graphql-axum", "tower-http"]
+gql = ["clap", "axum", "async-graphql", "async-graphql-axum", "tower-http", "nomos-http/gql"]

--- a/nomos-services/metrics/src/frontend/graphql/mod.rs
+++ b/nomos-services/metrics/src/frontend/graphql/mod.rs
@@ -1,9 +1,6 @@
 // std
 
 // crates
-use async_graphql::{EmptyMutation, EmptySubscription, Schema};
-use async_graphql_axum::{GraphQLRequest, GraphQLResponse};
-use axum::extract::State;
 use nomos_http::backends::HttpBackend;
 use nomos_http::bridge::{build_http_bridge, HttpBridgeRunner};
 use nomos_http::http::{handle_graphql_req, HttpMethod, HttpRequest};
@@ -80,18 +77,6 @@ where
         }
         Ok(())
     }))
-}
-
-pub async fn graphql_handler<Backend: MetricsBackend + Clone + Send + 'static + Sync>(
-    schema: State<Schema<Graphql<Backend>, EmptyMutation, EmptySubscription>>,
-    req: GraphQLRequest,
-) -> GraphQLResponse
-where
-    Backend::MetricsData: async_graphql::OutputType,
-{
-    let request = req.into_inner();
-    let resp = schema.execute(request).await;
-    GraphQLResponse::from(resp)
 }
 
 #[derive(Debug)]

--- a/nomos-services/metrics/src/frontend/graphql/mod.rs
+++ b/nomos-services/metrics/src/frontend/graphql/mod.rs
@@ -53,7 +53,7 @@ pub struct GraphqlServerSettings {
     pub cors_origins: Vec<String>,
 }
 
-async fn graphql_handler<Backend: MetricsBackend + Send + 'static + Sync>(
+pub async fn graphql_handler<Backend: MetricsBackend + Send + 'static + Sync>(
     schema: State<Schema<Graphql<Backend>, EmptyMutation, EmptySubscription>>,
     req: GraphQLRequest,
 ) -> GraphQLResponse

--- a/nomos-services/metrics/src/types.rs
+++ b/nomos-services/metrics/src/types.rs
@@ -542,7 +542,7 @@ impl<'de> Deserialize<'de> for Histogram {
         // TODO: this implementation is not correct because we cannot set samples for histogram,
         // need to wait prometheus support serde.
         SerializableHistogramOpts::deserialize(deserializer).map(
-            |SerializableHistogramOpts { val, opts }| {
+            |SerializableHistogramOpts { val: _, opts }| {
                 let x = prometheus::Histogram::with_opts(opts.clone()).unwrap();
                 Self { val: x, opts }
             },


### PR DESCRIPTION
Hi @bacv @danielSanchezQ @Zeegomo, ~~this is the draft for support add graphql handler. I cannot use something like `dyn async_graphql::ObjectType + 'static`, because `async_graphql::Object` is not object-safe. So I have to add a generic for `AxumBackend`. If this generic in `AxumBackend` is not acceptable, not quite sure if this problem can be solved by rust's new feature GAT, if not we may need to use `cfg(feature="gql")` to implement two different version of `HttpBackend` trait and `AxumBackend`.~~

Support add graphql handler.