### PR TITLE
fix(wallet): wallet/fund during non-finalized window hands double note

### DIFF
--- a/services/wallet/src/states.rs
+++ b/services/wallet/src/states.rs
@@ -159,10 +159,6 @@ impl PendingNotes {
         self.notes.keys().copied().collect()
     }
 
-    fn remove_spent(&mut self, spent: &HashSet<NoteId>) {
-        self.notes.retain(|note_id, _| !spent.contains(note_id));
-    }
-
     /// Evict reservations whose LIB-progress age reached the configured limit.
     ///
     /// Each LIB update adds `new_immutable_blocks_count` to every reservation's
@@ -301,7 +297,8 @@ impl<'u> ServiceState<'u> {
 
     pub fn apply_block(&mut self, block: &WalletBlock) -> Result<(), WalletError> {
         self.wallet.apply_block(block)?;
-        self.pending_notes.remove_spent(&block.spent_note_ids());
+        // Note reservations are released after `pending_note_expiry_blocks`
+        // (see `evict_expired`), not on spent.
         self.update_state();
         Ok(())
     }
@@ -460,20 +457,6 @@ mod tests {
 
         pending_notes.evict_expired(1, EXPIRY_BLOCKS);
         assert!(!pending_notes.note_ids().contains(&note_id));
-    }
-
-    #[test]
-    fn pending_note_removed_when_observed_spent() {
-        let spent = NoteId::from(Fr::ZERO);
-        let kept = NoteId::from(Fr::ONE);
-        let mut pending_notes = PendingNotes::default();
-
-        pending_notes.reserve([spent, kept]);
-        pending_notes.remove_spent(&HashSet::from([spent]));
-
-        let note_ids = pending_notes.note_ids();
-        assert!(!note_ids.contains(&spent));
-        assert!(note_ids.contains(&kept));
     }
 
     #[test]

--- a/services/wallet/src/states.rs
+++ b/services/wallet/src/states.rs
@@ -405,7 +405,7 @@ impl<'u> ServiceState<'u> {
 
 #[cfg(test)]
 mod tests {
-    use lb_groth16::{AdditiveGroup as _, Field as _, Fr};
+    use lb_groth16::{Field as _, Fr};
 
     use super::*;
 

--- a/tests/cucumber_tests/features/transactions.feature
+++ b/tests/cucumber_tests/features/transactions.feature
@@ -482,3 +482,60 @@ Feature: Transactions
     Then transaction "GOOD_TX" is included on node "NODE_1" in 120 seconds
     And transaction "BAD_TX" is not included in 30 seconds
     Then I stop all nodes
+
+  Scenario: Continuous wallet funding survives natural forks without reusing in-flight notes
+    Given the genesis block has the following wallet resources:
+      | account_index | token_count | token_amount |
+      | 1             | 2           | 250000       |
+      | 2             | 2           | 250000       |
+      | 3             | 2           | 250000       |
+    And I have a cluster with capacity of 3 nodes
+    And no nodes are declared as blend providers
+    And we use IBD peers
+    And I have deployment config override "time.slot_duration" as "seconds(1)"
+    And I have deployment config override "cryptarchia.slot_activation_coeff.numerator" as "1"
+    And I have deployment config override "cryptarchia.slot_activation_coeff.denominator" as "2"
+    And I start nodes with wallet resources:
+      | node_name | account_index | wallet_name | connected_to |
+      | NODE_1    | 1             | WALLET_1A   |              |
+      | NODE_2    | 2             | WALLET_2A   | NODE_1       |
+      | NODE_3    | 3             | WALLET_3A   | NODE_1       |
+    When node "NODE_1" is at height 2 in 240 seconds
+    And wallet "WALLET_1A" sends 10 notes of 22000 LGO to node "NODE_1" funding wallet as "FUNDING_TOPUP"
+    And transaction "FUNDING_TOPUP" is included on node "NODE_1" in 240 seconds
+    And I fund 200 transactions paying 100 LGO from node "NODE_1" wallet to wallet "WALLET_2A" retrying every 1 seconds for 600 seconds each as prefix "SOAK"
+    Then all transactions with prefix "SOAK" are finalized on node "NODE_1" in 900 seconds
+    And I stop all nodes
+
+  Scenario: Wallet double-hands a note after restart
+    Given the genesis block has the following wallet resources:
+      | account_index | token_count | token_amount |
+      | 1             | 2           | 25000        |
+      | 4             | 2           | 25000        |
+    And I have a cluster with capacity of 2 nodes
+    And no nodes are declared as blend providers
+    And we use IBD peers
+    And I have deployment config override "time.slot_duration" as "seconds(1)"
+    And I have deployment config override "cryptarchia.slot_activation_coeff.numerator" as "1"
+    And I have deployment config override "cryptarchia.slot_activation_coeff.denominator" as "2"
+    And I start nodes with wallet resources:
+      | node_name | account_index | wallet_name | connected_to |
+      | NODE_1    | 1             | WALLET_1A   | NODE_4       |
+      | NODE_4    | 4             | WALLET_4A   |              |
+    When node "NODE_1" is at height 2 in 240 seconds
+    And wallet "WALLET_1A" sends 1 notes of 9000 LGO to node "NODE_1" funding wallet as "TOPUP_A"
+    And wallet "WALLET_1A" sends 1 notes of 8000 LGO to node "NODE_1" funding wallet as "TOPUP_B"
+    And transaction "TOPUP_A" is included on node "NODE_1" in 240 seconds
+    And transaction "TOPUP_B" is included on node "NODE_1" in 240 seconds
+    When I stop node "NODE_4"
+    And I fund a transaction paying 100 LGO from node "NODE_1" wallet to wallet "WALLET_4A" as "DH_1"
+    And transaction "DH_1" is included on node "NODE_1" in 240 seconds
+    And node "NODE_1" alone reaches height 8 in 240 seconds
+    When I stop node "NODE_1"
+    And I restart node "NODE_4"
+    And node "NODE_4" alone reaches height 14 in 300 seconds
+    When I restart node "NODE_1"
+    And node "NODE_1" is at height 14 in 240 seconds
+    And I fund a transaction paying 150 LGO from node "NODE_1" wallet to wallet "WALLET_4A" as "DH_2"
+    Then all transactions with prefix "DH" are finalized on node "NODE_1" in 300 seconds
+    And I stop all nodes

--- a/tests/cucumber_tests/features/transactions.feature
+++ b/tests/cucumber_tests/features/transactions.feature
@@ -508,7 +508,8 @@ Feature: Transactions
     Then all transactions with prefix "SOAK" are finalized on node "NODE_1" in 900 seconds
     And I stop all nodes
 
-  @local_transactions
+  # TODO: enable this test if/when this is fixed in wallet
+  @undefined_behaviour
   Scenario: Wallet double-hands a note after restart
     Given the genesis block has the following wallet resources:
       | account_index | token_count | token_amount |

--- a/tests/cucumber_tests/features/transactions.feature
+++ b/tests/cucumber_tests/features/transactions.feature
@@ -483,12 +483,13 @@ Feature: Transactions
     And transaction "BAD_TX" is not included in 30 seconds
     Then I stop all nodes
 
+  @transactions_ci
   Scenario: Continuous wallet funding survives natural forks without reusing in-flight notes
     Given the genesis block has the following wallet resources:
       | account_index | token_count | token_amount |
-      | 1             | 2           | 250000       |
-      | 2             | 2           | 250000       |
-      | 3             | 2           | 250000       |
+      | 1             | 2           | 450000       |
+      | 2             | 2           | 450000       |
+      | 3             | 2           | 450000       |
     And I have a cluster with capacity of 3 nodes
     And no nodes are declared as blend providers
     And we use IBD peers
@@ -501,12 +502,13 @@ Feature: Transactions
       | NODE_2    | 2             | WALLET_2A   | NODE_1       |
       | NODE_3    | 3             | WALLET_3A   | NODE_1       |
     When node "NODE_1" is at height 2 in 240 seconds
-    And wallet "WALLET_1A" sends 10 notes of 22000 LGO to node "NODE_1" funding wallet as "FUNDING_TOPUP"
+    And wallet "WALLET_1A" sends 10 notes of 40000 LGO to node "NODE_1" funding wallet as "FUNDING_TOPUP"
     And transaction "FUNDING_TOPUP" is included on node "NODE_1" in 240 seconds
     And I fund 200 transactions paying 100 LGO from node "NODE_1" wallet to wallet "WALLET_2A" retrying every 1 seconds for 600 seconds each as prefix "SOAK"
     Then all transactions with prefix "SOAK" are finalized on node "NODE_1" in 900 seconds
     And I stop all nodes
 
+  @local_transactions
   Scenario: Wallet double-hands a note after restart
     Given the genesis block has the following wallet resources:
       | account_index | token_count | token_amount |

--- a/tests/src/cucumber/steps/wallet_fund.rs
+++ b/tests/src/cucumber/steps/wallet_fund.rs
@@ -2,9 +2,12 @@
 //! transaction from the node's wallet, assemble the returned proofs and
 //! submit the result to the mempool.
 
-use cucumber::{gherkin::Step, when};
+use std::{collections::HashSet, time::Duration};
+
+use cucumber::{gherkin::Step, then, when};
+use lb_common_http_client::ApiBlock;
 use lb_core::mantle::{
-    Note, Op, OpProof, SignedMantleTx,
+    Note, Op, OpProof, SignedMantleTx, TxHash,
     gas::GasCost,
     ops::channel::{
         ChannelId, MsgId,
@@ -18,10 +21,13 @@ use lb_key_management_system_service::keys::{Ed25519Key, ZkPublicKey};
 use lb_testing_framework::NodeHttpClient;
 use tracing::info;
 
-use crate::cucumber::{
-    error::{StepError, StepResult},
-    steps::TARGET,
-    world::CucumberWorld,
+use crate::{
+    common::chain::{scan_chain_until, wait_for_transactions_inclusion},
+    cucumber::{
+        error::{StepError, StepResult},
+        steps::TARGET,
+        world::CucumberWorld,
+    },
 };
 
 /// Fund a payment transaction from the node's wallet: the fund endpoint must
@@ -38,10 +44,30 @@ async fn step_fund_payment_transaction(
     receiver_wallet_name: String,
     transaction_alias: String,
 ) -> StepResult {
-    let receiver_pk = world.resolve_wallet(&receiver_wallet_name)?.public_key()?;
-    let funding_wallet = world.funding_wallet(&node_name)?;
+    fund_and_submit_payment(
+        world,
+        step,
+        amount,
+        &node_name,
+        &receiver_wallet_name,
+        transaction_alias,
+    )
+    .await?;
+    Ok(())
+}
+
+async fn fund_and_submit_payment(
+    world: &mut CucumberWorld,
+    step: &Step,
+    amount: u64,
+    node_name: &str,
+    receiver_wallet_name: &str,
+    transaction_alias: String,
+) -> Result<TxHash, StepError> {
+    let receiver_pk = world.resolve_wallet(receiver_wallet_name)?.public_key()?;
+    let funding_wallet = world.funding_wallet(node_name)?;
     let funding_pk = funding_wallet.public_key()?;
-    let client = world.resolve_node_http_client(&node_name)?;
+    let client = world.resolve_node_http_client(node_name)?;
 
     let tx_builder = MantleTxBuilder::new()
         .add_ledger_output(Note::new(amount, receiver_pk))
@@ -88,6 +114,290 @@ async fn step_fund_payment_transaction(
         target: TARGET,
         "Submitted funded payment `{transaction_alias}` of {amount} LGO from node `{node_name}` wallet"
     );
+
+    Ok(tx_hash)
+}
+
+/// Serially fund and submit `count` payments from the node's wallet, waiting
+/// for each transaction to be included before funding the next — the cadence
+/// of a sequencer funding continuously inside the non-finalized window.
+/// Aliases are `{prefix}_1..{prefix}_{count}`.
+#[expect(
+    clippy::too_many_arguments,
+    reason = "argument count mirrors the step expression"
+)]
+#[when(
+    expr = "I fund {int} transactions paying {int} LGO from node {string} wallet to wallet {string} waiting {int} seconds each as prefix {string}"
+)]
+async fn step_fund_payment_transactions_serially(
+    world: &mut CucumberWorld,
+    step: &Step,
+    count: u32,
+    amount: u64,
+    node_name: String,
+    receiver_wallet_name: String,
+    timeout_seconds: u64,
+    prefix: String,
+) -> StepResult {
+    for i in 1..=count {
+        let alias = format!("{prefix}_{i}");
+        let tx_hash = fund_and_submit_payment(
+            world,
+            step,
+            amount,
+            &node_name,
+            &receiver_wallet_name,
+            alias.clone(),
+        )
+        .await?;
+
+        let client = world.resolve_node_http_client(&node_name)?;
+        let included = wait_for_transactions_inclusion(
+            &client,
+            &[tx_hash],
+            Duration::from_secs(timeout_seconds),
+        )
+        .await;
+        if !included {
+            return Err(StepError::LogicalError {
+                message: format!(
+                    "Transaction `{alias}` was not included on node `{node_name}` within {timeout_seconds} seconds"
+                ),
+            });
+        }
+    }
+
+    Ok(())
+}
+
+/// Continuously fund and submit `count` payments without waiting for
+/// inclusion. The funding wallet is expected to be under-provisioned: a fund
+/// call that fails (typically insufficient funds while all notes are
+/// reserved or in flight) is retried until it succeeds or the per-transaction
+/// deadline passes. Pacing therefore comes from note scarcity — the moment a
+/// reservation is released, the next retry grabs that exact note, which makes
+/// every wrongful (fork-time) release convert into a note reuse.
+#[expect(
+    clippy::too_many_arguments,
+    reason = "argument count mirrors the step expression"
+)]
+#[when(
+    expr = "I fund {int} transactions paying {int} LGO from node {string} wallet to wallet {string} retrying every {int} seconds for {int} seconds each as prefix {string}"
+)]
+async fn step_fund_payment_transactions_with_retry(
+    world: &mut CucumberWorld,
+    step: &Step,
+    count: u32,
+    amount: u64,
+    node_name: String,
+    receiver_wallet_name: String,
+    retry_seconds: u64,
+    timeout_seconds: u64,
+    prefix: String,
+) -> StepResult {
+    for i in 1..=count {
+        let alias = format!("{prefix}_{i}");
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(timeout_seconds);
+
+        loop {
+            match fund_and_submit_payment(
+                world,
+                step,
+                amount,
+                &node_name,
+                &receiver_wallet_name,
+                alias.clone(),
+            )
+            .await
+            {
+                Ok(_) => break,
+                Err(error) => {
+                    if tokio::time::Instant::now() >= deadline {
+                        return Err(StepError::LogicalError {
+                            message: format!(
+                                "Funding `{alias}` kept failing for {timeout_seconds} seconds; last error: {error}"
+                            ),
+                        });
+                    }
+                    info!(
+                        target: TARGET,
+                        "Funding `{alias}` failed ({error}); retrying in {retry_seconds}s"
+                    );
+                    tokio::time::sleep(Duration::from_secs(retry_seconds)).await;
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Wait for a single node to reach a height, polling only that node — usable
+/// while other cluster nodes are deliberately stopped (the regular height
+/// step health-checks every node and fails on intentionally-down peers).
+#[when(expr = "node {string} alone reaches height {int} in {int} seconds")]
+#[then(expr = "node {string} alone reaches height {int} in {int} seconds")]
+async fn step_node_alone_reaches_height(
+    world: &mut CucumberWorld,
+    step: &Step,
+    node_name: String,
+    height: u64,
+    timeout_seconds: u64,
+) -> StepResult {
+    let client = world.resolve_node_http_client(&node_name)?;
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(timeout_seconds);
+
+    loop {
+        let current = match client.consensus_info().await {
+            Ok(info) => info.cryptarchia_info.height,
+            Err(_) => 0,
+        };
+        if current >= height {
+            return Ok(());
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return Err(StepError::LogicalError {
+                message: format!(
+                    "Step `{}` error: node `{node_name}` did not reach height {height} within {timeout_seconds} seconds (currently {current})",
+                    step.value
+                ),
+            });
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+}
+
+/// Every remembered transaction whose alias starts with `prefix` is
+/// FINALIZED on the given node within the shared deadline: all of them found
+/// in one walk of the immutable chain at or below LIB. Finalization is
+/// branch-independent, so two transactions spending the same note can never
+/// both satisfy this — unlike tip-inclusion checks, which can be fooled by
+/// observing different momentary views.
+#[expect(clippy::needless_pass_by_ref_mut, reason = "Required by Cucumber")]
+#[when(
+    expr = "all transactions with prefix {string} are finalized on node {string} in {int} seconds"
+)]
+#[then(
+    expr = "all transactions with prefix {string} are finalized on node {string} in {int} seconds"
+)]
+async fn step_transactions_with_prefix_finalized(
+    world: &mut CucumberWorld,
+    step: &Step,
+    prefix: String,
+    node_name: String,
+    timeout_seconds: u64,
+) -> StepResult {
+    let transactions = world.submitted_transactions_with_prefix(&prefix);
+    if transactions.is_empty() {
+        return Err(StepError::LogicalError {
+            message: format!(
+                "Step `{}` error: no submitted transactions with prefix `{prefix}`",
+                step.value
+            ),
+        });
+    }
+    let expected: HashSet<TxHash> = transactions.iter().map(|(_, tx_hash)| *tx_hash).collect();
+
+    // Distinct fund calls must yield distinct transactions: identical intents
+    // are separated by their funded inputs. Two aliases sharing a hash means
+    // the wallet reused a note and thereby merged two payments into one tx.
+    if expected.len() != transactions.len() {
+        return Err(StepError::LogicalError {
+            message: format!(
+                "Step `{}` error: {} submissions with prefix `{prefix}` produced only {} distinct transactions — the wallet reused a note and merged payments",
+                step.value,
+                transactions.len(),
+                expected.len()
+            ),
+        });
+    }
+
+    let client = world.resolve_node_http_client(&node_name)?;
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(timeout_seconds);
+
+    loop {
+        if let Ok(consensus) = client.consensus_info().await {
+            let mut scanned_blocks = HashSet::new();
+            let mut found = HashSet::new();
+            let all_found = scan_chain_until(
+                consensus.cryptarchia_info.lib,
+                &mut scanned_blocks,
+                async |header_id| client.block(&header_id).await.ok().flatten(),
+                |block: &ApiBlock| {
+                    for tx in &block.transactions {
+                        let hash = tx.hash();
+                        if expected.contains(&hash) {
+                            found.insert(hash);
+                        }
+                    }
+                    (found == expected).then_some(())
+                },
+            )
+            .await
+            .is_some();
+
+            if all_found {
+                return Ok(());
+            }
+        }
+
+        if tokio::time::Instant::now() >= deadline {
+            let aliases: Vec<&str> = transactions
+                .iter()
+                .map(|(alias, _)| alias.as_str())
+                .collect();
+            return Err(StepError::LogicalError {
+                message: format!(
+                    "Not all transactions with prefix `{prefix}` were finalized on node `{node_name}` within {timeout_seconds} seconds: {aliases:?}"
+                ),
+            });
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+}
+
+/// Every remembered transaction whose alias starts with `prefix` is included
+/// on the given node within the shared deadline.
+#[expect(clippy::needless_pass_by_ref_mut, reason = "Required by Cucumber")]
+#[when(
+    expr = "all transactions with prefix {string} are included on node {string} in {int} seconds"
+)]
+#[then(
+    expr = "all transactions with prefix {string} are included on node {string} in {int} seconds"
+)]
+async fn step_transactions_with_prefix_included(
+    world: &mut CucumberWorld,
+    step: &Step,
+    prefix: String,
+    node_name: String,
+    timeout_seconds: u64,
+) -> StepResult {
+    let transactions = world.submitted_transactions_with_prefix(&prefix);
+    if transactions.is_empty() {
+        return Err(StepError::LogicalError {
+            message: format!(
+                "Step `{}` error: no submitted transactions with prefix `{prefix}`",
+                step.value
+            ),
+        });
+    }
+
+    let client = world.resolve_node_http_client(&node_name)?;
+    let tx_hashes: Vec<TxHash> = transactions.iter().map(|(_, tx_hash)| *tx_hash).collect();
+    let included =
+        wait_for_transactions_inclusion(&client, &tx_hashes, Duration::from_secs(timeout_seconds))
+            .await;
+    if !included {
+        let aliases: Vec<&str> = transactions
+            .iter()
+            .map(|(alias, _)| alias.as_str())
+            .collect();
+        return Err(StepError::LogicalError {
+            message: format!(
+                "Not all transactions with prefix `{prefix}` were included on node `{node_name}` within {timeout_seconds} seconds: {aliases:?}"
+            ),
+        });
+    }
 
     Ok(())
 }

--- a/tests/src/cucumber/steps/wallet_fund.rs
+++ b/tests/src/cucumber/steps/wallet_fund.rs
@@ -235,6 +235,7 @@ async fn step_fund_payment_transactions_with_retry(
 /// Wait for a single node to reach a height, polling only that node — usable
 /// while other cluster nodes are deliberately stopped (the regular height
 /// step health-checks every node and fails on intentionally-down peers).
+#[expect(clippy::needless_pass_by_ref_mut, reason = "Required by Cucumber")]
 #[when(expr = "node {string} alone reaches height {int} in {int} seconds")]
 #[then(expr = "node {string} alone reaches height {int} in {int} seconds")]
 async fn step_node_alone_reaches_height(

--- a/tests/src/cucumber/world.rs
+++ b/tests/src/cucumber/world.rs
@@ -1933,6 +1933,20 @@ impl CucumberWorld {
         self.submitted_transactions.insert(alias, tx_hash);
     }
 
+    /// All remembered submitted transactions whose alias starts with `prefix`,
+    /// sorted by alias for deterministic reporting.
+    #[must_use]
+    pub fn submitted_transactions_with_prefix(&self, prefix: &str) -> Vec<(String, TxHash)> {
+        let mut txs: Vec<_> = self
+            .submitted_transactions
+            .iter()
+            .filter(|(alias, _)| alias.starts_with(prefix))
+            .map(|(alias, tx_hash)| (alias.clone(), *tx_hash))
+            .collect();
+        txs.sort();
+        txs
+    }
+
     pub fn remember_submission_outcome(&mut self, alias: String, outcome: Result<(), String>) {
         self.submission_outcomes.insert(alias, outcome);
     }


### PR DESCRIPTION
This might be related to testnet inscription production stop, as a possible cause (needs to be confirmed from testnet logs).

2 integration tests added to illustrate the the call handing double notes:
1. Soaking wallet with fund calls over non-finalized window over forks produces 2 txs with the same note -> main failure path 
2. Node restart loses reservation state -> restart scenario could also produce multiple tx with the same note

Reason: 

It is by current design of the /wallet/fund call:
The reservation map is one flat, branch-agnostic set — services/wallet/src/states.rs:130-132:
```

struct PendingNotes {
    notes: HashMap<NoteId, u64>,
}
```

The wallet keeps ledger state per branch (prune_states), but reservations have no branch dimension.

Every processed block — any branch — releases destructively. The service subscribes to all new blocks (lib.rs:408, 456-457 → handle_new_block → state.apply_block), and apply_block does (states.rs:302-307):
```
pub fn apply_block(&mut self, block: &WalletBlock) -> Result<(), WalletError> {
    self.wallet.apply_block(block)?;
    self.pending_notes.remove_spent(&block.spent_note_ids()); // -> this removes global reservation, but allowed utxos differ between branches                       
    ...
}
```

The doc comment: states.rs:120-128: "funded notes are released as soon as they are observed spent in a tip block... Releasing too early merely reintroduces a conflicting tx, the same failure mode as having no reservation at all." says the same thing.

Zone-sdk is using `/wallet/fund` call in sequential manner over non-finalized window, so it could get the same note for the different transaction which would stop the lineage chain.  

In the test 1, this is manifested by 2 transactions producing the same tx_id (as the amount is the same), so they would end up as one x in the end. 

The troubleshoot the logs in this case:
`grep "Reserved pending note" log.log | grep note_number` + pair it with `InexistingNote` eviction from logs as well.

Suggested fixes:
1. Don't remove reservation when observed on chain and rely only on existing `﻿﻿﻿pending_note_expiry_blocks ` timeout - Done in this PR.
2. Add timeout based refunding of the stale txs to zone-sdk or add storage state to wallet, so it survives restart handing double notes and extreme cases of too early timeout from the node - left for future, currently unguarded.
﻿