### PR TITLE
refactor: gas constants

### DIFF
--- a/core/src/mantle/gas.rs
+++ b/core/src/mantle/gas.rs
@@ -171,13 +171,14 @@ pub trait OperationGas<Profile: GasProfile>: ProvableOperation {
 }
 
 pub trait SignedOperationExecutionGas {
-    fn gas_signature_count(&self) -> Value;
+    /// The factor `execution_gas` scales the operation's base gas cost by.
+    fn gas_multiplier(&self) -> Value;
 
+    /// Calculates the execution gas.
     fn execution_gas<Profile: GasProfile>(&self) -> Result<Gas, GasOverflow>
     where
         Self: OperationGas<Profile>,
     {
-        let multiplier = self.gas_signature_count();
-        Self::GAS_CONSTANT.checked_mul(multiplier)
+        Self::GAS_CONSTANT.checked_mul(self.gas_multiplier())
     }
 }

--- a/core/src/mantle/gas.rs
+++ b/core/src/mantle/gas.rs
@@ -130,32 +130,6 @@ pub trait TxGasCalculator {
 #[error("Gas overflow")]
 pub struct GasOverflow;
 
-impl<T: TxGasCalculator> TxGasCalculator for &T {
-    type Context = T::Context;
-
-    fn total_gas_cost<Profile: GasProfile>(
-        &self,
-        context: &Self::Context,
-    ) -> Result<GasCost, GasOverflow> {
-        T::total_gas_cost::<Profile>(self, context)
-    }
-
-    fn storage_gas_cost(&self, context: &Self::Context) -> Result<GasCost, GasOverflow> {
-        T::storage_gas_cost(self, context)
-    }
-
-    fn execution_gas_consumption<Profile: GasProfile>(
-        &self,
-        context: &Self::Context,
-    ) -> Result<Gas, GasOverflow> {
-        T::execution_gas_consumption::<Profile>(self, context)
-    }
-
-    fn storage_gas_consumption(&self, context: &Self::Context) -> Result<Gas, GasOverflow> {
-        T::storage_gas_consumption(self, context)
-    }
-}
-
 mod private {
     pub trait Sealed {}
 }

--- a/core/src/mantle/gas.rs
+++ b/core/src/mantle/gas.rs
@@ -107,7 +107,7 @@ impl Display for GasCost {
     }
 }
 
-pub trait GasCalculator {
+pub trait TxGasCalculator {
     type Context;
 
     /// Returns the gas cost of this operation.
@@ -130,7 +130,7 @@ pub trait GasCalculator {
 #[error("Gas overflow")]
 pub struct GasOverflow;
 
-impl<T: GasCalculator> GasCalculator for &T {
+impl<T: TxGasCalculator> TxGasCalculator for &T {
     type Context = T::Context;
 
     fn total_gas_cost<Profile: GasProfile>(

--- a/core/src/mantle/gas.rs
+++ b/core/src/mantle/gas.rs
@@ -111,14 +111,14 @@ pub trait GasCalculator {
     type Context;
 
     /// Returns the gas cost of this operation.
-    fn total_gas_cost<Constants: GasConstants>(
+    fn total_gas_cost<Profile: GasProfile>(
         &self,
         context: &Self::Context,
     ) -> Result<GasCost, GasOverflow>;
 
     fn storage_gas_cost(&self, context: &Self::Context) -> Result<GasCost, GasOverflow>;
 
-    fn execution_gas_consumption<Constants: GasConstants>(
+    fn execution_gas_consumption<Profile: GasProfile>(
         &self,
         context: &Self::Context,
     ) -> Result<Gas, GasOverflow>;
@@ -133,22 +133,22 @@ pub struct GasOverflow;
 impl<T: GasCalculator> GasCalculator for &T {
     type Context = T::Context;
 
-    fn total_gas_cost<Constants: GasConstants>(
+    fn total_gas_cost<Profile: GasProfile>(
         &self,
         context: &Self::Context,
     ) -> Result<GasCost, GasOverflow> {
-        T::total_gas_cost::<Constants>(self, context)
+        T::total_gas_cost::<Profile>(self, context)
     }
 
     fn storage_gas_cost(&self, context: &Self::Context) -> Result<GasCost, GasOverflow> {
         T::storage_gas_cost(self, context)
     }
 
-    fn execution_gas_consumption<Constants: GasConstants>(
+    fn execution_gas_consumption<Profile: GasProfile>(
         &self,
         context: &Self::Context,
     ) -> Result<Gas, GasOverflow> {
-        T::execution_gas_consumption::<Constants>(self, context)
+        T::execution_gas_consumption::<Profile>(self, context)
     }
 
     fn storage_gas_consumption(&self, context: &Self::Context) -> Result<Gas, GasOverflow> {
@@ -160,22 +160,22 @@ mod private {
     pub trait Sealed {}
 }
 
-pub trait GasConstants: private::Sealed {}
+pub trait GasProfile: private::Sealed {}
 
-pub struct MainnetGasConstants;
-impl private::Sealed for MainnetGasConstants {}
-impl GasConstants for MainnetGasConstants {}
+pub struct MainnetGasProfile;
+impl private::Sealed for MainnetGasProfile {}
+impl GasProfile for MainnetGasProfile {}
 
-pub trait OperationGas<Constants: GasConstants>: ProvableOperation {
+pub trait OperationGas<Profile: GasProfile>: ProvableOperation {
     const GAS_CONSTANT: Gas;
 }
 
 pub trait SignedOperationExecutionGas {
     fn gas_signature_count(&self) -> Value;
 
-    fn execution_gas<Constants: GasConstants>(&self) -> Result<Gas, GasOverflow>
+    fn execution_gas<Profile: GasProfile>(&self) -> Result<Gas, GasOverflow>
     where
-        Self: OperationGas<Constants>,
+        Self: OperationGas<Profile>,
     {
         let multiplier = self.gas_signature_count();
         Self::GAS_CONSTANT.checked_mul(multiplier)

--- a/core/src/mantle/gas.rs
+++ b/core/src/mantle/gas.rs
@@ -5,7 +5,7 @@ use std::{
 
 use serde::{Deserialize, Serialize};
 
-use crate::mantle::{Value, ledger::ProvableOperation};
+use crate::mantle::Value;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct Gas(Value);
@@ -166,7 +166,7 @@ pub struct MainnetGasProfile;
 impl private::Sealed for MainnetGasProfile {}
 impl GasProfile for MainnetGasProfile {}
 
-pub trait OperationGas<Profile: GasProfile>: ProvableOperation {
+pub trait OperationGas<Profile: GasProfile> {
     const GAS_CONSTANT: Gas;
 }
 

--- a/core/src/mantle/gas.rs
+++ b/core/src/mantle/gas.rs
@@ -141,7 +141,7 @@ impl private::Sealed for MainnetGasProfile {}
 impl GasProfile for MainnetGasProfile {}
 
 pub trait OperationGas<Profile: GasProfile> {
-    const GAS_CONSTANT: Gas;
+    const GAS_COST: Gas;
 }
 
 pub trait SignedOperationExecutionGas {
@@ -153,6 +153,6 @@ pub trait SignedOperationExecutionGas {
     where
         Self: OperationGas<Profile>,
     {
-        Self::GAS_CONSTANT.checked_mul(self.gas_multiplier())
+        Self::GAS_COST.checked_mul(self.gas_multiplier())
     }
 }

--- a/core/src/mantle/gas.rs
+++ b/core/src/mantle/gas.rs
@@ -5,7 +5,7 @@ use std::{
 
 use serde::{Deserialize, Serialize};
 
-use crate::mantle::Value;
+use crate::mantle::{Value, ledger::ProvableOperation};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct Gas(Value);
@@ -156,54 +156,28 @@ impl<T: GasCalculator> GasCalculator for &T {
     }
 }
 
-pub trait GasConstants {
-    /// Verify the proof of ownership and relative balance.
-    const TRANSFER: Gas;
-
-    /// Verify the inscription signature.
-    const CHANNEL_INSCRIBE: Gas;
-
-    /// Verify the administrator signature.
-    const CHANNEL_CONFIG: Gas;
-
-    /// Verify the deposit signature.
-    const CHANNEL_DEPOSIT: Gas;
-
-    /// Verify the withdrawal signature.
-    const CHANNEL_WITHDRAW: Gas;
-
-    /// Verify the transfer signature.
-    const CHANNEL_TRANSFER: Gas;
-
-    /// Verify the proof of ownership.
-    const SDP_DECLARE: Gas;
-
-    /// Verify the proof of ownership.
-    const SDP_WITHDRAW: Gas;
-
-    /// Store the active message.
-    const SDP_ACTIVE: Gas;
-
-    /// Consume a reward ticket.
-    const LEADER_CLAIM: Gas;
-
-    /// Claim a `PoW` reward
-    const CLAIM_POW_REWARD: Gas;
+mod private {
+    pub trait Sealed {}
 }
 
-pub struct MainnetGasConstants;
+pub trait GasConstants: private::Sealed {}
 
-impl GasConstants for MainnetGasConstants {
-    const TRANSFER: Gas = Gas(590);
-    const CHANNEL_INSCRIBE: Gas = Gas(56);
-    const CHANNEL_CONFIG: Gas = Gas(56);
-    const CHANNEL_DEPOSIT: Gas = Gas(590);
-    const CHANNEL_WITHDRAW: Gas = Gas(56);
-    const CHANNEL_TRANSFER: Gas = Gas(56);
-    const SDP_DECLARE: Gas = Gas(646);
-    const SDP_WITHDRAW: Gas = Gas(590);
-    const SDP_ACTIVE: Gas = Gas(590);
-    const LEADER_CLAIM: Gas = Gas(580);
-    // TODO: Fix this value once decided
-    const CLAIM_POW_REWARD: Gas = Gas(1);
+pub struct MainnetGasConstants;
+impl private::Sealed for MainnetGasConstants {}
+impl GasConstants for MainnetGasConstants {}
+
+pub trait OperationGas<Constants: GasConstants>: ProvableOperation {
+    const GAS_CONSTANT: Gas;
+}
+
+pub trait SignedOperationExecutionGas {
+    fn gas_signature_count(&self) -> Value;
+
+    fn execution_gas<Constants: GasConstants>(&self) -> Result<Gas, GasOverflow>
+    where
+        Self: OperationGas<Constants>,
+    {
+        let multiplier = self.gas_signature_count();
+        Self::GAS_CONSTANT.checked_mul(multiplier)
+    }
 }

--- a/core/src/mantle/mod.rs
+++ b/core/src/mantle/mod.rs
@@ -9,7 +9,7 @@ pub mod transactions;
 mod channel_notes;
 mod fixtures;
 
-pub use gas::{GasCalculator, GasConstants};
+pub use gas::{GasCalculator, GasProfile};
 pub use ledger::{Note, NoteId, Utxo, Value};
 pub use ops::{Op, OpProof};
 pub use transactions::{

--- a/core/src/mantle/mod.rs
+++ b/core/src/mantle/mod.rs
@@ -9,7 +9,7 @@ pub mod transactions;
 mod channel_notes;
 mod fixtures;
 
-pub use gas::{GasCalculator, GasProfile};
+pub use gas::{GasProfile, TxGasCalculator};
 pub use ledger::{Note, NoteId, Utxo, Value};
 pub use ops::{Op, OpProof};
 pub use transactions::{

--- a/core/src/mantle/ops/channel/channel_transfer.rs
+++ b/core/src/mantle/ops/channel/channel_transfer.rs
@@ -63,7 +63,7 @@ impl ProvableOperation for ChannelTransferOp {
 }
 
 impl OperationGas<MainnetGasProfile> for ChannelTransferOp {
-    const GAS_CONSTANT: Gas = Gas::new(56);
+    const GAS_COST: Gas = Gas::new(56);
 }
 
 impl PreverifiableOperation<verification_mode::StandardMode> for ChannelTransferOp {

--- a/core/src/mantle/ops/channel/channel_transfer.rs
+++ b/core/src/mantle/ops/channel/channel_transfer.rs
@@ -6,6 +6,7 @@ use crate::{
     mantle::{
         TxHash,
         channel::{Channels, Error},
+        gas::{Gas, MainnetGasConstants, OperationGas},
         ledger::{
             ExecutableOperation, Inputs, Outputs, PreverifiableOperation, ProvableOperation, Utxo,
             Utxos, VerifiableOperation, verification_mode,
@@ -57,6 +58,10 @@ pub struct ChannelTransferExecutionContext {
 
 impl ProvableOperation for ChannelTransferOp {
     type Proof = ChannelMultiSigProof;
+}
+
+impl OperationGas<MainnetGasConstants> for ChannelTransferOp {
+    const GAS_CONSTANT: Gas = Gas::new(56);
 }
 
 impl PreverifiableOperation<verification_mode::StandardMode> for ChannelTransferOp {

--- a/core/src/mantle/ops/channel/channel_transfer.rs
+++ b/core/src/mantle/ops/channel/channel_transfer.rs
@@ -4,18 +4,18 @@ use serde::{Deserialize, Serialize};
 use crate::{
     events::TxEvent,
     mantle::{
-        TxHash,
+        TxHash, Value,
         channel::{Channels, Error},
-        gas::{Gas, MainnetGasProfile, OperationGas},
+        gas::{Gas, MainnetGasProfile, OperationGas, SignedOperationExecutionGas},
         ledger::{
             ExecutableOperation, Inputs, Outputs, PreverifiableOperation, ProvableOperation, Utxo,
-            Utxos, VerifiableOperation, verification_mode,
+            Utxos, VerifiableOperation, verification_mode, verification_mode::VerificationMode,
         },
         ops::{
-            OpId,
+            OpId, SignedOp,
             channel::{ChannelId, verification::verify_channel_multi_sig},
         },
-        transactions::{OperationVerificationHelper, hash::TxHashView},
+        transactions::{OperationVerificationHelper, hash::TxHashView, states::VerificationState},
     },
     proofs::channel_multi_sig_proof::ChannelMultiSigProof,
     sdp::locked_notes::LockedNotes,
@@ -57,6 +57,8 @@ pub struct ChannelTransferExecutionContext {
 }
 
 impl ProvableOperation for ChannelTransferOp {
+    // `SignedOperationExecutionGas::gas_multiplier` below reads this proof's
+    // signature count. If this changes, update that too.
     type Proof = ChannelMultiSigProof;
 }
 
@@ -171,5 +173,15 @@ impl ExecutableOperation for ChannelTransferOp {
         }
 
         Ok((context, Vec::new()))
+    }
+}
+
+impl<State: VerificationState, Mode: VerificationMode> SignedOperationExecutionGas
+    for SignedOp<ChannelTransferOp, State, Mode>
+{
+    fn gas_multiplier(&self) -> Value {
+        let signature_count = self.proof().signatures().len();
+        Value::try_from(signature_count)
+            .expect("Channel multi-signature proofs are bound to u16::MAX signatures.")
     }
 }

--- a/core/src/mantle/ops/channel/channel_transfer.rs
+++ b/core/src/mantle/ops/channel/channel_transfer.rs
@@ -6,7 +6,7 @@ use crate::{
     mantle::{
         TxHash,
         channel::{Channels, Error},
-        gas::{Gas, MainnetGasConstants, OperationGas},
+        gas::{Gas, MainnetGasProfile, OperationGas},
         ledger::{
             ExecutableOperation, Inputs, Outputs, PreverifiableOperation, ProvableOperation, Utxo,
             Utxos, VerifiableOperation, verification_mode,
@@ -60,7 +60,7 @@ impl ProvableOperation for ChannelTransferOp {
     type Proof = ChannelMultiSigProof;
 }
 
-impl OperationGas<MainnetGasConstants> for ChannelTransferOp {
+impl OperationGas<MainnetGasProfile> for ChannelTransferOp {
     const GAS_CONSTANT: Gas = Gas::new(56);
 }
 

--- a/core/src/mantle/ops/channel/config.rs
+++ b/core/src/mantle/ops/channel/config.rs
@@ -9,6 +9,7 @@ use crate::{
     events::TxEvent,
     mantle::{
         channel::{ChannelState, Channels, Error, SlotTimeframe, SlotTimeout},
+        gas::{Gas, MainnetGasConstants, OperationGas},
         ledger::{
             ExecutableOperation, PreverifiableOperation, ProvableOperation, VerifiableOperation,
             verification_mode,
@@ -52,6 +53,10 @@ pub struct ChannelConfigExecutionContext {
 
 impl ProvableOperation for ChannelConfigOp {
     type Proof = ChannelMultiSigProof;
+}
+
+impl OperationGas<MainnetGasConstants> for ChannelConfigOp {
+    const GAS_CONSTANT: Gas = Gas::new(56);
 }
 
 impl PreverifiableOperation<verification_mode::StandardMode> for ChannelConfigOp {

--- a/core/src/mantle/ops/channel/config.rs
+++ b/core/src/mantle/ops/channel/config.rs
@@ -9,7 +9,7 @@ use crate::{
     events::TxEvent,
     mantle::{
         channel::{ChannelState, Channels, Error, SlotTimeframe, SlotTimeout},
-        gas::{Gas, MainnetGasConstants, OperationGas},
+        gas::{Gas, MainnetGasProfile, OperationGas},
         ledger::{
             ExecutableOperation, PreverifiableOperation, ProvableOperation, VerifiableOperation,
             verification_mode,
@@ -55,7 +55,7 @@ impl ProvableOperation for ChannelConfigOp {
     type Proof = ChannelMultiSigProof;
 }
 
-impl OperationGas<MainnetGasConstants> for ChannelConfigOp {
+impl OperationGas<MainnetGasProfile> for ChannelConfigOp {
     const GAS_CONSTANT: Gas = Gas::new(56);
 }
 

--- a/core/src/mantle/ops/channel/config.rs
+++ b/core/src/mantle/ops/channel/config.rs
@@ -8,13 +8,15 @@ use crate::{
     crypto::{Digest as _, Hasher},
     events::TxEvent,
     mantle::{
+        Value,
         channel::{ChannelState, Channels, Error, SlotTimeframe, SlotTimeout},
-        gas::{Gas, MainnetGasProfile, OperationGas},
+        gas::{Gas, MainnetGasProfile, OperationGas, SignedOperationExecutionGas},
         ledger::{
             ExecutableOperation, PreverifiableOperation, ProvableOperation, VerifiableOperation,
-            verification_mode,
+            verification_mode, verification_mode::VerificationMode,
         },
-        transactions::hash::TxHashView,
+        ops::SignedOp,
+        transactions::{hash::TxHashView, states::VerificationState},
     },
     proofs::channel_multi_sig_proof::ChannelMultiSigProof,
 };
@@ -52,6 +54,8 @@ pub struct ChannelConfigExecutionContext {
 }
 
 impl ProvableOperation for ChannelConfigOp {
+    // `SignedOperationExecutionGas::gas_multiplier` below reads this proof's
+    // signature count. If this changes, update that too.
     type Proof = ChannelMultiSigProof;
 }
 
@@ -155,5 +159,15 @@ impl ExecutableOperation for ChannelConfigOp {
             );
         }
         Ok((context, Vec::new()))
+    }
+}
+
+impl<State: VerificationState, Mode: VerificationMode> SignedOperationExecutionGas
+    for SignedOp<ChannelConfigOp, State, Mode>
+{
+    fn gas_multiplier(&self) -> Value {
+        let signature_count = self.proof().signatures().len();
+        Value::try_from(signature_count)
+            .expect("Channel multi-signature proofs are bound to u16::MAX signatures.")
     }
 }

--- a/core/src/mantle/ops/channel/config.rs
+++ b/core/src/mantle/ops/channel/config.rs
@@ -60,7 +60,7 @@ impl ProvableOperation for ChannelConfigOp {
 }
 
 impl OperationGas<MainnetGasProfile> for ChannelConfigOp {
-    const GAS_CONSTANT: Gas = Gas::new(56);
+    const GAS_COST: Gas = Gas::new(56);
 }
 
 impl PreverifiableOperation<verification_mode::StandardMode> for ChannelConfigOp {

--- a/core/src/mantle/ops/channel/deposit.rs
+++ b/core/src/mantle/ops/channel/deposit.rs
@@ -7,7 +7,7 @@ use crate::{
     events::{DepositRecreatedNotes, TxEvent, TxEventPayload},
     mantle::{
         channel::{Channels, Error},
-        gas::{Gas, MainnetGasConstants, OperationGas},
+        gas::{Gas, MainnetGasProfile, OperationGas},
         ledger::{
             ExecutableOperation, Inputs, InputsError, Outputs, PreverifiableOperation,
             ProvableOperation, Utxos, VerifiableOperation, verification_mode,
@@ -69,7 +69,7 @@ impl ProvableOperation for DepositOp {
     type Proof = ZkSignature;
 }
 
-impl OperationGas<MainnetGasConstants> for DepositOp {
+impl OperationGas<MainnetGasProfile> for DepositOp {
     const GAS_CONSTANT: Gas = Gas::new(590);
 }
 

--- a/core/src/mantle/ops/channel/deposit.rs
+++ b/core/src/mantle/ops/channel/deposit.rs
@@ -75,7 +75,7 @@ impl ProvableOperation for DepositOp {
 }
 
 impl OperationGas<MainnetGasProfile> for DepositOp {
-    const GAS_CONSTANT: Gas = Gas::new(590);
+    const GAS_COST: Gas = Gas::new(590);
 }
 
 impl PreverifiableOperation<verification_mode::StandardMode> for DepositOp {

--- a/core/src/mantle/ops/channel/deposit.rs
+++ b/core/src/mantle/ops/channel/deposit.rs
@@ -7,6 +7,7 @@ use crate::{
     events::{DepositRecreatedNotes, TxEvent, TxEventPayload},
     mantle::{
         channel::{Channels, Error},
+        gas::{Gas, MainnetGasConstants, OperationGas},
         ledger::{
             ExecutableOperation, Inputs, InputsError, Outputs, PreverifiableOperation,
             ProvableOperation, Utxos, VerifiableOperation, verification_mode,
@@ -66,6 +67,10 @@ pub struct DepositExecutionContext {
 
 impl ProvableOperation for DepositOp {
     type Proof = ZkSignature;
+}
+
+impl OperationGas<MainnetGasConstants> for DepositOp {
+    const GAS_CONSTANT: Gas = Gas::new(590);
 }
 
 impl PreverifiableOperation<verification_mode::StandardMode> for DepositOp {

--- a/core/src/mantle/ops/channel/deposit.rs
+++ b/core/src/mantle/ops/channel/deposit.rs
@@ -6,14 +6,19 @@ use serde::{Deserialize, Serialize};
 use crate::{
     events::{DepositRecreatedNotes, TxEvent, TxEventPayload},
     mantle::{
+        Value,
         channel::{Channels, Error},
-        gas::{Gas, MainnetGasProfile, OperationGas},
+        gas::{Gas, MainnetGasProfile, OperationGas, SignedOperationExecutionGas},
         ledger::{
             ExecutableOperation, Inputs, InputsError, Outputs, PreverifiableOperation,
             ProvableOperation, Utxos, VerifiableOperation, verification_mode,
+            verification_mode::VerificationMode,
         },
-        ops::{OpId, channel::ChannelId},
-        transactions::hash::{TxHash, TxHashView},
+        ops::{OpId, SignedOp, channel::ChannelId},
+        transactions::{
+            hash::{TxHash, TxHashView},
+            states::VerificationState,
+        },
     },
     sdp::locked_notes::LockedNotes,
 };
@@ -154,5 +159,13 @@ impl ExecutableOperation for DepositOp {
         .collect();
 
         Ok((context, events))
+    }
+}
+
+impl<State: VerificationState, Mode: VerificationMode> SignedOperationExecutionGas
+    for SignedOp<DepositOp, State, Mode>
+{
+    fn gas_multiplier(&self) -> Value {
+        1
     }
 }

--- a/core/src/mantle/ops/channel/inscribe.rs
+++ b/core/src/mantle/ops/channel/inscribe.rs
@@ -91,7 +91,7 @@ impl ProvableOperation for InscriptionOp {
 }
 
 impl OperationGas<MainnetGasProfile> for InscriptionOp {
-    const GAS_CONSTANT: Gas = Gas::new(56);
+    const GAS_COST: Gas = Gas::new(56);
 }
 
 impl PreverifiableOperation<verification_mode::StandardMode> for InscriptionOp {

--- a/core/src/mantle/ops/channel/inscribe.rs
+++ b/core/src/mantle/ops/channel/inscribe.rs
@@ -13,7 +13,7 @@ use crate::{
     events::TxEvent,
     mantle::{
         channel::{ChannelState, Channels, Error},
-        gas::{Gas, MainnetGasConstants, OperationGas},
+        gas::{Gas, MainnetGasProfile, OperationGas},
         ledger::{
             ExecutableOperation, PreverifiableOperation, ProvableOperation, VerifiableOperation,
             verification_mode,
@@ -89,7 +89,7 @@ impl ProvableOperation for InscriptionOp {
     type Proof = Ed25519Signature;
 }
 
-impl OperationGas<MainnetGasConstants> for InscriptionOp {
+impl OperationGas<MainnetGasProfile> for InscriptionOp {
     const GAS_CONSTANT: Gas = Gas::new(56);
 }
 

--- a/core/src/mantle/ops/channel/inscribe.rs
+++ b/core/src/mantle/ops/channel/inscribe.rs
@@ -12,14 +12,15 @@ use crate::{
     crypto::{Digest as _, Hasher},
     events::TxEvent,
     mantle::{
+        Value,
         channel::{ChannelState, Channels, Error},
-        gas::{Gas, MainnetGasProfile, OperationGas},
+        gas::{Gas, MainnetGasProfile, OperationGas, SignedOperationExecutionGas},
         ledger::{
             ExecutableOperation, PreverifiableOperation, ProvableOperation, VerifiableOperation,
-            verification_mode,
+            verification_mode, verification_mode::VerificationMode,
         },
-        ops::channel::config::Keys,
-        transactions::hash::TxHashView,
+        ops::{SignedOp, channel::config::Keys},
+        transactions::{hash::TxHashView, states::VerificationState},
     },
 };
 
@@ -191,6 +192,14 @@ impl ExecutableOperation for InscriptionOp {
             },
         );
         Ok((context, Vec::new()))
+    }
+}
+
+impl<State: VerificationState, Mode: VerificationMode> SignedOperationExecutionGas
+    for SignedOp<InscriptionOp, State, Mode>
+{
+    fn gas_multiplier(&self) -> Value {
+        1
     }
 }
 

--- a/core/src/mantle/ops/channel/inscribe.rs
+++ b/core/src/mantle/ops/channel/inscribe.rs
@@ -13,6 +13,7 @@ use crate::{
     events::TxEvent,
     mantle::{
         channel::{ChannelState, Channels, Error},
+        gas::{Gas, MainnetGasConstants, OperationGas},
         ledger::{
             ExecutableOperation, PreverifiableOperation, ProvableOperation, VerifiableOperation,
             verification_mode,
@@ -86,6 +87,10 @@ pub struct InscriptionExecutionContext {
 
 impl ProvableOperation for InscriptionOp {
     type Proof = Ed25519Signature;
+}
+
+impl OperationGas<MainnetGasConstants> for InscriptionOp {
+    const GAS_CONSTANT: Gas = Gas::new(56);
 }
 
 impl PreverifiableOperation<verification_mode::StandardMode> for InscriptionOp {

--- a/core/src/mantle/ops/channel/withdraw.rs
+++ b/core/src/mantle/ops/channel/withdraw.rs
@@ -6,6 +6,7 @@ use crate::{
     mantle::{
         TxHash,
         channel::{Channels, Error},
+        gas::{Gas, MainnetGasConstants, OperationGas},
         ledger::{
             ExecutableOperation, Inputs, PreverifiableOperation, ProvableOperation, Utxos,
             VerifiableOperation, verification_mode,
@@ -49,6 +50,10 @@ pub struct WithdrawExecutionContext {
 
 impl ProvableOperation for ChannelWithdrawOp {
     type Proof = ChannelMultiSigProof;
+}
+
+impl OperationGas<MainnetGasConstants> for ChannelWithdrawOp {
+    const GAS_CONSTANT: Gas = Gas::new(56);
 }
 
 impl PreverifiableOperation<verification_mode::StandardMode> for ChannelWithdrawOp {

--- a/core/src/mantle/ops/channel/withdraw.rs
+++ b/core/src/mantle/ops/channel/withdraw.rs
@@ -55,7 +55,7 @@ impl ProvableOperation for ChannelWithdrawOp {
 }
 
 impl OperationGas<MainnetGasProfile> for ChannelWithdrawOp {
-    const GAS_CONSTANT: Gas = Gas::new(56);
+    const GAS_COST: Gas = Gas::new(56);
 }
 
 impl PreverifiableOperation<verification_mode::StandardMode> for ChannelWithdrawOp {

--- a/core/src/mantle/ops/channel/withdraw.rs
+++ b/core/src/mantle/ops/channel/withdraw.rs
@@ -4,18 +4,18 @@ use serde::{Deserialize, Serialize};
 use crate::{
     events::TxEvent,
     mantle::{
-        TxHash,
+        TxHash, Value,
         channel::{Channels, Error},
-        gas::{Gas, MainnetGasProfile, OperationGas},
+        gas::{Gas, MainnetGasProfile, OperationGas, SignedOperationExecutionGas},
         ledger::{
             ExecutableOperation, Inputs, PreverifiableOperation, ProvableOperation, Utxos,
-            VerifiableOperation, verification_mode,
+            VerifiableOperation, verification_mode, verification_mode::VerificationMode,
         },
         ops::{
-            OpId,
+            OpId, SignedOp,
             channel::{ChannelId, verification::verify_channel_multi_sig},
         },
-        transactions::{OperationVerificationHelper, hash::TxHashView},
+        transactions::{OperationVerificationHelper, hash::TxHashView, states::VerificationState},
     },
     proofs::channel_multi_sig_proof::ChannelMultiSigProof,
     sdp::locked_notes::LockedNotes,
@@ -49,6 +49,8 @@ pub struct WithdrawExecutionContext {
 }
 
 impl ProvableOperation for ChannelWithdrawOp {
+    // `SignedOperationExecutionGas::gas_multiplier` below reads this proof's
+    // signature count. If this changes, update that too.
     type Proof = ChannelMultiSigProof;
 }
 
@@ -145,5 +147,15 @@ impl ExecutableOperation for ChannelWithdrawOp {
         }
 
         Ok((context, Vec::new()))
+    }
+}
+
+impl<State: VerificationState, Mode: VerificationMode> SignedOperationExecutionGas
+    for SignedOp<ChannelWithdrawOp, State, Mode>
+{
+    fn gas_multiplier(&self) -> Value {
+        let signature_count = self.proof().signatures().len();
+        Value::try_from(signature_count)
+            .expect("Channel multi-signature proofs are bound to u16::MAX signatures.")
     }
 }

--- a/core/src/mantle/ops/channel/withdraw.rs
+++ b/core/src/mantle/ops/channel/withdraw.rs
@@ -6,7 +6,7 @@ use crate::{
     mantle::{
         TxHash,
         channel::{Channels, Error},
-        gas::{Gas, MainnetGasConstants, OperationGas},
+        gas::{Gas, MainnetGasProfile, OperationGas},
         ledger::{
             ExecutableOperation, Inputs, PreverifiableOperation, ProvableOperation, Utxos,
             VerifiableOperation, verification_mode,
@@ -52,7 +52,7 @@ impl ProvableOperation for ChannelWithdrawOp {
     type Proof = ChannelMultiSigProof;
 }
 
-impl OperationGas<MainnetGasConstants> for ChannelWithdrawOp {
+impl OperationGas<MainnetGasProfile> for ChannelWithdrawOp {
     const GAS_CONSTANT: Gas = Gas::new(56);
 }
 

--- a/core/src/mantle/ops/leader_claim.rs
+++ b/core/src/mantle/ops/leader_claim.rs
@@ -12,6 +12,7 @@ use crate::{
     events::{TxEvent, TxEventPayload},
     mantle::{
         Note, Utxo, Value,
+        gas::{Gas, MainnetGasConstants, OperationGas},
         ledger::{
             ExecutableOperation, PreverifiableOperation, ProvableOperation, Utxos,
             VerifiableOperation, verification_mode,
@@ -180,6 +181,10 @@ pub struct LeaderClaimExecutionContext {
 
 impl ProvableOperation for LeaderClaimOp {
     type Proof = Groth16LeaderClaimProof;
+}
+
+impl OperationGas<MainnetGasConstants> for LeaderClaimOp {
+    const GAS_CONSTANT: Gas = Gas::new(580);
 }
 
 impl PreverifiableOperation<verification_mode::StandardMode> for LeaderClaimOp {

--- a/core/src/mantle/ops/leader_claim.rs
+++ b/core/src/mantle/ops/leader_claim.rs
@@ -187,7 +187,7 @@ impl ProvableOperation for LeaderClaimOp {
 }
 
 impl OperationGas<MainnetGasProfile> for LeaderClaimOp {
-    const GAS_CONSTANT: Gas = Gas::new(580);
+    const GAS_COST: Gas = Gas::new(580);
 }
 
 impl PreverifiableOperation<verification_mode::StandardMode> for LeaderClaimOp {

--- a/core/src/mantle/ops/leader_claim.rs
+++ b/core/src/mantle/ops/leader_claim.rs
@@ -12,13 +12,16 @@ use crate::{
     events::{TxEvent, TxEventPayload},
     mantle::{
         Note, Utxo, Value,
-        gas::{Gas, MainnetGasProfile, OperationGas},
+        gas::{Gas, MainnetGasProfile, OperationGas, SignedOperationExecutionGas},
         ledger::{
             ExecutableOperation, PreverifiableOperation, ProvableOperation, Utxos,
-            VerifiableOperation, verification_mode,
+            VerifiableOperation, verification_mode, verification_mode::VerificationMode,
         },
-        ops::OpId,
-        transactions::hash::{TxHash, TxHashView},
+        ops::{OpId, SignedOp},
+        transactions::{
+            hash::{TxHash, TxHashView},
+            states::VerificationState,
+        },
     },
     proofs::leader_claim_proof::{
         Groth16LeaderClaimProof, LeaderClaimProof as _, LeaderClaimPublic,
@@ -268,6 +271,14 @@ impl ExecutableOperation for LeaderClaimOp {
                 },
             )],
         ))
+    }
+}
+
+impl<State: VerificationState, Mode: VerificationMode> SignedOperationExecutionGas
+    for SignedOp<LeaderClaimOp, State, Mode>
+{
+    fn gas_multiplier(&self) -> Value {
+        1
     }
 }
 

--- a/core/src/mantle/ops/leader_claim.rs
+++ b/core/src/mantle/ops/leader_claim.rs
@@ -12,7 +12,7 @@ use crate::{
     events::{TxEvent, TxEventPayload},
     mantle::{
         Note, Utxo, Value,
-        gas::{Gas, MainnetGasConstants, OperationGas},
+        gas::{Gas, MainnetGasProfile, OperationGas},
         ledger::{
             ExecutableOperation, PreverifiableOperation, ProvableOperation, Utxos,
             VerifiableOperation, verification_mode,
@@ -183,7 +183,7 @@ impl ProvableOperation for LeaderClaimOp {
     type Proof = Groth16LeaderClaimProof;
 }
 
-impl OperationGas<MainnetGasConstants> for LeaderClaimOp {
+impl OperationGas<MainnetGasProfile> for LeaderClaimOp {
     const GAS_CONSTANT: Gas = Gas::new(580);
 }
 

--- a/core/src/mantle/ops/mod.rs
+++ b/core/src/mantle/ops/mod.rs
@@ -30,10 +30,13 @@ use super::{
 };
 use crate::{
     crypto::{Digest as _, Hash, Hasher},
-    mantle::ops::{
-        internal::{OpDe, OpSer},
-        pow::ClaimPowRewardOp,
-        transfer::TransferOp,
+    mantle::{
+        gas::OperationGas,
+        ops::{
+            internal::{OpDe, OpSer},
+            pow::ClaimPowRewardOp,
+            transfer::TransferOp,
+        },
     },
     proofs::{
         channel_multi_sig_proof::ChannelMultiSigProof, leader_claim_proof::Groth16LeaderClaimProof,
@@ -203,6 +206,14 @@ impl BinaryDecode for Op {
     }
 }
 
+const fn gas_constant_of<Constants, Op>(_op: &Op) -> Gas
+where
+    Constants: GasConstants,
+    Op: OperationGas<Constants>,
+{
+    Op::GAS_CONSTANT
+}
+
 // We just check that the enum discriminant tag is encoded correctly, so a
 // single fixture is fine here.
 // TODO: Remove once the `BinaryCodec` macro supports enums.
@@ -228,17 +239,17 @@ impl Op {
     #[must_use]
     pub const fn execution_gas<Constants: GasConstants>(&self) -> Gas {
         match self {
-            Self::ChannelInscribe(_) => Constants::CHANNEL_INSCRIBE,
-            Self::ChannelConfig(_) => Constants::CHANNEL_CONFIG,
-            Self::ChannelDeposit(_) => Constants::CHANNEL_DEPOSIT,
-            Self::ChannelWithdraw(_) => Constants::CHANNEL_WITHDRAW,
-            Self::ChannelTransfer(_) => Constants::CHANNEL_TRANSFER,
-            Self::SDPDeclare(_) => Constants::SDP_DECLARE,
-            Self::SDPWithdraw(_) => Constants::SDP_WITHDRAW,
-            Self::SDPActive(_) => Constants::SDP_ACTIVE,
-            Self::LeaderClaim(_) => Constants::LEADER_CLAIM,
-            Self::Transfer(_) => Constants::TRANSFER,
-            Self::ClaimPowReward(_) => Constants::CLAIM_POW_REWARD,
+            Self::ChannelInscribe(op) => gas_constant_of(op),
+            Self::ChannelConfig(op) => gas_constant_of(op),
+            Self::ChannelDeposit(op) => gas_constant_of(op),
+            Self::ChannelWithdraw(op) => gas_constant_of(op),
+            Self::ChannelTransfer(op) => gas_constant_of(op),
+            Self::SDPDeclare(op) => gas_constant_of(op),
+            Self::SDPWithdraw(op) => gas_constant_of(op),
+            Self::SDPActive(op) => gas_constant_of(op),
+            Self::LeaderClaim(op) => gas_constant_of(op),
+            Self::Transfer(op) => gas_constant_of(op),
+            Self::ClaimPowReward(op) => gas_constant_of(op),
         }
     }
 

--- a/core/src/mantle/ops/mod.rs
+++ b/core/src/mantle/ops/mod.rs
@@ -22,7 +22,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 pub use signed_op::SignedOp;
 
 use super::{
-    gas::{Gas, GasConstants},
+    gas::{Gas, GasProfile},
     ops::{
         leader_claim::LeaderClaimOp,
         sdp::{SDPActiveOp, SDPDeclareOp, SDPWithdrawOp},
@@ -206,10 +206,10 @@ impl BinaryDecode for Op {
     }
 }
 
-const fn gas_constant_of<Constants, Op>(_op: &Op) -> Gas
+const fn gas_constant_of<Profile, Op>(_op: &Op) -> Gas
 where
-    Constants: GasConstants,
-    Op: OperationGas<Constants>,
+    Profile: GasProfile,
+    Op: OperationGas<Profile>,
 {
     Op::GAS_CONSTANT
 }
@@ -237,7 +237,7 @@ impl Op {
     }
 
     #[must_use]
-    pub const fn execution_gas<Constants: GasConstants>(&self) -> Gas {
+    pub const fn execution_gas<Profile: GasProfile>(&self) -> Gas {
         match self {
             Self::ChannelInscribe(op) => gas_constant_of(op),
             Self::ChannelConfig(op) => gas_constant_of(op),

--- a/core/src/mantle/ops/mod.rs
+++ b/core/src/mantle/ops/mod.rs
@@ -211,7 +211,7 @@ where
     Profile: GasProfile,
     Op: OperationGas<Profile>,
 {
-    Op::GAS_CONSTANT
+    Op::GAS_COST
 }
 
 // We just check that the enum discriminant tag is encoded correctly, so a

--- a/core/src/mantle/ops/pow.rs
+++ b/core/src/mantle/ops/pow.rs
@@ -12,7 +12,7 @@ use crate::{
     events::{TxEvent, TxEventPayload},
     mantle::{
         Note, TxHash, Utxo, Value,
-        gas::{Gas, MainnetGasConstants, OperationGas},
+        gas::{Gas, MainnetGasProfile, OperationGas},
         ledger::{
             ExecutableOperation, PreverifiableOperation, ProvableOperation, Utxos,
             VerifiableOperation, verification_mode,
@@ -267,7 +267,7 @@ impl ProvableOperation for ClaimPowRewardOp {
     type Proof = NoOpProof;
 }
 
-impl OperationGas<MainnetGasConstants> for ClaimPowRewardOp {
+impl OperationGas<MainnetGasProfile> for ClaimPowRewardOp {
     const GAS_CONSTANT: Gas = Gas::new(1);
 }
 

--- a/core/src/mantle/ops/pow.rs
+++ b/core/src/mantle/ops/pow.rs
@@ -268,7 +268,7 @@ impl ProvableOperation for ClaimPowRewardOp {
 }
 
 impl OperationGas<MainnetGasProfile> for ClaimPowRewardOp {
-    const GAS_CONSTANT: Gas = Gas::new(1);
+    const GAS_COST: Gas = Gas::new(1);
 }
 
 impl PreverifiableOperation<verification_mode::StandardMode> for ClaimPowRewardOp {

--- a/core/src/mantle/ops/pow.rs
+++ b/core/src/mantle/ops/pow.rs
@@ -12,6 +12,7 @@ use crate::{
     events::{TxEvent, TxEventPayload},
     mantle::{
         Note, TxHash, Utxo, Value,
+        gas::{Gas, MainnetGasConstants, OperationGas},
         ledger::{
             ExecutableOperation, PreverifiableOperation, ProvableOperation, Utxos,
             VerifiableOperation, verification_mode,
@@ -264,6 +265,10 @@ impl ClaimPoWRewardExecutionContext {
 
 impl ProvableOperation for ClaimPowRewardOp {
     type Proof = NoOpProof;
+}
+
+impl OperationGas<MainnetGasConstants> for ClaimPowRewardOp {
+    const GAS_CONSTANT: Gas = Gas::new(1);
 }
 
 impl PreverifiableOperation<verification_mode::StandardMode> for ClaimPowRewardOp {

--- a/core/src/mantle/ops/sdp/active.rs
+++ b/core/src/mantle/ops/sdp/active.rs
@@ -36,7 +36,7 @@ impl ProvableOperation for SDPActiveOp {
 }
 
 impl OperationGas<MainnetGasProfile> for SDPActiveOp {
-    const GAS_CONSTANT: Gas = Gas::new(590);
+    const GAS_COST: Gas = Gas::new(590);
 }
 
 impl PreverifiableOperation<verification_mode::StandardMode> for SDPActiveOp {

--- a/core/src/mantle/ops/sdp/active.rs
+++ b/core/src/mantle/ops/sdp/active.rs
@@ -7,12 +7,14 @@ use super::{SDPActiveOp, SdpError};
 use crate::{
     events::TxEvent,
     mantle::{
-        gas::{Gas, MainnetGasProfile, OperationGas},
+        Value,
+        gas::{Gas, MainnetGasProfile, OperationGas, SignedOperationExecutionGas},
         ledger::{
             Declarations, ExecutableOperation, PreverifiableOperation, ProvableOperation,
-            VerifiableOperation, verification_mode,
+            VerifiableOperation, verification_mode, verification_mode::VerificationMode,
         },
-        transactions::hash::TxHashView,
+        ops::SignedOp,
+        transactions::{hash::TxHashView, states::VerificationState},
     },
 };
 
@@ -113,5 +115,13 @@ impl ExecutableOperation for SDPActiveOp {
         );
 
         Ok((context, Vec::new()))
+    }
+}
+
+impl<State: VerificationState, Mode: VerificationMode> SignedOperationExecutionGas
+    for SignedOp<SDPActiveOp, State, Mode>
+{
+    fn gas_multiplier(&self) -> Value {
+        1
     }
 }

--- a/core/src/mantle/ops/sdp/active.rs
+++ b/core/src/mantle/ops/sdp/active.rs
@@ -7,7 +7,7 @@ use super::{SDPActiveOp, SdpError};
 use crate::{
     events::TxEvent,
     mantle::{
-        gas::{Gas, MainnetGasConstants, OperationGas},
+        gas::{Gas, MainnetGasProfile, OperationGas},
         ledger::{
             Declarations, ExecutableOperation, PreverifiableOperation, ProvableOperation,
             VerifiableOperation, verification_mode,
@@ -33,7 +33,7 @@ impl ProvableOperation for SDPActiveOp {
     type Proof = ZkSignature;
 }
 
-impl OperationGas<MainnetGasConstants> for SDPActiveOp {
+impl OperationGas<MainnetGasProfile> for SDPActiveOp {
     const GAS_CONSTANT: Gas = Gas::new(590);
 }
 

--- a/core/src/mantle/ops/sdp/active.rs
+++ b/core/src/mantle/ops/sdp/active.rs
@@ -7,6 +7,7 @@ use super::{SDPActiveOp, SdpError};
 use crate::{
     events::TxEvent,
     mantle::{
+        gas::{Gas, MainnetGasConstants, OperationGas},
         ledger::{
             Declarations, ExecutableOperation, PreverifiableOperation, ProvableOperation,
             VerifiableOperation, verification_mode,
@@ -30,6 +31,10 @@ pub struct SDPActiveExecutionContext {
 
 impl ProvableOperation for SDPActiveOp {
     type Proof = ZkSignature;
+}
+
+impl OperationGas<MainnetGasConstants> for SDPActiveOp {
+    const GAS_CONSTANT: Gas = Gas::new(590);
 }
 
 impl PreverifiableOperation<verification_mode::StandardMode> for SDPActiveOp {

--- a/core/src/mantle/ops/sdp/declare.rs
+++ b/core/src/mantle/ops/sdp/declare.rs
@@ -160,7 +160,7 @@ impl ProvableOperation for SDPDeclareOp {
 }
 
 impl OperationGas<MainnetGasProfile> for SDPDeclareOp {
-    const GAS_CONSTANT: Gas = Gas::new(646);
+    const GAS_COST: Gas = Gas::new(646);
 }
 
 impl PreverifiableOperation<verification_mode::StandardMode> for SDPDeclareOp {

--- a/core/src/mantle/ops/sdp/declare.rs
+++ b/core/src/mantle/ops/sdp/declare.rs
@@ -5,15 +5,15 @@ use super::{SDPDeclareOp, SdpError};
 use crate::{
     events::TxEvent,
     mantle::{
-        Note,
+        Note, Value,
         channel::Channels,
-        gas::{Gas, MainnetGasProfile, OperationGas},
+        gas::{Gas, MainnetGasProfile, OperationGas, SignedOperationExecutionGas},
         ledger::{
             Declarations, ExecutableOperation, PreverifiableOperation, ProvableOperation, Utxos,
-            VerifiableOperation, verification_mode,
+            VerifiableOperation, verification_mode, verification_mode::VerificationMode,
         },
-        ops::ZkAndEd25519Proof,
-        transactions::hash::TxHashView,
+        ops::{SignedOp, ZkAndEd25519Proof},
+        transactions::{hash::TxHashView, states::VerificationState},
     },
     sdp::{Declaration, MinStake, locked_notes::LockedNotes},
 };
@@ -251,6 +251,14 @@ impl ExecutableOperation for SDPDeclareOp {
         context: Self::Context<'a>,
     ) -> Result<(Self::Context<'a>, Vec<TxEvent>), Self::Error> {
         SDPDeclareValidationExt::execute(self, context)
+    }
+}
+
+impl<State: VerificationState, Mode: VerificationMode> SignedOperationExecutionGas
+    for SignedOp<SDPDeclareOp, State, Mode>
+{
+    fn gas_multiplier(&self) -> Value {
+        1
     }
 }
 

--- a/core/src/mantle/ops/sdp/declare.rs
+++ b/core/src/mantle/ops/sdp/declare.rs
@@ -7,6 +7,7 @@ use crate::{
     mantle::{
         Note,
         channel::Channels,
+        gas::{Gas, MainnetGasConstants, OperationGas},
         ledger::{
             Declarations, ExecutableOperation, PreverifiableOperation, ProvableOperation, Utxos,
             VerifiableOperation, verification_mode,
@@ -156,6 +157,10 @@ pub struct SDPDeclareExecutionContext {
 
 impl ProvableOperation for SDPDeclareOp {
     type Proof = ZkAndEd25519Proof;
+}
+
+impl OperationGas<MainnetGasConstants> for SDPDeclareOp {
+    const GAS_CONSTANT: Gas = Gas::new(646);
 }
 
 impl PreverifiableOperation<verification_mode::StandardMode> for SDPDeclareOp {

--- a/core/src/mantle/ops/sdp/declare.rs
+++ b/core/src/mantle/ops/sdp/declare.rs
@@ -7,7 +7,7 @@ use crate::{
     mantle::{
         Note,
         channel::Channels,
-        gas::{Gas, MainnetGasConstants, OperationGas},
+        gas::{Gas, MainnetGasProfile, OperationGas},
         ledger::{
             Declarations, ExecutableOperation, PreverifiableOperation, ProvableOperation, Utxos,
             VerifiableOperation, verification_mode,
@@ -159,7 +159,7 @@ impl ProvableOperation for SDPDeclareOp {
     type Proof = ZkAndEd25519Proof;
 }
 
-impl OperationGas<MainnetGasConstants> for SDPDeclareOp {
+impl OperationGas<MainnetGasProfile> for SDPDeclareOp {
     const GAS_CONSTANT: Gas = Gas::new(646);
 }
 

--- a/core/src/mantle/ops/sdp/withdraw.rs
+++ b/core/src/mantle/ops/sdp/withdraw.rs
@@ -7,12 +7,14 @@ use super::{SDPWithdrawOp, SdpError};
 use crate::{
     events::TxEvent,
     mantle::{
-        gas::{Gas, MainnetGasProfile, OperationGas},
+        Value,
+        gas::{Gas, MainnetGasProfile, OperationGas, SignedOperationExecutionGas},
         ledger::{
             Declarations, ExecutableOperation, PreverifiableOperation, ProvableOperation,
-            VerifiableOperation, verification_mode,
+            VerifiableOperation, verification_mode, verification_mode::VerificationMode,
         },
-        transactions::hash::TxHashView,
+        ops::SignedOp,
+        transactions::{hash::TxHashView, states::VerificationState},
     },
     sdp::{self, locked_notes::LockedNotes},
 };
@@ -148,5 +150,13 @@ impl ExecutableOperation for SDPWithdrawOp {
         );
 
         Ok((context, Vec::new()))
+    }
+}
+
+impl<State: VerificationState, Mode: VerificationMode> SignedOperationExecutionGas
+    for SignedOp<SDPWithdrawOp, State, Mode>
+{
+    fn gas_multiplier(&self) -> Value {
+        1
     }
 }

--- a/core/src/mantle/ops/sdp/withdraw.rs
+++ b/core/src/mantle/ops/sdp/withdraw.rs
@@ -39,7 +39,7 @@ impl ProvableOperation for SDPWithdrawOp {
 }
 
 impl OperationGas<MainnetGasProfile> for SDPWithdrawOp {
-    const GAS_CONSTANT: Gas = Gas::new(590);
+    const GAS_COST: Gas = Gas::new(590);
 }
 
 impl PreverifiableOperation<verification_mode::StandardMode> for SDPWithdrawOp {

--- a/core/src/mantle/ops/sdp/withdraw.rs
+++ b/core/src/mantle/ops/sdp/withdraw.rs
@@ -7,7 +7,7 @@ use super::{SDPWithdrawOp, SdpError};
 use crate::{
     events::TxEvent,
     mantle::{
-        gas::{Gas, MainnetGasConstants, OperationGas},
+        gas::{Gas, MainnetGasProfile, OperationGas},
         ledger::{
             Declarations, ExecutableOperation, PreverifiableOperation, ProvableOperation,
             VerifiableOperation, verification_mode,
@@ -36,7 +36,7 @@ impl ProvableOperation for SDPWithdrawOp {
     type Proof = ZkSignature;
 }
 
-impl OperationGas<MainnetGasConstants> for SDPWithdrawOp {
+impl OperationGas<MainnetGasProfile> for SDPWithdrawOp {
     const GAS_CONSTANT: Gas = Gas::new(590);
 }
 

--- a/core/src/mantle/ops/sdp/withdraw.rs
+++ b/core/src/mantle/ops/sdp/withdraw.rs
@@ -7,6 +7,7 @@ use super::{SDPWithdrawOp, SdpError};
 use crate::{
     events::TxEvent,
     mantle::{
+        gas::{Gas, MainnetGasConstants, OperationGas},
         ledger::{
             Declarations, ExecutableOperation, PreverifiableOperation, ProvableOperation,
             VerifiableOperation, verification_mode,
@@ -33,6 +34,10 @@ pub struct SDPWithdrawExecutionContext {
 
 impl ProvableOperation for SDPWithdrawOp {
     type Proof = ZkSignature;
+}
+
+impl OperationGas<MainnetGasConstants> for SDPWithdrawOp {
+    const GAS_CONSTANT: Gas = Gas::new(590);
 }
 
 impl PreverifiableOperation<verification_mode::StandardMode> for SDPWithdrawOp {

--- a/core/src/mantle/ops/signed_op.rs
+++ b/core/src/mantle/ops/signed_op.rs
@@ -3,7 +3,7 @@ use std::marker::PhantomData;
 use crate::{
     events::TxEvent,
     mantle::{
-        GasConstants,
+        GasProfile,
         gas::{Gas, OperationGas},
         ledger::{
             ExecutableOperation, Operation, PreverifiableOperation, ProvableOperation,
@@ -103,10 +103,10 @@ where
     type Proof = T::Proof;
 }
 
-impl<Constants, T, State, Mode> OperationGas<Constants> for SignedOp<T, State, Mode>
+impl<Profile, T, State, Mode> OperationGas<Profile> for SignedOp<T, State, Mode>
 where
-    Constants: GasConstants,
-    T: OperationGas<Constants>,
+    Profile: GasProfile,
+    T: OperationGas<Profile>,
     State: VerificationState,
     Mode: VerificationMode,
 {

--- a/core/src/mantle/ops/signed_op.rs
+++ b/core/src/mantle/ops/signed_op.rs
@@ -3,6 +3,8 @@ use std::marker::PhantomData;
 use crate::{
     events::TxEvent,
     mantle::{
+        GasConstants,
+        gas::{Gas, OperationGas},
         ledger::{
             ExecutableOperation, Operation, PreverifiableOperation, ProvableOperation,
             VerifiableOperation, verification_mode::VerificationMode,
@@ -90,4 +92,23 @@ impl<T: Operation<Mode>, Mode: VerificationMode> SignedOp<T, Verified, Mode> {
     > {
         self.operation.execute(context)
     }
+}
+
+impl<T, State, Mode> ProvableOperation for SignedOp<T, State, Mode>
+where
+    T: ProvableOperation,
+    Mode: VerificationMode,
+    State: VerificationState,
+{
+    type Proof = T::Proof;
+}
+
+impl<Constants, T, State, Mode> OperationGas<Constants> for SignedOp<T, State, Mode>
+where
+    Constants: GasConstants,
+    T: OperationGas<Constants>,
+    State: VerificationState,
+    Mode: VerificationMode,
+{
+    const GAS_CONSTANT: Gas = T::GAS_CONSTANT;
 }

--- a/core/src/mantle/ops/signed_op.rs
+++ b/core/src/mantle/ops/signed_op.rs
@@ -94,19 +94,10 @@ impl<T: Operation<Mode>, Mode: VerificationMode> SignedOp<T, Verified, Mode> {
     }
 }
 
-impl<T, State, Mode> ProvableOperation for SignedOp<T, State, Mode>
-where
-    T: ProvableOperation,
-    Mode: VerificationMode,
-    State: VerificationState,
-{
-    type Proof = T::Proof;
-}
-
 impl<Profile, T, State, Mode> OperationGas<Profile> for SignedOp<T, State, Mode>
 where
     Profile: GasProfile,
-    T: OperationGas<Profile>,
+    T: OperationGas<Profile> + ProvableOperation,
     State: VerificationState,
     Mode: VerificationMode,
 {

--- a/core/src/mantle/ops/signed_op.rs
+++ b/core/src/mantle/ops/signed_op.rs
@@ -101,5 +101,5 @@ where
     State: VerificationState,
     Mode: VerificationMode,
 {
-    const GAS_CONSTANT: Gas = T::GAS_CONSTANT;
+    const GAS_COST: Gas = T::GAS_COST;
 }

--- a/core/src/mantle/ops/transfer.rs
+++ b/core/src/mantle/ops/transfer.rs
@@ -92,7 +92,7 @@ impl ProvableOperation for TransferOp {
 }
 
 impl OperationGas<MainnetGasProfile> for TransferOp {
-    const GAS_CONSTANT: Gas = Gas::new(590);
+    const GAS_COST: Gas = Gas::new(590);
 }
 
 impl PreverifiableOperation<verification_mode::StandardMode> for TransferOp {

--- a/core/src/mantle/ops/transfer.rs
+++ b/core/src/mantle/ops/transfer.rs
@@ -6,14 +6,16 @@ use thiserror::Error;
 use crate::{
     events::TxEvent,
     mantle::{
+        Value,
         channel::Channels,
-        gas::{Gas, MainnetGasProfile, OperationGas},
+        gas::{Gas, MainnetGasProfile, OperationGas, SignedOperationExecutionGas},
         ledger::{
             self, ExecutableOperation, Inputs, Outputs, PreverifiableOperation, ProvableOperation,
             Utxo, Utxos, VerifiableOperation, verification_mode,
+            verification_mode::VerificationMode,
         },
-        ops::OpId,
-        transactions::hash::TxHashView,
+        ops::{OpId, SignedOp},
+        transactions::{hash::TxHashView, states::VerificationState},
     },
     sdp::locked_notes::LockedNotes,
 };
@@ -149,6 +151,14 @@ impl ExecutableOperation for TransferOp {
         // Add outputs from the ledger
         utxos = self.outputs.execute(utxos, self);
         Ok((utxos, Vec::new()))
+    }
+}
+
+impl<State: VerificationState, Mode: VerificationMode> SignedOperationExecutionGas
+    for SignedOp<TransferOp, State, Mode>
+{
+    fn gas_multiplier(&self) -> Value {
+        1
     }
 }
 

--- a/core/src/mantle/ops/transfer.rs
+++ b/core/src/mantle/ops/transfer.rs
@@ -7,6 +7,7 @@ use crate::{
     events::TxEvent,
     mantle::{
         channel::Channels,
+        gas::{Gas, MainnetGasConstants, OperationGas},
         ledger::{
             self, ExecutableOperation, Inputs, Outputs, PreverifiableOperation, ProvableOperation,
             Utxo, Utxos, VerifiableOperation, verification_mode,
@@ -86,6 +87,10 @@ pub struct TransferValidationContext<'a> {
 
 impl ProvableOperation for TransferOp {
     type Proof = ZkSignature;
+}
+
+impl OperationGas<MainnetGasConstants> for TransferOp {
+    const GAS_CONSTANT: Gas = Gas::new(590);
 }
 
 impl PreverifiableOperation<verification_mode::StandardMode> for TransferOp {

--- a/core/src/mantle/ops/transfer.rs
+++ b/core/src/mantle/ops/transfer.rs
@@ -7,7 +7,7 @@ use crate::{
     events::TxEvent,
     mantle::{
         channel::Channels,
-        gas::{Gas, MainnetGasConstants, OperationGas},
+        gas::{Gas, MainnetGasProfile, OperationGas},
         ledger::{
             self, ExecutableOperation, Inputs, Outputs, PreverifiableOperation, ProvableOperation,
             Utxo, Utxos, VerifiableOperation, verification_mode,
@@ -89,7 +89,7 @@ impl ProvableOperation for TransferOp {
     type Proof = ZkSignature;
 }
 
-impl OperationGas<MainnetGasConstants> for TransferOp {
+impl OperationGas<MainnetGasProfile> for TransferOp {
     const GAS_CONSTANT: Gas = Gas::new(590);
 }
 

--- a/core/src/mantle/traits/mantle_tx.rs
+++ b/core/src/mantle/traits/mantle_tx.rs
@@ -1,5 +1,5 @@
 use crate::mantle::{
-    GasCalculator, Op, OpProof,
+    Op, OpProof, TxGasCalculator,
     traits::{Hashable, StorageSize},
     transactions::{hash::TxHash, mantle_tx::RawMantleTx},
 };
@@ -7,7 +7,7 @@ use crate::mantle::{
 pub type OpWithProof<'a> = (&'a Op, &'a OpProof);
 
 // TODO: Supertrait to MantleTx and propagate
-pub trait MantleTxWithProofs: Hashable<Hash = TxHash> + GasCalculator + StorageSize {
+pub trait MantleTxWithProofs: Hashable<Hash = TxHash> + TxGasCalculator + StorageSize {
     /// Returns the underlying `MantleTx` that this transaction represents.
     fn mantle_tx(&self) -> &RawMantleTx;
 

--- a/core/src/mantle/traits/mantle_tx.rs
+++ b/core/src/mantle/traits/mantle_tx.rs
@@ -15,13 +15,3 @@ pub trait MantleTxWithProofs: Hashable<Hash = TxHash> + TxGasCalculator + Storag
     /// in this transaction.
     fn ops_with_proof(&self) -> impl Iterator<Item = OpWithProof<'_>>;
 }
-
-impl<T: MantleTxWithProofs> MantleTxWithProofs for &T {
-    fn mantle_tx(&self) -> &RawMantleTx {
-        T::mantle_tx(self)
-    }
-
-    fn ops_with_proof(&self) -> impl Iterator<Item = OpWithProof<'_>> {
-        T::ops_with_proof(self)
-    }
-}

--- a/core/src/mantle/traits/preverified_tx.rs
+++ b/core/src/mantle/traits/preverified_tx.rs
@@ -4,9 +4,3 @@ pub trait PreverifiedMantleTx: MantleTxWithProofs {
     /// Returns the cursor to the verified operations in this transaction.
     fn verified_ops(&self) -> VerifiedOps<'_>;
 }
-
-impl<T: PreverifiedMantleTx> PreverifiedMantleTx for &T {
-    fn verified_ops(&self) -> VerifiedOps<'_> {
-        T::verified_ops(self)
-    }
-}

--- a/core/src/mantle/transactions/builder.rs
+++ b/core/src/mantle/transactions/builder.rs
@@ -7,7 +7,7 @@ use thiserror::Error;
 
 use crate::{
     mantle::{
-        GasConstants, Note, NoteId, Op, Utxo, Value,
+        GasProfile, Note, NoteId, Op, Utxo, Value,
         gas::{GasCost, GasOverflow},
         ledger::{BoundedUtxos, Inputs, Outputs},
         ops::{channel::ChannelId, transfer::TransferOp},
@@ -141,7 +141,7 @@ impl MantleTxBuilder {
 
     /// `priority_fee` is deliberately left unreturned: the resulting excess
     /// balance above the mandatory fee is the transaction's execution tip.
-    pub fn return_change<G: GasConstants>(
+    pub fn return_change<G: GasProfile>(
         self,
         context: &MantleTxContext,
         change_pk: ZkPublicKey,
@@ -222,7 +222,7 @@ impl MantleTxBuilder {
     /// Predicts the minimum gas cost of the transaction once signed.
     /// See [`RawMantleTx::minimum_total_gas_cost`] to understand why this is
     /// only a minimum, not an exact cost.
-    pub fn minimum_gas_cost<G: GasConstants>(
+    pub fn minimum_gas_cost<G: GasProfile>(
         &self,
         context: &MantleTxContext,
     ) -> Result<GasCost, TxBuilderError> {
@@ -246,7 +246,7 @@ impl MantleTxBuilder {
         Ok(build.minimum_total_gas_cost::<G>(&context.gas_context)?)
     }
 
-    pub fn funding_delta<G: GasConstants>(
+    pub fn funding_delta<G: GasProfile>(
         &self,
         context: &MantleTxContext,
     ) -> Result<i128, TxBuilderError> {
@@ -307,7 +307,7 @@ mod tests {
     use super::*;
     use crate::{
         mantle::{
-            gas::MainnetGasConstants,
+            gas::MainnetGasProfile,
             ops::{
                 channel::{
                     deposit::{DepositOp, Metadata},
@@ -376,7 +376,7 @@ mod tests {
         assert_eq!(builder.net_balance(), 0);
         assert_eq!(
             builder
-                .funding_delta::<MainnetGasConstants>(&context)
+                .funding_delta::<MainnetGasProfile>(&context)
                 .unwrap(),
             0
         );
@@ -408,7 +408,7 @@ mod tests {
         assert_eq!(builder.net_balance(), 0);
         assert_eq!(
             builder
-                .funding_delta::<MainnetGasConstants>(&context)
+                .funding_delta::<MainnetGasProfile>(&context)
                 .unwrap(),
             0
         );
@@ -439,7 +439,7 @@ mod tests {
         assert_eq!(builder.net_balance(), 0);
         assert_eq!(
             builder
-                .funding_delta::<MainnetGasConstants>(&context)
+                .funding_delta::<MainnetGasProfile>(&context)
                 .unwrap(),
             0
         );
@@ -467,7 +467,7 @@ mod tests {
             leader_reward_amount: 0,
         };
 
-        let result = builder.minimum_gas_cost::<MainnetGasConstants>(&context);
+        let result = builder.minimum_gas_cost::<MainnetGasProfile>(&context);
 
         assert!(matches!(
             result,
@@ -501,7 +501,7 @@ mod tests {
         assert_eq!(builder.net_balance(), 0);
         assert_eq!(
             builder
-                .funding_delta::<MainnetGasConstants>(&context)
+                .funding_delta::<MainnetGasProfile>(&context)
                 .unwrap(),
             0
         );
@@ -528,14 +528,14 @@ mod tests {
         assert_eq!(builder.net_balance(), 10);
         assert_eq!(
             builder
-                .funding_delta::<MainnetGasConstants>(&context)
+                .funding_delta::<MainnetGasProfile>(&context)
                 .unwrap(),
             10 // zero gas price for now
         );
 
         // Add change note
         let builder = builder
-            .return_change::<MainnetGasConstants>(&context, ZkPublicKey::zero(), 0)
+            .return_change::<MainnetGasProfile>(&context, ZkPublicKey::zero(), 0)
             .unwrap()
             .unwrap();
 
@@ -543,7 +543,7 @@ mod tests {
         assert_eq!(builder.net_balance(), 0);
         assert_eq!(
             builder
-                .funding_delta::<MainnetGasConstants>(&context)
+                .funding_delta::<MainnetGasProfile>(&context)
                 .unwrap(),
             0 // zero gas price for now
         );
@@ -593,7 +593,7 @@ mod tests {
         assert_eq!(builder.net_balance(), -40);
         assert_eq!(
             builder
-                .funding_delta::<MainnetGasConstants>(&context)
+                .funding_delta::<MainnetGasProfile>(&context)
                 .unwrap(),
             -40 // zero gas price for now
         );
@@ -607,7 +607,7 @@ mod tests {
         assert_eq!(builder.net_balance(), 0);
         assert_eq!(
             builder
-                .funding_delta::<MainnetGasConstants>(&context)
+                .funding_delta::<MainnetGasProfile>(&context)
                 .unwrap(),
             0 // zero gas price for now
         );

--- a/core/src/mantle/transactions/genesis_tx.rs
+++ b/core/src/mantle/transactions/genesis_tx.rs
@@ -10,7 +10,7 @@ use crate::{
     crypto::{Digest as _, Hasher},
     mantle::{
         OpProof, SignedMantleTx,
-        gas::{Gas, GasCalculator, GasConstants, GasCost, GasOverflow},
+        gas::{Gas, GasCalculator, GasCost, GasOverflow, GasProfile},
         ops::{
             Op,
             channel::{ChannelId, MsgId, inscribe::InscriptionOp},
@@ -163,7 +163,7 @@ impl Hashable for GenesisTx {
 impl GasCalculator for GenesisTx {
     type Context = ();
 
-    fn total_gas_cost<Constants: GasConstants>(
+    fn total_gas_cost<Profile: GasProfile>(
         &self,
         _context: &Self::Context,
     ) -> Result<GasCost, GasOverflow> {
@@ -176,7 +176,7 @@ impl GasCalculator for GenesisTx {
         Ok(0.into())
     }
 
-    fn execution_gas_consumption<Constants: GasConstants>(
+    fn execution_gas_consumption<Profile: GasProfile>(
         &self,
         _context: &Self::Context,
     ) -> Result<Gas, GasOverflow> {

--- a/core/src/mantle/transactions/genesis_tx.rs
+++ b/core/src/mantle/transactions/genesis_tx.rs
@@ -10,7 +10,7 @@ use crate::{
     crypto::{Digest as _, Hasher},
     mantle::{
         OpProof, SignedMantleTx,
-        gas::{Gas, GasCalculator, GasCost, GasOverflow, GasProfile},
+        gas::{Gas, GasCost, GasOverflow, GasProfile, TxGasCalculator},
         ops::{
             Op,
             channel::{ChannelId, MsgId, inscribe::InscriptionOp},
@@ -160,7 +160,7 @@ impl Hashable for GenesisTx {
     }
 }
 
-impl GasCalculator for GenesisTx {
+impl TxGasCalculator for GenesisTx {
     type Context = ();
 
     fn total_gas_cost<Profile: GasProfile>(

--- a/core/src/mantle/transactions/mantle_tx.rs
+++ b/core/src/mantle/transactions/mantle_tx.rs
@@ -31,7 +31,7 @@ impl RawMantleTx {
     /// Predicts the minimum total gas cost of the transaction once signed.
     ///
     /// See [`minimum_signed_mantle_tx_size`] for why this doesn't implement
-    /// [`crate::mantle::GasCalculator`] which calculates an exact gas cost.
+    /// [`crate::mantle::TxGasCalculator`] which calculates an exact gas cost.
     pub fn minimum_total_gas_cost<Profile: GasProfile>(
         &self,
         context: &MantleTxGasContext,

--- a/core/src/mantle/transactions/mantle_tx.rs
+++ b/core/src/mantle/transactions/mantle_tx.rs
@@ -8,7 +8,7 @@ use crate::{
     block::MAX_BLOCK_TRANSACTIONS_SIZE,
     crypto::{Digest as _, Hasher},
     mantle::{
-        GasConstants, Op, SignedMantleTx, TxHash, Value,
+        GasProfile, Op, SignedMantleTx, TxHash, Value,
         channel::Channels,
         gas::{Gas, GasCost, GasOverflow},
         ops::{
@@ -32,11 +32,11 @@ impl RawMantleTx {
     ///
     /// See [`minimum_signed_mantle_tx_size`] for why this doesn't implement
     /// [`crate::mantle::GasCalculator`] which calculates an exact gas cost.
-    pub fn minimum_total_gas_cost<Constants: GasConstants>(
+    pub fn minimum_total_gas_cost<Profile: GasProfile>(
         &self,
         context: &MantleTxGasContext,
     ) -> Result<GasCost, GasOverflow> {
-        let execution_gas = self.minimum_execution_gas_consumption::<Constants>(context)?;
+        let execution_gas = self.minimum_execution_gas_consumption::<Profile>(context)?;
         let execution_gas_cost =
             GasCost::calculate(execution_gas, context.gas_prices.execution_base_gas_price)?;
         let storage_gas_cost = self.minimum_storage_gas_cost(context)?;
@@ -46,13 +46,13 @@ impl RawMantleTx {
 
     /// Predicts the minimum execution gas the transaction will consume once
     /// signed.
-    pub fn minimum_execution_gas_consumption<Constants: GasConstants>(
+    pub fn minimum_execution_gas_consumption<Profile: GasProfile>(
         &self,
         context: &MantleTxGasContext,
     ) -> Result<Gas, GasOverflow> {
         self.ops()
             .iter()
-            .map(|op| contextual_op_execution_gas::<Constants>(op, context))
+            .map(|op| contextual_op_execution_gas::<Profile>(op, context))
             .try_fold(Gas::from(0), |total, gas| total.checked_add(gas?))
     }
 
@@ -117,7 +117,7 @@ impl StorageSize for RawMantleTx {
     }
 }
 
-fn contextual_op_execution_gas<Constants: GasConstants>(
+fn contextual_op_execution_gas<Profile: GasProfile>(
     op: &Op,
     context: &MantleTxGasContext,
 ) -> Result<Gas, GasOverflow> {
@@ -133,10 +133,10 @@ fn contextual_op_execution_gas<Constants: GasConstants>(
         Op::ChannelTransfer(operation) => context
             .transfer_threshold(&operation.channel_id)
             .unwrap_or(0),
-        _ => return Ok(op.execution_gas::<Constants>()),
+        _ => return Ok(op.execution_gas::<Profile>()),
     };
 
-    op.execution_gas::<Constants>()
+    op.execution_gas::<Profile>()
         .checked_mul(Value::from(multiplier))
 }
 

--- a/core/src/mantle/transactions/signed_mantle_tx.rs
+++ b/core/src/mantle/transactions/signed_mantle_tx.rs
@@ -6,7 +6,7 @@ use crate::{
     crypto::{Digest as _, Hasher},
     mantle::{
         RawMantleTx, Value, VerificationError,
-        gas::{Gas, GasCalculator, GasConstants, GasCost, GasOverflow},
+        gas::{Gas, GasCalculator, GasCost, GasOverflow, GasProfile},
         ledger::{PreverifiableOperation, VerifiableOperation, verification_mode::StandardMode},
         ops::{
             Op, OpProof,
@@ -394,11 +394,11 @@ impl<State: VerificationState> MantleTxWithProofs for SignedMantleTx<State> {
 impl<State: VerificationState> GasCalculator for SignedMantleTx<State> {
     type Context = GasPrices;
 
-    fn total_gas_cost<Constants: GasConstants>(
+    fn total_gas_cost<Profile: GasProfile>(
         &self,
         context: &Self::Context,
     ) -> Result<GasCost, GasOverflow> {
-        let execution_gas = GasCalculator::execution_gas_consumption::<Constants>(&self, context)?;
+        let execution_gas = GasCalculator::execution_gas_consumption::<Profile>(&self, context)?;
         let execution_gas_cost =
             GasCost::calculate(execution_gas, context.execution_base_gas_price)?;
         let storage_gas_cost = GasCalculator::storage_gas_cost(self, context)?;
@@ -411,7 +411,7 @@ impl<State: VerificationState> GasCalculator for SignedMantleTx<State> {
         GasCost::calculate(storage_gas, context.storage_gas_price)
     }
 
-    fn execution_gas_consumption<Constants: GasConstants>(
+    fn execution_gas_consumption<Profile: GasProfile>(
         &self,
         _context: &Self::Context,
     ) -> Result<Gas, GasOverflow> {
@@ -419,7 +419,7 @@ impl<State: VerificationState> GasCalculator for SignedMantleTx<State> {
             .ops()
             .iter()
             .zip(self.ops_proofs.iter())
-            .map(|(op, proof)| signed_op_execution_gas::<Constants>(op, proof))
+            .map(|(op, proof)| signed_op_execution_gas::<Profile>(op, proof))
             .try_fold(Gas::from(0), |total, gas| total.checked_add(gas?))
     }
 
@@ -428,7 +428,7 @@ impl<State: VerificationState> GasCalculator for SignedMantleTx<State> {
     }
 }
 
-fn signed_op_execution_gas<Constants: GasConstants>(
+fn signed_op_execution_gas<Profile: GasProfile>(
     op: &Op,
     proof: &OpProof,
 ) -> Result<Gas, GasOverflow> {
@@ -440,12 +440,12 @@ fn signed_op_execution_gas<Constants: GasConstants>(
             Op::ChannelConfig(_) | Op::ChannelWithdraw(_) | Op::ChannelTransfer(_),
             OpProof::ChannelMultiSigProof(proof),
         ) => proof.signatures().len(),
-        _ => return Ok(op.execution_gas::<Constants>()),
+        _ => return Ok(op.execution_gas::<Profile>()),
     };
     let multiplier = Value::try_from(signature_count)
         .expect("channel multi-signature proofs are bounded to u16::MAX signatures");
 
-    op.execution_gas::<Constants>().checked_mul(multiplier)
+    op.execution_gas::<Profile>().checked_mul(multiplier)
 }
 
 impl<State: VerificationState> StorageSize for SignedMantleTx<State> {
@@ -635,7 +635,7 @@ mod tests {
     use crate::mantle::{
         Note, NoteId, Utxo,
         channel::Error,
-        gas::MainnetGasConstants,
+        gas::MainnetGasProfile,
         ledger::{Inputs, Outputs, OutputsError},
         ops::{
             channel::{
@@ -700,7 +700,7 @@ mod tests {
         );
 
         let gas = mantle_tx
-            .minimum_execution_gas_consumption::<MainnetGasConstants>(&context)
+            .minimum_execution_gas_consumption::<MainnetGasProfile>(&context)
             .unwrap();
 
         let expected_config_gas = u64::from(config_threshold) * 56;
@@ -751,11 +751,9 @@ mod tests {
         );
 
         let gas_prices = GasPrices::new(1, 0);
-        let gas = GasCalculator::execution_gas_consumption::<MainnetGasConstants>(
-            &signed_tx,
-            &gas_prices,
-        )
-        .unwrap();
+        let gas =
+            GasCalculator::execution_gas_consumption::<MainnetGasProfile>(&signed_tx, &gas_prices)
+                .unwrap();
 
         let expected_config_gas = config_keys.len() as u64 * 56;
         let expected_deposit_gas = 590;

--- a/core/src/mantle/transactions/signed_mantle_tx.rs
+++ b/core/src/mantle/transactions/signed_mantle_tx.rs
@@ -398,7 +398,7 @@ impl<State: VerificationState> TxGasCalculator for SignedMantleTx<State> {
         &self,
         context: &Self::Context,
     ) -> Result<GasCost, GasOverflow> {
-        let execution_gas = TxGasCalculator::execution_gas_consumption::<Profile>(&self, context)?;
+        let execution_gas = TxGasCalculator::execution_gas_consumption::<Profile>(self, context)?;
         let execution_gas_cost =
             GasCost::calculate(execution_gas, context.execution_base_gas_price)?;
         let storage_gas_cost = TxGasCalculator::storage_gas_cost(self, context)?;
@@ -407,7 +407,7 @@ impl<State: VerificationState> TxGasCalculator for SignedMantleTx<State> {
     }
 
     fn storage_gas_cost(&self, context: &Self::Context) -> Result<GasCost, GasOverflow> {
-        let storage_gas = TxGasCalculator::storage_gas_consumption(&self, context)?;
+        let storage_gas = TxGasCalculator::storage_gas_consumption(self, context)?;
         GasCost::calculate(storage_gas, context.storage_gas_price)
     }
 

--- a/core/src/mantle/transactions/signed_mantle_tx.rs
+++ b/core/src/mantle/transactions/signed_mantle_tx.rs
@@ -6,7 +6,7 @@ use crate::{
     crypto::{Digest as _, Hasher},
     mantle::{
         RawMantleTx, Value, VerificationError,
-        gas::{Gas, GasCalculator, GasCost, GasOverflow, GasProfile},
+        gas::{Gas, GasCost, GasOverflow, GasProfile, TxGasCalculator},
         ledger::{PreverifiableOperation, VerifiableOperation, verification_mode::StandardMode},
         ops::{
             Op, OpProof,
@@ -391,23 +391,23 @@ impl<State: VerificationState> MantleTxWithProofs for SignedMantleTx<State> {
     }
 }
 
-impl<State: VerificationState> GasCalculator for SignedMantleTx<State> {
+impl<State: VerificationState> TxGasCalculator for SignedMantleTx<State> {
     type Context = GasPrices;
 
     fn total_gas_cost<Profile: GasProfile>(
         &self,
         context: &Self::Context,
     ) -> Result<GasCost, GasOverflow> {
-        let execution_gas = GasCalculator::execution_gas_consumption::<Profile>(&self, context)?;
+        let execution_gas = TxGasCalculator::execution_gas_consumption::<Profile>(&self, context)?;
         let execution_gas_cost =
             GasCost::calculate(execution_gas, context.execution_base_gas_price)?;
-        let storage_gas_cost = GasCalculator::storage_gas_cost(self, context)?;
+        let storage_gas_cost = TxGasCalculator::storage_gas_cost(self, context)?;
 
         execution_gas_cost.checked_add(storage_gas_cost)
     }
 
     fn storage_gas_cost(&self, context: &Self::Context) -> Result<GasCost, GasOverflow> {
-        let storage_gas = GasCalculator::storage_gas_consumption(&self, context)?;
+        let storage_gas = TxGasCalculator::storage_gas_consumption(&self, context)?;
         GasCost::calculate(storage_gas, context.storage_gas_price)
     }
 
@@ -751,9 +751,11 @@ mod tests {
         );
 
         let gas_prices = GasPrices::new(1, 0);
-        let gas =
-            GasCalculator::execution_gas_consumption::<MainnetGasProfile>(&signed_tx, &gas_prices)
-                .unwrap();
+        let gas = TxGasCalculator::execution_gas_consumption::<MainnetGasProfile>(
+            &signed_tx,
+            &gas_prices,
+        )
+        .unwrap();
 
         let expected_config_gas = config_keys.len() as u64 * 56;
         let expected_deposit_gas = 590;

--- a/ledger/src/cryptarchia/mod.rs
+++ b/ledger/src/cryptarchia/mod.rs
@@ -9,7 +9,7 @@ use lb_core::{
     events::TxEvent,
     mantle::{
         NoteId, Utxo, Value,
-        gas::{Gas, GasConstants, GasCost, GasOverflow, GasPrice},
+        gas::{Gas, GasCost, GasOverflow, GasPrice, GasProfile},
         ledger::ExecutableOperation as _,
         ops::transfer::TransferOp,
         traits::GenesisTx,
@@ -465,7 +465,7 @@ impl LedgerState {
             .increment_block_density(slot))
     }
 
-    pub fn try_apply_transfer<Id, Constants: GasConstants>(
+    pub fn try_apply_transfer<Id, Profile: GasProfile>(
         mut self,
         transfer_op: &TransferOp,
     ) -> Result<(Self, Balance, Vec<TxEvent>), LedgerError<Id>> {
@@ -743,7 +743,7 @@ pub mod tests {
             GasCalculator as _, Note, Op,
             OpProof::ZkSig,
             RawMantleTx, SignedMantleTx,
-            gas::MainnetGasConstants,
+            gas::MainnetGasProfile,
             ledger::{Inputs, Outputs},
             ops::{leader_claim::VoucherCm, sdp::SDPDeclareOp},
             traits::Hashable as _,
@@ -856,7 +856,7 @@ pub mod tests {
             .update_epoch_state::<HeaderId>(slot, &SdpLedger::new(0.into()), ledger.config())?;
         let id = make_id(parent, slot, utxo);
         let proof = generate_proof(&ledger_state, &utxo, slot);
-        let (_, state, _) = ledger.prepare_update::<_, _, MainnetGasConstants>(
+        let (_, state, _) = ledger.prepare_update::<_, _, MainnetGasProfile>(
             id,
             parent,
             slot,
@@ -1607,8 +1607,8 @@ pub mod tests {
             vec![output_note],
         );
 
-        let _fees = tx.total_gas_cost::<MainnetGasConstants>(&GasPrices::new(0, 0));
-        let result = ledger_state.try_apply_transfer::<(), MainnetGasConstants>(&transfer_op);
+        let _fees = tx.total_gas_cost::<MainnetGasProfile>(&GasPrices::new(0, 0));
+        let result = ledger_state.try_apply_transfer::<(), MainnetGasProfile>(&transfer_op);
 
         assert!(result.is_err());
     }
@@ -1632,9 +1632,9 @@ pub mod tests {
         let (tx, transfer_op, _transfer_sig) =
             create_tx_with_transfer(&[(&note_sk, &input_utxo)], vec![output_note1, output_note2]);
 
-        let _fees = tx.total_gas_cost::<MainnetGasConstants>(&GasPrices::new(0, 0));
+        let _fees = tx.total_gas_cost::<MainnetGasProfile>(&GasPrices::new(0, 0));
         let (new_state, balance, events) = ledger_state
-            .try_apply_transfer::<(), MainnetGasConstants>(&transfer_op)
+            .try_apply_transfer::<(), MainnetGasProfile>(&transfer_op)
             .unwrap();
 
         assert_eq!(
@@ -1664,9 +1664,9 @@ pub mod tests {
             vec![],
         );
 
-        let _fees = tx.total_gas_cost::<MainnetGasConstants>(&GasPrices::new(0, 0));
+        let _fees = tx.total_gas_cost::<MainnetGasProfile>(&GasPrices::new(0, 0));
         let (final_state, final_balance, events) = new_state
-            .try_apply_transfer::<(), MainnetGasConstants>(&transfer_op)
+            .try_apply_transfer::<(), MainnetGasProfile>(&transfer_op)
             .unwrap();
 
         assert_eq!(
@@ -1719,7 +1719,7 @@ pub mod tests {
                 create_tx_with_transfer(&[(&ZkKey::zero(), &non_existent_utxo)], vec![]);
             let result = ledger_state
                 .clone()
-                .try_apply_transfer::<(), MainnetGasConstants>(&transfer_op);
+                .try_apply_transfer::<(), MainnetGasProfile>(&transfer_op);
             assert!(matches!(result, Err(LedgerError::Mantle(_))));
         }
     }
@@ -1742,7 +1742,7 @@ pub mod tests {
 
         let (_, balance, events) = ledger_state
             .clone()
-            .try_apply_transfer::<(), MainnetGasConstants>(&transfer_op)
+            .try_apply_transfer::<(), MainnetGasProfile>(&transfer_op)
             .unwrap();
         assert_eq!(balance, -1);
         assert!(events.is_empty());
@@ -1751,7 +1751,7 @@ pub mod tests {
             create_tx_with_transfer(&[(&input_sk, &input_utxo)], vec![output_note]);
         assert_eq!(
             ledger_state
-                .try_apply_transfer::<(), MainnetGasConstants>(&transfer_op,)
+                .try_apply_transfer::<(), MainnetGasProfile>(&transfer_op,)
                 .unwrap()
                 .1,
             0
@@ -1772,8 +1772,8 @@ pub mod tests {
         let (tx, transfer_op, _transfer_sig) =
             create_tx_with_transfer(&[(&input_sk, &input_utxo)], vec![]);
 
-        let _fees = tx.total_gas_cost::<MainnetGasConstants>(&GasPrices::new(0, 0));
-        let result = ledger_state.try_apply_transfer::<(), MainnetGasConstants>(&transfer_op);
+        let _fees = tx.total_gas_cost::<MainnetGasProfile>(&GasPrices::new(0, 0));
+        let result = ledger_state.try_apply_transfer::<(), MainnetGasProfile>(&transfer_op);
         assert!(result.is_ok());
 
         let (new_state, balance, events) = result.unwrap();

--- a/ledger/src/cryptarchia/mod.rs
+++ b/ledger/src/cryptarchia/mod.rs
@@ -740,9 +740,9 @@ pub mod tests {
     use lb_core::{
         crypto::{Digest as _, Hasher},
         mantle::{
-            GasCalculator as _, Note, Op,
+            Note, Op,
             OpProof::ZkSig,
-            RawMantleTx, SignedMantleTx,
+            RawMantleTx, SignedMantleTx, TxGasCalculator as _,
             gas::MainnetGasProfile,
             ledger::{Inputs, Outputs},
             ops::{leader_claim::VoucherCm, sdp::SDPDeclareOp},

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -17,7 +17,7 @@ use lb_core::{
     events::{Events, HeaderEvent, TxEvent, TxEventPayload},
     mantle::{
         NoteId, Op, Utxo, Value, VerificationError,
-        gas::{Gas, GasConstants, GasCost, GasOverflow},
+        gas::{Gas, GasCost, GasOverflow, GasProfile},
         ledger::ExecutableOperation as _,
         ops::{
             channel::{
@@ -152,7 +152,7 @@ where
     ///
     /// On success, a new [`LedgerState`] is returned, which can then be
     /// committed by calling [`Self::commit_update`].
-    pub fn prepare_update<'tx, Tx, LeaderProof, Constants>(
+    pub fn prepare_update<'tx, Tx, LeaderProof, Profile>(
         &self,
         id: Id,
         parent_id: Id,
@@ -163,7 +163,7 @@ where
     where
         Tx: PreverifiedMantleTx<Context = GasPrices> + 'tx,
         LeaderProof: leader_proof::LeaderProof,
-        Constants: GasConstants,
+        Profile: GasProfile,
         Id: Into<BlockHash>,
     {
         let parent_state = self
@@ -171,7 +171,7 @@ where
             .get(&parent_id)
             .ok_or(LedgerError::ParentNotFound(parent_id))?;
 
-        let (new_state, events) = parent_state.clone().try_update::<_, _, _, Constants>(
+        let (new_state, events) = parent_state.clone().try_update::<_, _, _, Profile>(
             id,
             slot,
             proof,
@@ -225,7 +225,7 @@ pub struct LedgerState {
 }
 
 impl LedgerState {
-    fn try_update<'tx, Tx, LeaderProof, Id, Constants>(
+    fn try_update<'tx, Tx, LeaderProof, Id, Profile>(
         self,
         block_id: Id,
         slot: Slot,
@@ -236,7 +236,7 @@ impl LedgerState {
     where
         Tx: PreverifiedMantleTx<Context = GasPrices> + 'tx,
         LeaderProof: leader_proof::LeaderProof,
-        Constants: GasConstants,
+        Profile: GasProfile,
         Id: Into<BlockHash>,
     {
         let (mut state, header_events) = self.try_apply_header(slot, proof, config)?;
@@ -245,7 +245,7 @@ impl LedgerState {
         // block's id is known — unlike a proposer's direct
         // `try_apply_header` call for a block still being built.
         state.mantle_ledger.add_seen_block(block_id.into(), slot);
-        let (mut state, tx_events) = state.try_apply_contents::<_, _, Constants>(config, txs)?;
+        let (mut state, tx_events) = state.try_apply_contents::<_, _, Profile>(config, txs)?;
         state.update_pow_difficulty(
             // count all claimed rewards
             tx_events
@@ -412,7 +412,7 @@ impl LedgerState {
     }
 
     /// Apply the contents of an update to the ledger state.
-    pub fn try_apply_contents<'tx, Tx, Id, Constants: GasConstants>(
+    pub fn try_apply_contents<'tx, Tx, Id, Profile: GasProfile>(
         mut self,
         config: &Config,
         txs: impl Iterator<Item = &'tx Tx>,
@@ -429,7 +429,7 @@ impl LedgerState {
         for tx in txs {
             let balance;
             let events;
-            (self, balance, events) = self.try_apply_tx::<_, _, Constants>(config, tx)?;
+            (self, balance, events) = self.try_apply_tx::<_, _, Profile>(config, tx)?;
             tx_events.extend(events);
 
             let gas_prices = GasPrices {
@@ -437,7 +437,7 @@ impl LedgerState {
                 storage_gas_price: *self.cryptarchia_ledger.storage_gas_price(),
             };
             // Check the transaction is balanced
-            let total_gas_cost = tx.total_gas_cost::<Constants>(&gas_prices)?;
+            let total_gas_cost = tx.total_gas_cost::<Profile>(&gas_prices)?;
             tracing::debug!(
                 balance,
                 total_gas_cost = total_gas_cost.into_inner(),
@@ -454,7 +454,7 @@ impl LedgerState {
 
             // Update the total of fee burned and tipped in the block
             let tx_fee_burned = GasCost::calculate(
-                tx.execution_gas_consumption::<Constants>(&gas_prices)?,
+                tx.execution_gas_consumption::<Profile>(&gas_prices)?,
                 gas_prices.execution_base_gas_price,
             )?
             .checked_add(tx.storage_gas_cost(&gas_prices)?)?;
@@ -463,7 +463,7 @@ impl LedgerState {
             total_fee_burned = total_fee_burned.checked_add(tx_fee_burned)?;
             total_fee_tip = total_fee_tip.checked_add(tx_fee_tip)?;
             total_block_execution_gas = total_block_execution_gas
-                .checked_add(tx.execution_gas_consumption::<Constants>(&gas_prices)?)?;
+                .checked_add(tx.execution_gas_consumption::<Profile>(&gas_prices)?)?;
             total_block_storage_gas =
                 total_block_storage_gas.checked_add(tx.storage_gas_consumption(&gas_prices)?)?;
 
@@ -584,7 +584,7 @@ impl LedgerState {
         clippy::too_many_lines,
         reason = "This will be refactored in an upcoming PR."
     )]
-    fn try_apply_op<Id, Constants: GasConstants>(
+    fn try_apply_op<Id, Profile: GasProfile>(
         mut self,
         op: &Op,
         config: &Config,
@@ -693,7 +693,7 @@ impl LedgerState {
                 let events;
                 (self.cryptarchia_ledger, transfer_balance, events) =
                     self.cryptarchia_ledger
-                        .try_apply_transfer::<_, Constants>(op)?;
+                        .try_apply_transfer::<_, Profile>(op)?;
                 balance = balance
                     .checked_add(transfer_balance)
                     .ok_or(LedgerError::BalanceOverflow)?;
@@ -740,7 +740,7 @@ impl LedgerState {
     ///
     /// If any operation fails verification or execution, returns a
     /// [`LedgerError`] describing the failure.
-    fn try_apply_tx<'tx, Tx, Id, Constants: GasConstants>(
+    fn try_apply_tx<'tx, Tx, Id, Profile: GasProfile>(
         mut self,
         config: &Config,
         tx: &'tx Tx,
@@ -762,7 +762,7 @@ impl LedgerState {
             let Some(op) = verified_ops.next(&helper).transpose()? else {
                 break;
             };
-            (self, balance, tx_events) = self.try_apply_op::<_, Constants>(
+            (self, balance, tx_events) = self.try_apply_op::<_, Profile>(
                 op,
                 config,
                 verified_ops.tx_hash_view().tx_hash(),
@@ -785,7 +785,7 @@ mod tests {
     use lb_core::{
         mantle::{
             GasCalculator as _, Note, OpProof, RawMantleTx, SignedMantleTx,
-            gas::MainnetGasConstants,
+            gas::MainnetGasProfile,
             ledger::{Inputs, Outputs, Utxos, VerifiableOperation as _},
             ops::{
                 OpId as _,
@@ -959,7 +959,7 @@ mod tests {
             &Key::Ed25519(signing_key.clone()),
         );
         ledger_state
-            .try_apply_tx::<_, HeaderId, MainnetGasConstants>(config, &tx)
+            .try_apply_tx::<_, HeaderId, MainnetGasProfile>(config, &tx)
             .unwrap()
             .0
     }
@@ -1029,7 +1029,7 @@ mod tests {
 
         let default_gas_prices = GasPrices::default();
         let fees = tx
-            .total_gas_cost::<MainnetGasConstants>(&default_gas_prices)
+            .total_gas_cost::<MainnetGasProfile>(&default_gas_prices)
             .unwrap();
         output_note.value = utxo.note.value - fees.into_inner();
 
@@ -1048,7 +1048,7 @@ mod tests {
 
         let new_id = [1; 32];
         let (_, state, events) = ledger
-            .prepare_update::<_, _, MainnetGasConstants>(
+            .prepare_update::<_, _, MainnetGasProfile>(
                 new_id,
                 genesis_id,
                 Slot::from(1u64),
@@ -1087,7 +1087,7 @@ mod tests {
         };
 
         let tx = create_signed_tx(Op::ChannelInscribe(inscribe_op), &Key::Ed25519(signing_key));
-        let result = state.try_apply_tx::<_, HeaderId, MainnetGasConstants>(&test_config, &tx);
+        let result = state.try_apply_tx::<_, HeaderId, MainnetGasProfile>(&test_config, &tx);
         assert!(result.is_ok());
 
         let (new_state, _, events) = result.unwrap();
@@ -1132,7 +1132,7 @@ mod tests {
             Op::ChannelConfig(config_op),
             &Key::MultiSequencer(config_proof),
         );
-        let result = state.try_apply_tx::<_, HeaderId, MainnetGasConstants>(&test_config, &tx);
+        let result = state.try_apply_tx::<_, HeaderId, MainnetGasProfile>(&test_config, &tx);
         assert!(result.is_ok());
 
         let (new_state, _, events) = result.unwrap();
@@ -1188,8 +1188,7 @@ mod tests {
         };
         let ops = vec![Op::ChannelDeposit(deposit.clone())];
         let tx = create_multi_signed_tx(ops, vec![&Key::Zk(sk)]);
-        let result =
-            ledger_state.try_apply_tx::<_, HeaderId, MainnetGasConstants>(&test_config, &tx);
+        let result = ledger_state.try_apply_tx::<_, HeaderId, MainnetGasProfile>(&test_config, &tx);
         let (new_state, balance, events) = result.unwrap();
         // The deposited note is consumed and re-created as a channel note under
         // a new NoteId.
@@ -1267,7 +1266,7 @@ mod tests {
         let deposit_ops = vec![Op::ChannelDeposit(deposit)];
         let tx = create_multi_signed_tx(deposit_ops, vec![&Key::Zk(sk)]);
         ledger_state = ledger_state
-            .try_apply_tx::<_, HeaderId, MainnetGasConstants>(&test_config, &tx)
+            .try_apply_tx::<_, HeaderId, MainnetGasProfile>(&test_config, &tx)
             .unwrap()
             .0;
 
@@ -1301,7 +1300,7 @@ mod tests {
         );
 
         let result =
-            ledger_state.try_apply_tx::<_, HeaderId, MainnetGasConstants>(&test_config, &signed_tx);
+            ledger_state.try_apply_tx::<_, HeaderId, MainnetGasProfile>(&test_config, &signed_tx);
         assert!(result.is_ok());
 
         let (new_state, tx_balance, events) = result.unwrap();
@@ -1342,7 +1341,7 @@ mod tests {
         let deposit_tx =
             create_multi_signed_tx(vec![Op::ChannelDeposit(deposit)], vec![&Key::Zk(sk)]);
         ledger_state = ledger_state
-            .try_apply_tx::<_, HeaderId, MainnetGasConstants>(&test_config, &deposit_tx)
+            .try_apply_tx::<_, HeaderId, MainnetGasProfile>(&test_config, &deposit_tx)
             .unwrap()
             .0;
 
@@ -1368,15 +1367,15 @@ mod tests {
             vec![&Key::MultiSequencer(withdraw_proof)],
         );
         ledger_state = ledger_state
-            .try_apply_tx::<_, HeaderId, MainnetGasConstants>(&test_config, &signed_withdraw)
+            .try_apply_tx::<_, HeaderId, MainnetGasProfile>(&test_config, &signed_withdraw)
             .unwrap()
             .0;
 
         assert!(!ledger_state.latest_utxos().contains(&utxo.id()));
 
         // Replaying the signed deposit fails: its input no longer exists.
-        let result = ledger_state
-            .try_apply_tx::<_, HeaderId, MainnetGasConstants>(&test_config, &deposit_tx);
+        let result =
+            ledger_state.try_apply_tx::<_, HeaderId, MainnetGasProfile>(&test_config, &deposit_tx);
         assert!(result.is_err());
     }
 
@@ -1406,7 +1405,7 @@ mod tests {
         let deposit_ops = vec![Op::ChannelDeposit(deposit)];
         let tx = create_multi_signed_tx(deposit_ops, vec![&Key::Zk(sk)]);
         ledger_state = ledger_state
-            .try_apply_tx::<_, HeaderId, MainnetGasConstants>(&test_config, &tx)
+            .try_apply_tx::<_, HeaderId, MainnetGasProfile>(&test_config, &tx)
             .unwrap()
             .0;
         // The deposit re-created the note as a channel note
@@ -1441,7 +1440,7 @@ mod tests {
 
         let err = ledger_state
             .clone()
-            .try_apply_tx::<_, HeaderId, MainnetGasConstants>(&test_config, &signed_tx)
+            .try_apply_tx::<_, HeaderId, MainnetGasProfile>(&test_config, &signed_tx)
             .unwrap_err();
         assert_eq!(
             err,
@@ -1479,7 +1478,7 @@ mod tests {
             &Key::Ed25519(signing_key.clone()),
         );
         state = state
-            .try_apply_tx::<_, HeaderId, MainnetGasConstants>(&test_config, &first_tx)
+            .try_apply_tx::<_, HeaderId, MainnetGasProfile>(&test_config, &first_tx)
             .unwrap()
             .0;
 
@@ -1498,7 +1497,7 @@ mod tests {
         );
         let result = state
             .clone()
-            .try_apply_tx::<_, HeaderId, MainnetGasConstants>(&test_config, &second_tx);
+            .try_apply_tx::<_, HeaderId, MainnetGasProfile>(&test_config, &second_tx);
         assert!(matches!(
             result,
             Err(LedgerError::VerificationError(
@@ -1522,7 +1521,7 @@ mod tests {
             &Key::Ed25519(signing_key),
         );
         let empty_result =
-            state.try_apply_tx::<_, HeaderId, MainnetGasConstants>(&test_config, &empty_tx);
+            state.try_apply_tx::<_, HeaderId, MainnetGasProfile>(&test_config, &empty_tx);
         assert!(matches!(
             empty_result,
             Err(LedgerError::VerificationError(
@@ -1555,7 +1554,7 @@ mod tests {
             &Key::Ed25519(signing_key),
         );
         state = state
-            .try_apply_tx::<_, HeaderId, MainnetGasConstants>(&test_config, &first_tx)
+            .try_apply_tx::<_, HeaderId, MainnetGasProfile>(&test_config, &first_tx)
             .unwrap()
             .0;
 
@@ -1571,8 +1570,7 @@ mod tests {
             Op::ChannelInscribe(second_inscribe),
             &Key::Ed25519(unauthorized_signing_key),
         );
-        let result =
-            state.try_apply_tx::<_, HeaderId, MainnetGasConstants>(&test_config, &second_tx);
+        let result = state.try_apply_tx::<_, HeaderId, MainnetGasProfile>(&test_config, &second_tx);
         assert!(matches!(
             result,
             Err(LedgerError::VerificationError(
@@ -1657,7 +1655,7 @@ mod tests {
         );
 
         let result = state
-            .try_apply_tx::<_, HeaderId, MainnetGasConstants>(&test_config, &tx)
+            .try_apply_tx::<_, HeaderId, MainnetGasProfile>(&test_config, &tx)
             .unwrap()
             .0;
 
@@ -1799,7 +1797,7 @@ mod tests {
         );
         // Pays 2925 fees = 2705 execution base fee + 0 execution tip + 220 storage
         let fees = tx
-            .total_gas_cost::<MainnetGasConstants>(&ledger.get_gas_prices())
+            .total_gas_cost::<MainnetGasProfile>(&ledger.get_gas_prices())
             .unwrap();
         output_note.value = utxo.note.value - fees.into_inner();
         let tx = create_tx(vec![utxo.id()], vec![output_note], &[sk])
@@ -1808,7 +1806,7 @@ mod tests {
 
         let result = ledger
             .clone()
-            .try_apply_contents::<_, HeaderId, MainnetGasConstants>(&config, std::iter::once(&tx));
+            .try_apply_contents::<_, HeaderId, MainnetGasProfile>(&config, std::iter::once(&tx));
         // The `unwrap` should succeed because the user pays at least the base fee of
         // 2705
         result.unwrap();
@@ -1816,7 +1814,7 @@ mod tests {
         ledger.cryptarchia_ledger = ledger.cryptarchia_ledger.set_execution_base_fee(10.into());
 
         let err = ledger
-            .try_apply_contents::<_, HeaderId, MainnetGasConstants>(&config, std::iter::once(&tx))
+            .try_apply_contents::<_, HeaderId, MainnetGasProfile>(&config, std::iter::once(&tx))
             .unwrap_err();
         // The transaction should be rejected because the price indicated for execution
         // doesn't cover the base fee that cost 27 050
@@ -1840,7 +1838,7 @@ mod tests {
         // The tx pays 794 fees = 590 execution base fee + 0 execution tip + 204
         // storage
         let fees = tx
-            .total_gas_cost::<MainnetGasConstants>(&ledger.get_gas_prices())
+            .total_gas_cost::<MainnetGasProfile>(&ledger.get_gas_prices())
             .unwrap();
         output_note.value = utxo.note.value - fees.into_inner();
         let tx = create_tx(
@@ -1853,7 +1851,7 @@ mod tests {
 
         let result = ledger
             .clone()
-            .try_apply_contents::<_, HeaderId, MainnetGasConstants>(&config, std::iter::once(&tx));
+            .try_apply_contents::<_, HeaderId, MainnetGasProfile>(&config, std::iter::once(&tx));
         // The `unwrap` should succeed because the user pays at least the base fee of
         // 794
         let (no_priority_fee_ledger, events) = result.unwrap();
@@ -1871,7 +1869,7 @@ mod tests {
         .unwrap();
 
         let result = ledger
-            .try_apply_contents::<_, HeaderId, MainnetGasConstants>(&config, std::iter::once(&tx));
+            .try_apply_contents::<_, HeaderId, MainnetGasProfile>(&config, std::iter::once(&tx));
         // The `unwrap` should succeed because the user pays at least the base fee of
         // 794
         let (priority_fee_ledger, events) = result.unwrap();
@@ -1913,7 +1911,7 @@ mod tests {
         assert!(storage_gas.into_inner() > 0);
 
         let (applied, _) = ledger
-            .try_apply_contents::<_, HeaderId, MainnetGasConstants>(&config, std::iter::once(&tx))
+            .try_apply_contents::<_, HeaderId, MainnetGasProfile>(&config, std::iter::once(&tx))
             .unwrap();
 
         // Storage gas consumed by the tx should be accumulated in the ledger
@@ -2174,7 +2172,7 @@ mod tests {
             assert_eq!(state.mantle_ledger.pow.epoch_reward(), 0);
 
             let err = state
-                .try_apply_tx::<_, HeaderId, MainnetGasConstants>(&config, &claim_tx())
+                .try_apply_tx::<_, HeaderId, MainnetGasProfile>(&config, &claim_tx())
                 .expect_err("claim should fail validation");
 
             assert!(matches!(
@@ -2193,7 +2191,7 @@ mod tests {
             let (state, config) = pow_ledger_state(1_000);
 
             let err = state
-                .try_apply_tx::<_, HeaderId, MainnetGasConstants>(&config, &claim_tx())
+                .try_apply_tx::<_, HeaderId, MainnetGasProfile>(&config, &claim_tx())
                 .expect_err("claim should fail validation");
 
             assert!(matches!(
@@ -2230,7 +2228,7 @@ mod tests {
             let epoch_reward = state.mantle_ledger.pow.epoch_reward();
 
             let (state, _balance, events) = state
-                .try_apply_tx::<_, HeaderId, MainnetGasConstants>(&config, &claim_tx())
+                .try_apply_tx::<_, HeaderId, MainnetGasProfile>(&config, &claim_tx())
                 .expect("claim should validate and execute");
 
             assert_eq!(
@@ -2269,11 +2267,11 @@ mod tests {
             // during tx-level validation.
             let (state, config) = claim_accepting_state();
             let (state, _, _) = state
-                .try_apply_tx::<_, HeaderId, MainnetGasConstants>(&config, &claim_tx())
+                .try_apply_tx::<_, HeaderId, MainnetGasProfile>(&config, &claim_tx())
                 .expect("first claim should succeed");
 
             let err = state
-                .try_apply_tx::<_, HeaderId, MainnetGasConstants>(&config, &claim_tx())
+                .try_apply_tx::<_, HeaderId, MainnetGasProfile>(&config, &claim_tx())
                 .expect_err("second claim should be rejected");
 
             assert!(matches!(
@@ -2303,7 +2301,7 @@ mod tests {
             let tx_hash = TxHash::from([9u8; 32]);
 
             let (state, _balance, events) = state
-                .try_apply_op::<HeaderId, MainnetGasConstants>(
+                .try_apply_op::<HeaderId, MainnetGasProfile>(
                     &Op::ClaimPowReward(op.clone()),
                     &config,
                     &tx_hash,
@@ -2372,22 +2370,10 @@ mod tests {
             let tx_hash = TxHash::from([9u8; 32]);
 
             let (state, _, _) = state
-                .try_apply_op::<HeaderId, MainnetGasConstants>(
-                    &op,
-                    &config,
-                    &tx_hash,
-                    0,
-                    Vec::new(),
-                )
+                .try_apply_op::<HeaderId, MainnetGasProfile>(&op, &config, &tx_hash, 0, Vec::new())
                 .expect("first claim should succeed");
             let (state, _, _) = state
-                .try_apply_op::<HeaderId, MainnetGasConstants>(
-                    &op,
-                    &config,
-                    &tx_hash,
-                    0,
-                    Vec::new(),
-                )
+                .try_apply_op::<HeaderId, MainnetGasProfile>(&op, &config, &tx_hash, 0, Vec::new())
                 .expect("second claim currently also succeeds (no validation)");
 
             assert_eq!(

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -784,7 +784,7 @@ mod tests {
     use cryptarchia::tests::{config, generate_proof, utxo};
     use lb_core::{
         mantle::{
-            GasCalculator as _, Note, OpProof, RawMantleTx, SignedMantleTx,
+            Note, OpProof, RawMantleTx, SignedMantleTx, TxGasCalculator as _,
             gas::MainnetGasProfile,
             ledger::{Inputs, Outputs, Utxos, VerifiableOperation as _},
             ops::{

--- a/services/chain/chain-leader/src/lib.rs
+++ b/services/chain/chain-leader/src/lib.rs
@@ -21,7 +21,7 @@ use lb_core::{
     header::HeaderId,
     mantle::{
         SignedMantleTx,
-        gas::MainnetGasConstants,
+        gas::MainnetGasProfile,
         traits::{Hashable, MantleTxWithProofs, StorageSize},
         transactions::{hash::TxHash, states::Preverified},
     },
@@ -619,7 +619,7 @@ where
             for tx in pending {
                 match ledger_state
                     .clone()
-                    .try_apply_contents::<_, HeaderId, MainnetGasConstants>(
+                    .try_apply_contents::<_, HeaderId, MainnetGasProfile>(
                         ledger_config,
                         iter::once(&tx),
                     ) {

--- a/services/chain/chain-service/src/lib.rs
+++ b/services/chain/chain-service/src/lib.rs
@@ -27,7 +27,7 @@ use lb_core::{
     events::Events,
     header::HeaderId,
     mantle::{
-        gas::MainnetGasConstants,
+        gas::MainnetGasProfile,
         traits::{MantleTxWithProofs, PreverifiedMantleTx},
         transactions::GasPrices,
     },
@@ -379,7 +379,7 @@ impl Cryptarchia {
         // A block number of this block if it's applied to the chain.
         let (_, state, events) = self
             .ledger
-            .prepare_update::<_, _, MainnetGasConstants>(
+            .prepare_update::<_, _, MainnetGasProfile>(
                 id,
                 parent,
                 slot,

--- a/services/wallet/src/lib.rs
+++ b/services/wallet/src/lib.rs
@@ -17,7 +17,7 @@ use lb_core::{
     header::HeaderId,
     mantle::{
         NoteId, Op, OpProof, SignedMantleTx, TxHash, Utxo, Value, VerificationError,
-        gas::{GasCost, GasOverflow, MainnetGasConstants},
+        gas::{GasCost, GasOverflow, MainnetGasProfile},
         ledger::Inputs,
         ops::{
             NoOpProof, ZkAndEd25519Proof,
@@ -557,7 +557,7 @@ where
                     }
                 };
 
-                let funded = match state.fund_tx::<MainnetGasConstants>(
+                let funded = match state.fund_tx::<MainnetGasProfile>(
                     tip,
                     &tx_builder,
                     change_pk,
@@ -1267,7 +1267,7 @@ where
             pk: request.funding_pk,
         }))?;
 
-        let funded_tx_builder = state.fund_tx::<MainnetGasConstants>(
+        let funded_tx_builder = state.fund_tx::<MainnetGasProfile>(
             request.tip,
             &tx_builder,
             request.funding_pk,
@@ -1299,7 +1299,7 @@ where
     ) -> Result<SignedMantleTx<Preverified>, WalletServiceError> {
         let context = ledger.tx_context();
         let net_balance = funded_tx_builder.net_balance();
-        let gas_cost = funded_tx_builder.minimum_gas_cost::<MainnetGasConstants>(&context)?;
+        let gas_cost = funded_tx_builder.minimum_gas_cost::<MainnetGasProfile>(&context)?;
         debug!(
             target: LOG_TARGET,
             net_balance,

--- a/services/wallet/src/states.rs
+++ b/services/wallet/src/states.rs
@@ -6,7 +6,7 @@ use std::{
 use lb_core::{
     header::HeaderId,
     mantle::{
-        GasConstants, NoteId, Value,
+        GasProfile, NoteId, Value,
         ops::leader_claim::{VoucherCm, VoucherNullifier},
         transactions::{MantleTxBuilder, MantleTxContext},
     },
@@ -360,7 +360,7 @@ impl<'u> ServiceState<'u> {
     /// Fund `tx_builder` from the wallet's UTXOs at `tip`, excluding notes
     /// already reserved for in-flight transactions. `priority_fee` is left
     /// as excess balance above the mandatory fee (the execution tip).
-    pub fn fund_tx<G: GasConstants>(
+    pub fn fund_tx<G: GasProfile>(
         &self,
         tip: HeaderId,
         tx_builder: &MantleTxBuilder,

--- a/tests/src/common/fee_spec.rs
+++ b/tests/src/common/fee_spec.rs
@@ -20,7 +20,7 @@ use std::collections::{HashMap, HashSet};
 use lb_common_http_client::ApiBlock;
 use lb_core::mantle::{
     Note, Op, SignedMantleTx, Utxo,
-    gas::{GasCalculator as _, MainnetGasConstants},
+    gas::{GasCalculator as _, MainnetGasProfile},
     traits::Hashable as _,
     transactions::{
         GasPrices, MantleTxBuilder, MantleTxContext, MantleTxGasContext,
@@ -157,7 +157,7 @@ pub fn self_transfer_paying_fee_at(
     let fee_for_output = |output_value: u64| {
         i128::from(
             builder_with_output(output_value)
-                .minimum_gas_cost::<MainnetGasConstants>(&context)
+                .minimum_gas_cost::<MainnetGasProfile>(&context)
                 .expect("gas cost should calculate")
                 .into_inner(),
         )
@@ -199,7 +199,7 @@ pub fn self_transfer_paying_fee_at(
 
     assert_eq!(
         builder
-            .funding_delta::<MainnetGasConstants>(&context)
+            .funding_delta::<MainnetGasProfile>(&context)
             .expect("funding delta should calculate"),
         tip,
         "the built transaction must carry exactly the requested tip"
@@ -284,7 +284,7 @@ pub fn fee_surplus_at<State: VerificationState>(
 ) -> Result<i128, String> {
     let paid = net_balance_against(genesis_utxos, tx)?;
     let required = tx
-        .total_gas_cost::<MainnetGasConstants>(prices)
+        .total_gas_cost::<MainnetGasProfile>(prices)
         .map_err(|source| format!("transaction gas cost calculation failed: {source}"))?;
 
     Ok(i128::from(paid) - i128::from(required.into_inner()))

--- a/tests/src/common/fee_spec.rs
+++ b/tests/src/common/fee_spec.rs
@@ -20,7 +20,7 @@ use std::collections::{HashMap, HashSet};
 use lb_common_http_client::ApiBlock;
 use lb_core::mantle::{
     Note, Op, SignedMantleTx, Utxo,
-    gas::{GasCalculator as _, MainnetGasProfile},
+    gas::{MainnetGasProfile, TxGasCalculator as _},
     traits::Hashable as _,
     transactions::{
         GasPrices, MantleTxBuilder, MantleTxContext, MantleTxGasContext,

--- a/tests/src/common/wallet/funding_from_chain.rs
+++ b/tests/src/common/wallet/funding_from_chain.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use lb_common_http_client::Error as HttpClientError;
 use lb_core::mantle::{
     Op, OpProof, SignedMantleTx, TxHash, Utxo,
-    gas::MainnetGasConstants,
+    gas::MainnetGasProfile,
     ops::channel::{ChannelId, ChannelKeyIndex},
     traits::Hashable as _,
     transactions::{
@@ -74,7 +74,7 @@ pub async fn funded_signed_tx(
     let funded_builder = fund_builder_from_wallet_source(&funding_source, &tx_builder, &tx_context)
         .expect("funding transaction should succeed");
     let fee = funded_builder
-        .minimum_gas_cost::<MainnetGasConstants>(&tx_context)
+        .minimum_gas_cost::<MainnetGasProfile>(&tx_context)
         .expect("funded tx gas cost should calculate")
         .into_inner();
 

--- a/tests/src/common/wallet/transaction/builder_funding.rs
+++ b/tests/src/common/wallet/transaction/builder_funding.rs
@@ -4,7 +4,7 @@ use std::{cmp::Ordering, collections::HashSet};
 
 use lb_core::mantle::{
     Note, Op, Utxo,
-    gas::MainnetGasConstants,
+    gas::MainnetGasProfile,
     ledger::{Inputs, Outputs},
     ops::transfer::TransferOp,
     transactions::{MantleTxBuilder, MantleTxContext},
@@ -25,7 +25,7 @@ pub fn fund_builder_from_wallet_source(
     tx_builder: &MantleTxBuilder,
     context: &MantleTxContext,
 ) -> Result<MantleTxBuilder, WalletError> {
-    wallet_state_from_utxos(source.available_utxos().to_vec()).fund_tx::<MainnetGasConstants>(
+    wallet_state_from_utxos(source.available_utxos().to_vec()).fund_tx::<MainnetGasProfile>(
         tx_builder,
         source.public_key(),
         [source.public_key()],
@@ -222,13 +222,13 @@ fn evaluate_standard_funding_inputs(
     let funded_builder = extend_wallet_funding_inputs(tx_builder, selected_inputs)?;
 
     match funded_builder
-        .funding_delta::<MainnetGasConstants>(context)?
+        .funding_delta::<MainnetGasProfile>(context)?
         .cmp(&0)
     {
         Ordering::Less => Ok(WalletFundingOutcome::NeedsMoreInputs),
         Ordering::Equal => Ok(WalletFundingOutcome::Funded(funded_builder)),
         Ordering::Greater => Ok(funded_builder
-            .return_change::<MainnetGasConstants>(context, change_pk, 0)?
+            .return_change::<MainnetGasProfile>(context, change_pk, 0)?
             .map_or(
                 WalletFundingOutcome::NeedsMoreInputs,
                 WalletFundingOutcome::Funded,
@@ -354,7 +354,7 @@ fn funding_delta_for_chunked_builder(
 ) -> Result<i128, WalletError> {
     let gas_cost = u128::from(
         tx_builder
-            .minimum_gas_cost::<MainnetGasConstants>(context)?
+            .minimum_gas_cost::<MainnetGasProfile>(context)?
             .into_inner(),
     );
     Ok(i128::try_from(input_sum)
@@ -401,7 +401,7 @@ mod tests {
             .expect("inscription test builder should fit op bounds");
         assert_eq!(
             tx_builder
-                .funding_delta::<MainnetGasConstants>(&context)
+                .funding_delta::<MainnetGasProfile>(&context)
                 .expect("zero-gas inscription funding delta should calculate"),
             0
         );
@@ -422,7 +422,7 @@ mod tests {
         assert_eq!(funded_builder.ledger_inputs(), &[funding_utxo]);
         assert_eq!(
             funded_builder
-                .funding_delta::<MainnetGasConstants>(&context)
+                .funding_delta::<MainnetGasProfile>(&context)
                 .expect("funded inscription delta should calculate"),
             0
         );

--- a/tests/src/common/wallet/transaction/signing.rs
+++ b/tests/src/common/wallet/transaction/signing.rs
@@ -3,7 +3,7 @@
 use std::collections::HashMap;
 
 use lb_core::mantle::{
-    GasCalculator as _, NoteId, Op, OpProof, RawMantleTx, SignedMantleTx, TxHash,
+    NoteId, Op, OpProof, RawMantleTx, SignedMantleTx, TxGasCalculator as _, TxHash,
     gas::MainnetGasProfile,
     traits::Hashable as _,
     transactions::{MantleTxBuilder, MantleTxContext, OpsProofs, mantle_tx::MantleTx as _},

--- a/tests/src/common/wallet/transaction/signing.rs
+++ b/tests/src/common/wallet/transaction/signing.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 
 use lb_core::mantle::{
     GasCalculator as _, NoteId, Op, OpProof, RawMantleTx, SignedMantleTx, TxHash,
-    gas::MainnetGasConstants,
+    gas::MainnetGasProfile,
     traits::Hashable as _,
     transactions::{MantleTxBuilder, MantleTxContext, OpsProofs, mantle_tx::MantleTx as _},
 };
@@ -31,7 +31,7 @@ pub(super) fn sign_prepared_wallet_transaction(
 
     let signed_tx = SignedMantleTx::new(mantle_tx, op_proofs).preverify()?;
     let spent_fee = signed_tx
-        .total_gas_cost::<MainnetGasConstants>(&gas_prices)?
+        .total_gas_cost::<MainnetGasProfile>(&gas_prices)?
         .into_inner();
 
     Ok(SignedWalletTransaction::new(

--- a/tests/src/cucumber/steps/manual_transactions/drain_wallets.rs
+++ b/tests/src/cucumber/steps/manual_transactions/drain_wallets.rs
@@ -6,7 +6,7 @@ use std::{
 
 use lb_core::mantle::{
     Note, Utxo,
-    gas::{GasCost, MainnetGasConstants},
+    gas::{GasCost, MainnetGasProfile},
     ledger::MAX_TRANSACTION_INPUTS,
     transactions::{
         GENESIS_EXECUTION_GAS_PRICE, GasPrices, MantleTxBuilder, MantleTxContext,
@@ -480,7 +480,7 @@ fn finalize_fee(builder: &MantleTxBuilder) -> Result<u64, StepError> {
         ..MantleTxContext::default()
     };
     builder
-        .minimum_gas_cost::<MainnetGasConstants>(&context)
+        .minimum_gas_cost::<MainnetGasProfile>(&context)
         .map(GasCost::into_inner)
         .map_err(|error| StepError::LogicalError {
             message: error.to_string(),

--- a/tests/testing_framework/src/workloads/transaction/workload.rs
+++ b/tests/testing_framework/src/workloads/transaction/workload.rs
@@ -10,7 +10,7 @@ use std::{
 use async_trait::async_trait;
 use lb_core::mantle::{
     Note, OpProof, SignedMantleTx, Utxo,
-    gas::MainnetGasConstants,
+    gas::MainnetGasProfile,
     ops::OpId as _,
     traits::{GenesisTx as _, Hashable as _},
     transactions::{GasPrices, MantleTxBuilder, MantleTxGasContext, states::Preverified},
@@ -289,7 +289,7 @@ fn build_wallet_transaction(
         .map_err(|err| format!("failed to build provisional tx: {err}"))?;
 
     let fee = provisional_tx
-        .minimum_total_gas_cost::<MainnetGasConstants>(gas_context)?
+        .minimum_total_gas_cost::<MainnetGasProfile>(gas_context)?
         .into_inner();
     let output_value = input.utxo.note.value.checked_sub(fee).ok_or_else(|| {
         format!(

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -15,7 +15,7 @@ use lb_core::{
     events::{Event, Events, HeaderEvent, TxEvent, TxEventPayload},
     header::HeaderId,
     mantle::{
-        GasConstants, NoteId, TxHash, Utxo, Value,
+        GasProfile, NoteId, TxHash, Utxo, Value,
         ops::{
             Op, OpId as _,
             channel::{
@@ -234,7 +234,7 @@ impl WalletState {
     /// Funds the transaction so its excess balance is exactly
     /// `priority_fee` above the mandatory fee — the excess is the
     /// transaction's execution tip. `0` funds to the exact minimum.
-    pub fn fund_tx<G: GasConstants>(
+    pub fn fund_tx<G: GasProfile>(
         &self,
         tx_builder: &MantleTxBuilder,
         change_pk: ZkPublicKey,
@@ -791,7 +791,7 @@ where
         clippy::too_many_arguments,
         reason = "thin passthrough to `WalletState::fund_tx` plus the tip"
     )]
-    pub fn fund_tx<G: GasConstants>(
+    pub fn fund_tx<G: GasProfile>(
         &self,
         tip: HeaderId,
         tx_builder: &MantleTxBuilder,
@@ -873,7 +873,7 @@ mod tests {
         mantle::{
             Note, OpProof, RawMantleTx, SignedMantleTx,
             channel::Channels,
-            gas::MainnetGasConstants as Gas,
+            gas::MainnetGasProfile as Gas,
             ledger::{Inputs, Outputs},
             ops::channel::{
                 ChannelId, MsgId,


### PR DESCRIPTION
## 1. What does this PR implement?
Yet another step into `SignedOp`.

1. Move each operation's gas constant onto the operation itself via `OperationGas<Constants>::GAS_CONSTANT`.
   Keys the constant to the operation type instead of a name lookup on a shared trait.
2. Rename `GasConstants`/`MainnetGasConstants` to `GasProfile`/`MainnetGasProfile`.
   Profile is a better fitting name after 1.
3. Add `SignedOperationExecutionGas`, giving each `SignedOp<Op, State, Mode>` its own `gas_multiplier` and `execution_gas`.
   This provides needed functionality to enable `SignedMantleTx` to calculate (execution) gas after we update it to use `SignedOp`.
4. Drop unused `OperationGas`'s `ProvableOperation` supertrait.
5. Rename `GasCalculator` to `TxGasCalculator`.
   Make clear the intention of the calculator, now that we have gas traits at the operation level too.
6. Standardize the internal calls in `SignedMantleTx`'s `TxGasCalculator` impl and drop the now-unused `&T` blanket impls for `TxGasCalculator`, `MantleTxWithProofs`, and `PreverifiedMantleTx`.

## 2. Does the code have enough context to be clearly understood?
Yes

## 3. Who are the specification authors and who is accountable for this PR?
@strinnityk 

## 4. Is the specification accurate and complete?
N/A

## 5. Does the implementation introduce changes in the specification?
N/A

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [X] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [X] 2. Description added.
* [X] 3. Context and links to Specification document(s) added.
* [X] 4. Main contact(s) (developers and specification authors) added
* [X] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [X] 6. Link PR to a specific milestone.
* [X] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
