### PR TITLE
feat(ledger): uncle-ref: include uncles to TSI

### DIFF
--- a/core/src/block/uncle.rs
+++ b/core/src/block/uncle.rs
@@ -4,7 +4,7 @@ use lb_key_management_system_keys::keys::Ed25519Signature;
 use lb_utils::bounded::UpperBoundedVec;
 use serde::{Deserialize, Serialize};
 
-use crate::header::Header;
+use crate::header::{Header, HeaderId};
 
 /// Signed headers of the uncles referenced by a block.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, BinaryCodec)]
@@ -28,6 +28,14 @@ impl UncleHeaders {
         slots
             .try_into()
             .expect("one slot per header, so the same bound holds")
+    }
+
+    pub fn ids(&self) -> impl Iterator<Item = HeaderId> {
+        self.0.iter().map(|uncle| uncle.header.id())
+    }
+
+    pub fn parents(&self) -> impl Iterator<Item = HeaderId> {
+        self.0.iter().map(|uncle| uncle.header.parent())
     }
 
     #[must_use]

--- a/ledger/src/cryptarchia/block_density.rs
+++ b/ledger/src/cryptarchia/block_density.rs
@@ -1,20 +1,23 @@
 use std::ops::RangeInclusive;
 
-use lb_cryptarchia_engine::{Epoch, Slot};
+use lb_cryptarchia_engine::{Epoch, Slot, UncleSlots};
+use rpds::HashTrieSetSync;
 
 use crate::Config;
 
 #[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct BlockDensity {
     period_range: RangeInclusive<Slot>,
-    density: u64,
+    /// The distinct slots occupied by the blocks of the chain and the uncles
+    /// they reference, within the period.
+    occupied_slots: HashTrieSetSync<Slot>,
 }
 
 impl BlockDensity {
     pub fn new(epoch: Epoch, config: &Config) -> Self {
         Self {
             period_range: Self::compute_period_range(epoch, config),
-            density: 0,
+            occupied_slots: HashTrieSetSync::new_sync(),
         }
     }
 
@@ -31,14 +34,27 @@ impl BlockDensity {
         start..=end
     }
 
-    pub fn increment_block_density(&mut self, new_slot: Slot) {
-        if self.period_range.contains(&new_slot) {
-            self.density += 1;
+    /// Marks the slots occupied by a block and the uncles it references.
+    ///
+    /// Skipped entirely if the block itself is outside the period, so that
+    /// the blocks after the period cannot alter the density with the uncles
+    /// they reference, even if the uncles are in the window.
+    ///
+    /// A slot occupied more than once is counted once.
+    pub fn mark_occupied_slots(&mut self, block_slot: Slot, uncle_slots: &UncleSlots) {
+        if !self.period_range.contains(&block_slot) {
+            return;
+        }
+        self.occupied_slots.insert_mut(block_slot);
+        for uncle_slot in uncle_slots.iter() {
+            if self.period_range.contains(uncle_slot) {
+                self.occupied_slots.insert_mut(*uncle_slot);
+            }
         }
     }
 
-    pub const fn current_block_density(&self) -> u64 {
-        self.density
+    pub fn current_block_density(&self) -> u64 {
+        self.occupied_slots.size() as u64
     }
 
     #[cfg(test)]
@@ -65,19 +81,45 @@ mod tests {
     }
 
     #[test]
-    fn test_increment_block_density() {
+    fn test_mark_occupied_slots() {
         let mut density = BlockDensity::new(1.into(), &config());
         assert_eq!(density.period_range(), &(100.into()..=159.into()));
-        density.increment_block_density(Slot::from(100));
+        density.mark_occupied_slots(Slot::from(100), &UncleSlots::default());
         assert_eq!(density.current_block_density(), 1);
-        density.increment_block_density(Slot::from(159));
+        density.mark_occupied_slots(Slot::from(159), &UncleSlots::default());
         assert_eq!(density.current_block_density(), 2);
-        density.increment_block_density(Slot::from(140)); // slot order doesn't matter
+        // slot order doesn't matter
+        density.mark_occupied_slots(Slot::from(140), &UncleSlots::default());
         assert_eq!(density.current_block_density(), 3);
-        density.increment_block_density(Slot::from(95)); // ignored
-        assert_eq!(density.current_block_density(), 3); // not changed
-        density.increment_block_density(Slot::from(160)); // ignored
-        assert_eq!(density.current_block_density(), 3); // not changed
+        // blocks outside the period are ignored
+        density.mark_occupied_slots(Slot::from(95), &UncleSlots::default());
+        assert_eq!(density.current_block_density(), 3);
+        density.mark_occupied_slots(Slot::from(160), &UncleSlots::default());
+        assert_eq!(density.current_block_density(), 3);
+    }
+
+    #[test]
+    fn test_mark_occupied_slots_with_uncles() {
+        let mut density = BlockDensity::new(1.into(), &config());
+        assert_eq!(density.period_range(), &(100.into()..=159.into()));
+
+        // A block and its uncles are marked together.
+        density.mark_occupied_slots(Slot::from(110), &[Slot::from(105)].into());
+        assert_eq!(density.current_block_density(), 2);
+
+        // A slot occupied more than once is counted once:
+        // slot 105 by another uncle, and slot 110 by an uncle of another block.
+        density.mark_occupied_slots(Slot::from(120), &[Slot::from(105), Slot::from(110)].into());
+        assert_eq!(density.current_block_density(), 3);
+
+        // Uncle slots outside the period are ignored.
+        density.mark_occupied_slots(Slot::from(130), &[Slot::from(99)].into());
+        assert_eq!(density.current_block_density(), 4);
+
+        // A block outside the period is skipped entirely, even if its uncles
+        // are within the period (late references).
+        density.mark_occupied_slots(Slot::from(160), &[Slot::from(150)].into());
+        assert_eq!(density.current_block_density(), 4);
     }
 
     fn config() -> Config {

--- a/ledger/src/cryptarchia/mod.rs
+++ b/ledger/src/cryptarchia/mod.rs
@@ -459,10 +459,41 @@ impl LedgerState {
         // Then, apply the proof and update the nonce. Finally, increment block density
         // since this function is called for a new block.
         Ok(self
-            .update_epoch_state(slot, sdp, config)?
-            .try_apply_proof(slot, proof, config)?
+            .update_epoch_state_and_apply_proof(slot, proof, sdp, config)?
             .update_nonce(&proof.entropy(), slot)
             .increment_block_density(slot))
+    }
+
+    /// Synthesizes the epoch state for `slot` and apply the proof.
+    fn update_epoch_state_and_apply_proof<LeaderProof, Id>(
+        self,
+        slot: Slot,
+        proof: &LeaderProof,
+        sdp: &SdpLedger,
+        config: &Config,
+    ) -> Result<Self, LedgerError<Id>>
+    where
+        LeaderProof: leader_proof::LeaderProof,
+    {
+        self.update_epoch_state(slot, sdp, config)?
+            .try_apply_proof(slot, proof, config)
+    }
+
+    /// Verifies a leadership proof for a block at `slot` whose parent is the
+    /// block this state belongs to, leaving the state untouched.
+    pub fn verify_proof_of_leadership<LeaderProof, Id>(
+        &self,
+        slot: Slot,
+        proof: &LeaderProof,
+        sdp: &SdpLedger,
+        config: &Config,
+    ) -> Result<(), LedgerError<Id>>
+    where
+        LeaderProof: leader_proof::LeaderProof,
+    {
+        self.clone()
+            .update_epoch_state_and_apply_proof(slot, proof, sdp, config)?;
+        Ok(())
     }
 
     pub fn try_apply_transfer<Id, Profile: GasProfile>(

--- a/ledger/src/cryptarchia/mod.rs
+++ b/ledger/src/cryptarchia/mod.rs
@@ -18,7 +18,7 @@ use lb_core::{
     proofs::leader_proof::{self, LeaderPublic},
     sdp::Declarations,
 };
-use lb_cryptarchia_engine::{Epoch, Slot};
+use lb_cryptarchia_engine::{Epoch, Slot, UncleSlots};
 use lb_groth16::{Fr, fr_from_bytes};
 use lb_utxotree::MerklePath;
 
@@ -449,6 +449,7 @@ impl LedgerState {
         self,
         slot: Slot,
         proof: &LeaderProof,
+        uncle_slots: &UncleSlots,
         sdp: &SdpLedger,
         config: &Config,
     ) -> Result<Self, LedgerError<Id>>
@@ -456,12 +457,12 @@ impl LedgerState {
         LeaderProof: leader_proof::LeaderProof,
     {
         // First, synthesize epoch state for `slot` before update the ledger state.
-        // Then, apply the proof and update the nonce. Finally, increment block density
-        // since this function is called for a new block.
+        // Then, apply the proof and update the nonce. Finally, mark the occupied
+        // slots since this function is called for a new block.
         Ok(self
             .update_epoch_state_and_apply_proof(slot, proof, sdp, config)?
             .update_nonce(&proof.entropy(), slot)
-            .increment_block_density(slot))
+            .mark_occupied_slots(slot, uncle_slots))
     }
 
     /// Synthesizes the epoch state for `slot` and apply the proof.
@@ -528,10 +529,9 @@ impl LedgerState {
         Self { nonce, ..self }
     }
 
-    // TODO: Count distinct occupied slots, including the countable uncles.
-    fn increment_block_density(self, slot: Slot) -> Self {
+    fn mark_occupied_slots(self, slot: Slot, uncle_slots: &UncleSlots) -> Self {
         let mut block_density = self.block_density.clone();
-        block_density.increment_block_density(slot);
+        block_density.mark_occupied_slots(slot, uncle_slots);
         Self {
             block_density,
             ..self
@@ -893,6 +893,7 @@ pub mod tests {
             parent,
             slot,
             &proof,
+            &UncleSlots::default(),
             std::iter::empty::<&SignedMantleTx<Preverified>>(),
         )?;
         ledger.commit_update(id, state);
@@ -1883,6 +1884,7 @@ pub mod tests {
             .try_apply_header::<DummyProof, HeaderId>(
                 slot,
                 &proof,
+                &UncleSlots::default(),
                 &SdpLedger::new(0.into()),
                 &config,
             )
@@ -1910,6 +1912,7 @@ pub mod tests {
             .try_apply_header::<DummyProof, HeaderId>(
                 slot,
                 &proof,
+                &UncleSlots::default(),
                 &SdpLedger::new(0.into()),
                 &config,
             )

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -32,7 +32,7 @@ use lb_core::{
     },
     proofs::leader_proof,
 };
-use lb_cryptarchia_engine::Slot;
+use lb_cryptarchia_engine::{Slot, UncleSlots};
 use lb_groth16::{AdditiveGroup as _, Fr};
 use mantle::LedgerState as MantleLedger;
 use rpds::HashTrieMapSync;
@@ -158,6 +158,7 @@ where
         parent_id: Id,
         slot: Slot,
         proof: &LeaderProof,
+        uncle_slots: &UncleSlots,
         txs: impl Iterator<Item = &'tx Tx>,
     ) -> Result<(Id, LedgerState, Events), LedgerError<Id>>
     where
@@ -175,6 +176,7 @@ where
             id,
             slot,
             proof,
+            uncle_slots,
             txs,
             &self.config,
         )?;
@@ -230,6 +232,7 @@ impl LedgerState {
         block_id: Id,
         slot: Slot,
         proof: &LeaderProof,
+        uncle_slots: &UncleSlots,
         txs: impl Iterator<Item = &'tx Tx>,
         config: &Config,
     ) -> Result<(Self, Events), LedgerError<Id>>
@@ -239,7 +242,7 @@ impl LedgerState {
         Profile: GasProfile,
         Id: Into<BlockHash>,
     {
-        let (mut state, header_events) = self.try_apply_header(slot, proof, config)?;
+        let (mut state, header_events) = self.try_apply_header(slot, proof, uncle_slots, config)?;
         // Record the applied block among the recently seen blocks `PoW`
         // claims may anchor to. This is the canonical apply path, where the
         // block's id is known — unlike a proposer's direct
@@ -272,6 +275,7 @@ impl LedgerState {
         self,
         slot: Slot,
         proof: &LeaderProof,
+        uncle_slots: &UncleSlots,
         config: &Config,
     ) -> Result<(Self, Vec<HeaderEvent>), LedgerError<Id>>
     where
@@ -283,6 +287,7 @@ impl LedgerState {
             .try_apply_header::<LeaderProof, Id>(
                 slot,
                 proof,
+                uncle_slots,
                 // TODO: threading SDP here because EpochState is currently embedded in
                 // CryptarchiaLedger.
                 // In the future, we will pull EpochState up into LedgerState.
@@ -1073,6 +1078,7 @@ mod tests {
                 genesis_id,
                 Slot::from(1u64),
                 &proof,
+                &UncleSlots::default(),
                 std::iter::once(&tx),
             )
             .unwrap();

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -314,6 +314,25 @@ impl LedgerState {
         ))
     }
 
+    /// Verifies a leadership proof for a block at `slot` whose parent is the
+    /// block this state belongs to, leaving the state untouched.
+    pub fn verify_proof_of_leadership<LeaderProof, Id>(
+        &self,
+        slot: Slot,
+        proof: &LeaderProof,
+        config: &Config,
+    ) -> Result<(), LedgerError<Id>>
+    where
+        LeaderProof: leader_proof::LeaderProof,
+    {
+        self.cryptarchia_ledger.verify_proof_of_leadership(
+            slot,
+            proof,
+            &self.mantle_ledger.sdp,
+            config,
+        )
+    }
+
     #[must_use]
     pub const fn get_gas_prices(&self) -> GasPrices {
         GasPrices {

--- a/services/chain/chain-leader/src/lib.rs
+++ b/services/chain/chain-leader/src/lib.rs
@@ -609,9 +609,23 @@ where
 
         let tx_stream: Pin<Box<_>> = Box::pin(txs_stream);
 
+        let uncle_headers = cryptarchia_api
+            .select_uncles(parent, slot)
+            .await
+            .unwrap_or_else(|err| {
+                error!(target: LOG_TARGET, ?slot, %err, "failed to select uncles");
+                // A proposal without uncles is still valid
+                UncleHeaders::empty()
+            });
+
         (ledger_state, _) = ledger_state
             .clone()
-            .try_apply_header::<Groth16LeaderProof, HeaderId>(slot, &proof, ledger_config)?;
+            .try_apply_header::<Groth16LeaderProof, HeaderId>(
+                slot,
+                &proof,
+                &uncle_headers.slots(),
+                ledger_config,
+            )?;
 
         // Collect all candidate transactions up front so the ones that fail can
         // be retried across multiple rounds.
@@ -669,15 +683,6 @@ where
 
         let valid_tx_stream = stream::iter(valid_txs);
         let txs = txs_for_block(valid_tx_stream).await;
-
-        let uncle_headers = cryptarchia_api
-            .select_uncles(parent, slot)
-            .await
-            .unwrap_or_else(|err| {
-                error!(target: LOG_TARGET, ?slot, %err, "failed to select uncles");
-                // A proposal without uncles is still valid
-                UncleHeaders::empty()
-            });
 
         let block = Block::create(parent, slot, uncle_headers, proof, txs, signing_key)?;
 

--- a/services/chain/chain-service/src/lib.rs
+++ b/services/chain/chain-service/src/lib.rs
@@ -403,6 +403,7 @@ impl Cryptarchia {
                 parent,
                 slot,
                 header.leader_proof(),
+                &block.uncle_headers().slots(),
                 block.transactions_iter(),
             )
             .map_err(|err| match err {

--- a/services/chain/chain-service/src/lib.rs
+++ b/services/chain/chain-service/src/lib.rs
@@ -9,6 +9,7 @@ pub mod storage;
 mod sync;
 #[cfg(test)]
 mod tests;
+mod uncle;
 
 use core::fmt::Debug;
 use std::{
@@ -65,6 +66,7 @@ pub use crate::{
     service::phases::PhaseTag,
     states::CryptarchiaConsensusState,
     sync::config::{BlockProviderConfig, SyncConfig},
+    uncle::UncleError,
 };
 use crate::{
     bootstrap::state::choose_engine_state,
@@ -115,6 +117,8 @@ pub enum Error {
     ParentIdNotFound(HeaderId),
     #[error("Awaiting genesis time")]
     AwaitingGenesisTime,
+    #[error("Invalid uncle {uncle}: {reason}")]
+    InvalidUncle { uncle: HeaderId, reason: UncleError },
 }
 
 struct InitializedCryptarchia {
@@ -387,6 +391,9 @@ impl Cryptarchia {
                 current_slot,
             });
         }
+
+        // A block is valid only if every uncle it carries is valid.
+        self.verify_uncles(block)?;
 
         // A block number of this block if it's applied to the chain.
         let (_, state, events) = self

--- a/services/chain/chain-service/src/tests/mod.rs
+++ b/services/chain/chain-service/src/tests/mod.rs
@@ -71,12 +71,13 @@ fn cryptarchia_switch_to_online() {
     while block_ids.len() < 4 {
         // TODO: Use a mock proof system instead of expensive real proof generation,
         // by refactoring `Cryptarchia`.
-        let block = try_build_block(
+        let (block, _) = try_build_block(
             &cryptarchia,
             *block_ids.last().unwrap(),
             utxo,
             &zk_key,
             slot,
+            UncleHeaders::empty(),
         )
         .expect("should find a winning slot");
 
@@ -149,7 +150,15 @@ async fn get_block_ids_from_memory_and_storage() {
     let mut slot = Slot::genesis().strict_add(1.into());
     let mut block_ids = vec![genesis_id];
     for _ in 0..2 {
-        let block = try_build_block(&cryptarchia, cryptarchia.tip(), utxo, &zk_key, slot).unwrap();
+        let (block, _) = try_build_block(
+            &cryptarchia,
+            cryptarchia.tip(),
+            utxo,
+            &zk_key,
+            slot,
+            UncleHeaders::empty(),
+        )
+        .unwrap();
         process_block(
             &mut cryptarchia,
             block.clone(),
@@ -194,7 +203,15 @@ async fn get_block_ids_from_memory_and_storage() {
     // Add 3 more blocks.
     // Now G, b1 are in storage, and b2~5 are in memory.
     for _ in 0..3 {
-        let block = try_build_block(&cryptarchia, cryptarchia.tip(), utxo, &zk_key, slot).unwrap();
+        let (block, _) = try_build_block(
+            &cryptarchia,
+            cryptarchia.tip(),
+            utxo,
+            &zk_key,
+            slot,
+            UncleHeaders::empty(),
+        )
+        .unwrap();
         process_block(
             &mut cryptarchia,
             block.clone(),
@@ -333,8 +350,15 @@ fn test_chain_with_next_block() -> (Cryptarchia, Block<SignedMantleTx<Preverifie
         0,
         UncleSlots::default(),
     );
-    let block =
-        try_build_block(&cryptarchia, cryptarchia.tip(), utxo, &zk_key, Slot::new(1)).unwrap();
+    let (block, _) = try_build_block(
+        &cryptarchia,
+        cryptarchia.tip(),
+        utxo,
+        &zk_key,
+        Slot::new(1),
+        UncleHeaders::empty(),
+    )
+    .unwrap();
 
     (cryptarchia, block)
 }
@@ -393,7 +417,8 @@ pub fn try_build_block(
     utxo: Utxo,
     key: &ZkKey,
     start_slot: Slot,
-) -> Option<Block<SignedMantleTx<Preverified>>> {
+    uncle_headers: UncleHeaders,
+) -> Option<(Block<SignedMantleTx<Preverified>>, Ed25519Key)> {
     let start_slot: u64 = start_slot.into();
     for slot in start_slot..=(start_slot + 1000) {
         let epoch_state = cryptarchia.epoch_state_for_slot(slot.into()).unwrap();
@@ -426,17 +451,16 @@ pub fn try_build_block(
         )
         .unwrap();
 
-        return Some(
-            Block::create(
-                parent,
-                slot.into(),
-                UncleHeaders::empty(),
-                proof,
-                BlockTransactions::empty(),
-                &signing_key,
-            )
-            .unwrap(),
-        );
+        let block = Block::create(
+            parent,
+            slot.into(),
+            uncle_headers,
+            proof,
+            BlockTransactions::empty(),
+            &signing_key,
+        )
+        .unwrap();
+        return Some((block, signing_key));
     }
 
     None

--- a/services/chain/chain-service/src/uncle.rs
+++ b/services/chain/chain-service/src/uncle.rs
@@ -1,0 +1,463 @@
+//! The uncle validity rules
+
+use std::collections::HashSet;
+
+use lb_core::{
+    block::{Block, SignedHeader, UncleHeaders},
+    codec::SerializeOp as _,
+    header::HeaderId,
+    proofs::leader_proof::LeaderProof as _,
+};
+use lb_cryptarchia_engine::Branch;
+
+use crate::{Cryptarchia, Error};
+
+#[expect(
+    clippy::multiple_inherent_impl,
+    reason = "grouping the uncle validity rules separately from the main impl"
+)]
+impl Cryptarchia {
+    /// Verifies every uncle carried by the block against the chain the block
+    /// extends.
+    pub(crate) fn verify_uncles<Tx>(&self, block: &Block<Tx>) -> Result<(), Error> {
+        if block.uncle_headers().is_empty() {
+            return Ok(());
+        }
+
+        let header = block.header();
+        let slot = header.slot();
+        let parent = self
+            .consensus
+            .branches()
+            .get(&header.parent())
+            .ok_or_else(|| Error::ParentMissing {
+                parent: header.parent(),
+                info: Box::new(self.info()),
+            })?;
+
+        // Each uncle must be strictly older than the block. The window rule
+        // `0 < slot - uncle_parent_slot <= w_u` is enforced by the ancestry
+        // verification below, and it implies that the uncle itself is also
+        // within the window since an uncle is newer than its parent.
+        for uncle in block.uncle_headers().iter() {
+            if uncle.header().slot() >= slot {
+                return Err(Error::InvalidUncle {
+                    uncle: uncle.header().id(),
+                    reason: UncleError::NotStrictlyOlder,
+                });
+            }
+        }
+
+        let uncle_reference_window = self
+            .ledger
+            .config()
+            .consensus_config
+            .uncle_reference_window()
+            .get();
+        let window_start = slot.into_inner().saturating_sub(uncle_reference_window);
+        self.verify_uncles_ancestry(block.uncle_headers(), parent, window_start)?;
+
+        for uncle in block.uncle_headers().iter() {
+            self.verify_uncle_proofs(uncle)
+                .map_err(|reason| Error::InvalidUncle {
+                    uncle: uncle.header().id(),
+                    reason,
+                })?;
+        }
+        Ok(())
+    }
+
+    /// Verifies that no uncle is on the chain of `parent` while the parent of
+    /// every uncle is, within the window:
+    /// `0 < slot - uncle.parent.slot <= w_u`.
+    fn verify_uncles_ancestry(
+        &self,
+        uncle_headers: &UncleHeaders,
+        parent: &Branch<HeaderId>,
+        window_start: u64,
+    ) -> Result<(), Error> {
+        let uncles: HashSet<_> = uncle_headers.ids().collect();
+        let uncle_parents: HashSet<_> = uncle_headers.parents().collect();
+
+        let mut found_uncle_parents = HashSet::new();
+        let mut current = Some(parent);
+        while let Some(block) = current {
+            // The walk is bounded by the window: only the ancestors within it
+            // can be uncle parents, and any on-chain uncle is newer than its
+            // in-window parent, so nothing below can affect the verdict.
+            if block.slot().into_inner() < window_start {
+                break;
+            }
+            if uncles.contains(&block.id()) {
+                return Err(Error::InvalidUncle {
+                    uncle: block.id(),
+                    reason: UncleError::OnChain,
+                });
+            }
+            if uncle_parents.contains(&block.id()) {
+                found_uncle_parents.insert(block.id());
+            }
+            if block.parent() == block.id() {
+                break; // Reached the oldest block in the tree.
+            }
+            current = self.consensus.branches().get(&block.parent());
+        }
+
+        // Return an error if any uncle's parent was not found on the chain.
+        for uncle in uncle_headers.iter() {
+            if !found_uncle_parents.contains(&uncle.header().parent()) {
+                return Err(Error::InvalidUncle {
+                    uncle: uncle.header().id(),
+                    reason: UncleError::ParentNotOnChain,
+                });
+            }
+        }
+        Ok(())
+    }
+
+    /// Verifies the signature and the leadership proof carried by an uncle.
+    fn verify_uncle_proofs(&self, uncle: &SignedHeader) -> Result<(), UncleError> {
+        // The signature must verify over the uncle's header, by its own leader.
+        let header_bytes = uncle
+            .header()
+            .to_bytes()
+            .map_err(|_| UncleError::InvalidSignature)?;
+        uncle
+            .header()
+            .leader_proof()
+            .leader_key()
+            .verify(&header_bytes, uncle.signature())
+            .map_err(|_| UncleError::InvalidSignature)?;
+
+        // The proof of leadership must verify against the ledger state of the
+        // uncle's parent, which must exist since the parent is on the chain.
+        let parent_state = self
+            .ledger
+            .state(&uncle.header().parent())
+            .expect("ledger state of a block on the chain must exist");
+        parent_state
+            .verify_proof_of_leadership::<_, HeaderId>(
+                uncle.header().slot(),
+                uncle.header().leader_proof(),
+                self.ledger.config(),
+            )
+            .map_err(|_| UncleError::InvalidProof)
+    }
+}
+
+/// Why an uncle carried by a block fails the uncle validity rules,
+/// making the block itself invalid.
+#[derive(Debug, thiserror::Error)]
+pub enum UncleError {
+    #[error("not strictly older than the block")]
+    NotStrictlyOlder,
+    #[error("parent not on the chain that the block is extending, within the window")]
+    ParentNotOnChain,
+    #[error("on the chain that the block is extending")]
+    OnChain,
+    #[error("invalid header signature")]
+    InvalidSignature,
+    #[error("invalid proof of leadership")]
+    InvalidProof,
+}
+
+#[cfg(test)]
+mod tests {
+    use lb_core::{
+        block::BlockTransactions,
+        header::{ContentId, Header},
+        mantle::{SignedMantleTx, Utxo, transactions::states::Preverified},
+        proofs::leader_proof::Groth16LeaderProof,
+    };
+    use lb_cryptarchia_engine::{Slot, UncleSlots};
+    use lb_key_management_system_keys::keys::{Ed25519Key, ZkKey};
+    use lb_ledger::LedgerState;
+    use rand::thread_rng;
+
+    use super::*;
+    use crate::tests::{ledger_config, try_build_block, utxo};
+
+    #[test]
+    fn test_accept_valid_uncle() {
+        let (mut cryptarchia, _, u1, _, zk_key, utxo) = chain_with_fork();
+
+        let (b2, _) = try_build_block(
+            &cryptarchia,
+            cryptarchia.tip(),
+            utxo,
+            &zk_key,
+            u1.header().slot().strict_add(1.into()),
+            UncleHeaders::new([signed_header(&u1)]),
+        )
+        .unwrap();
+
+        cryptarchia
+            .try_apply_block(&b2, b2.header().slot())
+            .expect("a block referencing a valid uncle should be applied");
+        assert_eq!(
+            cryptarchia
+                .consensus
+                .branches()
+                .get(&b2.header().id())
+                .unwrap()
+                .uncle_slots(),
+            &[u1.header().slot()].into()
+        );
+    }
+
+    #[test]
+    fn test_reject_uncle_not_strictly_older() {
+        let (mut cryptarchia, _, u1, u1_key, ..) = chain_with_fork();
+
+        // The block is at the same slot as the uncle it references.
+        let block = craft_block_with_uncles(
+            cryptarchia.tip(),
+            u1.header().slot(),
+            UncleHeaders::new([signed_header(&u1)]),
+            u1.header().leader_proof(),
+            &u1_key,
+        );
+
+        let Err(err) = cryptarchia.try_apply_block(&block, block.header().slot()) else {
+            panic!("expected the block to be rejected");
+        };
+        assert!(matches!(
+            err,
+            Error::InvalidUncle {
+                reason: UncleError::NotStrictlyOlder,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn test_reject_uncle_whose_parent_is_outside_window() {
+        let (mut cryptarchia, _, u1, u1_key, ..) = chain_with_fork();
+
+        // The block is more than `w_u` slots after the uncle's parent,
+        // which puts the uncle's parent outside the window.
+        let uncle_reference_window = cryptarchia
+            .ledger
+            .config()
+            .consensus_config
+            .uncle_reference_window()
+            .get();
+        let block = craft_block_with_uncles(
+            cryptarchia.tip(),
+            u1.header()
+                .slot()
+                .strict_add((uncle_reference_window + 1).into()),
+            UncleHeaders::new([signed_header(&u1)]),
+            u1.header().leader_proof(),
+            &u1_key,
+        );
+
+        let Err(err) = cryptarchia.try_apply_block(&block, block.header().slot()) else {
+            panic!("expected the block to be rejected");
+        };
+        assert!(matches!(
+            err,
+            Error::InvalidUncle {
+                reason: UncleError::ParentNotOnChain,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn test_reject_uncle_on_the_chain() {
+        let (mut cryptarchia, b1, u1, u1_key, ..) = chain_with_fork();
+
+        // The block references its own parent `B1` as an uncle.
+        let block = craft_block_with_uncles(
+            cryptarchia.tip(),
+            b1.header().slot().strict_add(1.into()),
+            UncleHeaders::new([signed_header(&b1)]),
+            u1.header().leader_proof(),
+            &u1_key,
+        );
+
+        let Err(err) = cryptarchia.try_apply_block(&block, block.header().slot()) else {
+            panic!("expected the block to be rejected");
+        };
+        assert!(matches!(
+            err,
+            Error::InvalidUncle {
+                reason: UncleError::OnChain,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn reject_uncle_whose_parent_is_not_on_the_chain() {
+        let (mut cryptarchia, _, u1, u1_key, ..) = chain_with_fork();
+
+        // An uncle whose parent is unknown to the chain.
+        let header = Header::new(
+            HeaderId::from([9u8; 32]),
+            ContentId::from([0u8; 32]),
+            u1.header().slot(),
+            u1.header().leader_proof().clone(),
+        );
+        let signature = header.sign(&u1_key).unwrap();
+        let block = craft_block_with_uncles(
+            cryptarchia.tip(),
+            u1.header().slot().strict_add(1.into()),
+            UncleHeaders::new([SignedHeader::new(header, signature)]),
+            u1.header().leader_proof(),
+            &u1_key,
+        );
+
+        let Err(err) = cryptarchia.try_apply_block(&block, block.header().slot()) else {
+            panic!("expected the block to be rejected");
+        };
+        assert!(matches!(
+            err,
+            Error::InvalidUncle {
+                reason: UncleError::ParentNotOnChain,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn reject_uncle_with_invalid_signature() {
+        let (mut cryptarchia, _, u1, u1_key, ..) = chain_with_fork();
+
+        // The uncle's header is intact, but signed by a key that is not its
+        // leader.
+        let signature = u1
+            .header()
+            .sign(&Ed25519Key::generate(&mut thread_rng()))
+            .unwrap();
+        let block = craft_block_with_uncles(
+            cryptarchia.tip(),
+            u1.header().slot().strict_add(1.into()),
+            UncleHeaders::new([SignedHeader::new(u1.header().clone(), signature)]),
+            u1.header().leader_proof(),
+            &u1_key,
+        );
+
+        let Err(err) = cryptarchia.try_apply_block(&block, block.header().slot()) else {
+            panic!("expected the block to be rejected");
+        };
+        assert!(matches!(
+            err,
+            Error::InvalidUncle {
+                reason: UncleError::InvalidSignature,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn reject_uncle_with_invalid_pol() {
+        let (mut cryptarchia, _, u1, u1_key, ..) = chain_with_fork();
+
+        // The uncle carries `U1`'s proof at a different slot, against which
+        // the proof was not proven. The signature itself is valid.
+        let wrong_uncle_slot = u1.header().slot().strict_add(1.into());
+        let header = Header::new(
+            HeaderId::from([0u8; 32]),
+            ContentId::from([0u8; 32]),
+            wrong_uncle_slot,
+            u1.header().leader_proof().clone(),
+        );
+        let signature = header.sign(&u1_key).unwrap();
+        let block = craft_block_with_uncles(
+            cryptarchia.tip(),
+            u1.header().slot().strict_add(2.into()),
+            UncleHeaders::new([SignedHeader::new(header, signature)]),
+            u1.header().leader_proof(),
+            &u1_key,
+        );
+
+        let Err(err) = cryptarchia.try_apply_block(&block, block.header().slot()) else {
+            panic!("expected the block to be rejected");
+        };
+        assert!(matches!(
+            err,
+            Error::InvalidUncle {
+                reason: UncleError::InvalidProof,
+                ..
+            }
+        ));
+    }
+
+    /// A chain `G --- B1` with a fork block `U1` also extending `G`, at the
+    /// same slot as `B1`.
+    #[expect(clippy::type_complexity, reason = "a test helper")]
+    fn chain_with_fork() -> (
+        Cryptarchia,
+        Block<SignedMantleTx<Preverified>>,
+        Block<SignedMantleTx<Preverified>>,
+        Ed25519Key,
+        ZkKey,
+        Utxo,
+    ) {
+        let config = ledger_config(3.try_into().unwrap());
+        let genesis_id = [0; 32].into();
+        let (zk_key, utxo) = utxo();
+        let mut cryptarchia = Cryptarchia::from_lib(
+            genesis_id,
+            LedgerState::from_utxos([utxo], &config),
+            genesis_id,
+            config,
+            lb_cryptarchia_engine::State::Bootstrapping,
+            Slot::genesis(),
+            0,
+            UncleSlots::default(),
+        );
+
+        // Both extend the genesis, and the same key wins the same slot, so the
+        // two blocks differ only in their (randomly generated) block leaders.
+        let (u1, u1_key) = try_build_block(
+            &cryptarchia,
+            genesis_id,
+            utxo,
+            &zk_key,
+            Slot::new(1),
+            UncleHeaders::empty(),
+        )
+        .unwrap();
+        let (b1, _) = try_build_block(
+            &cryptarchia,
+            genesis_id,
+            utxo,
+            &zk_key,
+            Slot::new(1),
+            UncleHeaders::empty(),
+        )
+        .unwrap();
+        cryptarchia
+            .try_apply_block(&b1, b1.header().slot())
+            .unwrap();
+
+        (cryptarchia, b1, u1, u1_key, zk_key, utxo)
+    }
+
+    fn signed_header(block: &Block<SignedMantleTx<Preverified>>) -> SignedHeader {
+        SignedHeader::new(block.header().clone(), *block.signature())
+    }
+
+    /// Crafts a block carrying the uncles, without a winning `PoL` for `slot`,
+    /// which is fine because uncles are verified before the block's own proof.
+    fn craft_block_with_uncles(
+        parent: HeaderId,
+        slot: Slot,
+        uncle_headers: UncleHeaders,
+        proof: &Groth16LeaderProof,
+        key: &Ed25519Key,
+    ) -> Block<SignedMantleTx<Preverified>> {
+        Block::create(
+            parent,
+            slot,
+            uncle_headers,
+            proof.clone(),
+            BlockTransactions::empty(),
+            key,
+        )
+        .unwrap()
+    }
+}

--- a/services/chain/chain-service/src/uncle.rs
+++ b/services/chain/chain-service/src/uncle.rs
@@ -19,6 +19,13 @@ use crate::{Cryptarchia, Error};
 impl Cryptarchia {
     /// Verifies every uncle carried by the block against the chain the block
     /// extends.
+    ///
+    /// # Rules
+    /// - Each uncle's slot must be older than the block's slot.
+    /// - Each uncle must not be on the chain that the block extends.
+    /// - Each uncle's parent must be on the chain the block extends, within the
+    ///   uncle reference window.
+    /// - Each uncle's header signature and `PoL` must be valid.
     pub(crate) fn verify_uncles<Tx>(&self, block: &Block<Tx>) -> Result<(), Error> {
         if block.uncle_headers().is_empty() {
             return Ok(());
@@ -35,10 +42,7 @@ impl Cryptarchia {
                 info: Box::new(self.info()),
             })?;
 
-        // Each uncle must be strictly older than the block. The window rule
-        // `0 < slot - uncle_parent_slot <= w_u` is enforced by the ancestry
-        // verification below, and it implies that the uncle itself is also
-        // within the window since an uncle is newer than its parent.
+        // Each uncle's slot must be older than the block's slot.
         for uncle in block.uncle_headers().iter() {
             if uncle.header().slot() >= slot {
                 return Err(Error::InvalidUncle {
@@ -48,6 +52,8 @@ impl Cryptarchia {
             }
         }
 
+        // Each uncle's parent must be on the chain the block extends, within the
+        // uncle reference window.
         let uncle_reference_window = self
             .ledger
             .config()
@@ -57,6 +63,7 @@ impl Cryptarchia {
         let window_start = slot.into_inner().saturating_sub(uncle_reference_window);
         self.verify_uncles_ancestry(block.uncle_headers(), parent, window_start)?;
 
+        // Each uncle's header signature and `PoL` must be valid.
         for uncle in block.uncle_headers().iter() {
             self.verify_uncle_proofs(uncle)
                 .map_err(|reason| Error::InvalidUncle {
@@ -67,9 +74,10 @@ impl Cryptarchia {
         Ok(())
     }
 
-    /// Verifies that no uncle is on the chain of `parent` while the parent of
-    /// every uncle is, within the window:
-    /// `0 < slot - uncle.parent.slot <= w_u`.
+    /// Verifies the following rules:
+    /// - Each uncle must not be on the chain that the block extends.
+    /// - Each uncle's parent must be on the chain the block extends, within the
+    ///   uncle reference window.
     fn verify_uncles_ancestry(
         &self,
         uncle_headers: &UncleHeaders,
@@ -79,12 +87,11 @@ impl Cryptarchia {
         let uncles: HashSet<_> = uncle_headers.ids().collect();
         let uncle_parents: HashSet<_> = uncle_headers.parents().collect();
 
+        // Walk back the chain from the block's parent to the window boundary,
+        // collecting the uncle parents that are found during the walk-back.
         let mut found_uncle_parents = HashSet::new();
         let mut current = Some(parent);
         while let Some(block) = current {
-            // The walk is bounded by the window: only the ancestors within it
-            // can be uncle parents, and any on-chain uncle is newer than its
-            // in-window parent, so nothing below can affect the verdict.
             if block.slot().into_inner() < window_start {
                 break;
             }
@@ -103,7 +110,7 @@ impl Cryptarchia {
             current = self.consensus.branches().get(&block.parent());
         }
 
-        // Return an error if any uncle's parent was not found on the chain.
+        // Return an error if any uncle's parent was not found during the walk-back.
         for uncle in uncle_headers.iter() {
             if !found_uncle_parents.contains(&uncle.header().parent()) {
                 return Err(Error::InvalidUncle {

--- a/services/wallet/src/lib.rs
+++ b/services/wallet/src/lib.rs
@@ -610,7 +610,13 @@ where
                     funding_pk,
                     max_tx_fee,
                 };
-                let response = Self::build_leader_claim_tx(request, ledger, state, kms).await;
+                // Pinned to keep the future off the stack: `LedgerState` is
+                // passed by value and grew past the `clippy::large_futures`
+                // threshold, by 720 bytes for `PoW` and 112 for the uncle
+                // slots.
+                // TODO: consider passing it by reference so we can remove `Box::pin`.
+                let response =
+                    Box::pin(Self::build_leader_claim_tx(request, ledger, state, kms)).await;
 
                 match response {
                     Ok(built_tx) => {


### PR DESCRIPTION
## 1. What does this PR implement?

This is the 5th (last) PR for the [Uncle Reference RFC](https://github.com/logos-co/logos-lips/pull/385). 

If you want to understand what the uncle reference is, please see a short summary in the PR https://github.com/logos-blockchain/logos-blockchain/pull/3281.

Previously, the TSI (Total Stake Inference) counted the number of blocks in the honest chain within the first `6*k/f` slots. 
Now, the TSI counts the number of distinct occupied slots:
- When applying a block to the ledger, now we accumulate the slot of the block and its uncles to the `BlockDensity`, so that the TSI can account for uncles.
- TSI doesn’t need to verify each uncle because they are verified when the block is validated.

## 2. Does the code have enough context to be clearly understood?

Please see the `Epoch State Pseudocode` and the TSI part of the RFC. 

## 3. Who are the specification authors and who is accountable for this PR?

Spec: @madxor. PR: @youngjoon-lee.

## 4. Is the specification accurate and complete?

Yes

## 5. Does the implementation introduce changes in the specification?

No
