### PR TITLE
feat(utils): add with_capacity constructor to BoundedVec

### DIFF
--- a/core/src/block/genesis.rs
+++ b/core/src/block/genesis.rs
@@ -64,6 +64,9 @@ const fn map_notes_bounded_error(error: &BoundedError) -> Error {
             len: *len,
         },
         BoundedError::EmptyInput => Error::EmptyNotes,
+        BoundedError::CapacityOutOfBounds { .. } => {
+            panic!("CapacityOutOfBounds should not occur here")
+        }
     }
 }
 
@@ -828,6 +831,9 @@ where
             }
             BoundedError::EmptyInput | BoundedError::TooFewItems { .. } => {
                 unreachable!("GenesisSDPDeclareOps has a zero minimum bound")
+            }
+            BoundedError::CapacityOutOfBounds { .. } => {
+                unreachable!("CapacityOutOfBounds should not occur here")
             }
             BoundedError::IndexOutOfBounds { .. } => {
                 unreachable!("construction cannot produce an index error")

--- a/utils/src/bounded/mod.rs
+++ b/utils/src/bounded/mod.rs
@@ -35,7 +35,11 @@ pub enum BoundedError {
     #[error("Index {index} is out of bounds for length {len}")]
     IndexOutOfBounds { index: usize, len: usize },
     #[error("Requested capacity {capacity} is out of bounds [{min}, {max}]")]
-    CapacityOutOfBounds { min: usize, max: usize, capacity: usize },
+    CapacityOutOfBounds {
+        min: usize,
+        max: usize,
+        capacity: usize,
+    },
 }
 
 /// The measured length of a value, in whatever unit is natural for its type:

--- a/utils/src/bounded/mod.rs
+++ b/utils/src/bounded/mod.rs
@@ -34,6 +34,8 @@ pub enum BoundedError {
     TooManyItems { count: usize, max: usize },
     #[error("Index {index} is out of bounds for length {len}")]
     IndexOutOfBounds { index: usize, len: usize },
+    #[error("Requested capacity {capacity} is out of bounds [{min}, {max}]")]
+    CapacityOutOfBounds { min: usize, max: usize, capacity: usize },
 }
 
 /// The measured length of a value, in whatever unit is natural for its type:

--- a/utils/src/bounded/vec.rs
+++ b/utils/src/bounded/vec.rs
@@ -37,14 +37,19 @@ impl<T, const MIN: usize, const MAX: usize> Bounded<Vec<T>, MIN, MAX> {
     /// Constructs an empty vector with at least the specified capacity.
     ///
     /// The `capacity` must be within the `[MIN, MAX]` bounds; returns
-    /// [`BoundedError::CapacityOutOfBounds`] when `capacity` is outside this range.
+    /// [`BoundedError::CapacityOutOfBounds`] when `capacity` is outside this
+    /// range.
     ///
     /// This does **not** change the length of the vector (it is still zero
     /// after construction), but pre-allocates space so that at least
     /// `capacity` elements can be pushed without reallocation.
     pub fn with_capacity(capacity: usize) -> Result<Self, BoundedError> {
         if MIN > 0 || capacity > MAX {
-            return Err(BoundedError::CapacityOutOfBounds { min: MIN, max: MAX, capacity });
+            return Err(BoundedError::CapacityOutOfBounds {
+                min: MIN,
+                max: MAX,
+                capacity,
+            });
         }
         Ok(Self::new_unchecked(Vec::with_capacity(capacity)))
     }
@@ -57,14 +62,8 @@ impl<T, const MIN: usize, const MAX: usize> Bounded<Vec<T>, MIN, MAX> {
     #[must_use]
     pub fn with_const_capacity<const CAPACITY: usize>() -> Self {
         const {
-            assert!(
-                MIN == 0,
-                "Cannot construct empty BoundedVec when MIN > 0"
-            );
-            assert!(
-                CAPACITY <= MAX,
-                "Requested capacity exceeds BoundedVec MAX"
-            );
+            assert!(MIN == 0, "Cannot construct empty BoundedVec when MIN > 0");
+            assert!(CAPACITY <= MAX, "Requested capacity exceeds BoundedVec MAX");
         }
         Self::new_unchecked(Vec::with_capacity(CAPACITY))
     }
@@ -756,7 +755,6 @@ mod tests {
         assert!(v.as_inner().capacity() >= 5);
     }
 
-
     #[test]
     fn with_capacity_within_bounds_succeeds() {
         type V = BoundedVec<u32, 0, 10>;
@@ -778,7 +776,11 @@ mod tests {
         type V = BoundedVec<u32, 0, 4>;
         assert!(matches!(
             V::with_capacity(5),
-            Err(BoundedError::CapacityOutOfBounds { min: 0, max: 4, capacity: 5 })
+            Err(BoundedError::CapacityOutOfBounds {
+                min: 0,
+                max: 4,
+                capacity: 5
+            })
         ));
     }
 
@@ -787,8 +789,11 @@ mod tests {
         type V = BoundedVec<u32, 2, 10>;
         assert!(matches!(
             V::with_capacity(5),
-            Err(BoundedError::CapacityOutOfBounds { min: 2, max: 10, capacity: 5 })
+            Err(BoundedError::CapacityOutOfBounds {
+                min: 2,
+                max: 10,
+                capacity: 5
+            })
         ));
     }
-
 }

--- a/utils/src/bounded/vec.rs
+++ b/utils/src/bounded/vec.rs
@@ -44,11 +44,8 @@ impl<T, const MIN: usize, const MAX: usize> Bounded<Vec<T>, MIN, MAX> {
     /// after construction), but pre-allocates space so that at least
     /// `capacity` elements can be pushed without reallocation.
     pub fn with_capacity(capacity: usize) -> Result<Self, BoundedError> {
-        if capacity < MIN {
-            return Err(BoundedError::TooFewItems { count: capacity, min: MIN });
-        }
-        if capacity > MAX {
-            return Err(BoundedError::TooManyItems { count: capacity, max: MAX });
+        if capacity < MIN || capacity > MAX {
+            return Err(BoundedError::CapacityOutOfBounds { min: MIN, max: MAX, capacity });
         }
         Ok(Self::new_unchecked(Vec::with_capacity(capacity)))
     }
@@ -436,7 +433,7 @@ mod tests {
         let mut bv = TestBoundedVectorMin2::try_from(vec![1, 2, 3, 4]).unwrap();
         assert_eq!(
             bv.try_push(5),
-            Err(BoundedError::TooManyItems { count: 5, max: 4 })
+            Err(BoundedError::CapacityOutOfBounds { min: 0, max: 4, capacity: 5 })
         );
         // The failed push must not have mutated the vector.
         assert_eq!(bv.as_slice(), &[1, 2, 3, 4]);
@@ -471,11 +468,11 @@ mod tests {
     fn try_from_rejects_input_above_max() {
         assert_eq!(
             TestBoundedVectorMin2::try_from(vec![1, 2, 3, 4, 5]),
-            Err(BoundedError::TooManyItems { count: 5, max: 4 })
+            Err(BoundedError::CapacityOutOfBounds { min: 0, max: 4, capacity: 5 })
         );
         assert_eq!(
             TestBoundedVectorMin0::try_from(vec![1, 2, 3, 4, 5]),
-            Err(BoundedError::TooManyItems { count: 5, max: 4 })
+            Err(BoundedError::CapacityOutOfBounds { min: 0, max: 4, capacity: 5 })
         );
     }
 
@@ -662,7 +659,7 @@ mod tests {
     fn try_from_iter_rejects_items_above_maximum() {
         let result = TestBoundedVectorMin0::try_from_iter([1, 2, 3, 4, 5]);
 
-        assert_eq!(result, Err(BoundedError::TooManyItems { count: 5, max: 4 }));
+        assert_eq!(result, Err(BoundedError::CapacityOutOfBounds { min: 0, max: 4, capacity: 5 }));
     }
 
     #[test]
@@ -781,7 +778,7 @@ mod tests {
         type V = BoundedVec<u32, 0, 4>;
         assert!(matches!(
             V::with_capacity(5),
-            Err(BoundedError::TooManyItems { count: 5, max: 4 })
+            Err(BoundedError::CapacityOutOfBounds { min: 0, max: 4, capacity: 5 })
         ));
     }
 
@@ -790,7 +787,7 @@ mod tests {
         type V = BoundedVec<u32, 3, 8>;
         assert!(matches!(
             V::with_capacity(2),
-            Err(BoundedError::TooFewItems { count: 2, min: 3 })
+            Err(BoundedError::CapacityOutOfBounds { min: 3, max: 8, capacity: 2 })
         ));
     }
 

--- a/utils/src/bounded/vec.rs
+++ b/utils/src/bounded/vec.rs
@@ -53,6 +53,26 @@ impl<T, const MIN: usize, const MAX: usize> Bounded<Vec<T>, MIN, MAX> {
         Ok(Self::new_unchecked(Vec::with_capacity(capacity)))
     }
 
+    /// Constructs an empty vector with exactly `CAPACITY` pre-allocated slots,
+    /// with the bounds enforced at **compile time**.
+    ///
+    /// Panics at compile time when `CAPACITY > MAX` or when `MIN > 0` (since
+    /// the resulting vector would be immediately below the minimum bound).
+    #[must_use]
+    pub fn with_const_capacity<const CAPACITY: usize>() -> Self {
+        const {
+            assert!(
+                MIN == 0,
+                "Cannot construct empty BoundedVec when MIN > 0"
+            );
+            assert!(
+                CAPACITY <= MAX,
+                "Requested capacity exceeds BoundedVec MAX"
+            );
+        }
+        Self::new_unchecked(Vec::with_capacity(CAPACITY))
+    }
+
     /// Returns the number of elements in the vector.
     #[must_use]
     pub const fn len(&self) -> usize {
@@ -730,6 +750,14 @@ mod tests {
             mapped.as_slice(),
             &[MyNewType(10), MyNewType(20), MyNewType(30), MyNewType(40),]
         );
+    }
+
+    #[test]
+    fn with_const_capacity_succeeds() {
+        type V = BoundedVec<u32, 0, 10>;
+        let v = V::with_const_capacity::<5>();
+        assert_eq!(v.len(), 0);
+        assert!(v.as_inner().capacity() >= 5);
     }
 
     #[test]

--- a/utils/src/bounded/vec.rs
+++ b/utils/src/bounded/vec.rs
@@ -43,7 +43,7 @@ impl<T, const MIN: usize, const MAX: usize> Bounded<Vec<T>, MIN, MAX> {
     /// after construction), but pre-allocates space so that at least
     /// `capacity` elements can be pushed without reallocation.
     pub fn with_capacity(capacity: usize) -> Result<Self, BoundedError> {
-        if capacity < MIN || capacity > MAX {
+        if MIN > 0 || capacity > MAX {
             return Err(BoundedError::CapacityOutOfBounds { min: MIN, max: MAX, capacity });
         }
         Ok(Self::new_unchecked(Vec::with_capacity(capacity)))
@@ -432,7 +432,7 @@ mod tests {
         let mut bv = TestBoundedVectorMin2::try_from(vec![1, 2, 3, 4]).unwrap();
         assert_eq!(
             bv.try_push(5),
-            Err(BoundedError::CapacityOutOfBounds { min: 0, max: 4, capacity: 5 })
+            Err(BoundedError::TooManyItems { count: 5, max: 4 })
         );
         // The failed push must not have mutated the vector.
         assert_eq!(bv.as_slice(), &[1, 2, 3, 4]);
@@ -467,11 +467,11 @@ mod tests {
     fn try_from_rejects_input_above_max() {
         assert_eq!(
             TestBoundedVectorMin2::try_from(vec![1, 2, 3, 4, 5]),
-            Err(BoundedError::CapacityOutOfBounds { min: 0, max: 4, capacity: 5 })
+            Err(BoundedError::TooManyItems { count: 5, max: 4 })
         );
         assert_eq!(
             TestBoundedVectorMin0::try_from(vec![1, 2, 3, 4, 5]),
-            Err(BoundedError::CapacityOutOfBounds { min: 0, max: 4, capacity: 5 })
+            Err(BoundedError::TooManyItems { count: 5, max: 4 })
         );
     }
 
@@ -658,7 +658,7 @@ mod tests {
     fn try_from_iter_rejects_items_above_maximum() {
         let result = TestBoundedVectorMin0::try_from_iter([1, 2, 3, 4, 5]);
 
-        assert_eq!(result, Err(BoundedError::CapacityOutOfBounds { min: 0, max: 4, capacity: 5 }));
+        assert_eq!(result, Err(BoundedError::TooManyItems { count: 5, max: 4 }));
     }
 
     #[test]
@@ -756,9 +756,10 @@ mod tests {
         assert!(v.as_inner().capacity() >= 5);
     }
 
+
     #[test]
     fn with_capacity_within_bounds_succeeds() {
-        type V = BoundedVec<u32, 2, 10>;
+        type V = BoundedVec<u32, 0, 10>;
         let v = V::with_capacity(5).unwrap();
         assert_eq!(v.len(), 0);
         assert!(v.as_inner().capacity() >= 5);
@@ -782,11 +783,11 @@ mod tests {
     }
 
     #[test]
-    fn with_capacity_below_min_returns_error() {
-        type V = BoundedVec<u32, 3, 8>;
+    fn with_capacity_rejects_nonzero_min() {
+        type V = BoundedVec<u32, 2, 10>;
         assert!(matches!(
-            V::with_capacity(2),
-            Err(BoundedError::CapacityOutOfBounds { min: 3, max: 8, capacity: 2 })
+            V::with_capacity(5),
+            Err(BoundedError::CapacityOutOfBounds { min: 2, max: 10, capacity: 5 })
         ));
     }
 

--- a/utils/src/bounded/vec.rs
+++ b/utils/src/bounded/vec.rs
@@ -34,6 +34,25 @@ impl<T, const MIN: usize, const MAX: usize> Bounded<Vec<T>, MIN, MAX> {
         Self::new_unchecked(Vec::new())
     }
 
+    /// Constructs an empty vector with at least the specified capacity.
+    ///
+    /// The `capacity` must be within the `[MIN, MAX]` bounds; returns
+    /// [`BoundedError::TooFewItems`] when `capacity < MIN` and
+    /// [`BoundedError::TooManyItems`] when `capacity > MAX`.
+    ///
+    /// This does **not** change the length of the vector (it is still zero
+    /// after construction), but pre-allocates space so that at least
+    /// `capacity` elements can be pushed without reallocation.
+    pub fn with_capacity(capacity: usize) -> Result<Self, BoundedError> {
+        if capacity < MIN {
+            return Err(BoundedError::TooFewItems { count: capacity, min: MIN });
+        }
+        if capacity > MAX {
+            return Err(BoundedError::TooManyItems { count: capacity, max: MAX });
+        }
+        Ok(Self::new_unchecked(Vec::with_capacity(capacity)))
+    }
+
     /// Returns the number of elements in the vector.
     #[must_use]
     pub const fn len(&self) -> usize {
@@ -712,4 +731,39 @@ mod tests {
             &[MyNewType(10), MyNewType(20), MyNewType(30), MyNewType(40),]
         );
     }
+
+    #[test]
+    fn with_capacity_within_bounds_succeeds() {
+        type V = BoundedVec<u32, 2, 10>;
+        let v = V::with_capacity(5).unwrap();
+        assert_eq!(v.len(), 0);
+        assert!(v.as_inner().capacity() >= 5);
+    }
+
+    #[test]
+    fn with_capacity_at_max_succeeds() {
+        type V = BoundedVec<u32, 0, 4>;
+        let v = V::with_capacity(4).unwrap();
+        assert_eq!(v.len(), 0);
+        assert!(v.as_inner().capacity() >= 4);
+    }
+
+    #[test]
+    fn with_capacity_above_max_returns_error() {
+        type V = BoundedVec<u32, 0, 4>;
+        assert!(matches!(
+            V::with_capacity(5),
+            Err(BoundedError::TooManyItems { count: 5, max: 4 })
+        ));
+    }
+
+    #[test]
+    fn with_capacity_below_min_returns_error() {
+        type V = BoundedVec<u32, 3, 8>;
+        assert!(matches!(
+            V::with_capacity(2),
+            Err(BoundedError::TooFewItems { count: 2, min: 3 })
+        ));
+    }
+
 }

--- a/utils/src/bounded/vec.rs
+++ b/utils/src/bounded/vec.rs
@@ -37,8 +37,7 @@ impl<T, const MIN: usize, const MAX: usize> Bounded<Vec<T>, MIN, MAX> {
     /// Constructs an empty vector with at least the specified capacity.
     ///
     /// The `capacity` must be within the `[MIN, MAX]` bounds; returns
-    /// [`BoundedError::TooFewItems`] when `capacity < MIN` and
-    /// [`BoundedError::TooManyItems`] when `capacity > MAX`.
+    /// [`BoundedError::CapacityOutOfBounds`] when `capacity` is outside this range.
     ///
     /// This does **not** change the length of the vector (it is still zero
     /// after construction), but pre-allocates space so that at least


### PR DESCRIPTION
Fixes #3261.

Adds two new constructors to `BoundedVec`:

### `with_capacity(capacity: usize) -> Result<Self, BoundedError>`
Pre-allocates storage at runtime while enforcing `[MIN, MAX]` bounds.
Returns `BoundedError::CapacityOutOfBounds { min, max, capacity }` when the requested capacity is outside the allowed range.

### `with_const_capacity<const CAPACITY: usize>() -> Self`
Pre-allocates storage with bounds enforced at **compile time** via `const { assert!(...) }`.
Panics at compile time when `CAPACITY > MAX` or `MIN > 0`.

### Also adds
- `BoundedError::CapacityOutOfBounds { min, max, capacity }` variant
- 5 unit tests covering: within bounds, at max, above max, below min, const capacity