### PR TITLE
feat(chain): uncle-ref: verify uncles when applying a block

### DIFF
--- a/core/src/block/uncle.rs
+++ b/core/src/block/uncle.rs
@@ -4,7 +4,7 @@ use lb_key_management_system_keys::keys::Ed25519Signature;
 use lb_utils::bounded::UpperBoundedVec;
 use serde::{Deserialize, Serialize};
 
-use crate::header::Header;
+use crate::header::{Header, HeaderId};
 
 /// Signed headers of the uncles referenced by a block.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, BinaryCodec)]
@@ -28,6 +28,14 @@ impl UncleHeaders {
         slots
             .try_into()
             .expect("one slot per header, so the same bound holds")
+    }
+
+    pub fn ids(&self) -> impl Iterator<Item = HeaderId> {
+        self.0.iter().map(|uncle| uncle.header.id())
+    }
+
+    pub fn parents(&self) -> impl Iterator<Item = HeaderId> {
+        self.0.iter().map(|uncle| uncle.header.parent())
     }
 
     #[must_use]

--- a/ledger/src/cryptarchia/mod.rs
+++ b/ledger/src/cryptarchia/mod.rs
@@ -459,10 +459,41 @@ impl LedgerState {
         // Then, apply the proof and update the nonce. Finally, increment block density
         // since this function is called for a new block.
         Ok(self
-            .update_epoch_state(slot, sdp, config)?
-            .try_apply_proof(slot, proof, config)?
+            .update_epoch_state_and_apply_proof(slot, proof, sdp, config)?
             .update_nonce(&proof.entropy(), slot)
             .increment_block_density(slot))
+    }
+
+    /// Synthesizes the epoch state for `slot` and apply the proof.
+    fn update_epoch_state_and_apply_proof<LeaderProof, Id>(
+        self,
+        slot: Slot,
+        proof: &LeaderProof,
+        sdp: &SdpLedger,
+        config: &Config,
+    ) -> Result<Self, LedgerError<Id>>
+    where
+        LeaderProof: leader_proof::LeaderProof,
+    {
+        self.update_epoch_state(slot, sdp, config)?
+            .try_apply_proof(slot, proof, config)
+    }
+
+    /// Verifies a leadership proof for a block at `slot` whose parent is the
+    /// block this state belongs to, leaving the state untouched.
+    pub fn verify_proof_of_leadership<LeaderProof, Id>(
+        &self,
+        slot: Slot,
+        proof: &LeaderProof,
+        sdp: &SdpLedger,
+        config: &Config,
+    ) -> Result<(), LedgerError<Id>>
+    where
+        LeaderProof: leader_proof::LeaderProof,
+    {
+        self.clone()
+            .update_epoch_state_and_apply_proof(slot, proof, sdp, config)?;
+        Ok(())
     }
 
     pub fn try_apply_transfer<Id, Profile: GasProfile>(

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -314,6 +314,25 @@ impl LedgerState {
         ))
     }
 
+    /// Verifies a leadership proof for a block at `slot` whose parent is the
+    /// block this state belongs to, leaving the state untouched.
+    pub fn verify_proof_of_leadership<LeaderProof, Id>(
+        &self,
+        slot: Slot,
+        proof: &LeaderProof,
+        config: &Config,
+    ) -> Result<(), LedgerError<Id>>
+    where
+        LeaderProof: leader_proof::LeaderProof,
+    {
+        self.cryptarchia_ledger.verify_proof_of_leadership(
+            slot,
+            proof,
+            &self.mantle_ledger.sdp,
+            config,
+        )
+    }
+
     #[must_use]
     pub const fn get_gas_prices(&self) -> GasPrices {
         GasPrices {

--- a/services/chain/chain-service/src/lib.rs
+++ b/services/chain/chain-service/src/lib.rs
@@ -9,6 +9,7 @@ pub mod storage;
 mod sync;
 #[cfg(test)]
 mod tests;
+mod uncle;
 
 use core::fmt::Debug;
 use std::{
@@ -65,6 +66,7 @@ pub use crate::{
     service::phases::PhaseTag,
     states::CryptarchiaConsensusState,
     sync::config::{BlockProviderConfig, SyncConfig},
+    uncle::UncleError,
 };
 use crate::{
     bootstrap::state::choose_engine_state,
@@ -115,6 +117,8 @@ pub enum Error {
     ParentIdNotFound(HeaderId),
     #[error("Awaiting genesis time")]
     AwaitingGenesisTime,
+    #[error("Invalid uncle {uncle}: {reason}")]
+    InvalidUncle { uncle: HeaderId, reason: UncleError },
 }
 
 struct InitializedCryptarchia {
@@ -387,6 +391,9 @@ impl Cryptarchia {
                 current_slot,
             });
         }
+
+        // A block is valid only if every uncle it carries is valid.
+        self.verify_uncles(block)?;
 
         // A block number of this block if it's applied to the chain.
         let (_, state, events) = self

--- a/services/chain/chain-service/src/tests/mod.rs
+++ b/services/chain/chain-service/src/tests/mod.rs
@@ -71,12 +71,13 @@ fn cryptarchia_switch_to_online() {
     while block_ids.len() < 4 {
         // TODO: Use a mock proof system instead of expensive real proof generation,
         // by refactoring `Cryptarchia`.
-        let block = try_build_block(
+        let (block, _) = try_build_block(
             &cryptarchia,
             *block_ids.last().unwrap(),
             utxo,
             &zk_key,
             slot,
+            UncleHeaders::empty(),
         )
         .expect("should find a winning slot");
 
@@ -149,7 +150,15 @@ async fn get_block_ids_from_memory_and_storage() {
     let mut slot = Slot::genesis().strict_add(1.into());
     let mut block_ids = vec![genesis_id];
     for _ in 0..2 {
-        let block = try_build_block(&cryptarchia, cryptarchia.tip(), utxo, &zk_key, slot).unwrap();
+        let (block, _) = try_build_block(
+            &cryptarchia,
+            cryptarchia.tip(),
+            utxo,
+            &zk_key,
+            slot,
+            UncleHeaders::empty(),
+        )
+        .unwrap();
         process_block(
             &mut cryptarchia,
             block.clone(),
@@ -194,7 +203,15 @@ async fn get_block_ids_from_memory_and_storage() {
     // Add 3 more blocks.
     // Now G, b1 are in storage, and b2~5 are in memory.
     for _ in 0..3 {
-        let block = try_build_block(&cryptarchia, cryptarchia.tip(), utxo, &zk_key, slot).unwrap();
+        let (block, _) = try_build_block(
+            &cryptarchia,
+            cryptarchia.tip(),
+            utxo,
+            &zk_key,
+            slot,
+            UncleHeaders::empty(),
+        )
+        .unwrap();
         process_block(
             &mut cryptarchia,
             block.clone(),
@@ -333,8 +350,15 @@ fn test_chain_with_next_block() -> (Cryptarchia, Block<SignedMantleTx<Preverifie
         0,
         UncleSlots::default(),
     );
-    let block =
-        try_build_block(&cryptarchia, cryptarchia.tip(), utxo, &zk_key, Slot::new(1)).unwrap();
+    let (block, _) = try_build_block(
+        &cryptarchia,
+        cryptarchia.tip(),
+        utxo,
+        &zk_key,
+        Slot::new(1),
+        UncleHeaders::empty(),
+    )
+    .unwrap();
 
     (cryptarchia, block)
 }
@@ -393,7 +417,8 @@ pub fn try_build_block(
     utxo: Utxo,
     key: &ZkKey,
     start_slot: Slot,
-) -> Option<Block<SignedMantleTx<Preverified>>> {
+    uncle_headers: UncleHeaders,
+) -> Option<(Block<SignedMantleTx<Preverified>>, Ed25519Key)> {
     let start_slot: u64 = start_slot.into();
     for slot in start_slot..=(start_slot + 1000) {
         let epoch_state = cryptarchia.epoch_state_for_slot(slot.into()).unwrap();
@@ -426,17 +451,16 @@ pub fn try_build_block(
         )
         .unwrap();
 
-        return Some(
-            Block::create(
-                parent,
-                slot.into(),
-                UncleHeaders::empty(),
-                proof,
-                BlockTransactions::empty(),
-                &signing_key,
-            )
-            .unwrap(),
-        );
+        let block = Block::create(
+            parent,
+            slot.into(),
+            uncle_headers,
+            proof,
+            BlockTransactions::empty(),
+            &signing_key,
+        )
+        .unwrap();
+        return Some((block, signing_key));
     }
 
     None

--- a/services/chain/chain-service/src/uncle.rs
+++ b/services/chain/chain-service/src/uncle.rs
@@ -1,0 +1,463 @@
+//! The uncle validity rules
+
+use std::collections::HashSet;
+
+use lb_core::{
+    block::{Block, SignedHeader, UncleHeaders},
+    codec::SerializeOp as _,
+    header::HeaderId,
+    proofs::leader_proof::LeaderProof as _,
+};
+use lb_cryptarchia_engine::Branch;
+
+use crate::{Cryptarchia, Error};
+
+#[expect(
+    clippy::multiple_inherent_impl,
+    reason = "grouping the uncle validity rules separately from the main impl"
+)]
+impl Cryptarchia {
+    /// Verifies every uncle carried by the block against the chain the block
+    /// extends.
+    pub(crate) fn verify_uncles<Tx>(&self, block: &Block<Tx>) -> Result<(), Error> {
+        if block.uncle_headers().is_empty() {
+            return Ok(());
+        }
+
+        let header = block.header();
+        let slot = header.slot();
+        let parent = self
+            .consensus
+            .branches()
+            .get(&header.parent())
+            .ok_or_else(|| Error::ParentMissing {
+                parent: header.parent(),
+                info: Box::new(self.info()),
+            })?;
+
+        // Each uncle must be strictly older than the block. The window rule
+        // `0 < slot - uncle_parent_slot <= w_u` is enforced by the ancestry
+        // verification below, and it implies that the uncle itself is also
+        // within the window since an uncle is newer than its parent.
+        for uncle in block.uncle_headers().iter() {
+            if uncle.header().slot() >= slot {
+                return Err(Error::InvalidUncle {
+                    uncle: uncle.header().id(),
+                    reason: UncleError::NotStrictlyOlder,
+                });
+            }
+        }
+
+        let uncle_reference_window = self
+            .ledger
+            .config()
+            .consensus_config
+            .uncle_reference_window()
+            .get();
+        let window_start = slot.into_inner().saturating_sub(uncle_reference_window);
+        self.verify_uncles_ancestry(block.uncle_headers(), parent, window_start)?;
+
+        for uncle in block.uncle_headers().iter() {
+            self.verify_uncle_proofs(uncle)
+                .map_err(|reason| Error::InvalidUncle {
+                    uncle: uncle.header().id(),
+                    reason,
+                })?;
+        }
+        Ok(())
+    }
+
+    /// Verifies that no uncle is on the chain of `parent` while the parent of
+    /// every uncle is, within the window:
+    /// `0 < slot - uncle.parent.slot <= w_u`.
+    fn verify_uncles_ancestry(
+        &self,
+        uncle_headers: &UncleHeaders,
+        parent: &Branch<HeaderId>,
+        window_start: u64,
+    ) -> Result<(), Error> {
+        let uncles: HashSet<_> = uncle_headers.ids().collect();
+        let uncle_parents: HashSet<_> = uncle_headers.parents().collect();
+
+        let mut found_uncle_parents = HashSet::new();
+        let mut current = Some(parent);
+        while let Some(block) = current {
+            // The walk is bounded by the window: only the ancestors within it
+            // can be uncle parents, and any on-chain uncle is newer than its
+            // in-window parent, so nothing below can affect the verdict.
+            if block.slot().into_inner() < window_start {
+                break;
+            }
+            if uncles.contains(&block.id()) {
+                return Err(Error::InvalidUncle {
+                    uncle: block.id(),
+                    reason: UncleError::OnChain,
+                });
+            }
+            if uncle_parents.contains(&block.id()) {
+                found_uncle_parents.insert(block.id());
+            }
+            if block.parent() == block.id() {
+                break; // Reached the oldest block in the tree.
+            }
+            current = self.consensus.branches().get(&block.parent());
+        }
+
+        // Return an error if any uncle's parent was not found on the chain.
+        for uncle in uncle_headers.iter() {
+            if !found_uncle_parents.contains(&uncle.header().parent()) {
+                return Err(Error::InvalidUncle {
+                    uncle: uncle.header().id(),
+                    reason: UncleError::ParentNotOnChain,
+                });
+            }
+        }
+        Ok(())
+    }
+
+    /// Verifies the signature and the leadership proof carried by an uncle.
+    fn verify_uncle_proofs(&self, uncle: &SignedHeader) -> Result<(), UncleError> {
+        // The signature must verify over the uncle's header, by its own leader.
+        let header_bytes = uncle
+            .header()
+            .to_bytes()
+            .map_err(|_| UncleError::InvalidSignature)?;
+        uncle
+            .header()
+            .leader_proof()
+            .leader_key()
+            .verify(&header_bytes, uncle.signature())
+            .map_err(|_| UncleError::InvalidSignature)?;
+
+        // The proof of leadership must verify against the ledger state of the
+        // uncle's parent, which must exist since the parent is on the chain.
+        let parent_state = self
+            .ledger
+            .state(&uncle.header().parent())
+            .expect("ledger state of a block on the chain must exist");
+        parent_state
+            .verify_proof_of_leadership::<_, HeaderId>(
+                uncle.header().slot(),
+                uncle.header().leader_proof(),
+                self.ledger.config(),
+            )
+            .map_err(|_| UncleError::InvalidProof)
+    }
+}
+
+/// Why an uncle carried by a block fails the uncle validity rules,
+/// making the block itself invalid.
+#[derive(Debug, thiserror::Error)]
+pub enum UncleError {
+    #[error("not strictly older than the block")]
+    NotStrictlyOlder,
+    #[error("parent not on the chain that the block is extending, within the window")]
+    ParentNotOnChain,
+    #[error("on the chain that the block is extending")]
+    OnChain,
+    #[error("invalid header signature")]
+    InvalidSignature,
+    #[error("invalid proof of leadership")]
+    InvalidProof,
+}
+
+#[cfg(test)]
+mod tests {
+    use lb_core::{
+        block::BlockTransactions,
+        header::{ContentId, Header},
+        mantle::{SignedMantleTx, Utxo, transactions::states::Preverified},
+        proofs::leader_proof::Groth16LeaderProof,
+    };
+    use lb_cryptarchia_engine::{Slot, UncleSlots};
+    use lb_key_management_system_keys::keys::{Ed25519Key, ZkKey};
+    use lb_ledger::LedgerState;
+    use rand::thread_rng;
+
+    use super::*;
+    use crate::tests::{ledger_config, try_build_block, utxo};
+
+    #[test]
+    fn test_accept_valid_uncle() {
+        let (mut cryptarchia, _, u1, _, zk_key, utxo) = chain_with_fork();
+
+        let (b2, _) = try_build_block(
+            &cryptarchia,
+            cryptarchia.tip(),
+            utxo,
+            &zk_key,
+            u1.header().slot().strict_add(1.into()),
+            UncleHeaders::new([signed_header(&u1)]),
+        )
+        .unwrap();
+
+        cryptarchia
+            .try_apply_block(&b2, b2.header().slot())
+            .expect("a block referencing a valid uncle should be applied");
+        assert_eq!(
+            cryptarchia
+                .consensus
+                .branches()
+                .get(&b2.header().id())
+                .unwrap()
+                .uncle_slots(),
+            &[u1.header().slot()].into()
+        );
+    }
+
+    #[test]
+    fn test_reject_uncle_not_strictly_older() {
+        let (mut cryptarchia, _, u1, u1_key, ..) = chain_with_fork();
+
+        // The block is at the same slot as the uncle it references.
+        let block = craft_block_with_uncles(
+            cryptarchia.tip(),
+            u1.header().slot(),
+            UncleHeaders::new([signed_header(&u1)]),
+            u1.header().leader_proof(),
+            &u1_key,
+        );
+
+        let Err(err) = cryptarchia.try_apply_block(&block, block.header().slot()) else {
+            panic!("expected the block to be rejected");
+        };
+        assert!(matches!(
+            err,
+            Error::InvalidUncle {
+                reason: UncleError::NotStrictlyOlder,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn test_reject_uncle_whose_parent_is_outside_window() {
+        let (mut cryptarchia, _, u1, u1_key, ..) = chain_with_fork();
+
+        // The block is more than `w_u` slots after the uncle's parent,
+        // which puts the uncle's parent outside the window.
+        let uncle_reference_window = cryptarchia
+            .ledger
+            .config()
+            .consensus_config
+            .uncle_reference_window()
+            .get();
+        let block = craft_block_with_uncles(
+            cryptarchia.tip(),
+            u1.header()
+                .slot()
+                .strict_add((uncle_reference_window + 1).into()),
+            UncleHeaders::new([signed_header(&u1)]),
+            u1.header().leader_proof(),
+            &u1_key,
+        );
+
+        let Err(err) = cryptarchia.try_apply_block(&block, block.header().slot()) else {
+            panic!("expected the block to be rejected");
+        };
+        assert!(matches!(
+            err,
+            Error::InvalidUncle {
+                reason: UncleError::ParentNotOnChain,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn test_reject_uncle_on_the_chain() {
+        let (mut cryptarchia, b1, u1, u1_key, ..) = chain_with_fork();
+
+        // The block references its own parent `B1` as an uncle.
+        let block = craft_block_with_uncles(
+            cryptarchia.tip(),
+            b1.header().slot().strict_add(1.into()),
+            UncleHeaders::new([signed_header(&b1)]),
+            u1.header().leader_proof(),
+            &u1_key,
+        );
+
+        let Err(err) = cryptarchia.try_apply_block(&block, block.header().slot()) else {
+            panic!("expected the block to be rejected");
+        };
+        assert!(matches!(
+            err,
+            Error::InvalidUncle {
+                reason: UncleError::OnChain,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn reject_uncle_whose_parent_is_not_on_the_chain() {
+        let (mut cryptarchia, _, u1, u1_key, ..) = chain_with_fork();
+
+        // An uncle whose parent is unknown to the chain.
+        let header = Header::new(
+            HeaderId::from([9u8; 32]),
+            ContentId::from([0u8; 32]),
+            u1.header().slot(),
+            u1.header().leader_proof().clone(),
+        );
+        let signature = header.sign(&u1_key).unwrap();
+        let block = craft_block_with_uncles(
+            cryptarchia.tip(),
+            u1.header().slot().strict_add(1.into()),
+            UncleHeaders::new([SignedHeader::new(header, signature)]),
+            u1.header().leader_proof(),
+            &u1_key,
+        );
+
+        let Err(err) = cryptarchia.try_apply_block(&block, block.header().slot()) else {
+            panic!("expected the block to be rejected");
+        };
+        assert!(matches!(
+            err,
+            Error::InvalidUncle {
+                reason: UncleError::ParentNotOnChain,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn reject_uncle_with_invalid_signature() {
+        let (mut cryptarchia, _, u1, u1_key, ..) = chain_with_fork();
+
+        // The uncle's header is intact, but signed by a key that is not its
+        // leader.
+        let signature = u1
+            .header()
+            .sign(&Ed25519Key::generate(&mut thread_rng()))
+            .unwrap();
+        let block = craft_block_with_uncles(
+            cryptarchia.tip(),
+            u1.header().slot().strict_add(1.into()),
+            UncleHeaders::new([SignedHeader::new(u1.header().clone(), signature)]),
+            u1.header().leader_proof(),
+            &u1_key,
+        );
+
+        let Err(err) = cryptarchia.try_apply_block(&block, block.header().slot()) else {
+            panic!("expected the block to be rejected");
+        };
+        assert!(matches!(
+            err,
+            Error::InvalidUncle {
+                reason: UncleError::InvalidSignature,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn reject_uncle_with_invalid_pol() {
+        let (mut cryptarchia, _, u1, u1_key, ..) = chain_with_fork();
+
+        // The uncle carries `U1`'s proof at a different slot, against which
+        // the proof was not proven. The signature itself is valid.
+        let wrong_uncle_slot = u1.header().slot().strict_add(1.into());
+        let header = Header::new(
+            HeaderId::from([0u8; 32]),
+            ContentId::from([0u8; 32]),
+            wrong_uncle_slot,
+            u1.header().leader_proof().clone(),
+        );
+        let signature = header.sign(&u1_key).unwrap();
+        let block = craft_block_with_uncles(
+            cryptarchia.tip(),
+            u1.header().slot().strict_add(2.into()),
+            UncleHeaders::new([SignedHeader::new(header, signature)]),
+            u1.header().leader_proof(),
+            &u1_key,
+        );
+
+        let Err(err) = cryptarchia.try_apply_block(&block, block.header().slot()) else {
+            panic!("expected the block to be rejected");
+        };
+        assert!(matches!(
+            err,
+            Error::InvalidUncle {
+                reason: UncleError::InvalidProof,
+                ..
+            }
+        ));
+    }
+
+    /// A chain `G --- B1` with a fork block `U1` also extending `G`, at the
+    /// same slot as `B1`.
+    #[expect(clippy::type_complexity, reason = "a test helper")]
+    fn chain_with_fork() -> (
+        Cryptarchia,
+        Block<SignedMantleTx<Preverified>>,
+        Block<SignedMantleTx<Preverified>>,
+        Ed25519Key,
+        ZkKey,
+        Utxo,
+    ) {
+        let config = ledger_config(3.try_into().unwrap());
+        let genesis_id = [0; 32].into();
+        let (zk_key, utxo) = utxo();
+        let mut cryptarchia = Cryptarchia::from_lib(
+            genesis_id,
+            LedgerState::from_utxos([utxo], &config),
+            genesis_id,
+            config,
+            lb_cryptarchia_engine::State::Bootstrapping,
+            Slot::genesis(),
+            0,
+            UncleSlots::default(),
+        );
+
+        // Both extend the genesis, and the same key wins the same slot, so the
+        // two blocks differ only in their (randomly generated) block leaders.
+        let (u1, u1_key) = try_build_block(
+            &cryptarchia,
+            genesis_id,
+            utxo,
+            &zk_key,
+            Slot::new(1),
+            UncleHeaders::empty(),
+        )
+        .unwrap();
+        let (b1, _) = try_build_block(
+            &cryptarchia,
+            genesis_id,
+            utxo,
+            &zk_key,
+            Slot::new(1),
+            UncleHeaders::empty(),
+        )
+        .unwrap();
+        cryptarchia
+            .try_apply_block(&b1, b1.header().slot())
+            .unwrap();
+
+        (cryptarchia, b1, u1, u1_key, zk_key, utxo)
+    }
+
+    fn signed_header(block: &Block<SignedMantleTx<Preverified>>) -> SignedHeader {
+        SignedHeader::new(block.header().clone(), *block.signature())
+    }
+
+    /// Crafts a block carrying the uncles, without a winning `PoL` for `slot`,
+    /// which is fine because uncles are verified before the block's own proof.
+    fn craft_block_with_uncles(
+        parent: HeaderId,
+        slot: Slot,
+        uncle_headers: UncleHeaders,
+        proof: &Groth16LeaderProof,
+        key: &Ed25519Key,
+    ) -> Block<SignedMantleTx<Preverified>> {
+        Block::create(
+            parent,
+            slot,
+            uncle_headers,
+            proof.clone(),
+            BlockTransactions::empty(),
+            key,
+        )
+        .unwrap()
+    }
+}

--- a/services/chain/chain-service/src/uncle.rs
+++ b/services/chain/chain-service/src/uncle.rs
@@ -19,6 +19,13 @@ use crate::{Cryptarchia, Error};
 impl Cryptarchia {
     /// Verifies every uncle carried by the block against the chain the block
     /// extends.
+    ///
+    /// # Rules
+    /// - Each uncle's slot must be older than the block's slot.
+    /// - Each uncle must not be on the chain that the block extends.
+    /// - Each uncle's parent must be on the chain the block extends, within the
+    ///   uncle reference window.
+    /// - Each uncle's header signature and `PoL` must be valid.
     pub(crate) fn verify_uncles<Tx>(&self, block: &Block<Tx>) -> Result<(), Error> {
         if block.uncle_headers().is_empty() {
             return Ok(());
@@ -35,10 +42,7 @@ impl Cryptarchia {
                 info: Box::new(self.info()),
             })?;
 
-        // Each uncle must be strictly older than the block. The window rule
-        // `0 < slot - uncle_parent_slot <= w_u` is enforced by the ancestry
-        // verification below, and it implies that the uncle itself is also
-        // within the window since an uncle is newer than its parent.
+        // Each uncle's slot must be older than the block's slot.
         for uncle in block.uncle_headers().iter() {
             if uncle.header().slot() >= slot {
                 return Err(Error::InvalidUncle {
@@ -48,6 +52,8 @@ impl Cryptarchia {
             }
         }
 
+        // Each uncle's parent must be on the chain the block extends, within the
+        // uncle reference window.
         let uncle_reference_window = self
             .ledger
             .config()
@@ -57,6 +63,7 @@ impl Cryptarchia {
         let window_start = slot.into_inner().saturating_sub(uncle_reference_window);
         self.verify_uncles_ancestry(block.uncle_headers(), parent, window_start)?;
 
+        // Each uncle's header signature and `PoL` must be valid.
         for uncle in block.uncle_headers().iter() {
             self.verify_uncle_proofs(uncle)
                 .map_err(|reason| Error::InvalidUncle {
@@ -67,9 +74,10 @@ impl Cryptarchia {
         Ok(())
     }
 
-    /// Verifies that no uncle is on the chain of `parent` while the parent of
-    /// every uncle is, within the window:
-    /// `0 < slot - uncle.parent.slot <= w_u`.
+    /// Verifies the following rules:
+    /// - Each uncle must not be on the chain that the block extends.
+    /// - Each uncle's parent must be on the chain the block extends, within the
+    ///   uncle reference window.
     fn verify_uncles_ancestry(
         &self,
         uncle_headers: &UncleHeaders,
@@ -79,12 +87,11 @@ impl Cryptarchia {
         let uncles: HashSet<_> = uncle_headers.ids().collect();
         let uncle_parents: HashSet<_> = uncle_headers.parents().collect();
 
+        // Walk back the chain from the block's parent to the window boundary,
+        // collecting the uncle parents that are found during the walk-back.
         let mut found_uncle_parents = HashSet::new();
         let mut current = Some(parent);
         while let Some(block) = current {
-            // The walk is bounded by the window: only the ancestors within it
-            // can be uncle parents, and any on-chain uncle is newer than its
-            // in-window parent, so nothing below can affect the verdict.
             if block.slot().into_inner() < window_start {
                 break;
             }
@@ -103,7 +110,7 @@ impl Cryptarchia {
             current = self.consensus.branches().get(&block.parent());
         }
 
-        // Return an error if any uncle's parent was not found on the chain.
+        // Return an error if any uncle's parent was not found during the walk-back.
         for uncle in uncle_headers.iter() {
             if !found_uncle_parents.contains(&uncle.header().parent()) {
                 return Err(Error::InvalidUncle {


### PR DESCRIPTION
## 1. What does this PR implement?

This is the 4th PR for the [Uncle Reference RFC](https://github.com/logos-co/logos-lips/pull/385). 

If you want to understand what the uncle reference is, please see a short summary in the PR https://github.com/logos-blockchain/logos-blockchain/pull/3281.

In a previous PR https://github.com/logos-blockchain/logos-blockchain/pull/3283, we implemented selecting/including uncles to a new block proposal. This PR implements verifying those uncles. If a block contains uncles that don’t meet criteria, it must be rejected, so that we can converge to the consistent total stake, resulting in the consistent epoch nonce in the end. 

- Verify uncles when applying a block. Reject the block if any of uncles are invalid. 
  - I left comments to explain how the validation works, as simple as possible. I believe that is sufficient to understand the logic. 
- This PR doesn’t touch TSI. 

A next PR is the final one of this series. It will update TSI to account for uncles. 

## 2. Does the code have enough context to be clearly understood?

Please see the `Block Header Validation` part in the RFC. 

## 3. Who are the specification authors and who is accountable for this PR?

Spec: @madxor. PR: @youngjoon-lee.

## 4. Is the specification accurate and complete?

This PR implements the revised rule agreed with @madxor (`0 < A.slot - U.parent.slot <= w_u`); the spec update is pending simulation results.

## 5. Does the implementation introduce changes in the specification?

Yes, the parent-window rule above; agreed with @madxor, spec update pending.
