### PR TITLE
fix: validate MAX_MSG_LEN before allocation in unpack_from_reader

### DIFF
--- a/c-bindings/src/api/lifecycle.rs
+++ b/c-bindings/src/api/lifecycle.rs
@@ -164,7 +164,7 @@ pub unsafe extern "C" fn stop_node(node: *mut LogosBlockchainNode) -> OperationS
 
 #[cfg(test)]
 mod test {
-    use std::{path::PathBuf, sync::LazyLock};
+    use std::{ffi::CString, path::PathBuf, sync::LazyLock};
 
     use crate::api::lifecycle::{start_lb_node, stop_node};
 
@@ -231,19 +231,11 @@ mod test {
     #[test]
     fn test_basic_lifecycle() {
         let _guard = NodeStateGuard::from_current_crate();
+        let config_path = CString::new(STANDALONE_NODE_CONFIG_PATH.to_str().unwrap()).unwrap();
+        let deployment_path =
+            CString::new(STANDALONE_DEPLOYMENT_CONFIG_PATH.to_str().unwrap()).unwrap();
 
-        let start_status = start_lb_node(
-            STANDALONE_NODE_CONFIG_PATH
-                .to_str()
-                .unwrap()
-                .as_ptr()
-                .cast::<i8>(),
-            STANDALONE_DEPLOYMENT_CONFIG_PATH
-                .to_str()
-                .unwrap()
-                .as_ptr()
-                .cast::<i8>(),
-        );
+        let start_status = start_lb_node(config_path.as_ptr(), deployment_path.as_ptr());
 
         assert!(
             start_status.is_ok(),

--- a/consensus/cryptarchia-sync/src/libp2p/packing.rs
+++ b/consensus/cryptarchia-sync/src/libp2p/packing.rs
@@ -30,6 +30,13 @@ where
 {
     let packed_message = message.to_bytes()?;
 
+    if packed_message.len() > MAX_MSG_LEN {
+        return Err(PackingError::MessageTooLarge {
+            max: MAX_MSG_LEN,
+            actual: packed_message.len(),
+        });
+    }
+
     let length_prefix: LenType =
         packed_message
             .len()
@@ -62,7 +69,36 @@ where
     R: AsyncReadExt + Unpin,
 {
     let data_length = read_data_length(reader).await?;
+    if data_length > MAX_MSG_LEN {
+        return Err(PackingError::MessageTooLarge {
+            max: MAX_MSG_LEN,
+            actual: data_length,
+        });
+    }
     let mut data = vec![0u8; data_length];
     reader.read_exact(&mut data).await?;
     Ok(Message::from_bytes(&data)?)
+}
+
+#[cfg(test)]
+mod tests {
+    use futures::io::Cursor;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn reject_oversized_message_on_read() {
+        let oversized_len = (MAX_MSG_LEN as u32) + 1;
+        let header = oversized_len.to_le_bytes();
+        let mut reader = Cursor::new(header.to_vec());
+
+        let result = unpack_from_reader::<Vec<u8>, _>(&mut reader).await;
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(matches!(
+            err,
+            PackingError::MessageTooLarge { max, actual }
+                if max == MAX_MSG_LEN && actual == oversized_len as usize
+        ));
+    }
 }


### PR DESCRIPTION
## Summary

Validates the length prefix against \MAX_MSG_LEN\ (16 MiB) **before** allocating the receive buffer in \unpack_from_reader\. Without this check, a malicious peer can send a 4-byte header with \data_length = u32::MAX\ and force a ~4 GiB heap allocation per stream.

## Changes

- **\unpack_from_reader\**: Added an early \data_length > MAX_MSG_LEN\ guard that returns \PackingError::MessageTooLarge\ before the \ec!\ allocation.
- **\pack_to_writer\**: Added an explicit \MAX_MSG_LEN\ check on the serialized payload. Previously it only rejected messages that overflowed \u32\, not the 16 MiB protocol limit.
- Added a unit test (\eject_oversized_message_on_read\) that confirms oversized length prefixes are rejected without allocating.

## Related Issue

Closes #2460