### PR TITLE
[for evaluation after testnet 0.2.0] feat: add bounded blocks streaming to zone sdk

### DIFF
--- a/zone-sdk/src/adapter.rs
+++ b/zone-sdk/src/adapter.rs
@@ -1,9 +1,9 @@
 use std::{collections::HashMap, pin::Pin};
 
 use async_trait::async_trait;
-use futures::{Stream, stream};
+use futures::{Stream, StreamExt as _, stream};
 use lb_common_http_client::{
-    ApiBlock, BlockInfo, ChainServiceInfo, CommonHttpClient, Error, Event, EventPayload, Events,
+     BlockInfo, ChainServiceInfo, CommonHttpClient, Error, Event, EventPayload, Events,
     ProcessedBlockEvent, Slot,
 };
 use lb_core::{
@@ -15,7 +15,7 @@ use lb_core::{
         ops::{OpId as _, channel::ChannelId},
     },
 };
-use lb_http_api_common::queries::BlocksStreamQuery;
+use lb_http_api_common::queries::{BlockFilter, BlockSortOrder, BlocksStreamQuery};
 use reqwest::Url;
 use tracing::warn;
 
@@ -39,15 +39,7 @@ pub trait Node {
 
     async fn lib_stream(&self) -> Result<BoxStream<BlockInfo>, Error>;
 
-    async fn block(&self, id: HeaderId) -> Result<Option<ApiBlock>, Error>;
-
     async fn block_events(&self, id: HeaderId) -> Result<Option<Events>, Error>;
-
-    async fn immutable_blocks(
-        &self,
-        slot_from: Slot,
-        slot_to: Slot,
-    ) -> Result<Vec<ApiBlock>, Error>;
 
     async fn zone_messages_in_block(
         &self,
@@ -111,27 +103,9 @@ impl Node for NodeHttpClient {
         Ok(Box::pin(stream))
     }
 
-    async fn block(&self, id: HeaderId) -> Result<Option<ApiBlock>, Error> {
-        self.client.get_block_by_id(self.base_url.clone(), id).await
-    }
-
     async fn block_events(&self, id: HeaderId) -> Result<Option<Events>, Error> {
         self.client
             .get_block_events(self.base_url.clone(), id)
-            .await
-    }
-
-    async fn immutable_blocks(
-        &self,
-        slot_from: Slot,
-        slot_to: Slot,
-    ) -> Result<Vec<ApiBlock>, Error> {
-        self.client
-            .get_immutable_blocks(
-                self.base_url.clone(),
-                slot_from.into_inner(),
-                slot_to.into_inner(),
-            )
             .await
     }
 
@@ -169,22 +143,25 @@ impl Node for NodeHttpClient {
         slot_to: Slot,
         channel_id: ChannelId,
     ) -> Result<BoxStream<(ZoneMessage, Slot)>, Error> {
-        let blocks = self
-            .client
-            .get_immutable_blocks(
-                self.base_url.clone(),
-                slot_from.into_inner(),
-                slot_to.into_inner(),
-            )
+        let blocks_stream = self
+            .blocks_range_stream(BlocksStreamQuery {
+                slot_from: Some(slot_from.into_inner()),
+                slot_to: Some(slot_to.into_inner()),
+                order: Some(BlockSortOrder::Ascending),
+                blocks_limit: None,
+                server_batch_size: None,
+                block_filter: Some(BlockFilter::ImmutableOnly),
+            })
             .await?;
+        let processed_block: Vec<ProcessedBlockEvent> = blocks_stream.collect().await;
 
         let mut all_messages = Vec::new();
-        for block in blocks {
-            let slot = block.header.slot;
-            let deposit_amounts = if has_channel_deposit(&block.transactions, channel_id) {
+        for item in processed_block {
+            let slot = item.block.header.slot;
+            let deposit_amounts = if has_channel_deposit(&item.block.transactions, channel_id) {
                 let events = self
                     .client
-                    .get_block_events(self.base_url.clone(), block.header.id)
+                    .get_block_events(self.base_url.clone(), item.block.header.id)
                     .await?
                     .unwrap_or_default();
                 build_deposit_amounts(&events)
@@ -192,7 +169,7 @@ impl Node for NodeHttpClient {
                 HashMap::new()
             };
 
-            for message in block_to_messages(block.transactions, channel_id, &deposit_amounts) {
+            for message in block_to_messages(item.block.transactions, channel_id, &deposit_amounts) {
                 all_messages.push((message, slot));
             }
         }

--- a/zone-sdk/src/indexer.rs
+++ b/zone-sdk/src/indexer.rs
@@ -93,7 +93,7 @@ where
                     .checked_sub(1)
                     .expect("slot shouldn't overflow"),
             ))
-            .min(lib_slot);
+                .min(lib_slot);
 
             match self
                 .node
@@ -111,7 +111,7 @@ where
                 }
             }
         })
-        .flatten();
+            .flatten();
 
         Ok(stream)
     }
@@ -122,8 +122,7 @@ mod tests {
 
     use async_trait::async_trait;
     use lb_common_http_client::{
-        ApiBlock, BlockInfo, ChainServiceInfo, ChainServiceMode, CryptarchiaInfo,
-        ProcessedBlockEvent, State,
+        BlockInfo, ChainServiceInfo, ChainServiceMode, CryptarchiaInfo, ProcessedBlockEvent, State,
     };
     use lb_core::{
         header::HeaderId,
@@ -367,26 +366,11 @@ mod tests {
             Ok(Box::pin(futures::stream::empty()))
         }
 
-        async fn block(
-            &self,
-            _id: HeaderId,
-        ) -> Result<Option<ApiBlock>, lb_common_http_client::Error> {
-            Ok(None)
-        }
-
         async fn block_events(
             &self,
             _id: HeaderId,
         ) -> Result<Option<lb_common_http_client::Events>, lb_common_http_client::Error> {
             Ok(None)
-        }
-
-        async fn immutable_blocks(
-            &self,
-            _slot_from: Slot,
-            _slot_to: Slot,
-        ) -> Result<Vec<ApiBlock>, lb_common_http_client::Error> {
-            Ok(Vec::new())
         }
 
         async fn zone_messages_in_block(

--- a/zone-sdk/src/sequencer.rs
+++ b/zone-sdk/src/sequencer.rs
@@ -26,6 +26,7 @@ use lb_core::{
     },
     proofs::channel_multi_sig_proof::{ChannelMultiSigProof, IndexedSignature},
 };
+use lb_http_api_common::queries::{BlockFilter, BlockSortOrder, BlocksStreamQuery};
 use lb_key_management_system_service::keys::{Ed25519Key, Ed25519Signature};
 use tokio::sync::{broadcast, mpsc, watch};
 use tracing::{debug, error, info, warn};
@@ -1975,7 +1976,15 @@ where
 
     // 2. Backfill canonical chain if parent is missing
     if !s.has_block(&parent_id) && parent_id != s.lib() {
-        backfill_canonical(s, parent_id, channel_id, node).await;
+        backfill_canonical(
+            s,
+            *lib_slot + 1,
+            event.block.header.slot,
+            block_id,
+            channel_id,
+            node,
+        )
+        .await;
     }
 
     // Extract tx hashes and inscription info for our channel
@@ -2090,45 +2099,57 @@ where
         items: Vec::new(),
     };
 
-    let blocks = node
-        .immutable_blocks(Slot::from(from_slot), Slot::from(to_slot))
-        .await
-        .map_err(|e| {
-            error!(?from_slot, ?to_slot, ?e, "Failed to fetch immutable blocks");
-            Error::Network(format!(
-                "failed to fetch blocks (slots {from_slot}..{to_slot}): {e}"
-            ))
-        })?;
+    let blocks_range_stream_result = node
+        .blocks_range_stream(BlocksStreamQuery {
+            slot_from: Some(from_slot),
+            slot_to: Some(to_slot),
+            order: Some(BlockSortOrder::Ascending),
+            blocks_limit: None,
+            server_batch_size: None,
+            block_filter: Some(BlockFilter::ImmutableOnly),
+        })
+        .await;
 
-    for block in blocks {
-        let our_txs: Vec<TxHash> = block
-            .transactions
-            .iter()
-            .filter(|tx| matches_channel(tx, channel_id))
-            .map(|tx| tx.mantle_tx.hash())
-            .collect();
+    match blocks_range_stream_result {
+        Ok(mut blocks) => {
+            while let Some(block) = blocks.next().await.map(|event| event.block) {
+                let our_txs: Vec<TxHash> = block
+                    .transactions
+                    .iter()
+                    .filter(|tx| matches_channel(tx, channel_id))
+                    .map(|tx| tx.mantle_tx.hash())
+                    .collect();
 
-        let inscriptions = extract_inscriptions(&block.transactions, channel_id);
+                let inscriptions = extract_inscriptions(&block.transactions, channel_id);
 
-        // Fetch + validate deposit events for this block BEFORE mutating
-        // state — on error we leave state untouched so the caller can retry.
-        let deposit_amounts =
-            fetch_block_deposit_amounts(node, block.header.id, &block.transactions, channel_id)
+                // Fetch + validate deposit events for this block BEFORE mutating
+                // state — on error we leave state untouched so the caller can retry.
+                let deposit_amounts = fetch_block_deposit_amounts(
+                    node,
+                    block.header.id,
+                    &block.transactions,
+                    channel_id,
+                )
                 .await?;
-        let block_items =
-            extract_finalized_items(&block.transactions, channel_id, &deposit_amounts);
+                let block_items =
+                    extract_finalized_items(&block.transactions, channel_id, &deposit_amounts);
 
-        result.our_tx_hashes.extend(our_txs.iter().copied());
-        result.items.extend(block_items);
+                result.our_tx_hashes.extend(our_txs.iter().copied());
+                result.items.extend(block_items);
 
-        let current_lib = state.lib();
-        state.process_block(
-            block.header.id,
-            block.header.parent_block,
-            current_lib,
-            our_txs,
-            inscriptions,
-        );
+                let current_lib = state.lib();
+                state.process_block(
+                    block.header.id,
+                    block.header.parent_block,
+                    current_lib,
+                    our_txs,
+                    inscriptions,
+                );
+            }
+        }
+        Err(e) => {
+            warn!("Failed to fetch blocks (slots {from_slot}..{to_slot}): {e}");
+        }
     }
 
     Ok(result)
@@ -2301,60 +2322,56 @@ fn extract_finalized_items(
 /// Uses `state.lib()` during replay to avoid premature finalization.
 /// The caller is responsible for triggering finalization after backfill
 /// completes.
+#[expect(
+    clippy::cognitive_complexity,
+    reason = "TODO: address this in a dedicated refactor"
+)]
 async fn backfill_canonical<Node>(
     state: &mut TxState,
-    missing_parent: HeaderId,
+    from_slot: Slot,
+    to_slot: Slot,
+    skip_block_id: HeaderId,
     channel_id: ChannelId,
     node: &Node,
 ) where
     Node: adapter::Node + Sync,
 {
-    debug!("Backfilling canonical chain from {:?}", missing_parent);
-    let blocks = walk_back_to_known(state, missing_parent, node).await;
-    let lib = state.lib();
-    for block in &blocks {
-        apply_backfilled_block(state, block, channel_id, lib);
+    if from_slot > to_slot {
+        return;
+    }
+
+    debug!(
+        "Backfilling canonical chain from slot {:?} to {:?}",
+        from_slot, to_slot
+    );
+    let blocks_range_stream_result = node
+        .blocks_range_stream(BlocksStreamQuery {
+            slot_from: Some(from_slot.into()),
+            slot_to: Some(to_slot.into()),
+            order: Some(BlockSortOrder::Ascending),
+            blocks_limit: None,
+            server_batch_size: None,
+            block_filter: Some(BlockFilter::MutableAndImmutable),
+        })
+        .await;
+    let mut blocks_stream = match blocks_range_stream_result {
+        Ok(stream) => stream,
+        Err(e) => {
+            warn!(
+                "Failed to fetch canonical backfill range (slots {:?}..{:?}). Error: {e}",
+                from_slot, to_slot
+            );
+            return;
+        }
+    };
+
+    while let Some(block) = blocks_stream.next().await.map(|event| event.block) {
+        if block.header.id == skip_block_id || state.has_block(&block.header.id) {
+            continue;
+        }
+        apply_backfilled_block(state, &block, channel_id, state.lib());
     }
     debug!("Canonical backfill complete");
-}
-
-/// Walk backwards from `from` until a block the state already knows about (or
-/// LIB) is reached. Returns blocks in forward order (oldest first).
-async fn walk_back_to_known<Node>(
-    state: &TxState,
-    from: HeaderId,
-    node: &Node,
-) -> Vec<lb_common_http_client::ApiBlock>
-where
-    Node: adapter::Node + Sync,
-{
-    let mut blocks = Vec::new();
-    let mut current = from;
-    let lib = state.lib();
-
-    while !state.has_block(&current) && current != lib {
-        match node.block(current).await {
-            Ok(Some(block)) => {
-                let parent = block.header.parent_block;
-                blocks.push(block);
-                current = parent;
-            }
-            Ok(None) => {
-                warn!("Block {:?} not found during canonical backfill", current);
-                break;
-            }
-            Err(e) => {
-                warn!(
-                    "Failed to fetch block {:?} during canonical backfill: {e}",
-                    current
-                );
-                break;
-            }
-        }
-    }
-
-    blocks.reverse();
-    blocks
 }
 
 fn apply_backfilled_block(
@@ -2575,7 +2592,6 @@ mod tests {
         },
         proofs::leader_proof::Groth16LeaderProof,
     };
-    use lb_http_api_common::queries::BlocksStreamQuery;
     use lb_key_management_system_service::keys::ZkKey;
     use num_bigint::BigUint;
     use rand::{RngCore as _, thread_rng};
@@ -3064,26 +3080,11 @@ mod tests {
             Ok(Box::pin(futures::stream::pending()))
         }
 
-        async fn block(
-            &self,
-            _id: HeaderId,
-        ) -> Result<Option<ApiBlock>, lb_common_http_client::Error> {
-            unimplemented!()
-        }
-
         async fn block_events(
             &self,
             _id: HeaderId,
         ) -> Result<Option<lb_common_http_client::Events>, lb_common_http_client::Error> {
             Ok(None)
-        }
-
-        async fn immutable_blocks(
-            &self,
-            _slot_from: Slot,
-            _slot_to: Slot,
-        ) -> Result<Vec<ApiBlock>, lb_common_http_client::Error> {
-            Ok(Vec::new())
         }
 
         async fn zone_messages_in_block(
@@ -3166,32 +3167,11 @@ mod tests {
             Ok(Box::pin(futures::stream::pending()))
         }
 
-        async fn block(
-            &self,
-            _id: HeaderId,
-        ) -> Result<Option<ApiBlock>, lb_common_http_client::Error> {
-            Ok(None)
-        }
-
         async fn block_events(
             &self,
             _id: HeaderId,
         ) -> Result<Option<lb_common_http_client::Events>, lb_common_http_client::Error> {
             Ok(None)
-        }
-
-        async fn immutable_blocks(
-            &self,
-            slot_from: Slot,
-            slot_to: Slot,
-        ) -> Result<Vec<ApiBlock>, lb_common_http_client::Error> {
-            // Cold-start backfill range is [0, 0] when lib_slot is genesis,
-            // so we only return the genesis block for that exact range.
-            if slot_from == Slot::genesis() && slot_to == Slot::genesis() {
-                Ok(vec![self.genesis_block.clone()])
-            } else {
-                Ok(Vec::new())
-            }
         }
 
         async fn zone_messages_in_block(


### PR DESCRIPTION

## 1. What does this PR implement?

Added bounded blocks streaming to zone sdk using the new `pub async fn get_blocks_range_stream(` client HTTP interface, replacing the `pub async fn get_immutable_blocks(` and `pub async fn get_block_by_id(` client interface calls.

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@hansieodendaal, @pradovic 

## 4. Is the specification accurate and complete?

Yes

## 5. Does the implementation introduce changes in the specification?

No

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [X] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [X] 2. Description added.
* [X] 3. Context and links to Specification document(s) added.
* [X] 4. Main contact(s) (developers and specification authors) added
* [X] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [X] 6. Link PR to a specific milestone.
* [X] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
