### PR TITLE
feat(chain): uncle-ref: select uncles when proposing a block

### DIFF
--- a/consensus/cryptarchia-engine/src/lib.rs
+++ b/consensus/cryptarchia-engine/src/lib.rs
@@ -10,11 +10,15 @@ use std::{
 };
 
 pub use config::*;
+use lb_utils::bounded::UpperBoundedVec;
 use rpds::{HashTrieMapSync, HashTrieSetSync};
 use thiserror::Error;
 pub use time::{Epoch, EpochConfig, Slot};
 
 pub(crate) const LOG_TARGET: &str = "cryptarchia::engine";
+
+/// Slots occupied by the uncles a block references.
+pub type UncleSlots = UpperBoundedVec<Slot, MAX_UNCLES>;
 
 #[derive(Clone, Debug, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum State {
@@ -34,7 +38,7 @@ impl State {
     }
 
     /// Runs the fork choice rule and returns the selected new local chain tip.
-    fn fork_choice<Id>(cryptarchia: &Cryptarchia<Id>) -> Branch<Id>
+    fn fork_choice<Id>(cryptarchia: &Cryptarchia<Id>) -> &Branch<Id>
     where
         Id: Eq + Hash + Copy,
     {
@@ -42,11 +46,11 @@ impl State {
             Self::Bootstrapping => {
                 let k = cryptarchia.config.security_param().get().into();
                 let s_gen = cryptarchia.config.s_gen();
-                maxvalid_bg(cryptarchia.local_chain, &cryptarchia.branches, k, s_gen)
+                maxvalid_bg(&cryptarchia.local_chain, &cryptarchia.branches, k, s_gen)
             }
             Self::Online => {
                 let k = cryptarchia.config.security_param().get().into();
-                maxvalid_mc(cryptarchia.local_chain, &cryptarchia.branches, k)
+                maxvalid_mc(&cryptarchia.local_chain, &cryptarchia.branches, k)
             }
         }
     }
@@ -72,12 +76,12 @@ impl State {
 /// paper k defines the forking depth of chain we accept without more
 /// analysis s defines the length of time (unit of slots) after the fork
 /// happened we will inspect for chain density
-fn maxvalid_bg<Id>(
-    local_chain: Branch<Id>,
-    branches: &Branches<Id>,
+fn maxvalid_bg<'b, Id>(
+    local_chain: &'b Branch<Id>,
+    branches: &'b Branches<Id>,
     k: u64,
     s_gen: NonZero<u64>,
-) -> Branch<Id>
+) -> &'b Branch<Id>
 where
     Id: Eq + Hash + Copy,
 {
@@ -86,7 +90,7 @@ where
     let forks = branches.branches();
     for chain in forks {
         let lowest_common_ancestor = branches
-            .lca(&cmax, &chain)
+            .lca(cmax, chain)
             .expect("local chain and fork must have a common ancestor");
         let m = cmax.length - lowest_common_ancestor.length;
         if m <= k {
@@ -98,8 +102,8 @@ where
             // The chain is forking too much, we need to pay a bit more attention
             // In particular, select the chain that is the densest after the fork
             let density_slot = Slot::from(u64::from(lowest_common_ancestor.slot) + s_gen.get());
-            let cmax_density = branches.walk_back_before(&cmax, density_slot).length;
-            let candidate_density = branches.walk_back_before(&chain, density_slot).length;
+            let cmax_density = branches.walk_back_before(cmax, density_slot).length;
+            let candidate_density = branches.walk_back_before(chain, density_slot).length;
             if cmax_density < candidate_density {
                 cmax = chain;
             }
@@ -110,7 +114,11 @@ where
 
 /// Implementation of the fork choice rule as defined in the Ouroboros Praos
 /// paper k defines the forking depth of chain we can accept.
-fn maxvalid_mc<Id>(local_chain: Branch<Id>, branches: &Branches<Id>, k: u64) -> Branch<Id>
+fn maxvalid_mc<'b, Id>(
+    local_chain: &'b Branch<Id>,
+    branches: &'b Branches<Id>,
+    k: u64,
+) -> &'b Branch<Id>
 where
     Id: Eq + Hash + Copy,
 {
@@ -119,7 +127,7 @@ where
     let forks = branches.branches();
     for chain in forks {
         let lowest_common_ancestor = branches
-            .lca(&cmax, &chain)
+            .lca(cmax, chain)
             .expect("local chain and fork must have a common ancestor");
         let m = cmax.length - lowest_common_ancestor.length;
         if m <= k && cmax.length < chain.length {
@@ -160,13 +168,16 @@ where
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct Branch<Id> {
     id: Id,
     parent: Id,
     slot: Slot,
     // chain length
     length: u64,
+    /// Slots of the uncles this block references, for the uncle selection of
+    /// the blocks extending it.
+    uncle_slots: UncleSlots,
 }
 
 impl<Id: Copy> Branch<Id> {
@@ -182,13 +193,16 @@ impl<Id: Copy> Branch<Id> {
     pub const fn length(&self) -> u64 {
         self.length
     }
+    pub const fn uncle_slots(&self) -> &UncleSlots {
+        &self.uncle_slots
+    }
 }
 
 impl<Id> Branches<Id>
 where
     Id: Eq + Hash + Copy,
 {
-    pub fn from_lib(lib: Id, slot: Slot, length: u64) -> Self {
+    pub fn from_lib(lib: Id, slot: Slot, length: u64, uncle_slots: UncleSlots) -> Self {
         let mut branches = HashTrieMapSync::new_sync();
         branches.insert_mut(
             lib,
@@ -197,6 +211,7 @@ where
                 parent: lib,
                 slot,
                 length,
+                uncle_slots,
             },
         );
         let mut tips = HashTrieSetSync::new_sync();
@@ -212,7 +227,13 @@ where
     ///
     /// On error, `self` is not modified.
     #[must_use = "this returns the result of the operation, without modifying the original"]
-    fn apply_header(&mut self, header: Id, parent: Id, slot: Slot) -> Result<(), Error<Id>> {
+    fn apply_header(
+        &mut self,
+        header: Id,
+        parent: Id,
+        slot: Slot,
+        uncle_slots: UncleSlots,
+    ) -> Result<(), Error<Id>> {
         let parent_branch = self
             .branches
             .get(&parent)
@@ -237,20 +258,25 @@ where
                 parent,
                 length,
                 slot,
+                uncle_slots,
             },
         );
 
         Ok(())
     }
 
-    pub fn branches(&self) -> impl Iterator<Item = Branch<Id>> + '_ {
-        self.tips.iter().map(|id| self.branches[id])
+    pub fn branches(&self) -> impl Iterator<Item = &Branch<Id>> + '_ {
+        self.tips.iter().map(|id| &self.branches[id])
     }
 
     /// find the lowest common ancestor of two branches
     ///
     /// `None` if the two branches have no common ancestor in this tree.
-    pub fn lca<'a>(&'a self, mut b1: &'a Branch<Id>, mut b2: &'a Branch<Id>) -> Option<Branch<Id>> {
+    pub fn lca<'a>(
+        &'a self,
+        mut b1: &'a Branch<Id>,
+        mut b2: &'a Branch<Id>,
+    ) -> Option<&'a Branch<Id>> {
         // first reduce branches to the same length
         while b1.length > b2.length {
             b1 = self.parent(b1)?;
@@ -266,7 +292,7 @@ where
             b2 = self.parent(b2)?;
         }
 
-        Some(*b1)
+        Some(b1)
     }
 
     pub fn get(&self, id: &Id) -> Option<&Branch<Id>> {
@@ -285,7 +311,7 @@ where
 
     /// Walk back the chain until the target slot, stopping at the oldest block
     /// in the tree.
-    fn walk_back_before(&self, branch: &Branch<Id>, slot: Slot) -> Branch<Id> {
+    fn walk_back_before<'a>(&'a self, branch: &'a Branch<Id>, slot: Slot) -> &'a Branch<Id> {
         let mut current = branch;
         while current.slot > slot {
             let Some(parent) = self.parent(current) else {
@@ -293,7 +319,7 @@ where
             };
             current = parent;
         }
-        *current
+        current
     }
 
     /// Walk back the chain and return all blocks in the range
@@ -319,16 +345,16 @@ where
 
     /// Returns the min(n, A)-th ancestor of the provided block, where A is the
     /// number of ancestors of this block.
-    fn nth_ancestor(&self, branch: &Branch<Id>, mut n: u64) -> Branch<Id> {
+    fn nth_ancestor<'a>(&'a self, branch: &'a Branch<Id>, mut n: u64) -> &'a Branch<Id> {
         let mut current = branch;
         while n > 0 {
             n -= 1;
             let Some(parent) = self.parent(current) else {
-                return *current;
+                return current;
             };
             current = parent;
         }
-        *current
+        current
     }
 }
 
@@ -357,14 +383,22 @@ impl<Id> Cryptarchia<Id>
 where
     Id: Eq + Hash + Copy + Debug,
 {
-    pub fn from_lib(id: Id, config: Config, state: State, slot: Slot, length: u64) -> Self {
+    pub fn from_lib(
+        id: Id,
+        config: Config,
+        state: State,
+        slot: Slot,
+        length: u64,
+        uncle_slots: UncleSlots,
+    ) -> Self {
         Self {
-            branches: Branches::from_lib(id, slot, length),
+            branches: Branches::from_lib(id, slot, length, uncle_slots.clone()),
             local_chain: Branch {
                 id,
                 length,
                 parent: id,
                 slot,
+                uncle_slots,
             },
             config,
             state,
@@ -381,12 +415,12 @@ where
         id: Id,
         parent: Id,
         slot: Slot,
+        uncle_slots: UncleSlots,
     ) -> Result<(PrunedBlocks<Id>, ReorgedBlocks<Id>), Error<Id>> {
-        let old_local_chain = self.local_chain;
+        let old_local_chain = self.local_chain.clone();
 
-        self.branches.apply_header(id, parent, slot)?;
-        let new_local_chain = self.fork_choice();
-        self.local_chain = new_local_chain;
+        self.branches.apply_header(id, parent, slot, uncle_slots)?;
+        self.local_chain = self.fork_choice().clone();
 
         // Before `update_lib` which may prune blocks,
         // collect the reorged blocks in the old local chain.
@@ -398,7 +432,7 @@ where
             // whose pairwise LCAs don't lie on `old_local_chain`'s parent chain.
             let lca = self
                 .branches
-                .lca(&old_local_chain, &new_local_chain)
+                .lca(&old_local_chain, &self.local_chain)
                 .expect("old and new local chains must have a common ancestor");
             ReorgedBlocks(
                 self.branches
@@ -437,7 +471,7 @@ where
     }
 
     /// Runs the fork choice rule and returns the selected new local chain tip.
-    pub fn fork_choice(&self) -> Branch<Id> {
+    pub fn fork_choice(&self) -> &Branch<Id> {
         State::fork_choice(self)
     }
 
@@ -481,7 +515,7 @@ where
         &self,
         max_div_depth: u64,
     ) -> impl Iterator<Item = ForkDivergenceInfo<Id>> + '_ {
-        let local_chain = self.local_chain;
+        let local_chain = &self.local_chain;
         let Some(deepest_div_block) = local_chain.length.checked_sub(max_div_depth) else {
             tracing::debug!(
                 target: LOG_TARGET,
@@ -495,24 +529,27 @@ where
             // elsewhere without the need to re-calculate it.
             let lca = self
                 .branches
-                .lca(&local_chain, &fork)
+                .lca(local_chain, fork)
                 .expect("local chain and fork must have a common ancestor");
             // If the fork is diverged deeper than `deepest_div_block`, it's prunable.
-            (lca.length < deepest_div_block).then_some(ForkDivergenceInfo { tip: fork, lca })
+            (lca.length < deepest_div_block).then_some(ForkDivergenceInfo {
+                tip: fork.clone(),
+                lca: lca.clone(),
+            })
         }))
     }
 
     /// Returns all the forks that are not part of the local canonical chain.
     ///
     /// The result contains both prunable and non prunable forks.
-    pub fn non_canonical_forks(&self) -> impl Iterator<Item = Branch<Id>> + '_ {
+    pub fn non_canonical_forks(&self) -> impl Iterator<Item = &Branch<Id>> + '_ {
         self.branches
             .branches()
             .filter(|fork_tip| fork_tip.id != self.tip())
     }
 
     /// Remove all blocks of a fork from `tip` to `lca`, excluding `lca`.
-    fn prune_fork(&mut self, &ForkDivergenceInfo { lca, tip }: &ForkDivergenceInfo<Id>) -> Vec<Id> {
+    fn prune_fork(&mut self, ForkDivergenceInfo { lca, tip }: &ForkDivergenceInfo<Id>) -> Vec<Id> {
         let tip_removed = self.branches.tips.remove_mut(&tip.id);
         if !tip_removed {
             tracing::error!(target: LOG_TARGET, "Fork tip {tip:#?} not found in the set of tips.");
@@ -521,7 +558,7 @@ where
         let mut current_tip = tip.id;
         let mut removed_blocks = vec![];
         while current_tip != lca.id {
-            let Some(branch) = self.branches.branches.get(&current_tip).copied() else {
+            let Some(branch) = self.branches.branches.get(&current_tip).cloned() else {
                 // If tip is not in branch set, it means this tip was sharing part of its
                 // history with another fork that has already been removed.
                 break;
@@ -542,10 +579,12 @@ where
     fn prune_immutable_blocks(&mut self) -> impl Iterator<Item = (Slot, Id)> + '_ {
         let mut block = self.lib_branch().parent;
         std::iter::from_fn(move || {
-            let branch = self.branches.branches.get(&block).copied()?;
+            let &Branch {
+                id, parent, slot, ..
+            } = self.branches.branches.get(&block)?;
             self.branches.branches.remove_mut(&block);
-            block = branch.parent;
-            Some((branch.slot, branch.id))
+            block = parent;
+            Some((slot, id))
         })
     }
 
@@ -694,7 +733,7 @@ pub mod tests {
 
     use lb_utils::math::NonNegativeRatio;
 
-    use super::{Cryptarchia, Error, Slot, maxvalid_bg};
+    use super::{Cryptarchia, Error, Slot, UncleSlots, maxvalid_bg};
     use crate::{Config, ReorgedBlocks, State};
 
     #[must_use]
@@ -734,12 +773,13 @@ pub mod tests {
             State::Bootstrapping,
             0.into(),
             0,
+            UncleSlots::default(),
         );
         let mut parent = engine.lib();
         for i in 1..length.get() {
             let new_block = hash(&i);
             let (_, reorged_blocks) = engine
-                .receive_block(new_block, parent, i.into())
+                .receive_block(new_block, parent, i.into(), UncleSlots::default())
                 .expect("test block to be applied successfully.");
             assert!(
                 reorged_blocks.is_empty(),
@@ -755,15 +795,16 @@ pub mod tests {
         // parent
         // └── child
 
-        let mut branches = super::Branches::from_lib(hash(&0u64), 0.into(), 0);
+        let mut branches =
+            super::Branches::from_lib(hash(&0u64), 0.into(), 0, UncleSlots::default());
         let parent = hash(&1u64);
         let child = hash(&2u64);
 
         branches
-            .apply_header(parent, hash(&0u64), 2.into())
+            .apply_header(parent, hash(&0u64), 2.into(), UncleSlots::default())
             .unwrap();
         assert!(matches!(
-            branches.apply_header(child, parent, 1.into()),
+            branches.apply_header(child, parent, 1.into(), UncleSlots::default()),
             Err(Error::InvalidSlot(_))
         ));
     }
@@ -773,7 +814,7 @@ pub mod tests {
         // b0(LIB) - b1 - b2      c0 (a separate tree)
         let cryptarchia = create_canonical_chain(3.try_into().unwrap(), None);
         let branches = cryptarchia.branches();
-        let other = super::Branches::from_lib(hash(&100u64), 0.into(), 0);
+        let other = super::Branches::from_lib(hash(&100u64), 0.into(), 0, UncleSlots::default());
 
         assert!(
             branches
@@ -788,9 +829,10 @@ pub mod tests {
     #[test]
     fn walk_back_before_stops_at_the_oldest_block() {
         // b0(LIB, slot 5) - b1(slot 6)
-        let mut branches = super::Branches::from_lib(hash(&0u64), 5.into(), 0);
+        let mut branches =
+            super::Branches::from_lib(hash(&0u64), 5.into(), 0, UncleSlots::default());
         branches
-            .apply_header(hash(&1u64), hash(&0u64), 6.into())
+            .apply_header(hash(&1u64), hash(&0u64), 6.into(), UncleSlots::default())
             .unwrap();
 
         // Slot 0 precedes the oldest block, so the walk stops there.
@@ -838,7 +880,7 @@ pub mod tests {
         //     \
         //      b3
         assert!(matches!(
-            cryptarchia.receive_block(hash(&3u64), hash(&0u64), 1.into()),
+            cryptarchia.receive_block(hash(&3u64), hash(&0u64), 1.into(), UncleSlots::default()),
             Err(Error::ParentMissing(_)),
         ));
     }
@@ -862,7 +904,7 @@ pub mod tests {
             if slot % 2 == 0 {
                 let new_block = hash(&format!("short-{slot}"));
                 let (_, reorged_blocks) = engine
-                    .receive_block(new_block, short_p, slot.into())
+                    .receive_block(new_block, short_p, slot.into(), UncleSlots::default())
                     .unwrap();
                 assert!(reorged_blocks.is_empty());
                 short_p = new_block;
@@ -875,7 +917,7 @@ pub mod tests {
             if slot % 3 == 0 {
                 let new_block = hash(&format!("long-{slot}"));
                 let (_, reorged_blocks) = engine
-                    .receive_block(new_block, long_p, slot.into())
+                    .receive_block(new_block, long_p, slot.into(), UncleSlots::default())
                     .unwrap();
                 assert!(reorged_blocks.is_empty());
                 long_p = new_block;
@@ -887,7 +929,7 @@ pub mod tests {
         for slot in (initial_height + s_gen)..(initial_height + 2 * s_gen) {
             let new_block = hash(&format!("long-{slot}"));
             let (_, reorged_blocks) = engine
-                .receive_block(new_block, long_p, slot.into())
+                .receive_block(new_block, long_p, slot.into(), UncleSlots::default())
                 .unwrap();
             assert!(reorged_blocks.is_empty());
             long_p = new_block;
@@ -912,7 +954,7 @@ pub mod tests {
             for slot in initial_height..=tip_height {
                 let new_block = hash(&format!("dense-{slot}"));
                 let (_, reorged_blocks) = engine
-                    .receive_block(new_block, parent, slot.into())
+                    .receive_block(new_block, parent, slot.into(), UncleSlots::default())
                     .unwrap();
 
                 if slot < tip_height {
@@ -961,8 +1003,14 @@ pub mod tests {
 
     #[test]
     fn test_getters() {
-        let engine =
-            <Cryptarchia<_>>::from_lib(hash(&0u64), config(), State::Bootstrapping, 0.into(), 0);
+        let engine = <Cryptarchia<_>>::from_lib(
+            hash(&0u64),
+            config(),
+            State::Bootstrapping,
+            0.into(),
+            0,
+            UncleSlots::default(),
+        );
         let id_0 = engine.lib();
 
         // Get branch directly from HashMap
@@ -1002,7 +1050,7 @@ pub mod tests {
         let mut cryptarchia = create_canonical_chain(50.try_into().unwrap(), Some(config_with(50)));
         // Add a fork from genesis block
         let (pruned_blocks, _) = cryptarchia
-            .receive_block(hash(&100u64), hash(&0u64), 1.into())
+            .receive_block(hash(&100u64), hash(&0u64), 1.into(), UncleSlots::default())
             .expect("test block to be applied successfully.");
         // No block was pruned during Boostrapping.
         assert!(pruned_blocks.all().next().is_none());
@@ -1023,11 +1071,11 @@ pub mod tests {
         // Add two new blocks to the local honest chain,
         // and check if the LIB is updated and blocks are pruned.
         let (pruned_blocks, _) = cryptarchia
-            .receive_block(hash(&50u64), hash(&49u64), 50.into())
+            .receive_block(hash(&50u64), hash(&49u64), 50.into(), UncleSlots::default())
             .expect("test block to be applied successfully.");
         assert!(pruned_blocks.is_empty());
         let (pruned_blocks, _) = cryptarchia
-            .receive_block(hash(&51u64), hash(&50u64), 51.into())
+            .receive_block(hash(&51u64), hash(&50u64), 51.into(), UncleSlots::default())
             .expect("test block to be applied successfully.");
         // The LIB was updated to b1.
         assert_eq!(cryptarchia.lib(), hash(&1u64));
@@ -1052,7 +1100,12 @@ pub mod tests {
         //                               b100
         let mut cryptarchia = create_canonical_chain(50.try_into().unwrap(), Some(config_with(10)));
         let (pruned_blocks, _) = cryptarchia
-            .receive_block(hash(&100u64), hash(&40u64), 41.into())
+            .receive_block(
+                hash(&100u64),
+                hash(&40u64),
+                41.into(),
+                UncleSlots::default(),
+            )
             .expect("test block to be applied successfully.");
         // No block was pruned during Boostrapping.
         assert!(pruned_blocks.all().next().is_none());
@@ -1103,13 +1156,28 @@ pub mod tests {
 
         let mut cryptarchia = create_canonical_chain(50.try_into().unwrap(), Some(config_with(10)));
         cryptarchia
-            .receive_block(hash(&100u64), hash(&38u64), 39.into())
+            .receive_block(
+                hash(&100u64),
+                hash(&38u64),
+                39.into(),
+                UncleSlots::default(),
+            )
             .expect("test block to be applied successfully.");
         cryptarchia
-            .receive_block(hash(&101u64), hash(&39u64), 40.into())
+            .receive_block(
+                hash(&101u64),
+                hash(&39u64),
+                40.into(),
+                UncleSlots::default(),
+            )
             .expect("test block to be applied successfully.");
         let (pruned_blocks, _) = cryptarchia
-            .receive_block(hash(&102u64), hash(&40u64), 41.into())
+            .receive_block(
+                hash(&102u64),
+                hash(&40u64),
+                41.into(),
+                UncleSlots::default(),
+            )
             .expect("test block to be applied successfully.");
         // No block was pruned during Boostrapping.
         assert!(pruned_blocks.all().next().is_none());
@@ -1149,13 +1217,28 @@ pub mod tests {
         //                           b100  b101
         let mut cryptarchia = create_canonical_chain(50.try_into().unwrap(), Some(config_with(10)));
         cryptarchia
-            .receive_block(hash(&100u64), hash(&38u64), 39.into())
+            .receive_block(
+                hash(&100u64),
+                hash(&38u64),
+                39.into(),
+                UncleSlots::default(),
+            )
             .expect("test block to be applied successfully.");
         cryptarchia
-            .receive_block(hash(&200u64), hash(&38u64), 39.into())
+            .receive_block(
+                hash(&200u64),
+                hash(&38u64),
+                39.into(),
+                UncleSlots::default(),
+            )
             .expect("test block to be applied successfully.");
         let (pruned_blocks, _) = cryptarchia
-            .receive_block(hash(&101u64), hash(&39u64), 40.into())
+            .receive_block(
+                hash(&101u64),
+                hash(&39u64),
+                40.into(),
+                UncleSlots::default(),
+            )
             .expect("test block to be applied successfully.");
         // No block was pruned during Boostrapping.
         assert!(pruned_blocks.all().next().is_none());
@@ -1200,13 +1283,28 @@ pub mod tests {
         //                                  b200
         let mut cryptarchia = create_canonical_chain(50.try_into().unwrap(), Some(config_with(10)));
         cryptarchia
-            .receive_block(hash(&100u64), hash(&38u64), 39.into())
+            .receive_block(
+                hash(&100u64),
+                hash(&38u64),
+                39.into(),
+                UncleSlots::default(),
+            )
             .expect("test block to be applied successfully.");
         cryptarchia
-            .receive_block(hash(&101u64), hash(&100u64), 40.into())
+            .receive_block(
+                hash(&101u64),
+                hash(&100u64),
+                40.into(),
+                UncleSlots::default(),
+            )
             .expect("test block to be applied successfully.");
         let (pruned_blocks, _) = cryptarchia
-            .receive_block(hash(&200u64), hash(&100u64), 41.into())
+            .receive_block(
+                hash(&200u64),
+                hash(&100u64),
+                41.into(),
+                UncleSlots::default(),
+            )
             .expect("test block to be applied successfully.");
         // No block was pruned during Boostrapping.
         assert!(pruned_blocks.all().next().is_none());
@@ -1262,6 +1360,7 @@ pub mod tests {
                 hash(&100u64),
                 cryptarchia.lib(),
                 cryptarchia.lib_branch().slot.strict_add(1.into()),
+                UncleSlots::default(),
             )
             .expect("test block to be applied successfully.");
         assert_eq!(cryptarchia.lib(), hash(&7u64));
@@ -1279,6 +1378,7 @@ pub mod tests {
                 hash(&101u64),
                 cryptarchia.tip_branch().parent,
                 cryptarchia.tip_branch().slot,
+                UncleSlots::default(),
             )
             .expect("test block to be applied successfully.");
         assert_eq!(cryptarchia.lib(), hash(&7u64));
@@ -1298,6 +1398,7 @@ pub mod tests {
                 hash(&102u64),
                 cryptarchia.tip(),
                 cryptarchia.tip_branch().slot.strict_add(1.into()),
+                UncleSlots::default(),
             )
             .expect("test block to be applied successfully.");
         assert_eq!(cryptarchia.lib(), hash(&8u64));

--- a/consensus/cryptarchia-engine/src/lib.rs
+++ b/consensus/cryptarchia-engine/src/lib.rs
@@ -1819,11 +1819,16 @@ mod uncle_tests {
         assert_eq!(selected, [u2, u1, u3]);
     }
 
+    /// A config whose uncle reference window `floor(W/f)` is exactly
+    /// `uncle_reference_window` slots, by picking an `f` just below 1.
     #[must_use]
-    fn config(uncle_reference_window: u64) -> Config {
+    fn config(uncle_reference_window: u32) -> Config {
         Config::new(
             NonZero::new(10).unwrap(),
-            NonNegativeRatio::new(1, 10.try_into().unwrap()),
+            NonNegativeRatio::new(
+                uncle_reference_window + 1,
+                (uncle_reference_window + 2).try_into().unwrap(),
+            ),
             1f64.try_into().expect("1 > 0"),
             uncle_reference_window.try_into().unwrap(),
         )
@@ -1832,7 +1837,7 @@ mod uncle_tests {
     type HeaderId = u64;
 
     fn build_tree(
-        uncle_reference_window: u64,
+        uncle_reference_window: u32,
         genesis: HeaderId,
         blocks: impl IntoIterator<Item = (HeaderId, HeaderId, Slot)>,
     ) -> Cryptarchia<HeaderId> {
@@ -1846,7 +1851,7 @@ mod uncle_tests {
     }
 
     fn build_tree_with_uncle_slots(
-        uncle_reference_window: u64,
+        uncle_reference_window: u32,
         genesis: HeaderId,
         blocks: impl IntoIterator<Item = (HeaderId, HeaderId, Slot, UncleSlots)>,
     ) -> Cryptarchia<HeaderId> {

--- a/consensus/cryptarchia-engine/src/lib.rs
+++ b/consensus/cryptarchia-engine/src/lib.rs
@@ -5,7 +5,7 @@ mod fixtures;
 
 use core::{fmt::Debug, hash::Hash};
 use std::{
-    collections::{BTreeMap, HashSet},
+    collections::{BTreeMap, HashMap, HashSet},
     num::NonZero,
 };
 
@@ -647,40 +647,64 @@ where
 
     /// Selects uncles for a new block extending `parent` at `slot`.
     ///
-    /// ```text
-    ///          |---- window ------|
-    ///          |                  |
-    /// b1 .. -- b3 -- b4 -- b5 -- b6 <- adding b7
-    ///  |       |           |
-    ///  |       |           |-----f3
-    ///  |       |---- f2 -- f21
-    ///  |------------ f1
-    /// ```
+    /// First, this function filters candidates which meet all of the following
+    /// conditions:
+    /// - An uncle is the 1st block of a fork off the chain of `parent`.
+    /// - An uncle's slot is `< slot`.
+    /// - An uncle's parent slot is within the uncle reference window.
+    ///   - `0 < slot - uncle.parent.slot <= w_u`.
+    /// - An uncle's slot is not already occupied by the ancestors of `parent`
+    ///   (including `parent` itself) and their uncles.
     ///
-    /// `f2` and `f3` are selected because their parents are in the window and
-    /// each is the first block of its fork. `f1` is not a valid uncle even
-    /// though it is in the window, because its parent `b1` is older than the
-    /// window: `0 < slot - uncle_parent_slot <= w_u`.
+    /// After that,
+    /// - All uncle candidates are ordered by `(parent.slot, slot, id)`.
+    /// - The first [`MAX_UNCLES`] uncles are selected.
+    /// - But, if an uncle's slot is already taken by another uncle selected
+    ///   earlier, the uncle is excluded.
+    ///
+    /// # Example
+    /// ```text
+    ///          |---------------------- window -------------------------|
+    ///          |                                                       |
+    /// - b1(1) - b2(2) ------ b3(4, uncle_slots=[3]) -- b4(6)           <- adding b5(9)
+    ///    |       |            |                         |----------------- u9(9)
+    ///    |       |            |                         |---u7(7)--u8(8)
+    ///    |       |            |----------------------------------- u6(8)
+    ///    |       |            |------------------- u5(5)
+    ///    |       |-------------------------------- u4(5)
+    ///    |       |---------- u3(4)
+    ///    |       |---- u2(3)
+    ///    |------ u1(2)
+    /// ```
+    /// Only `[u4, u6, u7]` are selected.
+    /// - u1's parent is out of the window.
+    /// - u2's slot(3) is already occupied by b3's uncle.
+    /// - u3's slot(4) is already occupied by b3.
+    /// - u5's slot is already taken by u4 selected earlier.
+    /// - u8 is not the 1st block of a fork.
+    /// - u9's slot(9) is not smaller than the slot(9) of the new block.
     pub fn select_uncles(&self, parent: &Branch<Id>, slot: Slot) -> Vec<&Branch<Id>>
     where
         Id: Ord,
     {
-        // An uncle must satisfy `0 < slot - uncle_slot <= w_u`, so the window is
-        // `[window_start, slot)`.
         let window_start =
             u64::from(slot).saturating_sub(self.config.uncle_reference_window().get());
 
-        let (ancestor_ids, occupied_slots) = self.collect_chain_within_window(parent, window_start);
-        let mut candidates =
-            self.uncle_candidates(slot, window_start, &ancestor_ids, &occupied_slots);
+        let (ancestors, occupied_slots) = self.collect_chain_within_window(parent, window_start);
+        let mut candidates = self.uncle_candidates(slot, window_start, &ancestors, &occupied_slots);
 
-        // Oldest first, because the slot window moves and the oldest candidates
-        // are the clostest to expiring.
-        // One uncle per slot, breaking ties by smaller ID.
-        candidates.sort_unstable_by_key(|uncle| (uncle.slot, uncle.id));
-        candidates.dedup_by_key(|uncle| uncle.slot);
-        candidates.truncate(MAX_UNCLES);
+        // Oldest parent first, because the slot window moves and the oldest candidates
+        // are the closest to expiring.
+        // One uncle per slot, breaking ties by the uncle's slot and ID.
         candidates
+            .sort_unstable_by_key(|(parent_slot, uncle)| (*parent_slot, uncle.slot, uncle.id));
+        let mut selected_slots = HashSet::new();
+        candidates
+            .into_iter()
+            .filter(|(_, uncle)| selected_slots.insert(uncle.slot))
+            .take(MAX_UNCLES)
+            .map(|(_, uncle)| uncle)
+            .collect()
     }
 
     /// Within the window, collects the ancestors of `parent` (including itself)
@@ -693,15 +717,15 @@ where
         &self,
         parent: &Branch<Id>,
         window_start: u64,
-    ) -> (HashSet<Id>, HashSet<Slot>) {
-        let mut ancestor_ids = HashSet::new();
+    ) -> (HashMap<Id, Slot>, HashSet<Slot>) {
+        let mut ancestors = HashMap::new();
         let mut occupied_slots = HashSet::new();
         let mut ancestor = Some(parent);
         while let Some(block) = ancestor {
             if block.slot.into_inner() < window_start {
                 break;
             }
-            ancestor_ids.insert(block.id);
+            ancestors.insert(block.id, block.slot);
             occupied_slots.insert(block.slot);
             occupied_slots.extend(
                 block
@@ -712,33 +736,35 @@ where
             );
             ancestor = self.branches.parent(block);
         }
-        (ancestor_ids, occupied_slots)
+        (ancestors, occupied_slots)
     }
 
     /// Collects uncle candidates by walking back all branches in the tree,
     /// to find the 1st block of each fork that meets the criteria.
+    ///
+    /// Each uncle candidate is returned with its parent's slot.
     ///
     /// Complexity: `O(n_forks * window_size)`
     fn uncle_candidates(
         &self,
         slot: Slot,
         window_start: u64,
-        ancestor_ids: &HashSet<Id>,
+        ancestors: &HashMap<Id, Slot>,
         occupied_slots: &HashSet<Slot>,
-    ) -> Vec<&Branch<Id>> {
-        let mut candidates: Vec<&Branch<Id>> = Vec::new();
+    ) -> Vec<(Slot, &Branch<Id>)> {
+        let mut candidates: Vec<(Slot, &Branch<Id>)> = Vec::new();
         for branch_tip in self.branches.branches() {
             let mut current = Some(branch_tip);
             while let Some(block) = current {
                 // Reached the chain of `parent` or the window's end.
-                if block.slot.into_inner() < window_start || ancestor_ids.contains(&block.id) {
+                if block.slot.into_inner() < window_start || ancestors.contains_key(&block.id) {
                     break;
                 }
                 if block.slot < slot
-                    && ancestor_ids.contains(&block.parent)
+                    && let Some(parent_slot) = ancestors.get(&block.parent)
                     && !occupied_slots.contains(&block.slot)
                 {
-                    candidates.push(block);
+                    candidates.push((*parent_slot, block));
                 }
                 current = self.branches.parent(block);
             }
@@ -1538,178 +1564,303 @@ pub mod tests {
             [(7.into(), hash(&7u64))].into(),
         );
     }
+}
 
-    #[test]
-    fn select_uncles_picks_oldest_first_blocks_of_forks() {
-        // g(0) -- b1(1) -- b2(3) -- b3(6; uncles=[4]) -- b4(8) <- adding b5(9)
-        //          |        |        |------------ u4(7) candidate
-        //          |        |-- u2(4)                    slot 4 already referenced by b3
-        //          |        |---- u5(5)                  candidate
-        //          |-- u1(2)                             candidate
-        //          |    |-------- d1(5)                  not the first block of a fork
-        //          |-- u3(2)                             candidate, same slot as u1
-        let g = hash(&0u64);
-        let [b1, b2, b3, b4] = [1u64, 2, 3, 4].map(|i| hash(&i));
-        let [u1, u2, u3, u4, u5, d1] = [20u64, 21, 22, 23, 24, 25].map(|i| hash(&i));
+#[cfg(test)]
+mod uncle_tests {
+    use std::num::NonZero;
 
-        let mut engine = Cryptarchia::from_lib(
-            g,
-            config_with(10),
-            State::Bootstrapping,
-            0.into(),
-            0,
-            UncleSlots::default(),
-        );
-        for (id, parent, slot, uncle_slots) in [
-            (b1, g, 1u64, UncleSlots::default()),
-            (b2, b1, 3, UncleSlots::default()),
-            (b3, b2, 6, [Slot::from(4u64)].into()),
-            (b4, b3, 8, UncleSlots::default()),
-            (u1, b1, 2, UncleSlots::default()),
-            (u3, b1, 2, UncleSlots::default()),
-            (d1, u1, 5, UncleSlots::default()),
-            (u2, b2, 4, UncleSlots::default()),
-            (u5, b2, 5, UncleSlots::default()),
-            (u4, b3, 7, UncleSlots::default()),
-        ] {
-            engine
-                .receive_block(id, parent, slot.into(), uncle_slots)
-                .expect("test block to be applied successfully.");
-        }
-        assert_eq!(engine.tip(), b4);
+    use lb_utils::math::NonNegativeRatio;
 
-        let selected: Vec<_> = engine
-            .select_uncles(engine.tip_branch(), 9.into())
-            .iter()
-            .map(|uncle| uncle.id())
-            .collect();
-        // Ties on the same slot are broken by the smaller ID.
-        assert_eq!(selected, [u1.min(u3), u5, u4]);
-    }
+    use crate::{Config, Cryptarchia, Slot, State, UncleSlots};
 
     #[test]
     fn select_uncles_honors_the_window() {
-        // g(0) -- a(8) -- b1(10)     <- adding b2(11)
-        //  |       |-- u9(9)         candidate
-        //  |       |------- u11(11)  not strictly older than the proposal slot
-        //  |-- u7(7)                 older than the window
-        //  |---- u8(8)               in the window, but its parent `g` is older
-        //                            (not a valid uncle)
-        let g = hash(&0u64);
-        let [a, b1, u7, u8, u9, u11] = [1u64, 2, 20, 21, 22, 23].map(|i| hash(&i));
-
-        // With `w_u = 3`, a proposal at slot 11 can only reference [8, 11).
-        let config = Config::new(
-            NonZero::new(10).unwrap(),
-            NonNegativeRatio::new(1, 10.try_into().unwrap()),
-            1f64.try_into().expect("1 > 0"),
-            NonZero::new(3).unwrap(),
-        );
-        let mut engine = Cryptarchia::from_lib(
+        //           |----- window ------|
+        //           |                   |
+        // g(0) ----- b1(8) -- b2(10)     <- adding b2(11)
+        //  |          |-- u3(9)
+        //  |          |------------------- u4(11)
+        //  |-- u1(7)
+        //  |-------- u2(8)
+        //
+        // Only u3 is selected. Other uncles are excluded because of the following
+        // reasons:
+        // - u1's parent is older than the window.
+        // - u2's parent is older than the window.
+        // - u4 is out of the window.
+        let [g, b1, b2, u1, u2, u3, u4] = [0u64, 1, 2, 3, 4, 5, 6];
+        let window = 3;
+        let engine = build_tree(
+            window,
             g,
-            config,
-            State::Bootstrapping,
-            0.into(),
-            0,
-            UncleSlots::default(),
+            [
+                (b1, g, 8.into()),
+                (b2, b1, 10.into()),
+                (u1, g, 7.into()),
+                (u2, g, 8.into()),
+                (u3, b1, 9.into()),
+                (u4, b1, 11.into()),
+            ],
         );
-        for (id, parent, slot) in [
-            (a, g, 8u64),
-            (b1, a, 10),
-            (u7, g, 7),
-            (u8, g, 8),
-            (u9, a, 9),
-            (u11, a, 11),
-        ] {
-            engine
-                .receive_block(id, parent, slot.into(), UncleSlots::default())
-                .expect("test block to be applied successfully.");
-        }
-        assert_eq!(engine.tip(), b1);
 
         let selected: Vec<_> = engine
-            .select_uncles(engine.tip_branch(), 11.into())
+            .select_uncles(engine.branches().get(&b2).unwrap(), 11.into())
             .iter()
             .map(|uncle| uncle.id())
             .collect();
-        assert_eq!(selected, [u9]);
+        assert_eq!(selected, [u3]);
     }
 
     #[test]
     fn select_uncles_selects_nothing_with_the_minimum_window() {
-        // g(0) -- b1(9)              <- adding b2(11)
-        //  |       |-- u10(10)       its parent is below the window
-        //  |                         (not a valid uncle)
-        //  |----- u9(9)              older than the window
+        //              |-- window ---|
+        //              |             |
+        // g(0) -- b1(9) -- b2(10)     <- adding b2(11)
+        //          |        |----------- u3(11)
+        //          |
+        //  |       |------ u2(10)
+        //  |
+        //  |----- u1(9)
         //
         // With `w_u = 1`, a proposal at slot 11 can only reference slot 10.
-        // Unless the chain has a block at exactly slot 10, the windowed walk
-        // collects no ancestor, so no candidate can pass the parent check; and
-        // if it has one, its own slot occupies the only referenceable slot.
-        // Either way, nothing is ever selected.
-        let g = hash(&0u64);
-        let [b1, u9, u10] = [1u64, 20, 21].map(|i| hash(&i));
-
-        let config = Config::new(
-            NonZero::new(10).unwrap(),
-            NonNegativeRatio::new(1, 10.try_into().unwrap()),
-            1f64.try_into().expect("1 > 0"),
-            NonZero::new(1).unwrap(),
-        );
-        let mut engine = Cryptarchia::from_lib(
+        // It means that no uncle can be selected.
+        let [g, b1, b2, u1, u2, u3] = [0u64, 1, 2, 3, 4, 5];
+        let window = 1;
+        let engine = build_tree(
+            window,
             g,
-            config,
-            State::Bootstrapping,
-            0.into(),
-            0,
-            UncleSlots::default(),
+            [
+                (b1, g, 9.into()),
+                (b2, b1, 10.into()),
+                (u1, g, 9.into()),
+                (u2, b1, 10.into()),
+                (u3, b2, 11.into()),
+            ],
         );
-        for (id, parent, slot) in [(b1, g, 9u64), (u9, g, 9), (u10, b1, 10)] {
-            engine
-                .receive_block(id, parent, slot.into(), UncleSlots::default())
-                .expect("test block to be applied successfully.");
-        }
 
-        let parent = engine.branches().get(&b1).unwrap();
-        assert!(engine.select_uncles(parent, 11.into()).is_empty());
+        assert!(
+            engine
+                .select_uncles(engine.branches().get(&b1).unwrap(), 11.into())
+                .is_empty()
+        );
     }
 
     #[test]
     fn select_uncles_takes_at_most_max_uncles() {
+        //  |----------------- window -------------------|
+        //  |                                            |
         // g(0) ----------------------------------- b1(6)  <- adding b2(7)
         //  |
-        //  |- f1(1) - f2(2) - f3(3) - f4(4) - f5(5)
-        let g = hash(&0u64);
-        let b1 = hash(&1u64);
-
-        let mut engine = Cryptarchia::from_lib(
+        //  |- u1(1)
+        //  |-------- u2(2)
+        //  |--------------- u3(3)
+        //  |--------------------- u4(4)
+        //  |--------------------------- u5(5)
+        //
+        // u1~u4 are selected. u5 is excluded because of `MAX_UNCLES=4`.
+        let [g, b1, u1, u2, u3, u4, u5] = [0u64, 1, 2, 3, 4, 5, 6];
+        let window = 10;
+        let engine = build_tree(
+            window,
             g,
-            config_with(10),
+            [
+                (b1, g, 6.into()),
+                (u1, g, 1.into()),
+                (u2, g, 2.into()),
+                (u3, g, 3.into()),
+                (u4, g, 4.into()),
+                (u5, g, 5.into()),
+            ],
+        );
+
+        let selected: Vec<_> = engine
+            .select_uncles(engine.branches().get(&b1).unwrap(), 7.into())
+            .iter()
+            .map(|uncle| uncle.id())
+            .collect();
+        assert_eq!(selected, [u1, u2, u3, u4]);
+    }
+
+    #[test]
+    fn select_uncles_takes_only_first_block_of_forks() {
+        //  |----------------- window -------------------|
+        //  |                                            |
+        // g(0) ----------------------------------- b1(6)  <- adding b2(7)
+        //  |
+        //  |- u1(1) -- u2(2)
+        //
+        // Only u1 is selected. u2 is excluded because it is not the first
+        // block of the fork.
+        let [g, b1, u1, u2] = [0u64, 1u64, 2, 3];
+        let window = 10;
+        let engine = build_tree(
+            window,
+            g,
+            [(b1, g, 6.into()), (u1, g, 1.into()), (u2, u1, 2.into())],
+        );
+
+        let selected: Vec<_> = engine
+            .select_uncles(engine.branches().get(&b1).unwrap(), 7.into())
+            .iter()
+            .map(|uncle| uncle.id())
+            .collect();
+        assert_eq!(selected, [u1]);
+    }
+
+    #[test]
+    fn select_uncles_skips_occupied_slots() {
+        //        |------------------- window ------------------|
+        //        |                                             |
+        // g(0) -- b1(5) -- b3(7, uncle_slots=[6]) -- b4(8)     <- adding b5(10)
+        //           |       |                         |---u4(9)
+        //           |       |
+        //           |       |----------------------- u3(8)
+        //           |
+        //           |-- u1(6)
+        //           |-- u2(7)
+        //
+        // Only u4 is selected. Other uncles' slots are already occupied:
+        // - u1's slot 6 is occupied by b3's uncle slot.
+        // - u2's slot 7 is occupied by b3.
+        // - u3's slot 8 is occupied by b4.
+
+        let [g, b1, b3, b4, u1, u2, u3, u4] = [0u64, 1, 2, 3, 4, 5, 6, 7];
+        let window = 5;
+        let engine = build_tree_with_uncle_slots(
+            window,
+            g,
+            [
+                (b1, g, 5.into(), UncleSlots::default()),
+                (b3, b1, 7.into(), [6u64.into()].into()),
+                (b4, b3, 8.into(), UncleSlots::default()),
+                (u1, b1, 6.into(), UncleSlots::default()),
+                (u2, b1, 7.into(), UncleSlots::default()),
+                (u3, b3, 8.into(), UncleSlots::default()),
+                (u4, b4, 9.into(), UncleSlots::default()),
+            ],
+        );
+
+        let selected: Vec<_> = engine
+            .select_uncles(engine.branches().get(&b4).unwrap(), 10.into())
+            .iter()
+            .map(|uncle| uncle.id())
+            .collect();
+        assert_eq!(selected, [u4]);
+    }
+
+    #[test]
+    fn select_uncles_takes_one_uncle_per_slot() {
+        // |----------- window -----------|
+        // |                              |
+        // g(0) -- b1(6) --- b2(8)         <- adding b3(11)
+        //          |        |-------u3(10)
+        //          |        |--- u2(9)
+        //          |--------------- u1(10)
+        //
+        // [u1, u2] are selected. u3's slot is colliding with u1's slot.
+        let [g, b1, b2, u1, u2, u3] = [0u64, 1u64, 2, 3, 4, 5];
+        let window = 15;
+        let engine = build_tree(
+            window,
+            g,
+            [
+                (b1, g, 6.into()),
+                (b2, b1, 8.into()),
+                (u1, b1, 10.into()),
+                (u2, b2, 9.into()),
+                (u3, b2, 10.into()),
+            ],
+        );
+
+        let selected: Vec<_> = engine
+            .select_uncles(engine.branches().get(&b2).unwrap(), 11.into())
+            .iter()
+            .map(|uncle| uncle.id())
+            .collect();
+        assert_eq!(selected, [u1, u2]);
+    }
+
+    #[test]
+    fn select_uncles_ordering() {
+        // |-------------------- window ------------------|
+        // |                                              |
+        // g(0) -- b1(3) -- b2(4)                         <-- adding b3(8)
+        //          |         |------------------- u4(7)
+        //          |         |------------------- u3(7)
+        //          |--------------------- u1(6)
+        //          |--------------- u2(5)
+        //
+        // The order of the selected uncles should be: [u2, u1, u3].
+        // - The parent slot(3) of u1 and u2 is smaller than the parent slot(4) of u3
+        //   and u4.
+        // - u2's slot(5) is smaller than u1's slot(6).
+        // - u3's ID(3) is smaller than u4's ID(4).
+        let [g, b1, b2, u1, u2, u3, u4] = [0u64, 1u64, 2, 3, 4, 5, 6];
+        let window = 10;
+        let engine = build_tree(
+            window,
+            g,
+            [
+                (b1, g, 3.into()),
+                (b2, b1, 4.into()),
+                (u1, b1, 6.into()),
+                (u2, b1, 5.into()),
+                (u3, b2, 7.into()),
+                (u4, b2, 7.into()),
+            ],
+        );
+
+        let selected: Vec<_> = engine
+            .select_uncles(engine.branches().get(&b2).unwrap(), 8.into())
+            .iter()
+            .map(|uncle| uncle.id())
+            .collect();
+        assert_eq!(selected, [u2, u1, u3]);
+    }
+
+    #[must_use]
+    fn config(uncle_reference_window: u64) -> Config {
+        Config::new(
+            NonZero::new(10).unwrap(),
+            NonNegativeRatio::new(1, 10.try_into().unwrap()),
+            1f64.try_into().expect("1 > 0"),
+            uncle_reference_window.try_into().unwrap(),
+        )
+    }
+
+    type HeaderId = u64;
+
+    fn build_tree(
+        uncle_reference_window: u64,
+        genesis: HeaderId,
+        blocks: impl IntoIterator<Item = (HeaderId, HeaderId, Slot)>,
+    ) -> Cryptarchia<HeaderId> {
+        build_tree_with_uncle_slots(
+            uncle_reference_window,
+            genesis,
+            blocks
+                .into_iter()
+                .map(|(id, parent, slot)| (id, parent, slot, UncleSlots::default())),
+        )
+    }
+
+    fn build_tree_with_uncle_slots(
+        uncle_reference_window: u64,
+        genesis: HeaderId,
+        blocks: impl IntoIterator<Item = (HeaderId, HeaderId, Slot, UncleSlots)>,
+    ) -> Cryptarchia<HeaderId> {
+        let mut engine = Cryptarchia::from_lib(
+            genesis,
+            config(uncle_reference_window),
             State::Bootstrapping,
             0.into(),
             0,
             UncleSlots::default(),
         );
-        engine
-            .receive_block(b1, g, 6.into(), UncleSlots::default())
-            .expect("test block to be applied successfully.");
-        for slot in 1u64..=5 {
-            engine
-                .receive_block(hash(&(20 + slot)), g, slot.into(), UncleSlots::default())
-                .expect("test block to be applied successfully.");
+        for (id, parent, slot, uncle_slots) in blocks {
+            engine.receive_block(id, parent, slot, uncle_slots).unwrap();
         }
-
-        let selected: Vec<_> = engine
-            .select_uncles(engine.tip_branch(), 7.into())
-            .iter()
-            .map(|uncle| uncle.slot())
-            .collect();
-        // The oldest `MAX_UNCLES` candidates win; the one at slot 5 is dropped.
-        assert_eq!(
-            selected,
-            (1u64..=crate::MAX_UNCLES as u64)
-                .map(Slot::from)
-                .collect::<Vec<_>>()
-        );
+        engine
     }
 }

--- a/consensus/cryptarchia-engine/src/lib.rs
+++ b/consensus/cryptarchia-engine/src/lib.rs
@@ -356,6 +356,26 @@ where
         }
         current
     }
+
+    /// Walks back from `branch`, newest first, while the slot is newer than
+    /// `oldest_slot`. `branch` itself is yielded first if it qualifies.
+    ///
+    /// Ends early at the oldest block in the tree.
+    pub fn ancestors_newer_than<'s>(
+        &'s self,
+        branch: &'s Branch<Id>,
+        oldest_slot: Slot,
+    ) -> impl Iterator<Item = &'s Branch<Id>> + 's {
+        let mut current = Some(branch);
+        core::iter::from_fn(move || {
+            let branch = current?;
+            if branch.slot <= oldest_slot {
+                return None;
+            }
+            current = self.parent(branch);
+            Some(branch)
+        })
+    }
 }
 
 #[derive(Debug, Clone, Error)]
@@ -623,6 +643,107 @@ where
 
     pub const fn config(&self) -> &Config {
         &self.config
+    }
+
+    /// Selects uncles for a new block extending `parent` at `slot`.
+    ///
+    /// ```text
+    ///          |---- window ------|
+    ///          |                  |
+    /// b1 .. -- b3 -- b4 -- b5 -- b6 <- adding b7
+    ///  |       |           |
+    ///  |       |           |-----f3
+    ///  |       |---- f2 -- f21
+    ///  |------------ f1
+    /// ```
+    ///
+    /// `f2` and `f3` are selected because their parents are in the window and
+    /// each is the first block of its fork. `f1` is not a valid uncle even
+    /// though it is in the window, because its parent `b1` is older than the
+    /// window: `0 < slot - uncle_parent_slot <= w_u`.
+    pub fn select_uncles(&self, parent: &Branch<Id>, slot: Slot) -> Vec<&Branch<Id>>
+    where
+        Id: Ord,
+    {
+        // An uncle must satisfy `0 < slot - uncle_slot <= w_u`, so the window is
+        // `[window_start, slot)`.
+        let window_start =
+            u64::from(slot).saturating_sub(self.config.uncle_reference_window().get());
+
+        let (ancestor_ids, occupied_slots) = self.collect_chain_within_window(parent, window_start);
+        let mut candidates =
+            self.uncle_candidates(slot, window_start, &ancestor_ids, &occupied_slots);
+
+        // Oldest first, because the slot window moves and the oldest candidates
+        // are the clostest to expiring.
+        // One uncle per slot, breaking ties by smaller ID.
+        candidates.sort_unstable_by_key(|uncle| (uncle.slot, uncle.id));
+        candidates.dedup_by_key(|uncle| uncle.slot);
+        candidates.truncate(MAX_UNCLES);
+        candidates
+    }
+
+    /// Within the window, collects the ancestors of `parent` (including itself)
+    /// and the slots occupied by them and their uncles.
+    ///
+    /// Ancestors outside the window don't need to be checked because their
+    /// uncles must be older than the window.
+    /// Complexity: `O(window_size)`
+    fn collect_chain_within_window(
+        &self,
+        parent: &Branch<Id>,
+        window_start: u64,
+    ) -> (HashSet<Id>, HashSet<Slot>) {
+        let mut ancestor_ids = HashSet::new();
+        let mut occupied_slots = HashSet::new();
+        let mut ancestor = Some(parent);
+        while let Some(block) = ancestor {
+            if block.slot.into_inner() < window_start {
+                break;
+            }
+            ancestor_ids.insert(block.id);
+            occupied_slots.insert(block.slot);
+            occupied_slots.extend(
+                block
+                    .uncle_slots
+                    .iter()
+                    .filter(|uncle_slot| uncle_slot.into_inner() >= window_start)
+                    .copied(),
+            );
+            ancestor = self.branches.parent(block);
+        }
+        (ancestor_ids, occupied_slots)
+    }
+
+    /// Collects uncle candidates by walking back all branches in the tree,
+    /// to find the 1st block of each fork that meets the criteria.
+    ///
+    /// Complexity: `O(n_forks * window_size)`
+    fn uncle_candidates(
+        &self,
+        slot: Slot,
+        window_start: u64,
+        ancestor_ids: &HashSet<Id>,
+        occupied_slots: &HashSet<Slot>,
+    ) -> Vec<&Branch<Id>> {
+        let mut candidates: Vec<&Branch<Id>> = Vec::new();
+        for branch_tip in self.branches.branches() {
+            let mut current = Some(branch_tip);
+            while let Some(block) = current {
+                // Reached the chain of `parent` or the window's end.
+                if block.slot.into_inner() < window_start || ancestor_ids.contains(&block.id) {
+                    break;
+                }
+                if block.slot < slot
+                    && ancestor_ids.contains(&block.parent)
+                    && !occupied_slots.contains(&block.slot)
+                {
+                    candidates.push(block);
+                }
+                current = self.branches.parent(block);
+            }
+        }
+        candidates
     }
 }
 
@@ -1415,6 +1536,180 @@ pub mod tests {
         assert_eq!(
             pruned_blocks.immutable_blocks,
             [(7.into(), hash(&7u64))].into(),
+        );
+    }
+
+    #[test]
+    fn select_uncles_picks_oldest_first_blocks_of_forks() {
+        // g(0) -- b1(1) -- b2(3) -- b3(6; uncles=[4]) -- b4(8) <- adding b5(9)
+        //          |        |        |------------ u4(7) candidate
+        //          |        |-- u2(4)                    slot 4 already referenced by b3
+        //          |        |---- u5(5)                  candidate
+        //          |-- u1(2)                             candidate
+        //          |    |-------- d1(5)                  not the first block of a fork
+        //          |-- u3(2)                             candidate, same slot as u1
+        let g = hash(&0u64);
+        let [b1, b2, b3, b4] = [1u64, 2, 3, 4].map(|i| hash(&i));
+        let [u1, u2, u3, u4, u5, d1] = [20u64, 21, 22, 23, 24, 25].map(|i| hash(&i));
+
+        let mut engine = Cryptarchia::from_lib(
+            g,
+            config_with(10),
+            State::Bootstrapping,
+            0.into(),
+            0,
+            UncleSlots::default(),
+        );
+        for (id, parent, slot, uncle_slots) in [
+            (b1, g, 1u64, UncleSlots::default()),
+            (b2, b1, 3, UncleSlots::default()),
+            (b3, b2, 6, [Slot::from(4u64)].into()),
+            (b4, b3, 8, UncleSlots::default()),
+            (u1, b1, 2, UncleSlots::default()),
+            (u3, b1, 2, UncleSlots::default()),
+            (d1, u1, 5, UncleSlots::default()),
+            (u2, b2, 4, UncleSlots::default()),
+            (u5, b2, 5, UncleSlots::default()),
+            (u4, b3, 7, UncleSlots::default()),
+        ] {
+            engine
+                .receive_block(id, parent, slot.into(), uncle_slots)
+                .expect("test block to be applied successfully.");
+        }
+        assert_eq!(engine.tip(), b4);
+
+        let selected: Vec<_> = engine
+            .select_uncles(engine.tip_branch(), 9.into())
+            .iter()
+            .map(|uncle| uncle.id())
+            .collect();
+        // Ties on the same slot are broken by the smaller ID.
+        assert_eq!(selected, [u1.min(u3), u5, u4]);
+    }
+
+    #[test]
+    fn select_uncles_honors_the_window() {
+        // g(0) -- a(8) -- b1(10)     <- adding b2(11)
+        //  |       |-- u9(9)         candidate
+        //  |       |------- u11(11)  not strictly older than the proposal slot
+        //  |-- u7(7)                 older than the window
+        //  |---- u8(8)               in the window, but its parent `g` is older
+        //                            (not a valid uncle)
+        let g = hash(&0u64);
+        let [a, b1, u7, u8, u9, u11] = [1u64, 2, 20, 21, 22, 23].map(|i| hash(&i));
+
+        // With `w_u = 3`, a proposal at slot 11 can only reference [8, 11).
+        let config = Config::new(
+            NonZero::new(10).unwrap(),
+            NonNegativeRatio::new(1, 10.try_into().unwrap()),
+            1f64.try_into().expect("1 > 0"),
+            NonZero::new(3).unwrap(),
+        );
+        let mut engine = Cryptarchia::from_lib(
+            g,
+            config,
+            State::Bootstrapping,
+            0.into(),
+            0,
+            UncleSlots::default(),
+        );
+        for (id, parent, slot) in [
+            (a, g, 8u64),
+            (b1, a, 10),
+            (u7, g, 7),
+            (u8, g, 8),
+            (u9, a, 9),
+            (u11, a, 11),
+        ] {
+            engine
+                .receive_block(id, parent, slot.into(), UncleSlots::default())
+                .expect("test block to be applied successfully.");
+        }
+        assert_eq!(engine.tip(), b1);
+
+        let selected: Vec<_> = engine
+            .select_uncles(engine.tip_branch(), 11.into())
+            .iter()
+            .map(|uncle| uncle.id())
+            .collect();
+        assert_eq!(selected, [u9]);
+    }
+
+    #[test]
+    fn select_uncles_selects_nothing_with_the_minimum_window() {
+        // g(0) -- b1(9)              <- adding b2(11)
+        //  |       |-- u10(10)       its parent is below the window
+        //  |                         (not a valid uncle)
+        //  |----- u9(9)              older than the window
+        //
+        // With `w_u = 1`, a proposal at slot 11 can only reference slot 10.
+        // Unless the chain has a block at exactly slot 10, the windowed walk
+        // collects no ancestor, so no candidate can pass the parent check; and
+        // if it has one, its own slot occupies the only referenceable slot.
+        // Either way, nothing is ever selected.
+        let g = hash(&0u64);
+        let [b1, u9, u10] = [1u64, 20, 21].map(|i| hash(&i));
+
+        let config = Config::new(
+            NonZero::new(10).unwrap(),
+            NonNegativeRatio::new(1, 10.try_into().unwrap()),
+            1f64.try_into().expect("1 > 0"),
+            NonZero::new(1).unwrap(),
+        );
+        let mut engine = Cryptarchia::from_lib(
+            g,
+            config,
+            State::Bootstrapping,
+            0.into(),
+            0,
+            UncleSlots::default(),
+        );
+        for (id, parent, slot) in [(b1, g, 9u64), (u9, g, 9), (u10, b1, 10)] {
+            engine
+                .receive_block(id, parent, slot.into(), UncleSlots::default())
+                .expect("test block to be applied successfully.");
+        }
+
+        let parent = engine.branches().get(&b1).unwrap();
+        assert!(engine.select_uncles(parent, 11.into()).is_empty());
+    }
+
+    #[test]
+    fn select_uncles_takes_at_most_max_uncles() {
+        // g(0) ----------------------------------- b1(6)  <- adding b2(7)
+        //  |
+        //  |- f1(1) - f2(2) - f3(3) - f4(4) - f5(5)
+        let g = hash(&0u64);
+        let b1 = hash(&1u64);
+
+        let mut engine = Cryptarchia::from_lib(
+            g,
+            config_with(10),
+            State::Bootstrapping,
+            0.into(),
+            0,
+            UncleSlots::default(),
+        );
+        engine
+            .receive_block(b1, g, 6.into(), UncleSlots::default())
+            .expect("test block to be applied successfully.");
+        for slot in 1u64..=5 {
+            engine
+                .receive_block(hash(&(20 + slot)), g, slot.into(), UncleSlots::default())
+                .expect("test block to be applied successfully.");
+        }
+
+        let selected: Vec<_> = engine
+            .select_uncles(engine.tip_branch(), 7.into())
+            .iter()
+            .map(|uncle| uncle.slot())
+            .collect();
+        // The oldest `MAX_UNCLES` candidates win; the one at slot 5 is dropped.
+        assert_eq!(
+            selected,
+            (1u64..=crate::MAX_UNCLES as u64)
+                .map(Slot::from)
+                .collect::<Vec<_>>()
         );
     }
 }

--- a/core/src/block/uncle.rs
+++ b/core/src/block/uncle.rs
@@ -1,5 +1,5 @@
 use lb_codec::BinaryCodec;
-use lb_cryptarchia_engine::MAX_UNCLES;
+use lb_cryptarchia_engine::{MAX_UNCLES, Slot, UncleSlots};
 use lb_key_management_system_keys::keys::Ed25519Signature;
 use lb_utils::bounded::UpperBoundedVec;
 use serde::{Deserialize, Serialize};
@@ -19,6 +19,15 @@ impl UncleHeaders {
     #[must_use]
     pub const fn empty() -> Self {
         Self(UpperBoundedVec::new_unchecked(Vec::new()))
+    }
+
+    /// The slots the carried headers occupy.
+    #[must_use]
+    pub fn slots(&self) -> UncleSlots {
+        let slots: Vec<Slot> = self.0.iter().map(|uncle| uncle.header.slot()).collect();
+        slots
+            .try_into()
+            .expect("one slot per header, so the same bound holds")
     }
 
     #[must_use]

--- a/services/chain/chain-leader/src/lib.rs
+++ b/services/chain/chain-leader/src/lib.rs
@@ -471,6 +471,7 @@ where
                                 slot,
                                 proof,
                                 &signing_key,
+                                &cryptarchia_api,
                                 &relays,
                                 tip_state,
                                 &ledger_config,
@@ -575,13 +576,22 @@ where
 {
     #[instrument(
         level = "debug",
-        skip(relays, ledger_state, ledger_config, proof, signing_key)
+        skip(
+            relays,
+            ledger_state,
+            ledger_config,
+            cryptarchia_api,
+            proof,
+            signing_key
+        )
     )]
+    #[expect(clippy::too_many_arguments, reason = "Need all args")]
     async fn propose_block(
         parent: HeaderId,
         slot: Slot,
         proof: Groth16LeaderProof,
         signing_key: &Ed25519Key,
+        cryptarchia_api: &CryptarchiaServiceApi<CryptarchiaService, RuntimeServiceId>,
         relays: &CryptarchiaConsensusRelays<
             BlendService,
             Mempool,
@@ -660,8 +670,16 @@ where
         let valid_tx_stream = stream::iter(valid_txs);
         let txs = txs_for_block(valid_tx_stream).await;
 
-        // TODO: Select uncles.
-        let block = Block::create(parent, slot, UncleHeaders::empty(), proof, txs, signing_key)?;
+        let uncle_headers = cryptarchia_api
+            .select_uncles(parent, slot)
+            .await
+            .unwrap_or_else(|err| {
+                error!(target: LOG_TARGET, ?slot, %err, "failed to select uncles");
+                // A proposal without uncles is still valid
+                UncleHeaders::empty()
+            });
+
+        let block = Block::create(parent, slot, uncle_headers, proof, txs, signing_key)?;
 
         info!(
             "proposed block {:?} with {} transactions ({} removed)",

--- a/services/chain/chain-network/src/bootstrap/ibd.rs
+++ b/services/chain/chain-network/src/bootstrap/ibd.rs
@@ -359,7 +359,7 @@ mod tests {
         block::Proposal,
         sdp::{MinStake, ServiceParameters, ServiceType},
     };
-    use lb_cryptarchia_engine::{EpochConfig, Slot};
+    use lb_cryptarchia_engine::{EpochConfig, Slot, UncleSlots};
     use lb_ledger::{
         LedgerState,
         mantle::sdp::{ServiceRewardsParameters, rewards},
@@ -672,7 +672,7 @@ mod tests {
 
             self.cryptarchia
                 .consensus
-                .receive_block(block.id, block.parent, block.slot)
+                .receive_block(block.id, block.parent, block.slot, UncleSlots::default())
                 .map_err(|e| {
                     self.process_block_failures.fetch_add(1, Ordering::SeqCst);
                     Error::BlockProcessing(ChainError::InvalidBlock(format!(
@@ -930,6 +930,7 @@ mod tests {
             lb_cryptarchia_engine::State::Bootstrapping,
             0.into(),
             0,
+            UncleSlots::default(),
         )
     }
 

--- a/services/chain/chain-service/src/api.rs
+++ b/services/chain/chain-service/src/api.rs
@@ -1,7 +1,11 @@
 use std::pin::Pin;
 
 use futures::{Stream, TryStreamExt as _};
-use lb_core::{block::Block, events::Events, header::HeaderId};
+use lb_core::{
+    block::{Block, UncleHeaders},
+    events::Events,
+    header::HeaderId,
+};
 use lb_cryptarchia_engine::Slot;
 use lb_network_service::message::ChainSyncEvent;
 use overwatch::services::{ServiceData, relay::OutboundRelay};
@@ -249,6 +253,33 @@ where
 
         rx.await.map_err(|relay_error| {
             ApiError::CommsFailure(format!("{relay_error} while receiving GetBlockEvents"))
+        })
+    }
+
+    /// Selects uncles for a new block extending `parent` at `slot`.
+    pub async fn select_uncles(
+        &self,
+        parent: HeaderId,
+        slot: Slot,
+    ) -> Result<UncleHeaders, ApiError> {
+        let (reply_channel, rx) = oneshot::channel();
+
+        self.relay
+            .send(
+                Query::SelectUncles {
+                    parent,
+                    slot,
+                    reply_channel,
+                }
+                .into(),
+            )
+            .await
+            .map_err(|(relay_error, _)| {
+                ApiError::CommsFailure(format!("{relay_error} while sending SelectUncles"))
+            })?;
+
+        rx.await.map_err(|relay_error| {
+            ApiError::CommsFailure(format!("{relay_error} while receiving SelectUncles"))
         })
     }
 

--- a/services/chain/chain-service/src/lib.rs
+++ b/services/chain/chain-service/src/lib.rs
@@ -33,7 +33,7 @@ use lb_core::{
     },
     sdp::{Declaration, DeclarationId},
 };
-use lb_cryptarchia_engine::{Branch, PrunedBlocks, ReorgedBlocks};
+use lb_cryptarchia_engine::{Branch, PrunedBlocks, ReorgedBlocks, UncleSlots};
 pub use lb_cryptarchia_engine::{Epoch, Slot, State};
 pub use lb_ledger::EpochState;
 use lb_ledger::LedgerState;
@@ -293,6 +293,10 @@ pub struct Cryptarchia {
 impl Cryptarchia {
     /// Initialize a new [`Cryptarchia`] instance.
     #[must_use]
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "TODO: define Lib struct to reduce args"
+    )]
     pub fn from_lib(
         lib_id: HeaderId,
         lib_ledger_state: LedgerState,
@@ -301,6 +305,7 @@ impl Cryptarchia {
         state: State,
         lib_slot: Slot,
         lib_length: u64,
+        lib_uncle_slots: UncleSlots,
     ) -> Self {
         Self {
             consensus: <lb_cryptarchia_engine::Cryptarchia<_>>::from_lib(
@@ -309,6 +314,7 @@ impl Cryptarchia {
                 state,
                 lib_slot,
                 lib_length,
+                lib_uncle_slots,
             ),
             ledger: <lb_ledger::Ledger<_>>::new(lib_id, lib_ledger_state, ledger_config),
             genesis_id,
@@ -396,7 +402,7 @@ impl Cryptarchia {
 
         let (pruned_blocks, reorged_blocks) = self
             .consensus
-            .receive_block(id, parent, slot)
+            .receive_block(id, parent, slot, block.uncle_headers().slots())
             .map_err(|err| match err {
                 lb_cryptarchia_engine::Error::ParentMissing(parent) => Error::ParentMissing {
                     parent,
@@ -881,6 +887,7 @@ where
             state,
             recovery_state.lib_block_slot,
             recovery_state.lib_block_length,
+            recovery_state.lib_block_uncle_slots.clone(),
         );
 
         // Stream the already applied state.

--- a/services/chain/chain-service/src/lib.rs
+++ b/services/chain/chain-service/src/lib.rs
@@ -23,7 +23,7 @@ use derivative::Derivative;
 use futures::{Stream, TryStreamExt as _};
 use lb_chain_broadcast_service::BlockBroadcastService;
 use lb_core::{
-    block::{Block, genesis::GenesisBlock},
+    block::{Block, UncleHeaders, genesis::GenesisBlock},
     events::Events,
     header::HeaderId,
     mantle::{
@@ -199,6 +199,12 @@ pub enum Query {
     GetBlockEvents {
         id: HeaderId,
         reply_channel: oneshot::Sender<Option<Events>>,
+    },
+    /// Selects uncles for a new block extending `parent` at `slot`.
+    SelectUncles {
+        parent: HeaderId,
+        slot: Slot,
+        reply_channel: oneshot::Sender<UncleHeaders>,
     },
     /// Subscribe to be notified when the chain becomes online mode.
     /// Since chain never goes back after entering online,

--- a/services/chain/chain-service/src/metrics.rs
+++ b/services/chain/chain-service/src/metrics.rs
@@ -3,8 +3,8 @@ use lb_cryptarchia_sync::HeaderId;
 use lb_ledger::Ledger;
 
 pub fn emit_consensus_metrics(consensus: &Cryptarchia<HeaderId>, ledger: &Ledger<HeaderId>) {
-    let tip_branch = *consensus.tip_branch();
-    let lib_branch = *consensus.lib_branch();
+    let tip_branch = consensus.tip_branch();
+    let lib_branch = consensus.lib_branch();
 
     let height = tip_branch.length();
     let finalized_height = lib_branch.length();

--- a/services/chain/chain-service/src/service/mod.rs
+++ b/services/chain/chain-service/src/service/mod.rs
@@ -13,7 +13,7 @@ use bytes::Bytes;
 use futures::{Stream, StreamExt as _, future::join_all, stream};
 use lb_chain_broadcast_service::{BlockBroadcastMsg, BlockInfo};
 use lb_core::{
-    block::Block,
+    block::{Block, SignedHeader, UncleHeaders},
     events::Events,
     header::HeaderId,
     mantle::{
@@ -25,6 +25,7 @@ use lb_cryptarchia_engine::{PrunedBlocks, Slot};
 use lb_cryptarchia_sync::{BlocksUnavailableReason, ProviderResponse};
 use lb_network_service::message::ChainSyncEvent;
 use lb_storage_service::{api::chain::StorageChainApi, backends::StorageBackend};
+use lb_utils::bounded::UpperBoundedVec;
 use overwatch::{
     DynError,
     services::{relay::InboundRelay, state::StateUpdater},
@@ -280,6 +281,16 @@ where
                     error!("Could not send block events through channel");
                 });
             }
+            Query::SelectUncles {
+                parent,
+                slot,
+                reply_channel,
+            } => {
+                let uncles = self.select_uncles(parent, slot).await;
+                reply_channel.send(uncles).unwrap_or_else(|_| {
+                    error!("Could not send uncles through channel");
+                });
+            }
             Query::SubscribeChainOnline { sender } => {
                 sender
                     .send(self.chain_online_notifier.subscribe())
@@ -288,6 +299,41 @@ where
                     });
             }
         }
+    }
+
+    /// Selects uncles for a new block extending `parent` at `slot`.
+    async fn select_uncles(&self, parent: HeaderId, slot: Slot) -> UncleHeaders {
+        let Some(parent_branch) = self.cryptarchia.consensus.branches().get(&parent) else {
+            return UncleHeaders::empty();
+        };
+
+        let mut uncles = Vec::new();
+        for candidate in self
+            .cryptarchia
+            .consensus
+            .select_uncles(parent_branch, slot)
+        {
+            // Every block accepted into the block tree is persisted, so a
+            // candidate must be loadable. Even if not, a proposal is still
+            // valid with fewer uncles.
+            let Some(block) = self
+                .relays
+                .storage_adapter()
+                .get_block(&candidate.id())
+                .await
+            else {
+                error!(target: LOG_TARGET, candidate = ?candidate.id(), "uncle candidate not found in storage");
+                continue;
+            };
+            uncles.push(SignedHeader::new(
+                block.header().clone(),
+                *block.signature(),
+            ));
+        }
+
+        UncleHeaders::new(
+            UpperBoundedVec::try_from(uncles).expect("at most MAX_UNCLES uncles are selected"),
+        )
     }
 
     /// Record the current service state.

--- a/services/chain/chain-service/src/states.rs
+++ b/services/chain/chain-service/src/states.rs
@@ -14,6 +14,12 @@ pub struct CryptarchiaConsensusState {
     pub(crate) lib_ledger_state: LedgerState,
     pub(crate) lib_block_length: u64,
     pub(crate) lib_block_slot: lb_cryptarchia_engine::Slot,
+    /// The uncle slots in the LIB header.
+    /// These are unlikely to be used for future uncle selections,
+    /// given the depth of LIB. But, we save them because any blocks
+    /// in cryptarchia-engine must be restored to the same state as before
+    /// shutdown.
+    pub(crate) lib_block_uncle_slots: lb_cryptarchia_engine::UncleSlots,
     pub(crate) genesis_id: HeaderId,
     /// Set of blocks that have been pruned from the engine but have not yet
     /// been deleted from the persistence layer because of some unexpected
@@ -47,6 +53,7 @@ impl CryptarchiaConsensusState {
         };
         let lib_block_length = lib.length();
         let lib_block_slot = lib.slot();
+        let lib_block_uncle_slots = lib.uncle_slots().clone();
 
         Ok(Self {
             tip: cryptarchia.consensus.tip_branch().id(),
@@ -55,6 +62,7 @@ impl CryptarchiaConsensusState {
             lib_ledger_state,
             lib_block_length,
             lib_block_slot,
+            lib_block_uncle_slots,
             storage_blocks_to_remove,
             last_engine_state: Some(LastEngineState {
                 timestamp: SystemTime::now(),
@@ -98,6 +106,7 @@ impl ServiceState for CryptarchiaConsensusState {
             lib_ledger_state,
             lib_block_length: 0,
             lib_block_slot: lb_cryptarchia_engine::Slot::default(),
+            lib_block_uncle_slots: lb_cryptarchia_engine::UncleSlots::default(),
             genesis_id,
             storage_blocks_to_remove: HashSet::new(),
             last_engine_state: None,
@@ -122,7 +131,7 @@ mod tests {
         codec::{DeserializeOp as _, SerializeOp as _},
         sdp::{MinStake, ServiceParameters, ServiceType},
     };
-    use lb_cryptarchia_engine::State::Bootstrapping;
+    use lb_cryptarchia_engine::{State::Bootstrapping, UncleSlots};
     use lb_ledger::mantle::sdp::{ServiceRewardsParameters, rewards};
     use lb_utils::math::{NonNegativeF64, NonNegativeRatio};
 
@@ -189,6 +198,7 @@ mod tests {
                 Bootstrapping,
                 0.into(),
                 0,
+                UncleSlots::default(),
             );
 
             //      b4 - b5
@@ -200,32 +210,72 @@ mod tests {
             // Add 3 more blocks to canonical chain. `b0`, `b1`, `b2`, and `b3` represent
             // the canonical chain now.
             cryptarchia
-                .receive_block([1; 32].into(), genesis_header_id, 1.into())
+                .receive_block(
+                    [1; 32].into(),
+                    genesis_header_id,
+                    1.into(),
+                    UncleSlots::default(),
+                )
                 .expect("Block 1 to be added successfully on top of block 0.");
             cryptarchia
-                .receive_block([2; 32].into(), [1; 32].into(), 2.into())
+                .receive_block(
+                    [2; 32].into(),
+                    [1; 32].into(),
+                    2.into(),
+                    UncleSlots::default(),
+                )
                 .expect("Block 2 to be added successfully on top of block 1.");
             cryptarchia
-                .receive_block([3; 32].into(), [2; 32].into(), 3.into())
+                .receive_block(
+                    [3; 32].into(),
+                    [2; 32].into(),
+                    3.into(),
+                    UncleSlots::default(),
+                )
                 .expect("Block 3 to be added successfully on top of block 2.");
             // Add a 2-block fork from genesis
             cryptarchia
-                .receive_block([4; 32].into(), genesis_header_id, 1.into())
+                .receive_block(
+                    [4; 32].into(),
+                    genesis_header_id,
+                    1.into(),
+                    UncleSlots::default(),
+                )
                 .expect("Block 4 to be added successfully on top of block 0.");
             cryptarchia
-                .receive_block([5; 32].into(), [4; 32].into(), 2.into())
+                .receive_block(
+                    [5; 32].into(),
+                    [4; 32].into(),
+                    2.into(),
+                    UncleSlots::default(),
+                )
                 .expect("Block 5 to be added successfully on top of block 4.");
             // Add a second single-block fork from genesis
             cryptarchia
-                .receive_block([6; 32].into(), genesis_header_id, 1.into())
+                .receive_block(
+                    [6; 32].into(),
+                    genesis_header_id,
+                    1.into(),
+                    UncleSlots::default(),
+                )
                 .expect("Block 6 to be added successfully on top of block 0.");
             // Add a single-block fork from the block after genesis (block `1`)
             cryptarchia
-                .receive_block([7; 32].into(), [1; 32].into(), 2.into())
+                .receive_block(
+                    [7; 32].into(),
+                    [1; 32].into(),
+                    2.into(),
+                    UncleSlots::default(),
+                )
                 .expect("Block 7 to be added successfully on top of block 1.");
             // Add a single-block fork from the second block after genesis (block `2`)
             cryptarchia
-                .receive_block([8; 32].into(), [2; 32].into(), 3.into())
+                .receive_block(
+                    [8; 32].into(),
+                    [2; 32].into(),
+                    3.into(),
+                    UncleSlots::default(),
+                )
                 .expect("Block 8 to be added successfully on top of block 2.");
 
             cryptarchia.online()
@@ -321,13 +371,16 @@ mod tests {
             Bootstrapping,
             0.into(),
             0,
+            UncleSlots::default(),
         );
         let block_ids: Vec<HeaderId> = (1..=5u8).map(|i| [i; 32].into()).collect();
         let mut parent = genesis_header_id;
         for (i, &block_id) in block_ids.iter().enumerate() {
             let slot = (i as u64 + 1).into();
+            let uncle_slots =
+                UncleSlots::try_from(vec![lb_cryptarchia_engine::Slot::from(i as u64)]).unwrap();
             engine
-                .receive_block(block_id, parent, slot)
+                .receive_block(block_id, parent, slot, uncle_slots)
                 .unwrap_or_else(|_| panic!("Block {block_id} should be added successfully"));
             parent = block_id;
         }
@@ -371,7 +424,16 @@ mod tests {
             *engine.state(),
             saved_state.lib_block_slot,
             saved_state.lib_block_length,
+            saved_state.lib_block_uncle_slots.clone(),
         );
+
+        // Check the restore LIB is the same as before.
+        let restored_lib = restored.consensus.lib_branch();
+        let original_lib = engine.lib_branch();
+        assert_eq!(restored_lib.id(), original_lib.id());
+        assert_eq!(restored_lib.slot(), original_lib.slot());
+        assert_eq!(restored_lib.length(), original_lib.length());
+        assert_eq!(restored_lib.uncle_slots(), original_lib.uncle_slots());
 
         // Replay blocks between LIB and tip (as initialize_cryptarchia does).
         // Walk from tip back to LIB to find the blocks to replay.
@@ -384,11 +446,17 @@ mod tests {
         }
         blocks_to_replay.reverse();
         for (block_id, slot) in blocks_to_replay {
-            let parent_id = engine.branches().get(&block_id).unwrap().parent();
+            let branch = engine.branches().get(&block_id).unwrap();
+            let parent_id = branch.parent();
+            let uncle_slots = branch.uncle_slots().clone();
             restored
                 .consensus
-                .receive_block(block_id, parent_id, slot)
+                .receive_block(block_id, parent_id, slot, uncle_slots)
                 .unwrap_or_else(|_| panic!("Replay of {block_id} should succeed"));
+            assert_eq!(
+                restored.consensus.branches().get(&block_id).unwrap(),
+                engine.branches().get(&block_id).unwrap()
+            );
         }
 
         let info_after = restored.info();

--- a/services/chain/chain-service/src/sync/block_provider.rs
+++ b/services/chain/chain-service/src/sync/block_provider.rs
@@ -442,7 +442,8 @@ where
                 let known_branch = branches.get(known)?;
                 branches.lca(known_branch, target_branch)
             })
-            .max_by_key(Branch::length)
+            .max_by_key(|branch| branch.length())
+            .cloned()
     }
 
     async fn find_max_slot_immutable_block(
@@ -596,7 +597,7 @@ mod tests {
         },
         proofs::leader_proof::{LeaderPrivate, LeaderPublic},
     };
-    use lb_cryptarchia_engine::Config;
+    use lb_cryptarchia_engine::{Config, UncleSlots};
     use lb_groth16::Fr;
     use lb_key_management_system_keys::keys::{Ed25519Key, UnsecuredZkKey};
     use lb_storage_service::{
@@ -885,7 +886,7 @@ mod tests {
 
                 if i > 0 {
                     self.cryptarchia
-                        .receive_block(*header_id, *prev_header, *slot)
+                        .receive_block(*header_id, *prev_header, *slot, UncleSlots::default())
                         .expect("Failed to add block to cryptarchia");
                 }
 
@@ -922,7 +923,7 @@ mod tests {
             slot: Slot,
         ) {
             self.cryptarchia
-                .receive_block(header_id, prev_header, slot)
+                .receive_block(header_id, prev_header, slot, UncleSlots::default())
                 .expect("Failed to add block to cryptarchia");
 
             self.store_block_in_storage(block, header_id, slot).await;
@@ -1138,6 +1139,7 @@ mod tests {
                 lb_cryptarchia_engine::State::Bootstrapping,
                 0.into(),
                 0,
+                UncleSlots::default(),
             )
         }
     }

--- a/services/chain/chain-service/src/tests/mod.rs
+++ b/services/chain/chain-service/src/tests/mod.rs
@@ -16,7 +16,7 @@ use lb_core::{
     proofs::leader_proof::{Groth16LeaderProof, LeaderPrivate, LeaderPublic, check_winning},
     sdp::ServiceParameters,
 };
-use lb_cryptarchia_engine::{EpochConfig, Slot};
+use lb_cryptarchia_engine::{EpochConfig, Slot, UncleSlots};
 use lb_cryptarchia_sync::HeaderId;
 use lb_groth16::{AdditiveGroup as _, Fr};
 use lb_key_management_system_keys::keys::{Ed25519Key, ZkKey};
@@ -62,6 +62,7 @@ fn cryptarchia_switch_to_online() {
         lb_cryptarchia_engine::State::Bootstrapping,
         Slot::new(0),
         0,
+        UncleSlots::default(),
     );
 
     // Add 3 new blocks to the chain
@@ -141,6 +142,7 @@ async fn get_block_ids_from_memory_and_storage() {
         lb_cryptarchia_engine::State::Online,
         Slot::genesis(),
         0,
+        UncleSlots::default(),
     );
 
     // Add 2 blocks (not finalized yet since k=3)
@@ -329,6 +331,7 @@ fn test_chain_with_next_block() -> (Cryptarchia, Block<SignedMantleTx<Preverifie
         lb_cryptarchia_engine::State::Online,
         Slot::genesis(),
         0,
+        UncleSlots::default(),
     );
     let block =
         try_build_block(&cryptarchia, cryptarchia.tip(), utxo, &zk_key, Slot::new(1)).unwrap();


### PR DESCRIPTION
## 1. What does this PR implement?

This is the 3rd PR for the [Uncle Reference RFC](https://github.com/logos-co/logos-lips/pull/385). 

If you want to understand what the uncle reference is, please see a short summary in the PR https://github.com/logos-blockchain/logos-blockchain/pull/3281.

This PR is the block-proposer-side implementation. A block proposer can select/include uncles to a new block that he proposes. 

This PR implements the way how uncles are selected. The rule is defined in the RFC. Also, in a next PR, block validators will verify uncles by following some part of the same rule. 

- Chain leader service selects uncles when proposing a block. 
  - I left detailed doc comments to explain how uncles are selected. I believe, those comments explain the logic clearly. 
- The cryptarchia-engine `Branch` tracks `uncle_slots`, so occupied slots are known for selection.

A next PR would be the block-validator-side implementation: verifying uncle references included in a block when validating the block.


## 2. Does the code have enough context to be clearly?

Yes. See the `Uncle Selection` part in the RFC. 

## 3. Who are the specification authors and who is accountable for this PR?

Spec: @madxor. PR: @youngjoon-lee.

## 4. Is the specification accurate and complete?

The selection follows the revised validity rule agreed with @madxor (`0 < A.slot - U.parent.slot <= w_u`), which bounds all walks by the window. The spec update is pending simulation results.

## 5. Does the implementation introduce changes in the specification?

Yes, the parent-window rule above; agreed with @madxor, spec update pending.
