### PR TITLE
Add constructor for LogSettings

### DIFF
--- a/nomos-services/log/src/lib.rs
+++ b/nomos-services/log/src/lib.rs
@@ -37,6 +37,16 @@ pub struct LoggerSettings {
     level: Level,
 }
 
+impl Default for LoggerSettings {
+    fn default() -> Self {
+        Self {
+            backend: LoggerBackend::Stdout,
+            format: LoggerFormat::Json,
+            level: Level::DEBUG,
+        }
+    }
+}
+
 impl LoggerSettings {
     #[inline]
     pub const fn new(backend: LoggerBackend, format: LoggerFormat, level: Level) -> Self {

--- a/nomos-services/log/src/lib.rs
+++ b/nomos-services/log/src/lib.rs
@@ -37,6 +37,17 @@ pub struct LoggerSettings {
     level: Level,
 }
 
+impl LoggerSettings {
+    #[inline]
+    pub const fn new(backend: LoggerBackend, format: LoggerFormat, level: Level) -> Self {
+        Self {
+            backend,
+            format,
+            level,
+        }
+    }
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum LoggerFormat {
     Json,


### PR DESCRIPTION
The `LogSettings` currently can only be constructed by deserialization, this PR adds a normal constructor for `LogSettings` which is helpful for writing test cases.