### PR TITLE
feat(blend): re-introduce PoQ verification before message relaying

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4050,6 +4050,7 @@ dependencies = [
  "logos-blockchain-key-management-system-keys",
  "logos-blockchain-libp2p",
  "logos-blockchain-log-targets",
+ "logos-blockchain-utils",
  "test-log",
  "tokio",
  "tokio-stream",

--- a/blend/network/Cargo.toml
+++ b/blend/network/Cargo.toml
@@ -25,7 +25,9 @@ lb-groth16                    = { workspace = true }
 lb-key-management-system-keys = { workspace = true }
 lb-libp2p                     = { workspace = true }
 lb-log-targets                = { workspace = true }
+lb-utils                      = { features = ["tokio", "tokio-task-names"], workspace = true }
 libp2p                        = { workspace = true }
+tokio                         = { workspace = true }
 tracing                       = { workspace = true }
 
 [dev-dependencies]

--- a/blend/network/src/core/mod.rs
+++ b/blend/network/src/core/mod.rs
@@ -1,3 +1,4 @@
+pub mod poq_verification;
 pub mod with_core;
 pub mod with_edge;
 
@@ -20,9 +21,9 @@ use crate::core::{
 /// A composed behaviour that wraps the two sub-behaviours for dealing with core
 /// and edge nodes.
 #[derive(lb_libp2p::NetworkBehaviour)]
-pub struct NetworkBehaviour<ObservationWindowClockProvider> {
-    with_core: CoreToCoreBehaviour<ObservationWindowClockProvider>,
-    with_edge: CoreToEdgeBehaviour,
+pub struct NetworkBehaviour<ObservationWindowClockProvider, ProofsVerifier> {
+    with_core: CoreToCoreBehaviour<ObservationWindowClockProvider, ProofsVerifier>,
+    with_edge: CoreToEdgeBehaviour<ProofsVerifier>,
 }
 
 pub struct Config {
@@ -30,11 +31,16 @@ pub struct Config {
     pub with_edge: CoreToEdgeConfig,
 }
 
-impl<ObservationWindowClockProvider> NetworkBehaviour<ObservationWindowClockProvider> {
+impl<ObservationWindowClockProvider, ProofsVerifier>
+    NetworkBehaviour<ObservationWindowClockProvider, ProofsVerifier>
+where
+    ProofsVerifier: Clone,
+{
     pub fn new(
         config: &Config,
         observation_window_clock_provider: ObservationWindowClockProvider,
         current_epoch_info: (Membership<PeerId>, Epoch),
+        proofs_verifier: ProofsVerifier,
         local_peer_id: PeerId,
         protocol_name: StreamProtocol,
     ) -> Self {
@@ -43,37 +49,47 @@ impl<ObservationWindowClockProvider> NetworkBehaviour<ObservationWindowClockProv
                 &config.with_core,
                 observation_window_clock_provider,
                 current_epoch_info.clone(),
+                proofs_verifier.clone(),
                 local_peer_id,
                 protocol_name.clone(),
             ),
             with_edge: CoreToEdgeBehaviour::new(
                 &config.with_edge,
-                current_epoch_info.0,
+                current_epoch_info,
+                proofs_verifier,
                 protocol_name,
             ),
         }
     }
 
-    pub fn start_new_epoch(&mut self, new_epoch_info: (Membership<PeerId>, Epoch)) {
-        self.with_core_mut().start_new_epoch(new_epoch_info.clone());
-        self.with_edge_mut().start_new_epoch(new_epoch_info.0);
+    pub fn start_new_epoch(
+        &mut self,
+        new_epoch_info: (Membership<PeerId>, Epoch),
+        new_proofs_verifier: ProofsVerifier,
+    ) {
+        self.with_core_mut()
+            .start_new_epoch(new_epoch_info.clone(), new_proofs_verifier.clone());
+        self.with_edge_mut()
+            .start_new_epoch(new_epoch_info, new_proofs_verifier);
     }
 
-    pub const fn with_core(&self) -> &CoreToCoreBehaviour<ObservationWindowClockProvider> {
+    pub const fn with_core(
+        &self,
+    ) -> &CoreToCoreBehaviour<ObservationWindowClockProvider, ProofsVerifier> {
         &self.with_core
     }
 
     pub const fn with_core_mut(
         &mut self,
-    ) -> &mut CoreToCoreBehaviour<ObservationWindowClockProvider> {
+    ) -> &mut CoreToCoreBehaviour<ObservationWindowClockProvider, ProofsVerifier> {
         &mut self.with_core
     }
 
-    pub const fn with_edge(&self) -> &CoreToEdgeBehaviour {
+    pub const fn with_edge(&self) -> &CoreToEdgeBehaviour<ProofsVerifier> {
         &self.with_edge
     }
 
-    pub const fn with_edge_mut(&mut self) -> &mut CoreToEdgeBehaviour {
+    pub const fn with_edge_mut(&mut self) -> &mut CoreToEdgeBehaviour<ProofsVerifier> {
         &mut self.with_edge
     }
 

--- a/blend/network/src/core/mod.rs
+++ b/blend/network/src/core/mod.rs
@@ -1,6 +1,7 @@
-pub mod poq_verification;
 pub mod with_core;
 pub mod with_edge;
+
+mod poq_verification;
 
 #[cfg(test)]
 mod tests;

--- a/blend/network/src/core/poq_verification.rs
+++ b/blend/network/src/core/poq_verification.rs
@@ -43,7 +43,7 @@ pub enum PoQVerificationOutcome {
 /// peer's stream, so the message is only acted upon once the outcome is polled
 /// out of `pending_verifications`.
 pub fn spawn_poq_verification<Verifier>(
-    pending_verifications: &mut PendingPoQVerifications,
+    pending_verifications: &PendingPoQVerifications,
     message: EncapsulatedMessageWithVerifiedSignature,
     (sender, connection_id): (PeerId, ConnectionId),
     epoch: Epoch,

--- a/blend/network/src/core/poq_verification.rs
+++ b/blend/network/src/core/poq_verification.rs
@@ -1,0 +1,91 @@
+use core::{pin::Pin, task::Waker};
+use std::sync::Arc;
+
+use futures::stream::FuturesUnordered;
+use lb_blend_message::encap::{
+    ProofsVerifier,
+    validated::{
+        EncapsulatedMessageWithVerifiedPublicHeader, EncapsulatedMessageWithVerifiedSignature,
+    },
+};
+use lb_cryptarchia_engine::Epoch;
+use lb_log_targets::blend;
+use lb_utils::tokio::task::spawn_blocking;
+use libp2p::{PeerId, swarm::ConnectionId};
+
+const LOG_TARGET: &str = blend::network::core::core::BEHAVIOUR;
+
+/// The `PoQ` verifications a behaviour currently has running on the blocking
+/// pool.
+pub type PendingPoQVerifications =
+    FuturesUnordered<Pin<Box<dyn Future<Output = PoQVerificationOutcome> + Send>>>;
+
+/// The result of verifying the `PoQ` of a message received from a peer.
+pub enum PoQVerificationOutcome {
+    Verified {
+        message: Box<EncapsulatedMessageWithVerifiedPublicHeader>,
+        sender: PeerId,
+        epoch: Epoch,
+    },
+    /// The sender could not produce a valid `PoQ`. The connection it came in on
+    /// is reported so the behaviour can act on that peer.
+    Failed {
+        sender: PeerId,
+        connection_id: ConnectionId,
+    },
+}
+
+/// Dispatches the `PoQ` verification of a received message to the blocking
+/// pool.
+///
+/// Verification is a Groth16 proof check. Running it inline would stall the
+/// swarm task that drives this behaviour, which is also servicing every other
+/// peer's stream, so the message is only acted upon once the outcome is polled
+/// out of `pending_verifications`.
+pub fn spawn_poq_verification<Verifier>(
+    pending_verifications: &mut PendingPoQVerifications,
+    message: EncapsulatedMessageWithVerifiedSignature,
+    (sender, connection_id): (PeerId, ConnectionId),
+    epoch: Epoch,
+    verifier: &Arc<Verifier>,
+    waker: &mut Option<Waker>,
+) where
+    Verifier: ProofsVerifier + Send + Sync + 'static,
+{
+    let verifier = Arc::clone(verifier);
+    pending_verifications.push(Box::pin(async move {
+        let verification_result = spawn_blocking("logos/blend/verify-poq", move || {
+            // The verification error is rendered here because it is not `Send`, so it
+            // cannot cross back to the task polling this behaviour as-is.
+            message
+                .verify_proof_of_quota(&*verifier)
+                .map_err(|e| format!("{e:?}"))
+        })
+        .await;
+
+        match verification_result {
+            Ok(Ok(message)) => PoQVerificationOutcome::Verified {
+                message: Box::new(message),
+                sender,
+                epoch,
+            },
+            Ok(Err(e)) => {
+                tracing::debug!(target: LOG_TARGET, "PoQ verification failed for message received from peer {sender:?} for epoch {epoch:?}: {e}.");
+                PoQVerificationOutcome::Failed {
+                    sender,
+                    connection_id,
+                }
+            }
+            Err(e) => {
+                tracing::error!(target: LOG_TARGET, "PoQ verification task for the message received from peer {sender:?} for epoch {epoch:?} failed to complete: {e:?}.");
+                PoQVerificationOutcome::Failed {
+                    sender,
+                    connection_id,
+                }
+            }
+        }
+    }));
+    if let Some(waker) = waker.take() {
+        waker.wake();
+    }
+}

--- a/blend/network/src/core/tests/utils.rs
+++ b/blend/network/src/core/tests/utils.rs
@@ -6,13 +6,20 @@ use core::{
 use std::time::Duration;
 
 use lb_blend_message::{
-    MessageIdentifier, PayloadType, crypto::key_ext::Ed25519SecretKeyExt as _,
-    encap::validated::EncapsulatedMessageWithVerifiedPublicHeader, input::EncapsulationInput,
+    MessageIdentifier, PayloadType,
+    crypto::{key_ext::Ed25519SecretKeyExt as _, proofs::PoQVerificationInputsMinusSigningKey},
+    encap::{ProofsVerifier, validated::EncapsulatedMessageWithVerifiedPublicHeader},
+    input::EncapsulationInput,
 };
-use lb_blend_proofs::{quota::VerifiedProofOfQuota, selection::VerifiedProofOfSelection};
+use lb_blend_proofs::{
+    quota::{ProofOfQuota, VerifiedProofOfQuota},
+    selection::{ProofOfSelection, VerifiedProofOfSelection, inputs::VerifyInputs},
+};
 use lb_blend_scheduling::message_blend::provers::BlendLayerProof;
 use lb_cryptarchia_engine::Epoch;
-use lb_key_management_system_keys::keys::{Ed25519Signature, UnsecuredEd25519Key};
+use lb_key_management_system_keys::keys::{
+    Ed25519PublicKey, Ed25519Signature, UnsecuredEd25519Key,
+};
 use lb_libp2p::{NetworkBehaviour, ed25519, upgrade::Version};
 use libp2p::{
     PeerId, StreamProtocol, Swarm, Transport as _, core::transport::MemoryTransport,
@@ -21,6 +28,52 @@ use libp2p::{
 use libp2p_swarm_test::SwarmExt as _;
 
 pub const PROTOCOL_NAME: StreamProtocol = StreamProtocol::new("/blend/core-behaviour/test");
+
+/// A `PoQ` verifier for the behaviour tests, which either accepts or rejects
+/// every proof it is handed. The proof system itself is exercised elsewhere;
+/// here we only care about what a behaviour does with the verification outcome.
+#[derive(Debug, Clone, Copy)]
+pub struct TestProofsVerifier {
+    accepts: bool,
+}
+
+impl TestProofsVerifier {
+    pub const fn accepting() -> Self {
+        Self { accepts: true }
+    }
+
+    pub const fn rejecting() -> Self {
+        Self { accepts: false }
+    }
+}
+
+impl ProofsVerifier for TestProofsVerifier {
+    type Error = ();
+
+    fn new(_public_inputs: PoQVerificationInputsMinusSigningKey) -> Self {
+        Self::accepting()
+    }
+
+    fn verify_proof_of_quota(
+        &self,
+        proof: ProofOfQuota,
+        _signing_key: &Ed25519PublicKey,
+    ) -> Result<VerifiedProofOfQuota, Self::Error> {
+        self.accepts
+            .then(|| VerifiedProofOfQuota::from_proof_of_quota_unchecked(proof))
+            .ok_or(())
+    }
+
+    fn verify_proof_of_selection(
+        &self,
+        proof: ProofOfSelection,
+        _inputs: &VerifyInputs,
+    ) -> Result<VerifiedProofOfSelection, Self::Error> {
+        self.accepts
+            .then(|| VerifiedProofOfSelection::from_proof_of_selection_unchecked(proof))
+            .ok_or(())
+    }
+}
 
 /// `ß_max` used by the test messages, matching the `BehaviourBuilder` default.
 const NUM_BLEND_LAYERS: u64 = 3;

--- a/blend/network/src/core/with_core/behaviour/message_cache.rs
+++ b/blend/network/src/core/with_core/behaviour/message_cache.rs
@@ -3,10 +3,7 @@ use std::collections::{HashMap, HashSet, hash_map::Entry};
 use lb_blend_message::{
     MessageIdentifier,
     encap::{
-        encapsulated::EncapsulatedMessage,
-        validated::{
-            EncapsulatedMessageWithVerifiedPublicHeader, EncapsulatedMessageWithVerifiedSignature,
-        },
+        encapsulated::EncapsulatedMessage, validated::EncapsulatedMessageWithVerifiedPublicHeader,
     },
 };
 use libp2p::PeerId;
@@ -68,12 +65,15 @@ impl MessageCache {
     /// This means that we have received and validated the message, but we
     /// haven't forwarded it to our peers yet.
     ///
-    /// The function takes an `EncapsulatedMessageWithVerifiedSignature` as
-    /// input, since we want to mark the message as processed only after
-    /// validating it.
+    /// The function takes an `EncapsulatedMessageWithVerifiedPublicHeader` as
+    /// input because the cache is keyed by the `PoQ` key nullifier, which is
+    /// only meaningful once the `PoQ` it comes from has been verified. Marking
+    /// an unverified message would let anyone claim a nullifier by replaying
+    /// someone else's `PoQ` under their own signing key, which suppresses the
+    /// genuine message carrying it.
     pub fn mark_message_as_processed(
         &mut self,
-        message: &EncapsulatedMessageWithVerifiedSignature,
+        message: &EncapsulatedMessageWithVerifiedPublicHeader,
     ) {
         // Forwarded messages are also considered received (i.e. we ignore them if we
         // receive them later on), so we only mark the message as received if it
@@ -162,10 +162,7 @@ impl MessageCache {
 #[cfg(test)]
 mod tests {
     use lb_blend_message::encap::{
-        encapsulated::EncapsulatedMessage,
-        validated::{
-            EncapsulatedMessageWithVerifiedPublicHeader, EncapsulatedMessageWithVerifiedSignature,
-        },
+        encapsulated::EncapsulatedMessage, validated::EncapsulatedMessageWithVerifiedPublicHeader,
     };
     use libp2p::PeerId;
 
@@ -178,12 +175,6 @@ mod tests {
         TestEncapsulatedMessage::new(payload).into_inner()
     }
 
-    fn make_signature_verified(
-        message: &EncapsulatedMessageWithVerifiedPublicHeader,
-    ) -> EncapsulatedMessageWithVerifiedSignature {
-        message.clone().into()
-    }
-
     fn make_raw(payload: &[u8]) -> EncapsulatedMessage {
         make_verified(payload).into()
     }
@@ -194,7 +185,7 @@ mod tests {
         let msg = make_verified(b"fw-not-downgraded");
 
         cache.mark_message_as_forwarded(&msg);
-        cache.mark_message_as_processed(&make_signature_verified(&msg));
+        cache.mark_message_as_processed(&msg);
 
         assert_eq!(
             cache.message_status(&msg.id()),
@@ -208,7 +199,7 @@ mod tests {
         let mut cache = MessageCache::new();
         let msg = make_verified(b"proc-upgraded");
 
-        cache.mark_message_as_processed(&make_signature_verified(&msg));
+        cache.mark_message_as_processed(&msg);
         assert_eq!(
             cache.message_status(&msg.id()),
             Some(&MessageStatus::Processed)
@@ -228,7 +219,7 @@ mod tests {
         let proc_msg = make_verified(b"processed");
         let fwd_msg = make_verified(b"forwarded");
 
-        cache.mark_message_as_processed(&make_signature_verified(&proc_msg));
+        cache.mark_message_as_processed(&proc_msg);
         cache.mark_message_as_forwarded(&fwd_msg);
 
         let raw_proc: EncapsulatedMessage = proc_msg.into();
@@ -249,7 +240,7 @@ mod tests {
         let mut cache = MessageCache::new();
         let msg = make_verified(b"only-processed");
 
-        cache.mark_message_as_processed(&make_signature_verified(&msg));
+        cache.mark_message_as_processed(&msg);
         let raw: EncapsulatedMessage = msg.into();
 
         assert!(

--- a/blend/network/src/core/with_core/behaviour/message_cache.rs
+++ b/blend/network/src/core/with_core/behaviour/message_cache.rs
@@ -3,7 +3,10 @@ use std::collections::{HashMap, HashSet, hash_map::Entry};
 use lb_blend_message::{
     MessageIdentifier,
     encap::{
-        encapsulated::EncapsulatedMessage, validated::EncapsulatedMessageWithVerifiedSignature,
+        encapsulated::EncapsulatedMessage,
+        validated::{
+            EncapsulatedMessageWithVerifiedPublicHeader, EncapsulatedMessageWithVerifiedSignature,
+        },
     },
 };
 use libp2p::PeerId;
@@ -84,12 +87,12 @@ impl MessageCache {
     /// Mark a message as forwarded, meaning we won't allow the swarm to send
     /// any duplicates of it, nor process it if received from our peers.
     ///
-    /// The function takes an `EncapsulatedMessageWithVerifiedSignature` as
-    /// input, since we want to mark the message as forwarded only after
-    /// validating it.
+    /// The function takes an `EncapsulatedMessageWithVerifiedPublicHeader` as
+    /// input, since we want to mark the message as forwarded only after its
+    /// whole public header (signature *and* `PoQ`) has been verified.
     pub fn mark_message_as_forwarded(
         &mut self,
-        message: &EncapsulatedMessageWithVerifiedSignature,
+        message: &EncapsulatedMessageWithVerifiedPublicHeader,
     ) {
         self.messages.insert(message.id(), MessageStatus::Forwarded);
     }
@@ -159,7 +162,10 @@ impl MessageCache {
 #[cfg(test)]
 mod tests {
     use lb_blend_message::encap::{
-        encapsulated::EncapsulatedMessage, validated::EncapsulatedMessageWithVerifiedSignature,
+        encapsulated::EncapsulatedMessage,
+        validated::{
+            EncapsulatedMessageWithVerifiedPublicHeader, EncapsulatedMessageWithVerifiedSignature,
+        },
     };
     use libp2p::PeerId;
 
@@ -168,8 +174,14 @@ mod tests {
         with_core::behaviour::message_cache::{MessageCache, MessageStatus},
     };
 
-    fn make_verified(payload: &[u8]) -> EncapsulatedMessageWithVerifiedSignature {
-        TestEncapsulatedMessage::new(payload).into_inner().into()
+    fn make_verified(payload: &[u8]) -> EncapsulatedMessageWithVerifiedPublicHeader {
+        TestEncapsulatedMessage::new(payload).into_inner()
+    }
+
+    fn make_signature_verified(
+        message: &EncapsulatedMessageWithVerifiedPublicHeader,
+    ) -> EncapsulatedMessageWithVerifiedSignature {
+        message.clone().into()
     }
 
     fn make_raw(payload: &[u8]) -> EncapsulatedMessage {
@@ -182,7 +194,7 @@ mod tests {
         let msg = make_verified(b"fw-not-downgraded");
 
         cache.mark_message_as_forwarded(&msg);
-        cache.mark_message_as_processed(&msg);
+        cache.mark_message_as_processed(&make_signature_verified(&msg));
 
         assert_eq!(
             cache.message_status(&msg.id()),
@@ -196,7 +208,7 @@ mod tests {
         let mut cache = MessageCache::new();
         let msg = make_verified(b"proc-upgraded");
 
-        cache.mark_message_as_processed(&msg);
+        cache.mark_message_as_processed(&make_signature_verified(&msg));
         assert_eq!(
             cache.message_status(&msg.id()),
             Some(&MessageStatus::Processed)
@@ -216,7 +228,7 @@ mod tests {
         let proc_msg = make_verified(b"processed");
         let fwd_msg = make_verified(b"forwarded");
 
-        cache.mark_message_as_processed(&proc_msg);
+        cache.mark_message_as_processed(&make_signature_verified(&proc_msg));
         cache.mark_message_as_forwarded(&fwd_msg);
 
         let raw_proc: EncapsulatedMessage = proc_msg.into();
@@ -237,7 +249,7 @@ mod tests {
         let mut cache = MessageCache::new();
         let msg = make_verified(b"only-processed");
 
-        cache.mark_message_as_processed(&msg);
+        cache.mark_message_as_processed(&make_signature_verified(&msg));
         let raw: EncapsulatedMessage = msg.into();
 
         assert!(

--- a/blend/network/src/core/with_core/behaviour/mod.rs
+++ b/blend/network/src/core/with_core/behaviour/mod.rs
@@ -1003,7 +1003,7 @@ where
             match old_epoch.handle_received_serialized_encapsulated_message(
                 serialized_message,
                 (from_peer_id, from_connection_id),
-                &mut self.pending_poq_verifications,
+                &self.pending_poq_verifications,
             ) {
                 Ok(handled) => {
                     if handled {
@@ -1020,7 +1020,7 @@ where
             serialized_message,
             &mut self.message_cache,
             (from_peer_id, from_connection_id),
-            &mut self.pending_poq_verifications,
+            &self.pending_poq_verifications,
             &mut self.waker,
             self.current_epoch_info.1,
             self.num_blend_layers,

--- a/blend/network/src/core/with_core/behaviour/mod.rs
+++ b/blend/network/src/core/with_core/behaviour/mod.rs
@@ -145,6 +145,7 @@ pub enum SpamReason {
     UndeserializableMessage,
     DuplicateMessage,
     InvalidHeaderSignature,
+    InvalidProofOfQuota,
     TooManyMessages,
 }
 
@@ -686,6 +687,41 @@ impl<ObservationWindowClockProvider> Behaviour<ObservationWindowClockProvider> {
                 },
             );
         }
+    }
+
+    /// Mark the connection with the given peer as malicious and instruct its
+    /// connection handler to drop the substream, whether the connection belongs
+    /// to the current epoch or to the one being transitioned away from.
+    ///
+    /// Used for spam that this behaviour cannot detect on its own — an invalid
+    /// `PoQ`, which only the swarm can verify — so the peer is identified by ID
+    /// alone. Returns whether a connection with the peer was found.
+    pub fn close_spammy_connection_with_peer(
+        &mut self,
+        peer_id: PeerId,
+        reason: SpamReason,
+    ) -> bool {
+        if let Some(RemotePeerConnectionDetails { connection_id, .. }) =
+            self.negotiated_peers.get(&peer_id)
+        {
+            self.close_spammy_connection((peer_id, *connection_id), reason);
+            return true;
+        }
+        // The old epoch keeps no per-peer state beyond the connection, so there
+        // is nothing to mark: closing the substream is all we can do here. The
+        // swarm blocks the peer regardless of which epoch it was talking on.
+        if let Some(old_epoch) = &mut self.old_epoch
+            && let Some(connection) = old_epoch.negotiated_connection_with_peer(peer_id)
+        {
+            tracing::debug!(
+                target: LOG_TARGET,
+                "Closing old epoch connection {:?} with spammy peer {peer_id:?} for reason {reason:?}.",
+                connection.1
+            );
+            self.close_connection(connection);
+            return true;
+        }
+        false
     }
 
     /// Mark the connection with the sender of a malformed message as malicious

--- a/blend/network/src/core/with_core/behaviour/mod.rs
+++ b/blend/network/src/core/with_core/behaviour/mod.rs
@@ -6,13 +6,14 @@ use std::{
     collections::{HashMap, VecDeque, hash_map::Entry},
     convert::Infallible,
     ops::RangeInclusive,
+    sync::Arc,
     task::{Context, Poll, Waker},
 };
 
 use either::Either;
-use futures::Stream;
-use lb_blend_message::encap::validated::{
-    EncapsulatedMessageWithVerifiedPublicHeader, EncapsulatedMessageWithVerifiedSignature,
+use futures::{Stream, StreamExt as _};
+use lb_blend_message::encap::{
+    ProofsVerifier as ProofsVerifierTrait, validated::EncapsulatedMessageWithVerifiedPublicHeader,
 };
 use lb_blend_scheduling::membership::Membership;
 use lb_cryptarchia_engine::Epoch;
@@ -28,19 +29,22 @@ use libp2p::{
     },
 };
 
-use crate::core::with_core::{
-    behaviour::{
-        handler::{
-            ConnectionHandler, FromBehaviour, ToBehaviour, conn_maintenance::ConnectionMonitor,
+use crate::core::{
+    poq_verification::{PendingPoQVerifications, PoQVerificationOutcome},
+    with_core::{
+        behaviour::{
+            handler::{
+                ConnectionHandler, FromBehaviour, ToBehaviour, conn_maintenance::ConnectionMonitor,
+            },
+            message_cache::MessageCache,
+            old_epoch::OldEpoch,
+            utils::{
+                forward_validated_message_and_update_cache,
+                handle_received_serialized_encapsulated_message_and_update_cache,
+            },
         },
-        message_cache::MessageCache,
-        old_epoch::OldEpoch,
-        utils::{
-            forward_validated_message_and_update_cache,
-            handle_received_serialized_encapsulated_message_and_update_cache,
-        },
+        error::{ReceiveError, SendError},
     },
-    error::{ReceiveError, SendError},
 };
 
 mod handler;
@@ -96,7 +100,7 @@ impl RemotePeerConnectionDetails {
 /// propagates messages from the Blend service to the rest of the Blend network.
 ///
 /// The public header signature and uniqueness of incoming messages is validated according to the [Blend specification](https://lip.logos.co/blockchain/raw/blend-protocol.html) before the message is propagated to the swarm and to the Blend service.
-pub struct Behaviour<ObservationWindowClockProvider> {
+pub struct Behaviour<ObservationWindowClockProvider, ProofsVerifier> {
     /// Tracks connections between this node and other core nodes.
     ///
     /// Only connections with other core nodes that are established before the
@@ -119,6 +123,14 @@ pub struct Behaviour<ObservationWindowClockProvider> {
     message_cache: MessageCache,
     observation_window_clock_provider: ObservationWindowClockProvider,
     current_epoch_info: (Membership<PeerId>, Epoch),
+    /// Verifier for the `PoQ`s of the messages received in the current epoch.
+    ///
+    /// Shared rather than owned because a handle to it is passed to the
+    /// blocking pool for every message received.
+    proofs_verifier: Arc<ProofsVerifier>,
+    /// `PoQ` verifications currently running on the blocking pool, for messages
+    /// of either the current or the outgoing epoch.
+    pending_poq_verifications: PendingPoQVerifications,
     /// The [minimum, maximum] peering degree of this node.
     peering_degree: RangeInclusive<usize>,
     local_peer_id: PeerId,
@@ -130,7 +142,7 @@ pub struct Behaviour<ObservationWindowClockProvider> {
     num_blend_layers: NonZeroU64,
     /// States for processing messages from the old epoch
     /// before the transition period has passed.
-    old_epoch: Option<OldEpoch>,
+    old_epoch: Option<OldEpoch<ProofsVerifier>>,
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Copy)]
@@ -147,6 +159,19 @@ pub enum SpamReason {
     InvalidHeaderSignature,
     InvalidProofOfQuota,
     TooManyMessages,
+}
+
+impl SpamReason {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::UndeserializableMessage => "undeserializable_message",
+            Self::DuplicateMessage => "duplicate_message",
+            Self::InvalidHeaderSignature => "invalid_header_signature",
+            Self::InvalidProofOfQuota => "invalid_proof_of_quota",
+            Self::TooManyMessages => "too_many_messages",
+        }
+    }
 }
 
 impl NegotiatedPeerState {
@@ -190,10 +215,10 @@ struct ConnectionUpgradeFailure {
 
 #[derive(Debug)]
 pub enum Event {
-    /// A message received from one of the core peers, after its public header
-    /// signature has been verified.
+    /// A message received from one of the core peers, after its whole public
+    /// header — signature and `PoQ` — has been verified.
     Message {
-        message: Box<EncapsulatedMessageWithVerifiedSignature>,
+        message: Box<EncapsulatedMessageWithVerifiedPublicHeader>,
         sender: PeerId,
         epoch: Epoch,
     },
@@ -226,12 +251,15 @@ pub enum Event {
     },
 }
 
-impl<ObservationWindowClockProvider> Behaviour<ObservationWindowClockProvider> {
+impl<ObservationWindowClockProvider, ProofsVerifier>
+    Behaviour<ObservationWindowClockProvider, ProofsVerifier>
+{
     #[must_use]
     pub fn new(
         config: &Config,
         observation_window_clock_provider: ObservationWindowClockProvider,
         epoch_info: (Membership<PeerId>, Epoch),
+        proofs_verifier: ProofsVerifier,
         local_peer_id: PeerId,
         protocol_name: StreamProtocol,
     ) -> Self {
@@ -242,6 +270,8 @@ impl<ObservationWindowClockProvider> Behaviour<ObservationWindowClockProvider> {
             observation_window_clock_provider,
             message_cache: MessageCache::new_with_peer_capacity(epoch_info.0.size()),
             current_epoch_info: epoch_info,
+            proofs_verifier: Arc::new(proofs_verifier),
+            pending_poq_verifications: PendingPoQVerifications::new(),
             peering_degree: config.peering_degree.clone(),
             connections_waiting_upgrade: HashMap::new(),
             local_peer_id,
@@ -252,7 +282,11 @@ impl<ObservationWindowClockProvider> Behaviour<ObservationWindowClockProvider> {
         }
     }
 
-    pub(crate) fn start_new_epoch(&mut self, new_epoch_info: (Membership<PeerId>, Epoch)) {
+    pub(crate) fn start_new_epoch(
+        &mut self,
+        new_epoch_info: (Membership<PeerId>, Epoch),
+        new_proofs_verifier: ProofsVerifier,
+    ) {
         let current_epoch_number = self.current_epoch_info.1;
 
         // Close any connections that were still waiting to be upgraded: they
@@ -265,6 +299,8 @@ impl<ObservationWindowClockProvider> Behaviour<ObservationWindowClockProvider> {
             self.close_connection(connection);
         }
         self.current_epoch_info = new_epoch_info;
+        let current_epoch_proofs_verifier =
+            mem::replace(&mut self.proofs_verifier, Arc::new(new_proofs_verifier));
 
         self.stop_old_epoch();
 
@@ -276,6 +312,7 @@ impl<ObservationWindowClockProvider> Behaviour<ObservationWindowClockProvider> {
             mem::take(&mut self.message_cache),
             current_epoch_number,
             self.num_blend_layers,
+            current_epoch_proofs_verifier,
         ));
 
         tracing::debug!(target: LOG_TARGET, "Started a new epoch by passing negotiated peers and exchanged message IDs to the old epoch. Now, no negotiated peers in the current epoch.");
@@ -689,41 +726,6 @@ impl<ObservationWindowClockProvider> Behaviour<ObservationWindowClockProvider> {
         }
     }
 
-    /// Mark the connection with the given peer as malicious and instruct its
-    /// connection handler to drop the substream, whether the connection belongs
-    /// to the current epoch or to the one being transitioned away from.
-    ///
-    /// Used for spam that this behaviour cannot detect on its own — an invalid
-    /// `PoQ`, which only the swarm can verify — so the peer is identified by ID
-    /// alone. Returns whether a connection with the peer was found.
-    pub fn close_spammy_connection_with_peer(
-        &mut self,
-        peer_id: PeerId,
-        reason: SpamReason,
-    ) -> bool {
-        if let Some(RemotePeerConnectionDetails { connection_id, .. }) =
-            self.negotiated_peers.get(&peer_id)
-        {
-            self.close_spammy_connection((peer_id, *connection_id), reason);
-            return true;
-        }
-        // The old epoch keeps no per-peer state beyond the connection, so there
-        // is nothing to mark: closing the substream is all we can do here. The
-        // swarm blocks the peer regardless of which epoch it was talking on.
-        if let Some(old_epoch) = &mut self.old_epoch
-            && let Some(connection) = old_epoch.negotiated_connection_with_peer(peer_id)
-        {
-            tracing::debug!(
-                target: LOG_TARGET,
-                "Closing old epoch connection {:?} with spammy peer {peer_id:?} for reason {reason:?}.",
-                connection.1
-            );
-            self.close_connection(connection);
-            return true;
-        }
-        false
-    }
-
     /// Mark the connection with the sender of a malformed message as malicious
     /// and instruct its connection handler to drop the substream.
     fn close_spammy_connection(
@@ -879,8 +881,7 @@ impl<ObservationWindowClockProvider> Behaviour<ObservationWindowClockProvider> {
 
     /// Publish an already-encapsulated and validated message to all connected
     /// peers in the current epoch.
-    #[cfg(test)]
-    fn publish_message_with_validated_header_to_current_epoch(
+    pub fn publish_message_with_validated_header_to_current_epoch(
         &mut self,
         message: &EncapsulatedMessageWithVerifiedPublicHeader,
     ) -> Result<(), SendError> {
@@ -953,6 +954,44 @@ impl<ObservationWindowClockProvider> Behaviour<ObservationWindowClockProvider> {
         )
     }
 
+    /// Acts on a completed `PoQ` verification: a message that verified is
+    /// reported to the swarm, and a peer that could not prove its quota is
+    /// marked as spammy and disconnected, exactly like any other spammer this
+    /// behaviour detects.
+    fn handle_poq_verification_outcome(&mut self, outcome: PoQVerificationOutcome) {
+        match outcome {
+            PoQVerificationOutcome::Verified {
+                message,
+                sender,
+                epoch,
+            } => {
+                self.events
+                    .push_back(ToSwarm::GenerateEvent(Event::Message {
+                        message,
+                        sender,
+                        epoch,
+                    }));
+            }
+            PoQVerificationOutcome::Failed {
+                sender,
+                connection_id,
+            } => {
+                self.close_spammy_connection(
+                    (sender, connection_id),
+                    SpamReason::InvalidProofOfQuota,
+                );
+            }
+        }
+    }
+}
+
+/// The part of the behaviour that needs to verify the `PoQ` of the messages it
+/// receives, and so requires a usable verifier.
+impl<ObservationWindowClockProvider, ProofsVerifier>
+    Behaviour<ObservationWindowClockProvider, ProofsVerifier>
+where
+    ProofsVerifier: ProofsVerifierTrait + Send + Sync + 'static,
+{
     fn handle_received_serialized_encapsulated_message(
         &mut self,
         serialized_message: &[u8],
@@ -964,6 +1003,7 @@ impl<ObservationWindowClockProvider> Behaviour<ObservationWindowClockProvider> {
             match old_epoch.handle_received_serialized_encapsulated_message(
                 serialized_message,
                 (from_peer_id, from_connection_id),
+                &mut self.pending_poq_verifications,
             ) {
                 Ok(handled) => {
                     if handled {
@@ -979,11 +1019,12 @@ impl<ObservationWindowClockProvider> Behaviour<ObservationWindowClockProvider> {
         if let Err(receive_error) = handle_received_serialized_encapsulated_message_and_update_cache(
             serialized_message,
             &mut self.message_cache,
-            from_peer_id,
-            &mut self.events,
+            (from_peer_id, from_connection_id),
+            &mut self.pending_poq_verifications,
             &mut self.waker,
             self.current_epoch_info.1,
             self.num_blend_layers,
+            &self.proofs_verifier,
         ) {
             tracing::debug!(target: LOG_TARGET, "Failed to handle message from the current epoch: {receive_error:?}");
             let spam_reason = match receive_error {
@@ -1006,10 +1047,12 @@ fn update_connection_id_and_direction(
     existing_connection.connection_id = new_connection_id;
 }
 
-impl<ObservationWindowClockProvider> NetworkBehaviour for Behaviour<ObservationWindowClockProvider>
+impl<ObservationWindowClockProvider, ProofsVerifier> NetworkBehaviour
+    for Behaviour<ObservationWindowClockProvider, ProofsVerifier>
 where
     ObservationWindowClockProvider: IntervalStreamProvider<IntervalStream: Unpin + Send, IntervalItem = RangeInclusive<u64>>
         + 'static,
+    ProofsVerifier: ProofsVerifierTrait + Send + Sync + 'static,
 {
     type ConnectionHandler = Either<
         ConnectionHandler<ObservationWindowClockProvider::IntervalStream>,
@@ -1245,6 +1288,16 @@ where
 
         if let Some(event) = self.events.pop_front() {
             return Poll::Ready(event);
+        }
+
+        // Verifications complete off this task, so their outcome is picked up
+        // here: this is where a message becomes visible to the swarm, and hence
+        // relayable, and where a peer that failed to prove its quota is dropped.
+        while let Poll::Ready(Some(outcome)) = self.pending_poq_verifications.poll_next_unpin(cx) {
+            self.handle_poq_verification_outcome(outcome);
+            if let Some(event) = self.events.pop_front() {
+                return Poll::Ready(event);
+            }
         }
 
         self.waker = Some(cx.waker().clone());

--- a/blend/network/src/core/with_core/behaviour/mod.rs
+++ b/blend/network/src/core/with_core/behaviour/mod.rs
@@ -829,7 +829,7 @@ impl<ObservationWindowClockProvider> Behaviour<ObservationWindowClockProvider> {
     /// peers in the specified epoch.
     pub fn publish_message_with_validated_header(
         &mut self,
-        message: EncapsulatedMessageWithVerifiedPublicHeader,
+        message: &EncapsulatedMessageWithVerifiedPublicHeader,
         intended_epoch: Epoch,
     ) -> Result<(), SendError> {
         if self.current_epoch_info.1 != intended_epoch {
@@ -838,32 +838,37 @@ impl<ObservationWindowClockProvider> Behaviour<ObservationWindowClockProvider> {
             };
             return old_epoch.publish_message_with_validated_header(message, intended_epoch);
         }
-        self.forward_maybe_excluding(&message.into(), None)
-    }
-
-    /// Publish an already-encapsulated message with a valid public header
-    /// signature to all connected peers in the current epoch.
-    pub fn publish_message_with_validated_signature_to_current_epoch(
-        &mut self,
-        message: &EncapsulatedMessageWithVerifiedSignature,
-    ) -> Result<(), SendError> {
         self.forward_maybe_excluding(message, None)
     }
 
-    /// Forwards a message with a valid public header signature to all
-    /// non-spammy peers in the specified epoch, except the
-    /// [`except`] peer.
+    /// Publish an already-encapsulated and validated message to all connected
+    /// peers in the current epoch.
+    #[cfg(test)]
+    fn publish_message_with_validated_header_to_current_epoch(
+        &mut self,
+        message: &EncapsulatedMessageWithVerifiedPublicHeader,
+    ) -> Result<(), SendError> {
+        self.publish_message_with_validated_header(message, self.current_epoch_info.1)
+    }
+
+    /// Forwards a message with a verified public header to all non-spammy peers
+    /// in the specified epoch, except the [`except`] peer.
     ///
     /// If the epoch is the previous epoch, the message is forwarded to the
     /// peers in the old epoch. Otherwise, it is forwarded to the peers in
     /// the current epoch.
     ///
+    /// The input type is [`EncapsulatedMessageWithVerifiedPublicHeader`]
+    /// because a message received from a peer is relayed only after the Blend
+    /// service has verified its `PoQ`. The behaviour itself only verifies the
+    /// public header signature, so it cannot produce such a value on its own.
+    ///
     /// Returns [`Error::NoPeers`] if there are no connected peers that support
     /// the blend protocol, and [`Error::InvalidEpoch`] if the provided
     /// epoch does not match neither the current epoch nor the old epoch.
-    pub fn forward_message_with_validated_signature(
+    pub fn forward_message_with_verified_public_header(
         &mut self,
-        message: &EncapsulatedMessageWithVerifiedSignature,
+        message: &EncapsulatedMessageWithVerifiedPublicHeader,
         except: PeerId,
         intended_epoch: Epoch,
     ) -> Result<(), SendError> {
@@ -871,7 +876,7 @@ impl<ObservationWindowClockProvider> Behaviour<ObservationWindowClockProvider> {
             let Some(old_epoch) = &mut self.old_epoch else {
                 return Err(SendError::InvalidEpoch);
             };
-            return old_epoch.forward_message_with_validated_signature(
+            return old_epoch.forward_message_with_verified_public_header(
                 message,
                 except,
                 intended_epoch,
@@ -883,7 +888,7 @@ impl<ObservationWindowClockProvider> Behaviour<ObservationWindowClockProvider> {
 
     fn forward_maybe_excluding(
         &mut self,
-        message: &EncapsulatedMessageWithVerifiedSignature,
+        message: &EncapsulatedMessageWithVerifiedPublicHeader,
         excluded_peer: Option<PeerId>,
     ) -> Result<(), SendError> {
         tracing::trace!(

--- a/blend/network/src/core/with_core/behaviour/mod.rs
+++ b/blend/network/src/core/with_core/behaviour/mod.rs
@@ -965,6 +965,16 @@ impl<ObservationWindowClockProvider, ProofsVerifier>
                 sender,
                 epoch,
             } => {
+                // Only now that the `PoQ` has verified may the message claim its
+                // nullifier in the cache, so a copy arriving later is not verified
+                // again. It goes into the cache of the epoch it verified against.
+                if epoch == self.current_epoch_info.1 {
+                    self.message_cache.mark_message_as_processed(&message);
+                } else if let Some(old_epoch) = &mut self.old_epoch
+                    && epoch == old_epoch.epoch()
+                {
+                    old_epoch.mark_message_as_processed(&message);
+                }
                 self.events
                     .push_back(ToSwarm::GenerateEvent(Event::Message {
                         message,

--- a/blend/network/src/core/with_core/behaviour/old_epoch.rs
+++ b/blend/network/src/core/with_core/behaviour/old_epoch.rs
@@ -231,7 +231,7 @@ where
         &mut self,
         serialized_message: &[u8],
         (from_peer_id, from_connection_id): (PeerId, ConnectionId),
-        pending_verifications: &mut PendingPoQVerifications,
+        pending_verifications: &PendingPoQVerifications,
     ) -> Result<bool, ReceiveError> {
         if !self.is_negotiated(&(from_peer_id, from_connection_id)) {
             return Ok(false);

--- a/blend/network/src/core/with_core/behaviour/old_epoch.rs
+++ b/blend/network/src/core/with_core/behaviour/old_epoch.rs
@@ -199,6 +199,17 @@ impl OldEpoch {
             .is_some_and(|&id| id == *connection_id)
     }
 
+    /// Returns the connection with the given peer, if it is negotiated in the
+    /// old epoch.
+    pub(super) fn negotiated_connection_with_peer(
+        &self,
+        peer_id: PeerId,
+    ) -> Option<(PeerId, ConnectionId)> {
+        self.negotiated_peers
+            .get(&peer_id)
+            .map(|connection_id| (peer_id, *connection_id))
+    }
+
     /// Returns the peer IDs of all negotiated peers in the old epoch.
     pub fn negotiated_peer_ids(&self) -> impl Iterator<Item = &PeerId> {
         self.negotiated_peers.keys()

--- a/blend/network/src/core/with_core/behaviour/old_epoch.rs
+++ b/blend/network/src/core/with_core/behaviour/old_epoch.rs
@@ -2,11 +2,14 @@ use std::{
     collections::{HashMap, VecDeque, hash_map::Entry},
     convert::Infallible,
     num::NonZeroU64,
+    sync::Arc,
     task::{Context, Poll, Waker},
 };
 
 use either::Either;
-use lb_blend_message::encap::validated::EncapsulatedMessageWithVerifiedPublicHeader;
+use lb_blend_message::encap::{
+    ProofsVerifier as ProofsVerifierTrait, validated::EncapsulatedMessageWithVerifiedPublicHeader,
+};
 use lb_cryptarchia_engine::Epoch;
 use lb_log_targets::blend;
 use libp2p::{
@@ -14,39 +17,45 @@ use libp2p::{
     swarm::{ConnectionId, NotifyHandler, ToSwarm},
 };
 
-use crate::core::with_core::{
-    behaviour::{
-        Event,
-        handler::FromBehaviour,
-        message_cache::MessageCache,
-        utils::{
-            forward_validated_message_and_update_cache,
-            handle_received_serialized_encapsulated_message_and_update_cache,
+use crate::core::{
+    poq_verification::PendingPoQVerifications,
+    with_core::{
+        behaviour::{
+            Event,
+            handler::FromBehaviour,
+            message_cache::MessageCache,
+            utils::{
+                forward_validated_message_and_update_cache,
+                handle_received_serialized_encapsulated_message_and_update_cache,
+            },
         },
+        error::{ReceiveError, SendError},
     },
-    error::{ReceiveError, SendError},
 };
 
 const LOG_TARGET: &str = blend::network::core::core::behaviour::OLD;
 
 /// Defines behaviours for processing messages from the old epoch
 /// until the epoch transition period has passed.
-pub struct OldEpoch {
+pub struct OldEpoch<ProofsVerifier> {
     negotiated_peers: HashMap<PeerId, ConnectionId>,
     events: VecDeque<ToSwarm<Event, Either<FromBehaviour, Infallible>>>,
     waker: Option<Waker>,
     message_cache: MessageCache,
     epoch: Epoch,
     num_blend_layers: NonZeroU64,
+    /// Verifier for the `PoQ`s of the messages still arriving for this epoch.
+    proofs_verifier: Arc<ProofsVerifier>,
 }
 
-impl OldEpoch {
+impl<ProofsVerifier> OldEpoch<ProofsVerifier> {
     #[must_use]
     pub const fn new(
         negotiated_peers: HashMap<PeerId, ConnectionId>,
         message_cache: MessageCache,
         epoch: Epoch,
         num_blend_layers: NonZeroU64,
+        proofs_verifier: Arc<ProofsVerifier>,
     ) -> Self {
         Self {
             negotiated_peers,
@@ -55,6 +64,7 @@ impl OldEpoch {
             waker: None,
             epoch,
             num_blend_layers,
+            proofs_verifier,
         }
     }
 
@@ -133,43 +143,6 @@ impl OldEpoch {
         Ok(())
     }
 
-    /// Handles a message received from a peer.
-    ///
-    /// # Returns
-    /// - [`Ok(false)`] if the connection is not part of the epoch.
-    /// - [`Ok(true)`] if the message was successfully processed and forwarded.
-    /// - [`Err(Error)`] if the message is invalid or has already been
-    ///   exchanged.
-    pub(super) fn handle_received_serialized_encapsulated_message(
-        &mut self,
-        serialized_message: &[u8],
-        (from_peer_id, from_connection_id): (PeerId, ConnectionId),
-    ) -> Result<bool, ReceiveError> {
-        if !self.is_negotiated(&(from_peer_id, from_connection_id)) {
-            return Ok(false);
-        }
-
-        handle_received_serialized_encapsulated_message_and_update_cache(
-            serialized_message,
-            &mut self.message_cache,
-            from_peer_id,
-            &mut self.events,
-            &mut self.waker,
-            self.epoch,
-            self.num_blend_layers,
-        ).inspect_err(|receive_error| {
-            tracing::debug!(target: LOG_TARGET, "Failed to handle message from the old epoch: {receive_error:?}. Closing connection with spammy peer.");
-            self.events.push_back(ToSwarm::NotifyHandler {
-                peer_id: from_peer_id,
-                handler: NotifyHandler::One(from_connection_id),
-                event: Either::Left(FromBehaviour::CloseSubstreams),
-            });
-            self.try_wake();
-        })?;
-
-        Ok(true)
-    }
-
     /// Stops the old epoch by returning any events still queued, followed by
     /// the events to close all the substreams in the old epoch.
     ///
@@ -197,17 +170,6 @@ impl OldEpoch {
         self.negotiated_peers
             .get(peer_id)
             .is_some_and(|&id| id == *connection_id)
-    }
-
-    /// Returns the connection with the given peer, if it is negotiated in the
-    /// old epoch.
-    pub(super) fn negotiated_connection_with_peer(
-        &self,
-        peer_id: PeerId,
-    ) -> Option<(PeerId, ConnectionId)> {
-        self.negotiated_peers
-            .get(&peer_id)
-            .map(|connection_id| (peer_id, *connection_id))
     }
 
     /// Returns the peer IDs of all negotiated peers in the old epoch.
@@ -249,5 +211,51 @@ impl OldEpoch {
             self.waker = Some(cx.waker().clone());
             Poll::Pending
         }
+    }
+}
+
+/// The part of the old epoch that needs to verify the `PoQ` of the messages
+/// still arriving for it, and so requires a usable verifier.
+impl<ProofsVerifier> OldEpoch<ProofsVerifier>
+where
+    ProofsVerifier: ProofsVerifierTrait + Send + Sync + 'static,
+{
+    /// Handles a message received from a peer.
+    ///
+    /// # Returns
+    /// - [`Ok(false)`] if the connection is not part of the epoch.
+    /// - [`Ok(true)`] if the message was successfully processed and forwarded.
+    /// - [`Err(Error)`] if the message is invalid or has already been
+    ///   exchanged.
+    pub(super) fn handle_received_serialized_encapsulated_message(
+        &mut self,
+        serialized_message: &[u8],
+        (from_peer_id, from_connection_id): (PeerId, ConnectionId),
+        pending_verifications: &mut PendingPoQVerifications,
+    ) -> Result<bool, ReceiveError> {
+        if !self.is_negotiated(&(from_peer_id, from_connection_id)) {
+            return Ok(false);
+        }
+
+        handle_received_serialized_encapsulated_message_and_update_cache(
+            serialized_message,
+            &mut self.message_cache,
+            (from_peer_id, from_connection_id),
+            pending_verifications,
+            &mut self.waker,
+            self.epoch,
+            self.num_blend_layers,
+            &self.proofs_verifier,
+        ).inspect_err(|receive_error| {
+            tracing::debug!(target: LOG_TARGET, "Failed to handle message from the old epoch: {receive_error:?}. Closing connection with spammy peer.");
+            self.events.push_back(ToSwarm::NotifyHandler {
+                peer_id: from_peer_id,
+                handler: NotifyHandler::One(from_connection_id),
+                event: Either::Left(FromBehaviour::CloseSubstreams),
+            });
+            self.try_wake();
+        })?;
+
+        Ok(true)
     }
 }

--- a/blend/network/src/core/with_core/behaviour/old_epoch.rs
+++ b/blend/network/src/core/with_core/behaviour/old_epoch.rs
@@ -172,6 +172,21 @@ impl<ProofsVerifier> OldEpoch<ProofsVerifier> {
             .is_some_and(|&id| id == *connection_id)
     }
 
+    /// The epoch this is serving.
+    #[must_use]
+    pub const fn epoch(&self) -> Epoch {
+        self.epoch
+    }
+
+    /// Marks a message whose `PoQ` verified against this epoch's verifier as
+    /// processed, so a copy arriving later is not verified again.
+    pub fn mark_message_as_processed(
+        &mut self,
+        message: &EncapsulatedMessageWithVerifiedPublicHeader,
+    ) {
+        self.message_cache.mark_message_as_processed(message);
+    }
+
     /// Returns the peer IDs of all negotiated peers in the old epoch.
     pub fn negotiated_peer_ids(&self) -> impl Iterator<Item = &PeerId> {
         self.negotiated_peers.keys()

--- a/blend/network/src/core/with_core/behaviour/old_epoch.rs
+++ b/blend/network/src/core/with_core/behaviour/old_epoch.rs
@@ -6,9 +6,7 @@ use std::{
 };
 
 use either::Either;
-use lb_blend_message::encap::validated::{
-    EncapsulatedMessageWithVerifiedPublicHeader, EncapsulatedMessageWithVerifiedSignature,
-};
+use lb_blend_message::encap::validated::EncapsulatedMessageWithVerifiedPublicHeader;
 use lb_cryptarchia_engine::Epoch;
 use lb_log_targets::blend;
 use libp2p::{
@@ -67,14 +65,14 @@ impl OldEpoch {
     /// an error without sending the message.
     pub(super) fn publish_message_with_validated_header(
         &mut self,
-        message: EncapsulatedMessageWithVerifiedPublicHeader,
+        message: &EncapsulatedMessageWithVerifiedPublicHeader,
         intended_epoch: Epoch,
     ) -> Result<(), SendError> {
         if self.epoch != intended_epoch {
             return Err(SendError::InvalidEpoch);
         }
         forward_validated_message_and_update_cache(
-            &(message.into()),
+            message,
             self.negotiated_peers.iter(),
             &mut self.events,
             &mut self.message_cache,
@@ -82,14 +80,14 @@ impl OldEpoch {
         )
     }
 
-    /// Forward an encapsulated message with a validated signature to all
+    /// Forward an encapsulated message with a verified public header to all
     /// negotiated peers, except the specified one.
     ///
     /// If the specified epoch does not match the current epoch, it returns
     /// an error without sending the message.
-    pub(super) fn forward_message_with_validated_signature(
+    pub(super) fn forward_message_with_verified_public_header(
         &mut self,
-        message: &EncapsulatedMessageWithVerifiedSignature,
+        message: &EncapsulatedMessageWithVerifiedPublicHeader,
         except: PeerId,
         intended_epoch: Epoch,
     ) -> Result<(), SendError> {

--- a/blend/network/src/core/with_core/behaviour/tests/connection_maintenance.rs
+++ b/blend/network/src/core/with_core/behaviour/tests/connection_maintenance.rs
@@ -41,8 +41,8 @@ async fn detect_spammy_peer() {
     // Send two messages when only one was expected.
     dialing_swarm
         .behaviour_mut()
-        .publish_message_with_validated_signature_to_current_epoch(
-            &TestEncapsulatedMessage::new(b"msg1").into_inner().into(),
+        .publish_message_with_validated_header_to_current_epoch(
+            TestEncapsulatedMessage::new(b"msg1").as_ref(),
         )
         .unwrap();
     // Using `force_send_message_to_current_epoch_peer` because otherwise we won't

--- a/blend/network/src/core/with_core/behaviour/tests/epoch.rs
+++ b/blend/network/src/core/with_core/behaviour/tests/epoch.rs
@@ -2,6 +2,7 @@ use core::time::Duration;
 
 use either::Either;
 use futures::StreamExt as _;
+use lb_blend_message::encap::validated::EncapsulatedMessageWithVerifiedPublicHeader;
 use lb_blend_scheduling::membership::Membership;
 use lb_cryptarchia_engine::Epoch;
 use lb_libp2p::{NetworkBehaviour as _, SwarmEvent};
@@ -53,7 +54,7 @@ async fn publish_message() {
     let test_message = TestEncapsulatedMessageWithEpoch::new(epoch, b"msg");
     let result = dialer
         .behaviour_mut()
-        .publish_message_with_validated_header(test_message.clone(), epoch);
+        .publish_message_with_validated_header(&test_message, epoch);
     assert_eq!(result, Err(SendError::NoPeers));
 
     // Establish a connection for the new epoch.
@@ -62,7 +63,7 @@ async fn publish_message() {
     // Now we can send the message successfully.
     dialer
         .behaviour_mut()
-        .publish_message_with_validated_header(test_message.clone(), epoch)
+        .publish_message_with_validated_header(&test_message, epoch)
         .unwrap();
     loop {
         select! {
@@ -80,7 +81,7 @@ async fn publish_message() {
     assert_eq!(
         dialer
             .behaviour_mut()
-            .publish_message_with_validated_header(test_message.clone(), 1.into()),
+            .publish_message_with_validated_header(&test_message, 1.into()),
         Err(SendError::DuplicateMessage)
     );
 }
@@ -211,7 +212,7 @@ async fn forward_message() {
     let test_message = TestEncapsulatedMessageWithEpoch::new(old_epoch, b"msg");
     sender
         .behaviour_mut()
-        .publish_message_with_validated_header(test_message.clone(), old_epoch)
+        .publish_message_with_validated_header(&test_message, old_epoch)
         .unwrap();
 
     // We expect that the message goes through the forwarder and receiver1
@@ -223,7 +224,7 @@ async fn forward_message() {
                 if let SwarmEvent::Behaviour(Event::Message { message, epoch, sender }) = event {
                     assert_eq!(message.id(), test_message.id());
                     forwarder.behaviour_mut()
-                        .forward_message_with_validated_signature(&message, sender, epoch)
+                        .forward_message_with_verified_public_header(&EncapsulatedMessageWithVerifiedPublicHeader::from_message_unchecked((*message).into()), sender, epoch)
                         .unwrap();
                 }
             }
@@ -249,7 +250,7 @@ async fn forward_message() {
     let test_message = TestEncapsulatedMessageWithEpoch::new(new_epoch, b"msg");
     sender
         .behaviour_mut()
-        .publish_message_with_validated_header(test_message.clone(), new_epoch)
+        .publish_message_with_validated_header(&test_message, new_epoch)
         .unwrap();
 
     // We expect that the message goes through the forwarder and receiver2.
@@ -260,7 +261,7 @@ async fn forward_message() {
                 if let SwarmEvent::Behaviour(Event::Message { message, epoch, sender }) = event {
                     assert_eq!(message.id(), test_message.id());
                     forwarder.behaviour_mut()
-                        .forward_message_with_validated_signature(&message, sender, epoch)
+                        .forward_message_with_verified_public_header(&EncapsulatedMessageWithVerifiedPublicHeader::from_message_unchecked((*message).into()), sender, epoch)
                         .unwrap();
                 }
             }
@@ -351,7 +352,7 @@ async fn old_epoch_message_not_forwarded_back_to_sender() {
     let test_message = TestEncapsulatedMessageWithEpoch::new(old_epoch, b"msg");
     sender
         .behaviour_mut()
-        .publish_message_with_validated_header(test_message.clone(), old_epoch)
+        .publish_message_with_validated_header(&test_message, old_epoch)
         .unwrap();
 
     // Forwarder receives the message via the old epoch and forwards it,
@@ -363,7 +364,7 @@ async fn old_epoch_message_not_forwarded_back_to_sender() {
                 if let SwarmEvent::Behaviour(Event::Message { message, epoch, sender: msg_sender }) = forwarder_event {
                     assert_eq!(message.id(), test_message.id());
                     forwarder.behaviour_mut()
-                        .forward_message_with_validated_signature(&message, msg_sender, epoch)
+                        .forward_message_with_verified_public_header(&EncapsulatedMessageWithVerifiedPublicHeader::from_message_unchecked((*message).into()), msg_sender, epoch)
                         .unwrap();
                 }
             }
@@ -426,7 +427,7 @@ async fn publish_to_invalid_epoch_returns_error() {
     let test_message = TestEncapsulatedMessageWithEpoch::new(999.into(), b"invalid-epoch");
     let result = dialer
         .behaviour_mut()
-        .publish_message_with_validated_header(test_message.clone(), 999.into());
+        .publish_message_with_validated_header(&test_message, 999.into());
     assert_eq!(result, Err(SendError::InvalidEpoch));
 }
 
@@ -457,11 +458,9 @@ async fn forward_to_invalid_epoch_returns_error() {
     // Attempt to forward a message to an invalid epoch.
     let test_message = TestEncapsulatedMessageWithEpoch::new(999.into(), b"invalid-epoch");
     let fake_sender = *listener.local_peer_id();
-    let sig_verified: lb_blend_message::encap::validated::EncapsulatedMessageWithVerifiedSignature =
-        (*test_message).clone().into();
     let result = dialer
         .behaviour_mut()
-        .forward_message_with_validated_signature(&sig_verified, fake_sender, 999.into());
+        .forward_message_with_verified_public_header(&test_message, fake_sender, 999.into());
     assert_eq!(result, Err(SendError::InvalidEpoch));
 }
 
@@ -493,7 +492,7 @@ async fn event_message_carries_epoch_number() {
     let test_message = TestEncapsulatedMessageWithEpoch::new(epoch, b"epoch-check");
     dialer
         .behaviour_mut()
-        .publish_message_with_validated_header(test_message.clone(), epoch)
+        .publish_message_with_validated_header(&test_message, epoch)
         .unwrap();
 
     loop {

--- a/blend/network/src/core/with_core/behaviour/tests/epoch.rs
+++ b/blend/network/src/core/with_core/behaviour/tests/epoch.rs
@@ -12,7 +12,7 @@ use test_log::test;
 use tokio::{select, time::sleep};
 
 use crate::core::{
-    tests::utils::{TestEncapsulatedMessageWithEpoch, TestSwarm},
+    tests::utils::{TestEncapsulatedMessageWithEpoch, TestProofsVerifier, TestSwarm},
     with_core::{
         behaviour::{
             Event,
@@ -42,12 +42,14 @@ async fn publish_message() {
     // Start a new epoch before sending any message through the connection.
     epoch = Epoch::new(epoch.into_inner() + 1);
     let memberships = build_memberships(&[&dialer, &listener]);
-    dialer
-        .behaviour_mut()
-        .start_new_epoch((memberships[0].clone(), epoch));
-    listener
-        .behaviour_mut()
-        .start_new_epoch((memberships[1].clone(), epoch));
+    dialer.behaviour_mut().start_new_epoch(
+        (memberships[0].clone(), epoch),
+        TestProofsVerifier::accepting(),
+    );
+    listener.behaviour_mut().start_new_epoch(
+        (memberships[1].clone(), epoch),
+        TestProofsVerifier::accepting(),
+    );
 
     // Send a message but expect [`Error::NoPeers`]
     // because we haven't establish connections for the new epoch.
@@ -138,7 +140,10 @@ async fn fully_negotiated_racing_epoch_transition_is_ignored() {
 
     // The epoch transition fires while the handler's `FullyNegotiated` is still
     // in flight. `start_new_epoch` clears the pending-upgrade map.
-    behaviour.start_new_epoch((Membership::new_without_local(&[]), Epoch::new(1)));
+    behaviour.start_new_epoch(
+        (Membership::new_without_local(&[]), Epoch::new(1)),
+        TestProofsVerifier::accepting(),
+    );
     assert!(
         behaviour.connections_waiting_upgrade.is_empty(),
         "start_new_epoch must clear the pending-upgrade map"
@@ -197,15 +202,18 @@ async fn forward_message() {
     // - New epoch:           forwarder -> receiver2
     let new_epoch = Epoch::new(old_epoch.into_inner() + 1);
     let memberships = build_memberships(&[&sender, &forwarder, &receiver1, &receiver2]);
-    forwarder
-        .behaviour_mut()
-        .start_new_epoch((memberships[1].clone(), new_epoch));
-    receiver1
-        .behaviour_mut()
-        .start_new_epoch((memberships[2].clone(), new_epoch));
-    receiver2
-        .behaviour_mut()
-        .start_new_epoch((memberships[3].clone(), new_epoch));
+    forwarder.behaviour_mut().start_new_epoch(
+        (memberships[1].clone(), new_epoch),
+        TestProofsVerifier::accepting(),
+    );
+    receiver1.behaviour_mut().start_new_epoch(
+        (memberships[2].clone(), new_epoch),
+        TestProofsVerifier::accepting(),
+    );
+    receiver2.behaviour_mut().start_new_epoch(
+        (memberships[3].clone(), new_epoch),
+        TestProofsVerifier::accepting(),
+    );
     forwarder.connect_and_wait_for_upgrade(&mut receiver2).await;
 
     // The sender publishes a message built with the old epoch to the forwarder.
@@ -240,9 +248,10 @@ async fn forward_message() {
 
     // Now we start the new epoch for the sender as well.
     // Also, connect the sender to the forwarder for the new epoch.
-    sender
-        .behaviour_mut()
-        .start_new_epoch((memberships[0].clone(), new_epoch));
+    sender.behaviour_mut().start_new_epoch(
+        (memberships[0].clone(), new_epoch),
+        TestProofsVerifier::accepting(),
+    );
     sender.connect_and_wait_for_upgrade(&mut forwarder).await;
 
     // The sender publishes a new message built with the new epoch to the
@@ -293,12 +302,14 @@ async fn finish_epoch_transition() {
     // Start a new epoch.
     epoch = Epoch::new(epoch.into_inner() + 1);
     let memberships = build_memberships(&[&dialer, &listener]);
-    dialer
-        .behaviour_mut()
-        .start_new_epoch((memberships[0].clone(), epoch));
-    listener
-        .behaviour_mut()
-        .start_new_epoch((memberships[1].clone(), epoch));
+    dialer.behaviour_mut().start_new_epoch(
+        (memberships[0].clone(), epoch),
+        TestProofsVerifier::accepting(),
+    );
+    listener.behaviour_mut().start_new_epoch(
+        (memberships[1].clone(), epoch),
+        TestProofsVerifier::accepting(),
+    );
 
     // Finish the transition period
     dialer.behaviour_mut().finish_epoch_transition();
@@ -344,9 +355,10 @@ async fn old_epoch_message_not_forwarded_back_to_sender() {
     // connections move into the forwarder's old epoch.
     let new_epoch = Epoch::new(old_epoch.into_inner() + 1);
     let memberships = build_memberships(&[&sender, &forwarder, &receiver]);
-    forwarder
-        .behaviour_mut()
-        .start_new_epoch((memberships[1].clone(), new_epoch));
+    forwarder.behaviour_mut().start_new_epoch(
+        (memberships[1].clone(), new_epoch),
+        TestProofsVerifier::accepting(),
+    );
 
     // Sender publishes a message for the old epoch.
     let test_message = TestEncapsulatedMessageWithEpoch::new(old_epoch, b"msg");
@@ -415,12 +427,14 @@ async fn publish_to_invalid_epoch_returns_error() {
 
     // Start the first epoch and connect.
     let memberships = build_memberships(&[&dialer, &listener]);
-    dialer
-        .behaviour_mut()
-        .start_new_epoch((memberships[0].clone(), epoch));
-    listener
-        .behaviour_mut()
-        .start_new_epoch((memberships[1].clone(), epoch));
+    dialer.behaviour_mut().start_new_epoch(
+        (memberships[0].clone(), epoch),
+        TestProofsVerifier::accepting(),
+    );
+    listener.behaviour_mut().start_new_epoch(
+        (memberships[1].clone(), epoch),
+        TestProofsVerifier::accepting(),
+    );
     dialer.connect_and_wait_for_upgrade(&mut listener).await;
 
     // Attempt to publish to an epoch that neither matches the current nor old.
@@ -447,12 +461,14 @@ async fn forward_to_invalid_epoch_returns_error() {
 
     // Start the first epoch and connect.
     let memberships = build_memberships(&[&dialer, &listener]);
-    dialer
-        .behaviour_mut()
-        .start_new_epoch((memberships[0].clone(), epoch));
-    listener
-        .behaviour_mut()
-        .start_new_epoch((memberships[1].clone(), epoch));
+    dialer.behaviour_mut().start_new_epoch(
+        (memberships[0].clone(), epoch),
+        TestProofsVerifier::accepting(),
+    );
+    listener.behaviour_mut().start_new_epoch(
+        (memberships[1].clone(), epoch),
+        TestProofsVerifier::accepting(),
+    );
     dialer.connect_and_wait_for_upgrade(&mut listener).await;
 
     // Attempt to forward a message to an invalid epoch.
@@ -480,12 +496,14 @@ async fn event_message_carries_epoch_number() {
     // Start epoch 1 and connect.
     let epoch = Epoch::new(1);
     let memberships = build_memberships(&[&dialer, &listener]);
-    dialer
-        .behaviour_mut()
-        .start_new_epoch((memberships[0].clone(), epoch));
-    listener
-        .behaviour_mut()
-        .start_new_epoch((memberships[1].clone(), epoch));
+    dialer.behaviour_mut().start_new_epoch(
+        (memberships[0].clone(), epoch),
+        TestProofsVerifier::accepting(),
+    );
+    listener.behaviour_mut().start_new_epoch(
+        (memberships[1].clone(), epoch),
+        TestProofsVerifier::accepting(),
+    );
     dialer.connect_and_wait_for_upgrade(&mut listener).await;
 
     // Send a message for epoch 1.
@@ -538,9 +556,10 @@ async fn start_new_epoch_moves_peers_to_old_epoch() {
 
     // Start a new epoch.
     let memberships = build_memberships(&[&node_a, &node_b, &node_c]);
-    node_a
-        .behaviour_mut()
-        .start_new_epoch((memberships[0].clone(), 1.into()));
+    node_a.behaviour_mut().start_new_epoch(
+        (memberships[0].clone(), 1.into()),
+        TestProofsVerifier::accepting(),
+    );
 
     // After epoch transition: current negotiated_peers must be empty
     // and old_epoch must exist.
@@ -580,9 +599,10 @@ async fn finish_epoch_transition_emits_peer_disconnected_for_old_epoch_peers() {
 
     // Start a new epoch to move current peers into old epoch.
     let memberships = build_memberships(&[&node_a, &node_b, &node_c]);
-    node_a
-        .behaviour_mut()
-        .start_new_epoch((memberships[0].clone(), 1.into()));
+    node_a.behaviour_mut().start_new_epoch(
+        (memberships[0].clone(), 1.into()),
+        TestProofsVerifier::accepting(),
+    );
 
     // Finish the transition; this should close all old epoch connections.
     node_a.behaviour_mut().finish_epoch_transition();
@@ -631,12 +651,14 @@ async fn consecutive_epoch_transitions_replace_old_epoch() {
 
     // First epoch transition: move the current peer into old epoch.
     let memberships = build_memberships(&[&dialer, &listener]);
-    dialer
-        .behaviour_mut()
-        .start_new_epoch((memberships[0].clone(), 1.into()));
-    listener
-        .behaviour_mut()
-        .start_new_epoch((memberships[1].clone(), 1.into()));
+    dialer.behaviour_mut().start_new_epoch(
+        (memberships[0].clone(), 1.into()),
+        TestProofsVerifier::accepting(),
+    );
+    listener.behaviour_mut().start_new_epoch(
+        (memberships[1].clone(), 1.into()),
+        TestProofsVerifier::accepting(),
+    );
     assert!(dialer.behaviour().old_epoch.is_some());
 
     // Re-establish a connection for epoch 1 so there is something to move
@@ -647,12 +669,14 @@ async fn consecutive_epoch_transitions_replace_old_epoch() {
     // Second epoch transition: old epoch from epoch 0 gets stopped
     // and current peers from epoch 1 move into old epoch.
     let memberships = build_memberships(&[&dialer, &listener]);
-    dialer
-        .behaviour_mut()
-        .start_new_epoch((memberships[0].clone(), 2.into()));
-    listener
-        .behaviour_mut()
-        .start_new_epoch((memberships[1].clone(), 2.into()));
+    dialer.behaviour_mut().start_new_epoch(
+        (memberships[0].clone(), 2.into()),
+        TestProofsVerifier::accepting(),
+    );
+    listener.behaviour_mut().start_new_epoch(
+        (memberships[1].clone(), 2.into()),
+        TestProofsVerifier::accepting(),
+    );
     assert!(dialer.behaviour().old_epoch.is_some());
     assert_eq!(
         dialer.behaviour().negotiated_peers.len(),
@@ -712,18 +736,22 @@ async fn epoch_transition_reboots_peering_degree() {
 
     // Start epoch transition - all current peers move to old epoch.
     let memberships = build_memberships(&[&node_a, &node_b, &node_c, &node_d]);
-    node_a
-        .behaviour_mut()
-        .start_new_epoch((memberships[0].clone(), 1.into()));
-    node_b
-        .behaviour_mut()
-        .start_new_epoch((memberships[1].clone(), 1.into()));
-    node_c
-        .behaviour_mut()
-        .start_new_epoch((memberships[2].clone(), 1.into()));
-    node_d
-        .behaviour_mut()
-        .start_new_epoch((memberships[3].clone(), 1.into()));
+    node_a.behaviour_mut().start_new_epoch(
+        (memberships[0].clone(), 1.into()),
+        TestProofsVerifier::accepting(),
+    );
+    node_b.behaviour_mut().start_new_epoch(
+        (memberships[1].clone(), 1.into()),
+        TestProofsVerifier::accepting(),
+    );
+    node_c.behaviour_mut().start_new_epoch(
+        (memberships[2].clone(), 1.into()),
+        TestProofsVerifier::accepting(),
+    );
+    node_d.behaviour_mut().start_new_epoch(
+        (memberships[3].clone(), 1.into()),
+        TestProofsVerifier::accepting(),
+    );
 
     // After transition, new epoch has no peers, so all slots are available.
     assert_eq!(

--- a/blend/network/src/core/with_core/behaviour/tests/message_handling.rs
+++ b/blend/network/src/core/with_core/behaviour/tests/message_handling.rs
@@ -42,9 +42,7 @@ async fn message_sending_and_reception() {
     let test_message_id = test_message.id();
     dialing_swarm
         .behaviour_mut()
-        .publish_message_with_validated_signature_to_current_epoch(
-            &test_message.as_ref().clone().into(),
-        )
+        .publish_message_with_validated_header_to_current_epoch(test_message.as_ref())
         .unwrap();
 
     loop {
@@ -90,9 +88,7 @@ async fn message_sending_and_reception() {
     assert_eq!(
         dialing_swarm
             .behaviour_mut()
-            .publish_message_with_validated_signature_to_current_epoch(
-                &test_message.as_ref().clone().into()
-            ),
+            .publish_message_with_validated_header_to_current_epoch(test_message.as_ref()),
         Err(SendError::DuplicateMessage)
     );
 }
@@ -221,9 +217,7 @@ async fn duplicate_message_received_from_same_peer() {
     let test_message = TestEncapsulatedMessage::new(b"msg");
     dialing_swarm
         .behaviour_mut()
-        .publish_message_with_validated_signature_to_current_epoch(
-            &test_message.as_ref().clone().into(),
-        )
+        .publish_message_with_validated_header_to_current_epoch(test_message.as_ref())
         .unwrap();
 
     // Poll both swarms until the first message is fully received by the listener.
@@ -307,15 +301,11 @@ async fn duplicate_message_received_from_different_peers() {
     let test_message = TestEncapsulatedMessage::new(b"msg");
     dialing_swarm_1
         .behaviour_mut()
-        .publish_message_with_validated_signature_to_current_epoch(
-            &test_message.as_ref().clone().into(),
-        )
+        .publish_message_with_validated_header_to_current_epoch(test_message.as_ref())
         .unwrap();
     dialing_swarm_2
         .behaviour_mut()
-        .publish_message_with_validated_signature_to_current_epoch(
-            &test_message.as_ref().clone().into(),
-        )
+        .publish_message_with_validated_header_to_current_epoch(test_message.as_ref())
         .unwrap();
 
     // Verify that the message is bubbled up to the swarm only once
@@ -406,9 +396,7 @@ async fn message_already_forwarded_silently_ignored_when_received_from_peer() {
     // Node A forwards X to Node B. In Node A's cache X is now `Forwarded`.
     node_a
         .behaviour_mut()
-        .publish_message_with_validated_signature_to_current_epoch(
-            &test_message.as_ref().clone().into(),
-        )
+        .publish_message_with_validated_header_to_current_epoch(test_message.as_ref())
         .unwrap();
 
     // Wait until Node B has received the message.
@@ -483,9 +471,7 @@ async fn duplicate_message_in_old_epoch_disconnects_peer_without_swarm_notificat
     // Sender publishes X. Receiver marks it as `Processed` in its cache.
     sender
         .behaviour_mut()
-        .publish_message_with_validated_signature_to_current_epoch(
-            &test_message.as_ref().clone().into(),
-        )
+        .publish_message_with_validated_header_to_current_epoch(test_message.as_ref())
         .unwrap();
 
     loop {
@@ -671,7 +657,7 @@ async fn spammy_old_epoch_peer_does_not_affect_current_epoch() {
     let test_message = TestEncapsulatedMessageWithEpoch::new(1.into(), b"after-spam");
     sender
         .behaviour_mut()
-        .publish_message_with_validated_header(test_message.clone(), 1.into())
+        .publish_message_with_validated_header(&test_message, 1.into())
         .unwrap();
 
     loop {
@@ -715,9 +701,7 @@ async fn duplicate_message_from_old_epoch_after_epoch_rotation_is_suppressed() {
     let test_message = TestEncapsulatedMessage::new(b"msg");
     sender_a
         .behaviour_mut()
-        .publish_message_with_validated_signature_to_current_epoch(
-            &test_message.as_ref().clone().into(),
-        )
+        .publish_message_with_validated_header_to_current_epoch(test_message.as_ref())
         .unwrap();
 
     loop {
@@ -746,9 +730,7 @@ async fn duplicate_message_from_old_epoch_after_epoch_rotation_is_suppressed() {
     // cache, receiver must NOT emit a second `Message` event.
     sender_b
         .behaviour_mut()
-        .publish_message_with_validated_signature_to_current_epoch(
-            &test_message.as_ref().clone().into(),
-        )
+        .publish_message_with_validated_header_to_current_epoch(test_message.as_ref())
         .unwrap();
 
     let mut duplicate_message_received = false;

--- a/blend/network/src/core/with_core/behaviour/tests/message_handling.rs
+++ b/blend/network/src/core/with_core/behaviour/tests/message_handling.rs
@@ -9,7 +9,9 @@ use test_log::test;
 use tokio::{select, time::sleep};
 
 use crate::core::{
-    tests::utils::{TestEncapsulatedMessage, TestEncapsulatedMessageWithEpoch, TestSwarm},
+    tests::utils::{
+        TestEncapsulatedMessage, TestEncapsulatedMessageWithEpoch, TestProofsVerifier, TestSwarm,
+    },
     with_core::{
         behaviour::{
             Event, NegotiatedPeerState, SpamReason,
@@ -51,7 +53,7 @@ async fn message_sending_and_reception() {
             listening_event = listening_swarm.select_next_some() => {
                 if let SwarmEvent::Behaviour(Event::Message { message, sender, .. }) = listening_event {
                     assert_eq!(sender, *dialing_swarm.local_peer_id());
-                    assert_eq!(*message, test_message.clone().into_inner().into());
+                    assert_eq!(*message, test_message.clone().into_inner());
                     break;
                 }
             }
@@ -378,6 +380,64 @@ async fn invalid_signature_message_received() {
     }
 }
 
+/// A message whose `PoQ` does not verify is never reported to the swarm — so it
+/// can never be relayed — and its sender is marked as spammy and disconnected,
+/// exactly like a peer sending a message with an invalid signature.
+#[test(tokio::test)]
+async fn invalid_proof_of_quota_message_received() {
+    let (mut identities, nodes) = new_nodes_with_empty_address(2);
+    let mut dialing_swarm = TestSwarm::new(&identities.next().unwrap(), |id| {
+        BehaviourBuilder::new(id).with_membership(&nodes).build()
+    });
+    // The receiving side rejects every `PoQ` it is handed.
+    let mut listening_swarm = TestSwarm::new(&identities.next().unwrap(), |id| {
+        BehaviourBuilder::new(id)
+            .with_membership(&nodes)
+            .with_rejecting_proofs_verifier()
+            .build()
+    });
+
+    listening_swarm.listen().with_memory_addr_external().await;
+    dialing_swarm
+        .connect_and_wait_for_upgrade(&mut listening_swarm)
+        .await;
+
+    // The message is well-formed and correctly signed: only its `PoQ` fails.
+    let test_message = TestEncapsulatedMessage::new(b"invalid-poq");
+    dialing_swarm
+        .behaviour_mut()
+        .publish_message_with_validated_header_to_current_epoch(test_message.as_ref())
+        .unwrap();
+
+    let mut events_to_match = 2u8;
+    loop {
+        select! {
+            _ = dialing_swarm.select_next_some() => {}
+            listening_swarm_event = listening_swarm.select_next_some() => {
+                match listening_swarm_event {
+                    SwarmEvent::Behaviour(Event::Message { .. }) => {
+                        panic!("A message whose PoQ failed to verify must not be reported to the swarm");
+                    }
+                    SwarmEvent::Behaviour(Event::PeerDisconnected(peer_id, peer_state)) => {
+                        assert_eq!(peer_id, *dialing_swarm.local_peer_id());
+                        assert_eq!(peer_state, NegotiatedPeerState::Spammy(SpamReason::InvalidProofOfQuota));
+                        events_to_match -= 1;
+                    }
+                    SwarmEvent::ConnectionClosed { peer_id, endpoint, .. } => {
+                        assert_eq!(peer_id, *dialing_swarm.local_peer_id());
+                        assert!(endpoint.is_listener());
+                        events_to_match -= 1;
+                    }
+                    _ => {}
+                }
+            }
+        }
+        if events_to_match == 0 {
+            break;
+        }
+    }
+}
+
 #[test(tokio::test)]
 async fn message_already_forwarded_silently_ignored_when_received_from_peer() {
     let (mut identities, nodes) = new_nodes_with_empty_address(2);
@@ -489,9 +549,10 @@ async fn duplicate_message_in_old_epoch_disconnects_peer_without_swarm_notificat
     // epoch together with the existing message cache (which contains X as
     // `Processed`).
     let memberships = build_memberships(&[&sender, &receiver]);
-    receiver
-        .behaviour_mut()
-        .start_new_epoch((memberships[1].clone(), 1.into()));
+    receiver.behaviour_mut().start_new_epoch(
+        (memberships[1].clone(), 1.into()),
+        TestProofsVerifier::accepting(),
+    );
 
     // Wait long enough so that the connection monitor does not fire
     // `TooManyMessages` instead.
@@ -556,9 +617,10 @@ async fn undeserializable_message_in_old_epoch_closes_connection_without_swarm_n
     // Receiver starts a new epoch. Sender's connection moves to the old
     // epoch.
     let memberships = build_memberships(&[&sender, &receiver]);
-    receiver
-        .behaviour_mut()
-        .start_new_epoch((memberships[1].clone(), 1.into()));
+    receiver.behaviour_mut().start_new_epoch(
+        (memberships[1].clone(), 1.into()),
+        TestProofsVerifier::accepting(),
+    );
 
     // Sender sends garbage data over the old-epoch connection.
     sender
@@ -615,14 +677,16 @@ async fn spammy_old_epoch_peer_does_not_affect_current_epoch() {
     // Receiver starts a new epoch. Sender's connection moves to the old
     // epoch.
     let memberships = build_memberships(&[&sender, &receiver]);
-    receiver
-        .behaviour_mut()
-        .start_new_epoch((memberships[1].clone(), 1.into()));
+    receiver.behaviour_mut().start_new_epoch(
+        (memberships[1].clone(), 1.into()),
+        TestProofsVerifier::accepting(),
+    );
 
     // Re-connect for the new epoch.
-    sender
-        .behaviour_mut()
-        .start_new_epoch((memberships[0].clone(), 1.into()));
+    sender.behaviour_mut().start_new_epoch(
+        (memberships[0].clone(), 1.into()),
+        TestProofsVerifier::accepting(),
+    );
     sender.connect_and_wait_for_upgrade(&mut receiver).await;
 
     // Sender sends garbage over the old-epoch connection. This should
@@ -720,9 +784,10 @@ async fn duplicate_message_from_old_epoch_after_epoch_rotation_is_suppressed() {
     // as `Processed` is transferred into the old epoch object,
     // alongside the connections to both sender_a and sender_b.
     let memberships = build_memberships(&[&sender_a, &sender_b, &receiver]);
-    receiver
-        .behaviour_mut()
-        .start_new_epoch((memberships[2].clone(), 1.into()));
+    receiver.behaviour_mut().start_new_epoch(
+        (memberships[2].clone(), 1.into()),
+        TestProofsVerifier::accepting(),
+    );
 
     // Sender B sends the identical message X through its (still-open)
     // connection to receiver. From receiver's point of view this connection

--- a/blend/network/src/core/with_core/behaviour/tests/message_handling.rs
+++ b/blend/network/src/core/with_core/behaviour/tests/message_handling.rs
@@ -310,8 +310,12 @@ async fn duplicate_message_received_from_different_peers() {
         .publish_message_with_validated_header_to_current_epoch(test_message.as_ref())
         .unwrap();
 
-    // Verify that the message is bubbled up to the swarm only once
-    let mut received_message_count = 0u8;
+    // Both copies are reported to the swarm: nothing enters the message cache
+    // until a `PoQ` verifies, so the second copy cannot be recognised as a
+    // duplicate before it has been verified in its own right. What must not
+    // happen twice is the relay, so each report is forwarded on as the swarm
+    // would, and only the first one is expected to go out.
+    let mut forward_results = Vec::new();
     loop {
         select! {
             () = sleep(Duration::from_secs(5)) => {
@@ -320,13 +324,30 @@ async fn duplicate_message_received_from_different_peers() {
             _ = dialing_swarm_1.select_next_some() => {}
             _ = dialing_swarm_2.select_next_some() => {}
             listening_event = listening_swarm.select_next_some() => {
-                if let SwarmEvent::Behaviour(Event::Message { .. }) = listening_event {
-                    received_message_count += 1;
+                if let SwarmEvent::Behaviour(Event::Message { message, sender, epoch }) = listening_event {
+                    forward_results.push(
+                        listening_swarm
+                            .behaviour_mut()
+                            .forward_message_with_verified_public_header(&message, sender, epoch),
+                    );
                 }
             }
         }
     }
-    assert_eq!(received_message_count, 1);
+
+    let (relayed, rejected): (Vec<_>, Vec<_>) =
+        forward_results.iter().partition(|result| result.is_ok());
+    assert_eq!(
+        relayed.len(),
+        1,
+        "The message must be relayed exactly once, no matter how many peers sent it"
+    );
+    assert!(
+        rejected
+            .iter()
+            .all(|result| **result == Err(SendError::DuplicateMessage)),
+        "Every further copy must be rejected as a duplicate, got {rejected:?}"
+    );
 }
 
 #[test(tokio::test)]

--- a/blend/network/src/core/with_core/behaviour/tests/utils.rs
+++ b/blend/network/src/core/with_core/behaviour/tests/utils.rs
@@ -6,6 +6,7 @@ use core::{
 use std::{
     collections::{HashMap, VecDeque},
     iter::repeat_with,
+    sync::Arc,
 };
 
 use async_trait::async_trait;
@@ -23,9 +24,13 @@ use tokio::time::{MissedTickBehavior, interval};
 use tokio_stream::wrappers::IntervalStream;
 
 use crate::core::{
-    tests::utils::{PROTOCOL_NAME, TestSwarm},
+    poq_verification::PendingPoQVerifications,
+    tests::utils::{PROTOCOL_NAME, TestProofsVerifier, TestSwarm},
     with_core::behaviour::{Behaviour, Event, IntervalStreamProvider, message_cache::MessageCache},
 };
+
+/// The behaviour under test, with the `PoQ` verifier the tests use.
+pub type TestBehaviour = Behaviour<IntervalProvider, TestProofsVerifier>;
 
 #[derive(Clone)]
 pub struct IntervalProvider(Duration, RangeInclusive<u64>);
@@ -92,6 +97,7 @@ pub struct BehaviourBuilder {
     peering_degree: Option<RangeInclusive<usize>>,
     minimum_network_size: Option<NonZeroUsize>,
     num_blend_layers: Option<NonZeroU64>,
+    proofs_verifier: TestProofsVerifier,
 }
 
 impl BehaviourBuilder {
@@ -103,7 +109,14 @@ impl BehaviourBuilder {
             peering_degree: None,
             minimum_network_size: None,
             num_blend_layers: None,
+            proofs_verifier: TestProofsVerifier::accepting(),
         }
+    }
+
+    /// Makes the behaviour reject the `PoQ` of every message it receives.
+    pub const fn with_rejecting_proofs_verifier(mut self) -> Self {
+        self.proofs_verifier = TestProofsVerifier::rejecting();
+        self
     }
 
     pub fn with_membership(mut self, nodes: &[Node<PeerId>]) -> Self {
@@ -135,7 +148,7 @@ impl BehaviourBuilder {
         self
     }
 
-    pub fn build(self) -> Behaviour<IntervalProvider> {
+    pub fn build(self) -> TestBehaviour {
         Behaviour {
             negotiated_peers: HashMap::new(),
             connections_waiting_upgrade: HashMap::new(),
@@ -160,6 +173,8 @@ impl BehaviourBuilder {
                 .unwrap_or_else(|| 3.try_into().unwrap()),
             old_epoch: None,
             message_cache: MessageCache::new(),
+            proofs_verifier: Arc::new(self.proofs_verifier),
+            pending_poq_verifications: PendingPoQVerifications::new(),
         }
     }
 }
@@ -174,7 +189,7 @@ pub trait SwarmExt: libp2p_swarm_test::SwarmExt {
 }
 
 #[async_trait]
-impl SwarmExt for Swarm<Behaviour<IntervalProvider>> {
+impl SwarmExt for Swarm<TestBehaviour> {
     async fn connect_and_wait_for_upgrade<ListenerBehaviour>(
         &mut self,
         listener: &mut Swarm<ListenerBehaviour>,

--- a/blend/network/src/core/with_core/behaviour/utils.rs
+++ b/blend/network/src/core/with_core/behaviour/utils.rs
@@ -89,7 +89,7 @@ pub fn handle_received_serialized_encapsulated_message_and_update_cache<Verifier
     serialized_message: &[u8],
     message_cache: &mut MessageCache,
     (sender, connection_id): (PeerId, ConnectionId),
-    pending_verifications: &mut PendingPoQVerifications,
+    pending_verifications: &PendingPoQVerifications,
     waker: &mut Option<Waker>,
     epoch: Epoch,
     num_blend_layers: NonZeroU64,

--- a/blend/network/src/core/with_core/behaviour/utils.rs
+++ b/blend/network/src/core/with_core/behaviour/utils.rs
@@ -79,11 +79,11 @@ where
 /// returned to avoid processing the same message multiple times from the same
 /// peer, which could be a sign of a malicious peer.
 ///
-/// The message is only reported to the swarm once its `PoQ` verifies, which
-/// happens off the task polling this behaviour. Marking it as processed before
-/// the outcome is known is deliberate: the verdict depends only on the message
-/// and the epoch's verifier, so a copy arriving from another peer in the
-/// meantime would get the same answer and need not be verified again.
+/// The message is only reported to the swarm — and only entered into the
+/// message cache — once its `PoQ` verifies, which happens off the task polling
+/// this behaviour. Entering it any earlier would let anyone claim a nullifier
+/// by replaying someone else's `PoQ` under their own signing key, suppressing
+/// the genuine message that carries it.
 #[expect(clippy::too_many_arguments, reason = "categorize args")]
 pub fn handle_received_serialized_encapsulated_message_and_update_cache<Verifier>(
     serialized_message: &[u8],
@@ -120,10 +120,8 @@ where
         .verify_header_signature()
         .map_err(|_| ReceiveError::InvalidHeaderSignature)?;
 
-    message_cache.mark_message_as_processed(&validated_message);
-
-    // Verify the `PoQ` before the message is reported to the swarm, and hence
-    // before it can be relayed any further.
+    // Verify the `PoQ` before the message is reported to the swarm, entered into
+    // the cache, and hence before it can be relayed any further.
     spawn_poq_verification(
         pending_verifications,
         validated_message,

--- a/blend/network/src/core/with_core/behaviour/utils.rs
+++ b/blend/network/src/core/with_core/behaviour/utils.rs
@@ -1,8 +1,10 @@
 use core::{convert::Infallible, num::NonZeroU64, task::Waker};
-use std::collections::VecDeque;
+use std::{collections::VecDeque, sync::Arc};
 
 use either::Either;
-use lb_blend_message::encap::validated::EncapsulatedMessageWithVerifiedPublicHeader;
+use lb_blend_message::encap::{
+    ProofsVerifier, validated::EncapsulatedMessageWithVerifiedPublicHeader,
+};
 use lb_blend_scheduling::{
     deserialize_encapsulated_message, serialize_encapsulated_message_with_verified_public_header,
 };
@@ -12,9 +14,12 @@ use libp2p::{
     swarm::{ConnectionId, NotifyHandler, ToSwarm},
 };
 
-use crate::core::with_core::{
-    behaviour::{Event, handler::FromBehaviour, message_cache::MessageCache},
-    error::{ReceiveError, SendError},
+use crate::core::{
+    poq_verification::{PendingPoQVerifications, spawn_poq_verification},
+    with_core::{
+        behaviour::{Event, handler::FromBehaviour, message_cache::MessageCache},
+        error::{ReceiveError, SendError},
+    },
 };
 
 /// Forwards a message with a verified public header to the given peer
@@ -64,8 +69,8 @@ where
     Ok(())
 }
 
-/// Validates the signature of a received message, and notifies the swarm about
-/// it if it hasn't been processed already.
+/// Validates the signature of a received message and dispatches the
+/// verification of its `PoQ`, if it hasn't been processed already.
 ///
 /// The message cache is updated accordingly to mark the message as processed if
 /// it is valid and hasn't been processed before, or to ignore it if it has
@@ -73,15 +78,26 @@ where
 /// received message from the same peer, it is also ignored and an error is
 /// returned to avoid processing the same message multiple times from the same
 /// peer, which could be a sign of a malicious peer.
-pub fn handle_received_serialized_encapsulated_message_and_update_cache(
+///
+/// The message is only reported to the swarm once its `PoQ` verifies, which
+/// happens off the task polling this behaviour. Marking it as processed before
+/// the outcome is known is deliberate: the verdict depends only on the message
+/// and the epoch's verifier, so a copy arriving from another peer in the
+/// meantime would get the same answer and need not be verified again.
+#[expect(clippy::too_many_arguments, reason = "categorize args")]
+pub fn handle_received_serialized_encapsulated_message_and_update_cache<Verifier>(
     serialized_message: &[u8],
     message_cache: &mut MessageCache,
-    sender: PeerId,
-    events_queue: &mut VecDeque<ToSwarm<Event, Either<FromBehaviour, Infallible>>>,
+    (sender, connection_id): (PeerId, ConnectionId),
+    pending_verifications: &mut PendingPoQVerifications,
     waker: &mut Option<Waker>,
     epoch: Epoch,
     num_blend_layers: NonZeroU64,
-) -> Result<(), ReceiveError> {
+    proofs_verifier: &Arc<Verifier>,
+) -> Result<(), ReceiveError>
+where
+    Verifier: ProofsVerifier + Send + Sync + 'static,
+{
     // Deserialize the message.
     let deserialized_encapsulated_message =
         deserialize_encapsulated_message(serialized_message, &num_blend_layers)
@@ -104,17 +120,18 @@ pub fn handle_received_serialized_encapsulated_message_and_update_cache(
         .verify_header_signature()
         .map_err(|_| ReceiveError::InvalidHeaderSignature)?;
 
-    // Notify the swarm about the received message, so that it can be further
-    // processed by the core protocol module.
     message_cache.mark_message_as_processed(&validated_message);
-    events_queue.push_back(ToSwarm::GenerateEvent(Event::Message {
-        message: Box::new(validated_message),
-        sender,
+
+    // Verify the `PoQ` before the message is reported to the swarm, and hence
+    // before it can be relayed any further.
+    spawn_poq_verification(
+        pending_verifications,
+        validated_message,
+        (sender, connection_id),
         epoch,
-    }));
-    if let Some(waker) = waker.take() {
-        waker.wake();
-    }
+        proofs_verifier,
+        waker,
+    );
 
     Ok(())
 }

--- a/blend/network/src/core/with_core/behaviour/utils.rs
+++ b/blend/network/src/core/with_core/behaviour/utils.rs
@@ -2,9 +2,9 @@ use core::{convert::Infallible, num::NonZeroU64, task::Waker};
 use std::collections::VecDeque;
 
 use either::Either;
-use lb_blend_message::encap::validated::EncapsulatedMessageWithVerifiedSignature;
+use lb_blend_message::encap::validated::EncapsulatedMessageWithVerifiedPublicHeader;
 use lb_blend_scheduling::{
-    deserialize_encapsulated_message, serialize_encapsulated_message_with_verified_signature,
+    deserialize_encapsulated_message, serialize_encapsulated_message_with_verified_public_header,
 };
 use lb_cryptarchia_engine::Epoch;
 use libp2p::{
@@ -17,14 +17,18 @@ use crate::core::with_core::{
     error::{ReceiveError, SendError},
 };
 
-/// Forwards a message with a valid signature to the given peer connections, if
-/// it hasn't been forwarded already.
+/// Forwards a message with a verified public header to the given peer
+/// connections, if it hasn't been forwarded already.
 ///
 /// The message cache is also updated accordingly to mark the sent message as
 /// processed if it was sent to at least one peer, or to ignore it if it has
 /// already been forwarded before.
+///
+/// The input type is [`EncapsulatedMessageWithVerifiedPublicHeader`] because a
+/// message is relayed to the rest of the network only after its `PoQ` has been
+/// verified, which happens in the Blend service.
 pub fn forward_validated_message_and_update_cache<'epoch, PeerConnections>(
-    message: &EncapsulatedMessageWithVerifiedSignature,
+    message: &EncapsulatedMessageWithVerifiedPublicHeader,
     peer_connections: PeerConnections,
     events_queue: &'epoch mut VecDeque<ToSwarm<Event, Either<FromBehaviour, Infallible>>>,
     message_cache: &'epoch mut MessageCache,
@@ -42,7 +46,7 @@ where
         return Err(SendError::NoPeers);
     }
 
-    let serialized_message = serialize_encapsulated_message_with_verified_signature(message);
+    let serialized_message = serialize_encapsulated_message_with_verified_public_header(message);
 
     peer_connections.for_each(|(peer_id, connection_id)| {
         tracing::trace!("Notifying handler with peer {peer_id:?} on connection {connection_id:?} to deliver message.");
@@ -95,7 +99,7 @@ pub fn handle_received_serialized_encapsulated_message_and_update_cache(
         return Ok(());
     }
 
-    // Verify the message public header
+    // Verify the message signature
     let validated_message = deserialized_encapsulated_message
         .verify_header_signature()
         .map_err(|_| ReceiveError::InvalidHeaderSignature)?;

--- a/blend/network/src/core/with_edge/behaviour/mod.rs
+++ b/blend/network/src/core/with_edge/behaviour/mod.rs
@@ -3,13 +3,18 @@ use std::{
     collections::{HashSet, VecDeque},
     convert::Infallible,
     mem,
+    sync::Arc,
     task::{Context, Poll, Waker},
     time::Duration,
 };
 
 use either::Either;
-use lb_blend_message::encap::validated::EncapsulatedMessageWithVerifiedSignature;
+use futures::StreamExt as _;
+use lb_blend_message::encap::{
+    ProofsVerifier as ProofsVerifierTrait, validated::EncapsulatedMessageWithVerifiedPublicHeader,
+};
 use lb_blend_scheduling::{deserialize_encapsulated_message, membership::Membership};
+use lb_cryptarchia_engine::Epoch;
 use lb_log_targets::blend;
 use libp2p::{
     Multiaddr, PeerId, StreamProtocol,
@@ -21,7 +26,10 @@ use libp2p::{
     },
 };
 
-use crate::core::with_edge::behaviour::handler::{ConnectionHandler, FromBehaviour, ToBehaviour};
+use crate::core::{
+    poq_verification::{PendingPoQVerifications, PoQVerificationOutcome, spawn_poq_verification},
+    with_edge::behaviour::handler::{ConnectionHandler, FromBehaviour, ToBehaviour},
+};
 
 mod handler;
 
@@ -39,9 +47,9 @@ const LOG_TARGET: &str = blend::network::core::edge::BEHAVIOUR;
 )]
 #[derive(Debug)]
 pub enum Event {
-    /// A message received from one of the edge peers, after its signature
-    /// has been verified.
-    Message(EncapsulatedMessageWithVerifiedSignature),
+    /// A message received from one of the edge peers, after its whole public
+    /// header — signature and `PoQ` — has been verified.
+    Message(EncapsulatedMessageWithVerifiedPublicHeader),
     #[cfg(test)]
     NegotiatedConnection { peer: PeerId },
 }
@@ -59,12 +67,22 @@ pub struct Config {
 
 /// A [`NetworkBehaviour`]:
 /// - receives messages from edge nodes and forwards them to the swarm.
-pub struct Behaviour {
+pub struct Behaviour<ProofsVerifier> {
     /// Queue of events to yield to the swarm.
     events: VecDeque<ToSwarm<Event, Either<FromBehaviour, Infallible>>>,
     /// Waker that handles polling
     waker: Option<Waker>,
     current_membership: Membership<PeerId>,
+    /// The epoch the messages received from edge nodes belong to, needed to
+    /// pick them up again once their `PoQ` has been verified.
+    current_epoch: Epoch,
+    /// Verifier for the `PoQ`s of the messages received from edge nodes.
+    ///
+    /// Shared rather than owned because a handle to it is passed to the
+    /// blocking pool for every message received.
+    proofs_verifier: Arc<ProofsVerifier>,
+    /// `PoQ` verifications currently running on the blocking pool.
+    pending_poq_verifications: PendingPoQVerifications,
     // Timeout to close connection with an edge node if a message is not received on time.
     connection_timeout: Duration,
     upgraded_edge_peers: HashSet<(PeerId, ConnectionId)>,
@@ -74,17 +92,21 @@ pub struct Behaviour {
     num_blend_layers: NonZeroU64,
 }
 
-impl Behaviour {
+impl<ProofsVerifier> Behaviour<ProofsVerifier> {
     #[must_use]
     pub fn new(
         config: &Config,
-        current_epoch_info: Membership<PeerId>,
+        current_epoch_info: (Membership<PeerId>, Epoch),
+        proofs_verifier: ProofsVerifier,
         protocol_name: StreamProtocol,
     ) -> Self {
         Self {
             events: VecDeque::new(),
             waker: None,
-            current_membership: current_epoch_info,
+            current_membership: current_epoch_info.0,
+            current_epoch: current_epoch_info.1,
+            proofs_verifier: Arc::new(proofs_verifier),
+            pending_poq_verifications: PendingPoQVerifications::new(),
             connection_timeout: config.connection_timeout,
             upgraded_edge_peers: HashSet::with_capacity(config.max_incoming_connections),
             max_incoming_connections: config.max_incoming_connections,
@@ -94,8 +116,14 @@ impl Behaviour {
         }
     }
 
-    pub(crate) fn start_new_epoch(&mut self, new_epoch_info: Membership<PeerId>) {
-        self.current_membership = new_epoch_info;
+    pub(crate) fn start_new_epoch(
+        &mut self,
+        new_epoch_info: (Membership<PeerId>, Epoch),
+        new_proofs_verifier: ProofsVerifier,
+    ) {
+        self.current_membership = new_epoch_info.0;
+        self.current_epoch = new_epoch_info.1;
+        self.proofs_verifier = Arc::new(new_proofs_verifier);
         // Close all the connections without waiting for the transition period,
         // so that edge nodes can retry with the new membership.
         let peers = mem::take(&mut self.upgraded_edge_peers);
@@ -157,7 +185,13 @@ impl Behaviour {
         self.current_membership.size() >= self.minimum_network_size.get()
     }
 
-    fn handle_received_serialized_encapsulated_message(&mut self, serialized_message: &[u8]) {
+    fn handle_received_serialized_encapsulated_message(
+        &mut self,
+        serialized_message: &[u8],
+        connection: (PeerId, ConnectionId),
+    ) where
+        ProofsVerifier: ProofsVerifierTrait + Send + Sync + 'static,
+    {
         let Ok(deserialized_encapsulated_message) =
             deserialize_encapsulated_message(serialized_message, &self.num_blend_layers)
         else {
@@ -171,13 +205,45 @@ impl Behaviour {
             return;
         };
 
-        self.events
-            .push_back(ToSwarm::GenerateEvent(Event::Message(validated_message)));
-        self.try_wake();
+        // Verify the `PoQ` before the message is reported to the swarm, and hence
+        // before it can be published to the core nodes.
+        spawn_poq_verification(
+            &mut self.pending_poq_verifications,
+            validated_message,
+            connection,
+            self.current_epoch,
+            &self.proofs_verifier,
+            &mut self.waker,
+        );
+    }
+
+    /// Acts on a completed `PoQ` verification.
+    ///
+    /// Unlike a core peer, an edge node is not blocked when it fails: it holds
+    /// no peering slot, and its connection is closed after the single message
+    /// it came to deliver anyway.
+    fn handle_poq_verification_outcome(&mut self, outcome: PoQVerificationOutcome) {
+        match outcome {
+            PoQVerificationOutcome::Verified { message, .. } => {
+                self.events
+                    .push_back(ToSwarm::GenerateEvent(Event::Message(*message)));
+                self.try_wake();
+            }
+            PoQVerificationOutcome::Failed {
+                sender,
+                connection_id,
+            } => {
+                tracing::debug!(target: LOG_TARGET, "Dropping message from edge peer {sender:?}: its PoQ failed to verify.");
+                self.close_substream((sender, connection_id));
+            }
+        }
     }
 }
 
-impl NetworkBehaviour for Behaviour {
+impl<ProofsVerifier> NetworkBehaviour for Behaviour<ProofsVerifier>
+where
+    ProofsVerifier: ProofsVerifierTrait + Send + Sync + 'static,
+{
     type ConnectionHandler = Either<ConnectionHandler, DummyConnectionHandler>;
     type ToSwarm = Event;
 
@@ -248,7 +314,10 @@ impl NetworkBehaviour for Behaviour {
     ) {
         match event {
             Either::Left(ToBehaviour::Message(message)) => {
-                self.handle_received_serialized_encapsulated_message(&message);
+                self.handle_received_serialized_encapsulated_message(
+                    &message,
+                    (peer_id, connection_id),
+                );
             }
             Either::Left(ToBehaviour::SubstreamOpened) => {
                 self.handle_negotiated_connection((peer_id, connection_id));
@@ -264,10 +333,20 @@ impl NetworkBehaviour for Behaviour {
         cx: &mut Context<'_>,
     ) -> Poll<ToSwarm<Self::ToSwarm, THandlerInEvent<Self>>> {
         if let Some(event) = self.events.pop_front() {
-            Poll::Ready(event)
-        } else {
-            self.waker = Some(cx.waker().clone());
-            Poll::Pending
+            return Poll::Ready(event);
         }
+
+        // Verifications complete off this task, so their outcome is picked up
+        // here: this is where a message becomes visible to the swarm, and hence
+        // publishable to the core nodes.
+        while let Poll::Ready(Some(outcome)) = self.pending_poq_verifications.poll_next_unpin(cx) {
+            self.handle_poq_verification_outcome(outcome);
+            if let Some(event) = self.events.pop_front() {
+                return Poll::Ready(event);
+            }
+        }
+
+        self.waker = Some(cx.waker().clone());
+        Poll::Pending
     }
 }

--- a/blend/network/src/core/with_edge/behaviour/mod.rs
+++ b/blend/network/src/core/with_edge/behaviour/mod.rs
@@ -208,7 +208,7 @@ impl<ProofsVerifier> Behaviour<ProofsVerifier> {
         // Verify the `PoQ` before the message is reported to the swarm, and hence
         // before it can be published to the core nodes.
         spawn_poq_verification(
-            &mut self.pending_poq_verifications,
+            &self.pending_poq_verifications,
             validated_message,
             connection,
             self.current_epoch,

--- a/blend/network/src/core/with_edge/behaviour/mod.rs
+++ b/blend/network/src/core/with_edge/behaviour/mod.rs
@@ -49,7 +49,10 @@ const LOG_TARGET: &str = blend::network::core::edge::BEHAVIOUR;
 pub enum Event {
     /// A message received from one of the edge peers, after its whole public
     /// header — signature and `PoQ` — has been verified.
-    Message(EncapsulatedMessageWithVerifiedPublicHeader),
+    Message {
+        message: EncapsulatedMessageWithVerifiedPublicHeader,
+        epoch: Epoch,
+    },
     #[cfg(test)]
     NegotiatedConnection { peer: PeerId },
 }
@@ -224,9 +227,12 @@ impl<ProofsVerifier> Behaviour<ProofsVerifier> {
     /// it came to deliver anyway.
     fn handle_poq_verification_outcome(&mut self, outcome: PoQVerificationOutcome) {
         match outcome {
-            PoQVerificationOutcome::Verified { message, .. } => {
+            PoQVerificationOutcome::Verified { message, epoch, .. } => {
                 self.events
-                    .push_back(ToSwarm::GenerateEvent(Event::Message(*message)));
+                    .push_back(ToSwarm::GenerateEvent(Event::Message {
+                        message: *message,
+                        epoch,
+                    }));
                 self.try_wake();
             }
             PoQVerificationOutcome::Failed {

--- a/blend/network/src/core/with_edge/behaviour/tests/epoch.rs
+++ b/blend/network/src/core/with_edge/behaviour/tests/epoch.rs
@@ -11,7 +11,7 @@ use test_log::test;
 use tokio::{select, time::sleep};
 
 use crate::core::{
-    tests::utils::TestSwarm,
+    tests::utils::{TestProofsVerifier, TestSwarm},
     with_edge::behaviour::tests::utils::{BehaviourBuilder, StreamBehaviourExt as _},
 };
 
@@ -42,7 +42,9 @@ async fn start_new_epoch_closes_all_edge_connections() {
         id: core_membership_peer,
         public_key: Ed25519PublicKey::from_bytes(&[0; ED25519_PUBLIC_KEY_SIZE]).unwrap(),
     }]);
-    blend_swarm.behaviour_mut().start_new_epoch(new_membership);
+    blend_swarm
+        .behaviour_mut()
+        .start_new_epoch((new_membership, 0.into()), TestProofsVerifier::accepting());
 
     assert_eq!(
         blend_swarm.behaviour().upgraded_edge_peers.len(),
@@ -116,7 +118,9 @@ async fn epoch_transition_updates_membership_for_new_connections() {
         id: other_core_peer,
         public_key: Ed25519PublicKey::from_bytes(&[0; _]).unwrap(),
     }]);
-    blend_swarm.behaviour_mut().start_new_epoch(new_membership);
+    blend_swarm
+        .behaviour_mut()
+        .start_new_epoch((new_membership, 0.into()), TestProofsVerifier::accepting());
 
     // Now edge_swarm should be able to connect and upgrade.
     let _stream = edge_swarm

--- a/blend/network/src/core/with_edge/behaviour/tests/message_handling.rs
+++ b/blend/network/src/core/with_edge/behaviour/tests/message_handling.rs
@@ -42,7 +42,7 @@ async fn receive_valid_message() {
         select! {
             _ = edge_swarm.select_next_some() => {}
             core_swarm_event = core_swarm.select_next_some() => {
-                if let SwarmEvent::Behaviour(Event::Message(received_message)) = core_swarm_event {
+                if let SwarmEvent::Behaviour(Event::Message { message: received_message, .. }) = core_swarm_event {
                     assert_eq!(received_message, message.into_inner());
                     break;
                 }
@@ -83,7 +83,7 @@ async fn reject_message_with_invalid_proof_of_quota() {
             _ = edge_swarm.select_next_some() => {}
             core_swarm_event = core_swarm.select_next_some() => {
                 assert!(
-                    !matches!(core_swarm_event, SwarmEvent::Behaviour(Event::Message(_))),
+                    !matches!(core_swarm_event, SwarmEvent::Behaviour(Event::Message { .. })),
                     "A message whose PoQ failed to verify must not be reported to the swarm"
                 );
             }
@@ -121,7 +121,7 @@ async fn reject_message_with_unexpected_layer_count() {
             _ = edge_swarm.select_next_some() => {}
             core_swarm_event = core_swarm.select_next_some() => {
                 match core_swarm_event {
-                    SwarmEvent::Behaviour(Event::Message(_)) => {
+                    SwarmEvent::Behaviour(Event::Message { .. }) => {
                         panic!("No `Message` event should be generated for a message with an unexpected number of layers.");
                     }
                     SwarmEvent::ConnectionClosed { peer_id, .. } => {
@@ -189,7 +189,7 @@ async fn receive_malformed_message() {
             _ = edge_swarm.select_next_some() => {}
             core_swarm_event = core_swarm.select_next_some() => {
                 match core_swarm_event {
-                    SwarmEvent::Behaviour(Event::Message(_)) => {
+                    SwarmEvent::Behaviour(Event::Message { .. }) => {
                         panic!("No `Message` event should be generated for an invalid message received.");
                     }
                     SwarmEvent::ConnectionClosed { peer_id, .. } => {

--- a/blend/network/src/core/with_edge/behaviour/tests/message_handling.rs
+++ b/blend/network/src/core/with_edge/behaviour/tests/message_handling.rs
@@ -1,6 +1,7 @@
 use core::time::Duration;
 
-use futures::{StreamExt as _, select};
+use futures::{FutureExt as _, StreamExt as _, select};
+use futures_timer::Delay;
 use lb_blend_scheduling::serialize_encapsulated_message_with_verified_public_header;
 use lb_libp2p::SwarmEvent;
 use libp2p::PeerId;
@@ -42,9 +43,49 @@ async fn receive_valid_message() {
             _ = edge_swarm.select_next_some() => {}
             core_swarm_event = core_swarm.select_next_some() => {
                 if let SwarmEvent::Behaviour(Event::Message(received_message)) = core_swarm_event {
-                    assert_eq!(received_message, message.into_inner().into());
+                    assert_eq!(received_message, message.into_inner());
                     break;
                 }
+            }
+        }
+    }
+}
+
+/// A message from an edge node whose `PoQ` does not verify is never reported to
+/// the swarm, so it can never be published to the core nodes. Unlike a core
+/// peer, the edge node is not banned for it.
+#[test(tokio::test)]
+async fn reject_message_with_invalid_proof_of_quota() {
+    let mut core_swarm = TestSwarm::new_ephemeral(|_| {
+        BehaviourBuilder::new(PeerId::random())
+            .with_rejecting_proofs_verifier()
+            .build()
+    });
+    let mut edge_swarm = TestSwarm::new_ephemeral(|_| StreamBehaviour::new());
+
+    core_swarm.listen().with_memory_addr_external().await;
+    let stream = edge_swarm
+        .connect_and_upgrade_to_blend(&mut core_swarm)
+        .await;
+    // The message is well-formed and correctly signed: only its `PoQ` fails.
+    let message = TestEncapsulatedMessage::new(b"invalid-poq");
+    send_msg(
+        stream,
+        serialize_encapsulated_message_with_verified_public_header(message.as_ref()),
+    )
+    .await
+    .unwrap();
+
+    let mut deadline = Delay::new(Duration::from_secs(2)).fuse();
+    loop {
+        select! {
+            () = deadline => break,
+            _ = edge_swarm.select_next_some() => {}
+            core_swarm_event = core_swarm.select_next_some() => {
+                assert!(
+                    !matches!(core_swarm_event, SwarmEvent::Behaviour(Event::Message(_))),
+                    "A message whose PoQ failed to verify must not be reported to the swarm"
+                );
             }
         }
     }

--- a/blend/network/src/core/with_edge/behaviour/tests/utils.rs
+++ b/blend/network/src/core/with_edge/behaviour/tests/utils.rs
@@ -2,7 +2,10 @@ use core::{
     num::{NonZeroU64, NonZeroUsize},
     time::Duration,
 };
-use std::collections::{HashSet, VecDeque};
+use std::{
+    collections::{HashSet, VecDeque},
+    sync::Arc,
+};
 
 use async_trait::async_trait;
 use futures::StreamExt as _;
@@ -14,9 +17,13 @@ use libp2p_stream::Behaviour as StreamBehaviour;
 use libp2p_swarm_test::SwarmExt as _;
 
 use crate::core::{
-    tests::utils::PROTOCOL_NAME,
+    poq_verification::PendingPoQVerifications,
+    tests::utils::{PROTOCOL_NAME, TestProofsVerifier},
     with_edge::behaviour::{Behaviour, Event as BehaviourEvent},
 };
+
+/// The behaviour under test, with the `PoQ` verifier the tests use.
+pub type TestBehaviour = Behaviour<TestProofsVerifier>;
 
 pub struct BehaviourBuilder {
     core_peer_ids: Vec<PeerId>,
@@ -24,6 +31,7 @@ pub struct BehaviourBuilder {
     timeout: Option<Duration>,
     minimum_network_size: Option<NonZeroUsize>,
     num_blend_layers: Option<NonZeroU64>,
+    proofs_verifier: TestProofsVerifier,
 }
 
 impl BehaviourBuilder {
@@ -34,7 +42,14 @@ impl BehaviourBuilder {
             timeout: None,
             minimum_network_size: None,
             num_blend_layers: None,
+            proofs_verifier: TestProofsVerifier::accepting(),
         }
+    }
+
+    /// Makes the behaviour reject the `PoQ` of every message it receives.
+    pub const fn with_rejecting_proofs_verifier(mut self) -> Self {
+        self.proofs_verifier = TestProofsVerifier::rejecting();
+        self
     }
 
     pub fn with_num_blend_layers(mut self, num_blend_layers: u64) -> Self {
@@ -57,7 +72,7 @@ impl BehaviourBuilder {
         self
     }
 
-    pub fn build(self) -> Behaviour {
+    pub fn build(self) -> TestBehaviour {
         let current_membership = Membership::new_without_local(
             self.core_peer_ids
                 .into_iter()
@@ -74,6 +89,9 @@ impl BehaviourBuilder {
             events: VecDeque::new(),
             waker: None,
             current_membership,
+            current_epoch: 0.into(),
+            proofs_verifier: Arc::new(self.proofs_verifier),
+            pending_poq_verifications: PendingPoQVerifications::new(),
             connection_timeout: self.timeout.unwrap_or(Duration::from_secs(1)),
             upgraded_edge_peers: HashSet::new(),
             max_incoming_connections: self.max_incoming_connections.unwrap_or(100),
@@ -90,12 +108,12 @@ impl BehaviourBuilder {
 
 #[async_trait]
 pub trait StreamBehaviourExt: libp2p_swarm_test::SwarmExt {
-    async fn connect_and_upgrade_to_blend(&mut self, other: &mut Swarm<Behaviour>) -> Stream;
+    async fn connect_and_upgrade_to_blend(&mut self, other: &mut Swarm<TestBehaviour>) -> Stream;
 }
 
 #[async_trait]
 impl StreamBehaviourExt for Swarm<StreamBehaviour> {
-    async fn connect_and_upgrade_to_blend(&mut self, other: &mut Swarm<Behaviour>) -> Stream {
+    async fn connect_and_upgrade_to_blend(&mut self, other: &mut Swarm<TestBehaviour>) -> Stream {
         // We connect and return the stream preventing it from being dropped so the
         // blend node does not close the connection with an EOF error.
         self.connect(other).await;

--- a/nodes/node/binary/src/generic_services/blend/mod.rs
+++ b/nodes/node/binary/src/generic_services/blend/mod.rs
@@ -32,7 +32,7 @@ pub type BlendCoreRecoveryBackend<RuntimeServiceId> = StorageRecoveryBackend<
 >;
 
 pub type BlendCoreService<RuntimeServiceId> = lb_blend_service::core::BlendService<
-    lb_blend_service::core::backends::libp2p::Libp2pBlendBackend,
+    lb_blend_service::core::backends::libp2p::Libp2pBlendBackend<RealProofsVerifier>,
     PeerId,
     lb_blend_service::core::network::libp2p::Libp2pAdapter<RuntimeServiceId>,
     SdpService<RuntimeServiceId>,

--- a/services/blend/src/core/backends/libp2p/behaviour.rs
+++ b/services/blend/src/core/backends/libp2p/behaviour.rs
@@ -8,21 +8,24 @@ use crate::core::{
 };
 
 #[derive(NetworkBehaviour)]
-pub struct BlendBehaviour<ObservationWindowProvider> {
-    pub blend: lb_blend::network::core::NetworkBehaviour<ObservationWindowProvider>,
+pub struct BlendBehaviour<ObservationWindowProvider, ProofsVerifier> {
+    pub blend: lb_blend::network::core::NetworkBehaviour<ObservationWindowProvider, ProofsVerifier>,
     pub blocked_peers: libp2p::allow_block_list::Behaviour<BlockedPeers>,
 }
 
-impl<ObservationWindowProvider> BlendBehaviour<ObservationWindowProvider>
+impl<ObservationWindowProvider, ProofsVerifier>
+    BlendBehaviour<ObservationWindowProvider, ProofsVerifier>
 where
     ObservationWindowProvider: for<'c> From<(
         &'c BlendConfig<Libp2pBlendBackendSettings>,
         &'c Membership<PeerId>,
     )>,
+    ProofsVerifier: Clone,
 {
     pub fn new(
         config: &BlendConfig<Libp2pBlendBackendSettings>,
         current_membership_info: (Membership<PeerId>, Epoch),
+        proofs_verifier: ProofsVerifier,
     ) -> Self {
         let observation_window_interval_provider =
             ObservationWindowProvider::from((config, &current_membership_info.0));
@@ -50,6 +53,7 @@ where
                 },
                 observation_window_interval_provider,
                 current_membership_info,
+                proofs_verifier,
                 config.peer_id(),
                 config.backend.protocol_name.clone().into_inner(),
             ),

--- a/services/blend/src/core/backends/libp2p/mod.rs
+++ b/services/blend/src/core/backends/libp2p/mod.rs
@@ -5,8 +5,8 @@ use futures::{
     Stream, StreamExt as _,
     future::{AbortHandle, Abortable},
 };
-use lb_blend::message::encap::validated::{
-    EncapsulatedMessageWithVerifiedPublicHeader, EncapsulatedMessageWithVerifiedSignature,
+use lb_blend::message::encap::{
+    ProofsVerifier as ProofsVerifierTrait, validated::EncapsulatedMessageWithVerifiedPublicHeader,
 };
 use lb_chain_service::Epoch;
 use lb_log_targets::blend;
@@ -37,7 +37,7 @@ const LOG_TARGET: &str = blend::backend::LIBP2P;
 pub(crate) mod behaviour;
 pub mod settings;
 pub use self::settings::Libp2pBlendBackendSettings;
-mod swarm;
+pub(crate) mod swarm;
 pub(crate) mod tokio_provider;
 
 #[cfg(test)]
@@ -46,32 +46,36 @@ mod tests;
 pub(crate) use self::tests::utils as core_swarm_test_utils;
 
 /// A blend backend that uses the libp2p network stack.
-pub struct Libp2pBlendBackend {
+pub struct Libp2pBlendBackend<ProofsVerifier> {
     swarm_task_abort_handle: AbortHandle,
-    swarm_message_sender: mpsc::Sender<BlendSwarmMessage>,
-    incoming_message_sender: broadcast::Sender<(EncapsulatedMessageWithVerifiedSignature, Epoch)>,
+    swarm_message_sender: mpsc::Sender<BlendSwarmMessage<ProofsVerifier>>,
+    incoming_message_sender:
+        broadcast::Sender<(EncapsulatedMessageWithVerifiedPublicHeader, Epoch)>,
 }
 
 const CHANNEL_SIZE: usize = 64;
 
 #[async_trait]
-impl<Rng, RuntimeServiceId> BlendBackend<PeerId, Rng, RuntimeServiceId> for Libp2pBlendBackend
+impl<Rng, ProofsVerifier, RuntimeServiceId>
+    BlendBackend<PeerId, Rng, ProofsVerifier, RuntimeServiceId>
+    for Libp2pBlendBackend<ProofsVerifier>
 where
     Rng: RngCore + Clone + Send + 'static,
+    ProofsVerifier: ProofsVerifierTrait + Send + Sync + 'static,
 {
     type Settings = Libp2pBlendBackendSettings;
 
     fn new(
         config: BlendConfig<Self::Settings>,
         overwatch_handle: OverwatchHandle<RuntimeServiceId>,
-        current_epoch_info: BackendEpochInfo<PeerId>,
+        current_epoch_info: BackendEpochInfo<PeerId, ProofsVerifier>,
         rng: Rng,
     ) -> Self {
         let (swarm_message_sender, swarm_message_receiver) = mpsc::channel(CHANNEL_SIZE);
         let (incoming_message_sender, _) = broadcast::channel(CHANNEL_SIZE);
         let minimum_network_size = config.minimum_network_size.try_into().unwrap();
 
-        let swarm = BlendSwarm::<_, ObservationWindowTokioIntervalProvider>::new(SwarmParams {
+        let swarm = BlendSwarm::<_, ObservationWindowTokioIntervalProvider, _>::new(SwarmParams {
             config: &config,
             current_epoch_info,
             incoming_message_sender: incoming_message_sender.clone(),
@@ -115,7 +119,7 @@ where
         }
     }
 
-    async fn rotate_epoch(&mut self, new_epoch_info: BackendEpochInfo<PeerId>) {
+    async fn rotate_epoch(&mut self, new_epoch_info: BackendEpochInfo<PeerId, ProofsVerifier>) {
         if let Err(e) = self
             .swarm_message_sender
             .send(BlendSwarmMessage::StartNewEpoch(new_epoch_info))
@@ -137,7 +141,8 @@ where
 
     fn listen_to_incoming_messages(
         &mut self,
-    ) -> Pin<Box<dyn Stream<Item = (EncapsulatedMessageWithVerifiedSignature, Epoch)> + Send>> {
+    ) -> Pin<Box<dyn Stream<Item = (EncapsulatedMessageWithVerifiedPublicHeader, Epoch)> + Send>>
+    {
         Box::pin(
             BroadcastStream::new(self.incoming_message_sender.subscribe())
                 .filter_map(async |event| handle_incoming_broadcast_event(event)),
@@ -181,7 +186,7 @@ fn handle_incoming_broadcast_event<T>(event: Result<T, BroadcastStreamRecvError>
     }
 }
 
-impl Drop for Libp2pBlendBackend {
+impl<ProofsVerifier> Drop for Libp2pBlendBackend<ProofsVerifier> {
     fn drop(&mut self) {
         let Self {
             swarm_task_abort_handle,

--- a/services/blend/src/core/backends/libp2p/mod.rs
+++ b/services/blend/src/core/backends/libp2p/mod.rs
@@ -61,7 +61,7 @@ impl<Rng, ProofsVerifier, RuntimeServiceId>
     for Libp2pBlendBackend<ProofsVerifier>
 where
     Rng: RngCore + Clone + Send + 'static,
-    ProofsVerifier: ProofsVerifierTrait + Send + Sync + 'static,
+    ProofsVerifier: ProofsVerifierTrait + Clone + Send + Sync + 'static,
 {
     type Settings = Libp2pBlendBackendSettings;
 

--- a/services/blend/src/core/backends/libp2p/swarm.rs
+++ b/services/blend/src/core/backends/libp2p/swarm.rs
@@ -23,7 +23,7 @@ use lb_blend::{
         with_core::{
             behaviour::{
                 ConnectionUpgradeFailureReason, Event as CoreToCoreEvent, IntervalStreamProvider,
-                NegotiatedPeerState,
+                NegotiatedPeerState, SpamReason,
             },
             error::SendError,
         },
@@ -79,6 +79,19 @@ fn share_epoch_verifier<ProofsVerifier>(
     }
 }
 
+enum PoQVerificationOutcome {
+    Verified(Box<VerifiedInboundMessage>),
+    Rejected(InboundMessageSource),
+}
+
+/// An inbound message whose public header has been fully verified, ready to be
+/// relayed and handed to the service.
+struct VerifiedInboundMessage {
+    message: EncapsulatedMessageWithVerifiedPublicHeader,
+    epoch: Epoch,
+    source: InboundMessageSource,
+}
+
 /// Where an inbound message came from, which decides the set of peers it is
 /// relayed to once its public header has been verified.
 #[derive(Debug, Clone, Copy)]
@@ -97,14 +110,6 @@ impl InboundMessageSource {
             Self::Edge => metrics::InboundMessageType::Edge,
         }
     }
-}
-
-/// An inbound message whose public header has been fully verified, ready to be
-/// relayed and handed to the service.
-struct VerifiedInboundMessage {
-    message: EncapsulatedMessageWithVerifiedPublicHeader,
-    epoch: Epoch,
-    source: InboundMessageSource,
 }
 
 #[derive(Debug)]
@@ -151,7 +156,7 @@ impl DialAttempt {
 
 type PendingRetries = FuturesUnordered<Pin<Box<dyn Future<Output = (PeerId, DialAttempt)> + Send>>>;
 type PendingPoQVerifications =
-    FuturesUnordered<Pin<Box<dyn Future<Output = Option<VerifiedInboundMessage>> + Send>>>;
+    FuturesUnordered<Pin<Box<dyn Future<Output = Option<PoQVerificationOutcome>> + Send>>>;
 type FullMembershipRetry = Option<Pin<Box<dyn Future<Output = ()> + Send>>>;
 
 pub struct BlendSwarm<Rng, ObservationWindowProvider, ProofsVerifier>
@@ -593,9 +598,15 @@ where
                 self.handle_event(event);
                 predicate_matched
             }
-            Some(verified_message) = self.pending_poq_verifications.next() => {
-                if let Some(verified_message) = verified_message {
-                    self.handle_verified_inbound_message(verified_message);
+            Some(outcome) = self.pending_poq_verifications.next() => {
+                match outcome {
+                    Some(PoQVerificationOutcome::Verified(verified_message)) => {
+                        self.handle_verified_inbound_message(*verified_message);
+                    }
+                    Some(PoQVerificationOutcome::Rejected(source)) => {
+                        self.handle_failed_public_header_verification(source);
+                    }
+                    None => {}
                 }
                 false
             }
@@ -821,15 +832,17 @@ where
             .await;
 
             match verification_result {
-                Ok(Ok(message)) => Some(VerifiedInboundMessage {
-                    message,
-                    epoch,
-                    source,
-                }),
+                Ok(Ok(message)) => Some(PoQVerificationOutcome::Verified(Box::new(
+                    VerifiedInboundMessage {
+                        message,
+                        epoch,
+                        source,
+                    },
+                ))),
                 Ok(Err(e)) => {
                     tracing::debug!(target: LOG_TARGET, "Dropping message from {source:?} for epoch {epoch:?}: its public header failed verification: {e}. Neither relaying nor processing it.");
                     metrics::inbound_message_poq_verification_err(message_type);
-                    None
+                    Some(PoQVerificationOutcome::Rejected(source))
                 }
                 Err(e) => {
                     tracing::error!(target: LOG_TARGET, "Dropping message from {source:?} for epoch {epoch:?}: its public header verification task failed to complete: {e:?}.");
@@ -848,6 +861,20 @@ where
         } else {
             self.old_epoch_proofs_verifier.as_ref()
         }
+    }
+
+    fn handle_failed_public_header_verification(&mut self, source: InboundMessageSource) {
+        let InboundMessageSource::Core(peer_id) = source else {
+            tracing::trace!(target: LOG_TARGET, "Skip blocking edge peer {source:?} because of an invalid PoQ sent.");
+            return;
+        };
+        tracing::debug!(target: LOG_TARGET, "Blocking core peer {peer_id:?}: it sent a message whose public header failed verification.");
+
+        self.swarm
+            .behaviour_mut()
+            .blend
+            .with_core_mut()
+            .close_spammy_connection_with_peer(peer_id, SpamReason::InvalidProofOfQuota);
     }
 
     /// Relays a message whose public header has just been verified and hands it

--- a/services/blend/src/core/backends/libp2p/swarm.rs
+++ b/services/blend/src/core/backends/libp2p/swarm.rs
@@ -6,6 +6,7 @@ use core::{
 };
 use std::{
     collections::{HashMap, HashSet},
+    sync::Arc,
     time::Duration,
 };
 
@@ -32,6 +33,7 @@ use lb_blend::{
 };
 use lb_chain_service::Epoch;
 use lb_libp2p::{DialOpts, SwarmEvent};
+use lb_utils::tokio::task::spawn_blocking;
 use libp2p::{Multiaddr, PeerId, Swarm, SwarmBuilder, swarm::dial_opts::PeerCondition};
 use rand::RngCore;
 use tokio::{
@@ -60,6 +62,50 @@ use crate::{
 /// peers are already at their maximum peering degree — would re-dial the whole
 /// (rejecting) membership at event-loop speed, wasting CPU and flooding logs.
 const FULL_MEMBERSHIP_RETRY_DELAY: Duration = Duration::from_mins(1);
+
+/// Wraps an epoch's verifier in an [`Arc`] so it can be handed to the blocking
+/// pool once per inbound message without cloning the verifier itself.
+fn share_epoch_verifier<ProofsVerifier>(
+    BackendEpochInfo {
+        membership,
+        epoch,
+        proofs_verifier,
+    }: BackendEpochInfo<PeerId, ProofsVerifier>,
+) -> BackendEpochInfo<PeerId, Arc<ProofsVerifier>> {
+    BackendEpochInfo {
+        membership,
+        epoch,
+        proofs_verifier: Arc::new(proofs_verifier),
+    }
+}
+
+/// Where an inbound message came from, which decides the set of peers it is
+/// relayed to once its public header has been verified.
+#[derive(Debug, Clone, Copy)]
+enum InboundMessageSource {
+    /// A core peer, so the message is forwarded to every *other* core peer.
+    Core(PeerId),
+    /// An edge node, which has no core peer to exclude, so the message is
+    /// published to every core peer.
+    Edge,
+}
+
+impl InboundMessageSource {
+    const fn metrics_type(self) -> metrics::InboundMessageType {
+        match self {
+            Self::Core(_) => metrics::InboundMessageType::Core,
+            Self::Edge => metrics::InboundMessageType::Edge,
+        }
+    }
+}
+
+/// An inbound message whose public header has been fully verified, ready to be
+/// relayed and handed to the service.
+struct VerifiedInboundMessage {
+    message: EncapsulatedMessageWithVerifiedPublicHeader,
+    epoch: Epoch,
+    source: InboundMessageSource,
+}
 
 #[derive(Debug)]
 pub enum BlendSwarmMessage<ProofsVerifier> {
@@ -104,6 +150,8 @@ impl DialAttempt {
 }
 
 type PendingRetries = FuturesUnordered<Pin<Box<dyn Future<Output = (PeerId, DialAttempt)> + Send>>>;
+type PendingPoQVerifications =
+    FuturesUnordered<Pin<Box<dyn Future<Output = Option<VerifiedInboundMessage>> + Send>>>;
 type FullMembershipRetry = Option<Pin<Box<dyn Future<Output = ()> + Send>>>;
 
 pub struct BlendSwarm<Rng, ObservationWindowProvider, ProofsVerifier>
@@ -115,10 +163,11 @@ where
     swarm_messages_receiver: mpsc::Receiver<BlendSwarmMessage<ProofsVerifier>>,
     incoming_message_sender:
         broadcast::Sender<(EncapsulatedMessageWithVerifiedPublicHeader, Epoch)>,
-    current_epoch_info: BackendEpochInfo<PeerId, ProofsVerifier>,
+    current_epoch_info: BackendEpochInfo<PeerId, Arc<ProofsVerifier>>,
     /// Verifier for the messages still arriving for the previous epoch, kept
     /// until the epoch transition period is over.
-    old_epoch_proofs_verifier: Option<ProofsVerifier>,
+    old_epoch_proofs_verifier: Option<Arc<ProofsVerifier>>,
+    pending_poq_verifications: PendingPoQVerifications,
     rng: Rng,
     max_dial_attempts_per_connection: NonZeroU64,
     ongoing_dials: HashMap<PeerId, DialAttempt>,
@@ -149,7 +198,7 @@ where
             &'c BlendConfig<Libp2pBlendBackendSettings>,
             &'c Membership<PeerId>,
         )> + 'static,
-    ProofsVerifier: ProofsVerifierTrait,
+    ProofsVerifier: ProofsVerifierTrait + Send + Sync + 'static,
 {
     pub(super) fn new(
         SwarmParams {
@@ -195,8 +244,9 @@ where
             swarm,
             swarm_messages_receiver,
             incoming_message_sender,
-            current_epoch_info,
+            current_epoch_info: share_epoch_verifier(current_epoch_info),
             old_epoch_proofs_verifier: None,
+            pending_poq_verifications: FuturesUnordered::new(),
             rng,
             max_dial_attempts_per_connection: config.backend.max_dial_attempts_per_peer,
             ongoing_dials: HashMap::with_capacity(
@@ -220,7 +270,7 @@ where
     Rng: RngCore,
     ObservationWindowProvider:
         IntervalStreamProvider<IntervalStream: Unpin + Send, IntervalItem = RangeInclusive<u64>>,
-    ProofsVerifier: ProofsVerifierTrait,
+    ProofsVerifier: ProofsVerifierTrait + Send + Sync + 'static,
 {
     /// Dial random peers from the membership list,
     /// excluding the peers with a negotiated connection in the ongoing epoch,
@@ -359,15 +409,8 @@ where
         match blend_event {
             lb_blend::network::core::with_core::behaviour::Event::Message { message, sender, epoch } => {
                 // The behaviour has verified the public header signature; the PoQ is
-                // verified here, before the message is relayed any further.
-                let Some(verified_message) = self.verify_message_public_header(*message, epoch, metrics::InboundMessageType::Core) else {
-                    tracing::trace!(target: LOG_TARGET, "Dropping message from core peer {sender:?} for epoch {epoch:?} because its public header failed verification.");
-                    return;
-                };
-                // Forward message received from node to all other core nodes.
-                self.forward_received_core_message(&verified_message, sender, epoch);
-                // Bubble up to service for decapsulation and delaying.
-                self.report_message_to_service(verified_message, epoch, metrics::InboundMessageType::Core);
+                // verified before the message is relayed any further (in a separate task).
+                self.spawn_message_public_header_verification(*message, epoch, InboundMessageSource::Core(sender));
             }
             lb_blend::network::core::with_core::behaviour::Event::UnhealthyPeer(peer_id) => {
                 self.handle_unhealthy_peer(peer_id);
@@ -496,8 +539,10 @@ where
                 self.handle_publish_swarm_message(&message, epoch);
             }
             BlendSwarmMessage::StartNewEpoch(new_epoch_info) => {
-                let previous_epoch_info =
-                    mem::replace(&mut self.current_epoch_info, new_epoch_info);
+                let previous_epoch_info = mem::replace(
+                    &mut self.current_epoch_info,
+                    share_epoch_verifier(new_epoch_info),
+                );
                 // Messages for the previous epoch keep arriving during the transition
                 // period, so its verifier is kept around until the transition completes.
                 self.old_epoch_proofs_verifier = Some(previous_epoch_info.proofs_verifier);
@@ -548,6 +593,12 @@ where
                 self.handle_event(event);
                 predicate_matched
             }
+            Some(verified_message) = self.pending_poq_verifications.next() => {
+                if let Some(verified_message) = verified_message {
+                    self.handle_verified_inbound_message(verified_message);
+                }
+                false
+            }
             Some((peer_id, dial_attempt)) = self.pending_retries.next() => {
                 self.execute_retry(peer_id, dial_attempt);
                 false
@@ -589,7 +640,7 @@ impl<Rng, ObservationWindowProvider, ProofsVerifier>
 where
     ObservationWindowProvider:
         IntervalStreamProvider<IntervalStream: Unpin + Send, IntervalItem = RangeInclusive<u64>>,
-    ProofsVerifier: ProofsVerifierTrait,
+    ProofsVerifier: ProofsVerifierTrait + Send + Sync + 'static,
 {
     /// It tries to dial the specified peer.
     ///
@@ -730,38 +781,95 @@ where
         }
     }
 
-    /// Verifies the `PoQ` of a message received from a peer, with the verifier
-    /// of the epoch the message belongs to.
+    /// Dispatches the verification of an inbound message's `PoQ` to the
+    /// blocking pool, to be relayed and reported once (and only if) it
+    /// verifies.
     ///
     /// This is what gates the message from being relayed any further: the
-    /// behaviour only verifies the public header *signature*, and the resulting
+    /// behaviour only verifies the public header *signature*, and an
     /// [`EncapsulatedMessageWithVerifiedPublicHeader`] is the only thing the
-    /// forwarding functions accept, so a message that fails here — or that
+    /// forwarding functions accept, so a message that fails to verify — or that
     /// belongs to an epoch we no longer have a verifier for — can neither be
     /// relayed nor reported to the service.
-    fn verify_message_public_header(
+    ///
+    /// The verification is a Groth16 proof check: running it inline would stall
+    /// this task, which is also servicing every other peer's stream, the dial
+    /// retries and the peering-degree maintenance. Relaying therefore resumes
+    /// in [`Self::handle_verified_inbound_message`] once the result comes
+    /// back.
+    fn spawn_message_public_header_verification(
         &self,
         message: EncapsulatedMessageWithVerifiedSignature,
         epoch: Epoch,
-        message_type: metrics::InboundMessageType,
-    ) -> Option<EncapsulatedMessageWithVerifiedPublicHeader> {
-        let verifier = if epoch == self.current_epoch_info.epoch {
-            &self.current_epoch_info.proofs_verifier
-        } else if let Some(old_epoch_proofs_verifier) = &self.old_epoch_proofs_verifier {
-            old_epoch_proofs_verifier
-        } else {
-            tracing::debug!(target: LOG_TARGET, "Received message for epoch {epoch:?} with no verifier available. Dropping it.");
+        source: InboundMessageSource,
+    ) {
+        let message_type = source.metrics_type();
+
+        let Some(verifier) = self.proofs_verifier_for_epoch(epoch) else {
+            tracing::debug!(target: LOG_TARGET, "Dropping message from {source:?} for epoch {epoch:?}: no verifier available for that epoch.");
             metrics::inbound_message_poq_verification_err(message_type);
-            return None;
+            return;
         };
 
-        message
-            .verify_proof_of_quota(verifier)
-            .inspect_err(|e| {
-                tracing::debug!(target: LOG_TARGET, "PoQ verification failed for message received for epoch {epoch:?}: {e:?}. Neither relaying nor processing it.");
-                metrics::inbound_message_poq_verification_err(message_type);
+        let verifier = Arc::clone(verifier);
+        self.pending_poq_verifications.push(Box::pin(async move {
+            let verification_result = spawn_blocking("logos/blend/verify-public-header", move || {
+                message
+                    .verify_proof_of_quota(&*verifier)
+                    .map_err(|e| format!("{e:?}"))
             })
-            .ok()
+            .await;
+
+            match verification_result {
+                Ok(Ok(message)) => Some(VerifiedInboundMessage {
+                    message,
+                    epoch,
+                    source,
+                }),
+                Ok(Err(e)) => {
+                    tracing::debug!(target: LOG_TARGET, "Dropping message from {source:?} for epoch {epoch:?}: its public header failed verification: {e}. Neither relaying nor processing it.");
+                    metrics::inbound_message_poq_verification_err(message_type);
+                    None
+                }
+                Err(e) => {
+                    tracing::error!(target: LOG_TARGET, "Dropping message from {source:?} for epoch {epoch:?}: its public header verification task failed to complete: {e:?}.");
+                    None
+                }
+            }
+        }));
+    }
+
+    /// The verifier for the epoch a received message belongs to, if we still
+    /// hold one. Anything that is neither the current nor the epoch we are
+    /// transitioning away from cannot be verified.
+    fn proofs_verifier_for_epoch(&self, epoch: Epoch) -> Option<&Arc<ProofsVerifier>> {
+        if epoch == self.current_epoch_info.epoch {
+            Some(&self.current_epoch_info.proofs_verifier)
+        } else {
+            self.old_epoch_proofs_verifier.as_ref()
+        }
+    }
+
+    /// Relays a message whose public header has just been verified and hands it
+    /// to the service.
+    fn handle_verified_inbound_message(
+        &mut self,
+        VerifiedInboundMessage {
+            message,
+            epoch,
+            source,
+        }: VerifiedInboundMessage,
+    ) {
+        match source {
+            // Forward message received from node to all other core nodes.
+            InboundMessageSource::Core(sender) => {
+                self.forward_received_core_message(&message, sender, epoch);
+            }
+            // Forward message received from edge node to all the core nodes.
+            InboundMessageSource::Edge => self.publish_received_edge_message(&message, epoch),
+        }
+        // Bubble up to service for decapsulation and delaying.
+        self.report_message_to_service(message, epoch, source.metrics_type());
     }
 
     fn publish_received_edge_message(
@@ -776,7 +884,13 @@ where
             .with_core_mut()
             .publish_message_with_validated_header(msg, epoch)
         {
-            tracing::error!(target: LOG_TARGET, "Failed to publish message to blend network: {e:?}");
+            // `InvalidEpoch` is expected here: verification runs off this task, so the
+            // epoch transition it belonged to can complete before the result comes back.
+            if matches!(e, SendError::InvalidEpoch) {
+                tracing::trace!(target: LOG_TARGET, "Dropping message for epoch {epoch:?}, which is no longer served, after its public header was verified.");
+            } else {
+                tracing::error!(target: LOG_TARGET, "Failed to publish message to blend network: {e:?}");
+            }
             metrics::outbound_publish_err();
         } else {
             metrics::outbound_publish_ok();
@@ -799,8 +913,10 @@ where
             // If we have a single connection, then we will always hit the `NoPeers` error.
             // In this case it's ok not to log such error, since this function is only
             // called on FORWARDED messages, not on PUBLISHED ones, for which we want to
-            // know if that is the issue.
-            if !matches!(e, SendError::NoPeers) {
+            // know if that is the issue. `InvalidEpoch` is expected too: verification
+            // runs off this task, so the epoch transition the message belonged to can
+            // complete before the result comes back.
+            if !matches!(e, SendError::NoPeers | SendError::InvalidEpoch) {
                 tracing::error!(target: LOG_TARGET, "Failed to forward message to blend network: {e:?}");
                 metrics::outbound_forward_err();
             }
@@ -851,28 +967,17 @@ where
         tracing::trace!(target: LOG_TARGET, "Peer {peer_id} is healthy again");
     }
 
-    fn handle_blend_edge_behaviour_event(&mut self, blend_event: CoreToEdgeEvent) {
+    fn handle_blend_edge_behaviour_event(&self, blend_event: CoreToEdgeEvent) {
         match blend_event {
             lb_blend::network::core::with_edge::behaviour::Event::Message(message) => {
                 // Edge nodes only ever send messages for the current epoch.
                 let epoch = self.current_epoch_info.epoch;
                 // The behaviour has verified the public header signature; the PoQ is
-                // verified here, before the message is relayed any further.
-                let Some(verified_message) = self.verify_message_public_header(
+                // verified before the message is relayed any further, off this task.
+                self.spawn_message_public_header_verification(
                     message,
                     epoch,
-                    metrics::InboundMessageType::Edge,
-                ) else {
-                    tracing::trace!(target: LOG_TARGET, "Dropping message from edge peer for epoch {epoch:?} because its public header failed verification.");
-                    return;
-                };
-                // Forward message received from edge node to all the core nodes.
-                self.publish_received_edge_message(&verified_message, epoch);
-                // Bubble up to service for decapsulation and delaying.
-                self.report_message_to_service(
-                    verified_message,
-                    epoch,
-                    metrics::InboundMessageType::Edge,
+                    InboundMessageSource::Edge,
                 );
             }
         }
@@ -904,7 +1009,7 @@ where
     Rng: RngCore,
     ObservationWindowProvider: IntervalStreamProvider<IntervalStream: Unpin + Send, IntervalItem = RangeInclusive<u64>>
         + 'static,
-    ProofsVerifier: ProofsVerifierTrait,
+    ProofsVerifier: ProofsVerifierTrait + Send + Sync + 'static,
 {
     #[cfg(test)]
     #[expect(clippy::too_many_arguments, reason = "necessary for testing")]
@@ -932,8 +1037,9 @@ where
         let membership = current_epoch_info.membership.clone();
         Self {
             incoming_message_sender,
-            current_epoch_info,
+            current_epoch_info: share_epoch_verifier(current_epoch_info),
             old_epoch_proofs_verifier: None,
+            pending_poq_verifications: FuturesUnordered::new(),
             max_dial_attempts_per_connection,
             ongoing_dials: HashMap::new(),
             pending_retries: FuturesUnordered::new(),

--- a/services/blend/src/core/backends/libp2p/swarm.rs
+++ b/services/blend/src/core/backends/libp2p/swarm.rs
@@ -724,15 +724,25 @@ where
         }
     }
 
-    fn publish_received_edge_message(&mut self, msg: &EncapsulatedMessageWithVerifiedPublicHeader) {
+    fn publish_received_edge_message(
+        &mut self,
+        msg: &EncapsulatedMessageWithVerifiedPublicHeader,
+        epoch: Epoch,
+    ) {
         if let Err(e) = self
             .swarm
             .behaviour_mut()
             .blend
             .with_core_mut()
-            .publish_message_with_validated_header_to_current_epoch(msg)
+            .publish_message_with_validated_header(msg, epoch)
         {
-            tracing::error!(target: LOG_TARGET, "Failed to publish message to blend network: {e:?}");
+            // `InvalidEpoch` is expected: the message is verified off-task, so its
+            // epoch can stop being served before the outcome comes back.
+            if matches!(e, SendError::InvalidEpoch) {
+                tracing::trace!(target: LOG_TARGET, "Dropping message received from an edge node for epoch {epoch:?}, which is no longer served.");
+            } else {
+                tracing::error!(target: LOG_TARGET, "Failed to publish message to blend network: {e:?}");
+            }
             metrics::outbound_publish_err();
         } else {
             metrics::outbound_publish_ok();
@@ -811,15 +821,14 @@ where
 
     fn handle_blend_edge_behaviour_event(&mut self, blend_event: CoreToEdgeEvent) {
         match blend_event {
-            lb_blend::network::core::with_edge::behaviour::Event::Message(msg) => {
+            lb_blend::network::core::with_edge::behaviour::Event::Message { message, epoch } => {
+                // The epoch is the one the message was verified under, which is not
+                // necessarily the current one, so it is used for both the peers it goes
+                // to and the processor the service decapsulates it with.
                 // Forward message received from edge node to all the core nodes.
-                self.publish_received_edge_message(&msg);
+                self.publish_received_edge_message(&message, epoch);
                 // Bubble up to service for decapsulation and delaying.
-                self.report_message_to_service(
-                    msg,
-                    self.current_epoch_info.epoch,
-                    metrics::InboundMessageType::Edge,
-                );
+                self.report_message_to_service(message, epoch, metrics::InboundMessageType::Edge);
             }
         }
     }

--- a/services/blend/src/core/backends/libp2p/swarm.rs
+++ b/services/blend/src/core/backends/libp2p/swarm.rs
@@ -1,12 +1,10 @@
 use core::{
-    mem,
     num::{NonZeroU64, NonZeroUsize},
     ops::{Deref, RangeInclusive},
     pin::Pin,
 };
 use std::{
     collections::{HashMap, HashSet},
-    sync::Arc,
     time::Duration,
 };
 
@@ -14,16 +12,14 @@ use futures::{Stream, StreamExt as _, future::OptionFuture, stream::FuturesUnord
 use lb_blend::{
     message::encap::{
         ProofsVerifier as ProofsVerifierTrait,
-        validated::{
-            EncapsulatedMessageWithVerifiedPublicHeader, EncapsulatedMessageWithVerifiedSignature,
-        },
+        validated::EncapsulatedMessageWithVerifiedPublicHeader,
     },
     network::core::{
         NetworkBehaviourEvent,
         with_core::{
             behaviour::{
                 ConnectionUpgradeFailureReason, Event as CoreToCoreEvent, IntervalStreamProvider,
-                NegotiatedPeerState, SpamReason,
+                NegotiatedPeerState,
             },
             error::SendError,
         },
@@ -33,7 +29,6 @@ use lb_blend::{
 };
 use lb_chain_service::Epoch;
 use lb_libp2p::{DialOpts, SwarmEvent};
-use lb_utils::tokio::task::spawn_blocking;
 use libp2p::{Multiaddr, PeerId, Swarm, SwarmBuilder, swarm::dial_opts::PeerCondition};
 use rand::RngCore;
 use tokio::{
@@ -62,55 +57,6 @@ use crate::{
 /// peers are already at their maximum peering degree — would re-dial the whole
 /// (rejecting) membership at event-loop speed, wasting CPU and flooding logs.
 const FULL_MEMBERSHIP_RETRY_DELAY: Duration = Duration::from_mins(1);
-
-/// Wraps an epoch's verifier in an [`Arc`] so it can be handed to the blocking
-/// pool once per inbound message without cloning the verifier itself.
-fn share_epoch_verifier<ProofsVerifier>(
-    BackendEpochInfo {
-        membership,
-        epoch,
-        proofs_verifier,
-    }: BackendEpochInfo<PeerId, ProofsVerifier>,
-) -> BackendEpochInfo<PeerId, Arc<ProofsVerifier>> {
-    BackendEpochInfo {
-        membership,
-        epoch,
-        proofs_verifier: Arc::new(proofs_verifier),
-    }
-}
-
-enum PoQVerificationOutcome {
-    Verified(Box<VerifiedInboundMessage>),
-    Rejected(InboundMessageSource),
-}
-
-/// An inbound message whose public header has been fully verified, ready to be
-/// relayed and handed to the service.
-struct VerifiedInboundMessage {
-    message: EncapsulatedMessageWithVerifiedPublicHeader,
-    epoch: Epoch,
-    source: InboundMessageSource,
-}
-
-/// Where an inbound message came from, which decides the set of peers it is
-/// relayed to once its public header has been verified.
-#[derive(Debug, Clone, Copy)]
-enum InboundMessageSource {
-    /// A core peer, so the message is forwarded to every *other* core peer.
-    Core(PeerId),
-    /// An edge node, which has no core peer to exclude, so the message is
-    /// published to every core peer.
-    Edge,
-}
-
-impl InboundMessageSource {
-    const fn metrics_type(self) -> metrics::InboundMessageType {
-        match self {
-            Self::Core(_) => metrics::InboundMessageType::Core,
-            Self::Edge => metrics::InboundMessageType::Edge,
-        }
-    }
-}
 
 #[derive(Debug)]
 pub enum BlendSwarmMessage<ProofsVerifier> {
@@ -155,24 +101,19 @@ impl DialAttempt {
 }
 
 type PendingRetries = FuturesUnordered<Pin<Box<dyn Future<Output = (PeerId, DialAttempt)> + Send>>>;
-type PendingPoQVerifications =
-    FuturesUnordered<Pin<Box<dyn Future<Output = Option<PoQVerificationOutcome>> + Send>>>;
 type FullMembershipRetry = Option<Pin<Box<dyn Future<Output = ()> + Send>>>;
 
 pub struct BlendSwarm<Rng, ObservationWindowProvider, ProofsVerifier>
 where
     ObservationWindowProvider: IntervalStreamProvider<IntervalStream: Unpin + Send, IntervalItem = RangeInclusive<u64>>
         + 'static,
+    ProofsVerifier: ProofsVerifierTrait + Clone + Send + Sync + 'static,
 {
-    swarm: Swarm<BlendBehaviour<ObservationWindowProvider>>,
+    swarm: Swarm<BlendBehaviour<ObservationWindowProvider, ProofsVerifier>>,
     swarm_messages_receiver: mpsc::Receiver<BlendSwarmMessage<ProofsVerifier>>,
     incoming_message_sender:
         broadcast::Sender<(EncapsulatedMessageWithVerifiedPublicHeader, Epoch)>,
-    current_epoch_info: BackendEpochInfo<PeerId, Arc<ProofsVerifier>>,
-    /// Verifier for the messages still arriving for the previous epoch, kept
-    /// until the epoch transition period is over.
-    old_epoch_proofs_verifier: Option<Arc<ProofsVerifier>>,
-    pending_poq_verifications: PendingPoQVerifications,
+    current_epoch_info: BackendEpochInfo<PeerId, ProofsVerifier>,
     rng: Rng,
     max_dial_attempts_per_connection: NonZeroU64,
     ongoing_dials: HashMap<PeerId, DialAttempt>,
@@ -203,7 +144,7 @@ where
             &'c BlendConfig<Libp2pBlendBackendSettings>,
             &'c Membership<PeerId>,
         )> + 'static,
-    ProofsVerifier: ProofsVerifierTrait + Send + Sync + 'static,
+    ProofsVerifier: ProofsVerifierTrait + Clone + Send + Sync + 'static,
 {
     pub(super) fn new(
         SwarmParams {
@@ -228,6 +169,7 @@ where
                         current_epoch_info.membership.clone(),
                         current_epoch_info.epoch,
                     ),
+                    current_epoch_info.proofs_verifier.clone(),
                 )
             })
             .expect("Blend Behaviour should be built")
@@ -249,9 +191,7 @@ where
             swarm,
             swarm_messages_receiver,
             incoming_message_sender,
-            current_epoch_info: share_epoch_verifier(current_epoch_info),
-            old_epoch_proofs_verifier: None,
-            pending_poq_verifications: FuturesUnordered::new(),
+            current_epoch_info,
             rng,
             max_dial_attempts_per_connection: config.backend.max_dial_attempts_per_peer,
             ongoing_dials: HashMap::with_capacity(
@@ -275,7 +215,7 @@ where
     Rng: RngCore,
     ObservationWindowProvider:
         IntervalStreamProvider<IntervalStream: Unpin + Send, IntervalItem = RangeInclusive<u64>>,
-    ProofsVerifier: ProofsVerifierTrait + Send + Sync + 'static,
+    ProofsVerifier: ProofsVerifierTrait + Clone + Send + Sync + 'static,
 {
     /// Dial random peers from the membership list,
     /// excluding the peers with a negotiated connection in the ongoing epoch,
@@ -375,8 +315,10 @@ where
 
     fn handle_disconnected_peer(&mut self, peer_id: PeerId, peer_state: NegotiatedPeerState) {
         tracing::trace!(target: LOG_TARGET, "Peer {peer_id} disconnected with state {peer_state:?}.");
-        if peer_state.is_spammy() {
+        if let NegotiatedPeerState::Spammy(reason) = peer_state {
+            tracing::debug!(target: LOG_TARGET, "Blocking spammy peer {peer_id} for reason {reason:?}.");
             self.swarm.behaviour_mut().blocked_peers.block_peer(peer_id);
+            metrics::core_peer_blocked(reason.as_str());
         }
         self.check_and_dial_new_peers_except(&HashSet::from([peer_id]));
     }
@@ -413,9 +355,10 @@ where
     fn handle_blend_core_behaviour_event(&mut self, blend_event: CoreToCoreEvent) {
         match blend_event {
             lb_blend::network::core::with_core::behaviour::Event::Message { message, sender, epoch } => {
-                // The behaviour has verified the public header signature; the PoQ is
-                // verified before the message is relayed any further (in a separate task).
-                self.spawn_message_public_header_verification(*message, epoch, InboundMessageSource::Core(sender));
+                // Forward message received from node to all other core nodes.
+                self.forward_received_core_message(&message, sender, epoch);
+                // Bubble up to service for decapsulation and delaying.
+                self.report_message_to_service(*message, epoch, metrics::InboundMessageType::Core);
             }
             lb_blend::network::core::with_core::behaviour::Event::UnhealthyPeer(peer_id) => {
                 self.handle_unhealthy_peer(peer_id);
@@ -473,7 +416,10 @@ where
         clippy::cognitive_complexity,
         reason = "TODO: address this in a dedicated refactor"
     )]
-    fn handle_event(&mut self, event: SwarmEvent<BlendBehaviourEvent<ObservationWindowProvider>>) {
+    fn handle_event(
+        &mut self,
+        event: SwarmEvent<BlendBehaviourEvent<ObservationWindowProvider, ProofsVerifier>>,
+    ) {
         match event {
             SwarmEvent::ConnectionEstablished { peer_id, .. }
             | SwarmEvent::ConnectionClosed { peer_id, .. } => {
@@ -544,24 +490,20 @@ where
                 self.handle_publish_swarm_message(&message, epoch);
             }
             BlendSwarmMessage::StartNewEpoch(new_epoch_info) => {
-                let previous_epoch_info = mem::replace(
-                    &mut self.current_epoch_info,
-                    share_epoch_verifier(new_epoch_info),
+                self.current_epoch_info = new_epoch_info;
+                self.swarm.behaviour_mut().blend.start_new_epoch(
+                    (
+                        self.current_epoch_info.membership.clone(),
+                        self.current_epoch_info.epoch,
+                    ),
+                    self.current_epoch_info.proofs_verifier.clone(),
                 );
-                // Messages for the previous epoch keep arriving during the transition
-                // period, so its verifier is kept around until the transition completes.
-                self.old_epoch_proofs_verifier = Some(previous_epoch_info.proofs_verifier);
-                self.swarm.behaviour_mut().blend.start_new_epoch((
-                    self.current_epoch_info.membership.clone(),
-                    self.current_epoch_info.epoch,
-                ));
                 self.ongoing_dials.clear();
                 self.pending_retries.clear();
                 self.pending_full_membership_retry = None;
                 self.check_and_dial_new_peers();
             }
             BlendSwarmMessage::CompleteEpochTransition => {
-                self.old_epoch_proofs_verifier = None;
                 self.swarm.behaviour_mut().blend.finish_epoch_transition();
             }
             BlendSwarmMessage::GetNetworkInfo { reply } => {
@@ -586,7 +528,8 @@ where
         swarm_event_match_predicate: Predicate,
     ) -> bool
     where
-        Predicate: Fn(&SwarmEvent<BlendBehaviourEvent<ObservationWindowProvider>>) -> bool,
+        Predicate:
+            Fn(&SwarmEvent<BlendBehaviourEvent<ObservationWindowProvider, ProofsVerifier>>) -> bool,
     {
         tokio::select! {
             Some(msg) = self.swarm_messages_receiver.recv() => {
@@ -597,18 +540,6 @@ where
                 let predicate_matched = swarm_event_match_predicate(&event);
                 self.handle_event(event);
                 predicate_matched
-            }
-            Some(outcome) = self.pending_poq_verifications.next() => {
-                match outcome {
-                    Some(PoQVerificationOutcome::Verified(verified_message)) => {
-                        self.handle_verified_inbound_message(*verified_message);
-                    }
-                    Some(PoQVerificationOutcome::Rejected(source)) => {
-                        self.handle_failed_public_header_verification(source);
-                    }
-                    None => {}
-                }
-                false
             }
             Some((peer_id, dial_attempt)) = self.pending_retries.next() => {
                 self.execute_retry(peer_id, dial_attempt);
@@ -636,7 +567,8 @@ where
     #[cfg(test)]
     pub async fn poll_next_until<Predicate>(&mut self, swarm_event_match_predicate: Predicate)
     where
-        Predicate: Fn(&SwarmEvent<BlendBehaviourEvent<ObservationWindowProvider>>) -> bool + Copy,
+        Predicate: Fn(&SwarmEvent<BlendBehaviourEvent<ObservationWindowProvider, ProofsVerifier>>) -> bool
+            + Copy,
     {
         loop {
             if self.poll_next_and_match(swarm_event_match_predicate).await {
@@ -651,7 +583,7 @@ impl<Rng, ObservationWindowProvider, ProofsVerifier>
 where
     ObservationWindowProvider:
         IntervalStreamProvider<IntervalStream: Unpin + Send, IntervalItem = RangeInclusive<u64>>,
-    ProofsVerifier: ProofsVerifierTrait + Send + Sync + 'static,
+    ProofsVerifier: ProofsVerifierTrait + Clone + Send + Sync + 'static,
 {
     /// It tries to dial the specified peer.
     ///
@@ -792,132 +724,15 @@ where
         }
     }
 
-    /// Dispatches the verification of an inbound message's `PoQ` to the
-    /// blocking pool, to be relayed and reported once (and only if) it
-    /// verifies.
-    ///
-    /// This is what gates the message from being relayed any further: the
-    /// behaviour only verifies the public header *signature*, and an
-    /// [`EncapsulatedMessageWithVerifiedPublicHeader`] is the only thing the
-    /// forwarding functions accept, so a message that fails to verify — or that
-    /// belongs to an epoch we no longer have a verifier for — can neither be
-    /// relayed nor reported to the service.
-    ///
-    /// The verification is a Groth16 proof check: running it inline would stall
-    /// this task, which is also servicing every other peer's stream, the dial
-    /// retries and the peering-degree maintenance. Relaying therefore resumes
-    /// in [`Self::handle_verified_inbound_message`] once the result comes
-    /// back.
-    fn spawn_message_public_header_verification(
-        &self,
-        message: EncapsulatedMessageWithVerifiedSignature,
-        epoch: Epoch,
-        source: InboundMessageSource,
-    ) {
-        let message_type = source.metrics_type();
-
-        let Some(verifier) = self.proofs_verifier_for_epoch(epoch) else {
-            tracing::debug!(target: LOG_TARGET, "Dropping message from {source:?} for epoch {epoch:?}: no verifier available for that epoch.");
-            metrics::inbound_message_poq_verification_err(message_type);
-            return;
-        };
-
-        let verifier = Arc::clone(verifier);
-        self.pending_poq_verifications.push(Box::pin(async move {
-            let verification_result = spawn_blocking("logos/blend/verify-public-header", move || {
-                message
-                    .verify_proof_of_quota(&*verifier)
-                    .map_err(|e| format!("{e:?}"))
-            })
-            .await;
-
-            match verification_result {
-                Ok(Ok(message)) => Some(PoQVerificationOutcome::Verified(Box::new(
-                    VerifiedInboundMessage {
-                        message,
-                        epoch,
-                        source,
-                    },
-                ))),
-                Ok(Err(e)) => {
-                    tracing::debug!(target: LOG_TARGET, "Dropping message from {source:?} for epoch {epoch:?}: its public header failed verification: {e}. Neither relaying nor processing it.");
-                    metrics::inbound_message_poq_verification_err(message_type);
-                    Some(PoQVerificationOutcome::Rejected(source))
-                }
-                Err(e) => {
-                    tracing::error!(target: LOG_TARGET, "Dropping message from {source:?} for epoch {epoch:?}: its public header verification task failed to complete: {e:?}.");
-                    None
-                }
-            }
-        }));
-    }
-
-    /// The verifier for the epoch a received message belongs to, if we still
-    /// hold one. Anything that is neither the current nor the epoch we are
-    /// transitioning away from cannot be verified.
-    fn proofs_verifier_for_epoch(&self, epoch: Epoch) -> Option<&Arc<ProofsVerifier>> {
-        if epoch == self.current_epoch_info.epoch {
-            Some(&self.current_epoch_info.proofs_verifier)
-        } else {
-            self.old_epoch_proofs_verifier.as_ref()
-        }
-    }
-
-    fn handle_failed_public_header_verification(&mut self, source: InboundMessageSource) {
-        let InboundMessageSource::Core(peer_id) = source else {
-            tracing::trace!(target: LOG_TARGET, "Skip blocking edge peer {source:?} because of an invalid PoQ sent.");
-            return;
-        };
-        tracing::debug!(target: LOG_TARGET, "Blocking core peer {peer_id:?}: it sent a message whose public header failed verification.");
-
-        self.swarm
-            .behaviour_mut()
-            .blend
-            .with_core_mut()
-            .close_spammy_connection_with_peer(peer_id, SpamReason::InvalidProofOfQuota);
-    }
-
-    /// Relays a message whose public header has just been verified and hands it
-    /// to the service.
-    fn handle_verified_inbound_message(
-        &mut self,
-        VerifiedInboundMessage {
-            message,
-            epoch,
-            source,
-        }: VerifiedInboundMessage,
-    ) {
-        match source {
-            // Forward message received from node to all other core nodes.
-            InboundMessageSource::Core(sender) => {
-                self.forward_received_core_message(&message, sender, epoch);
-            }
-            // Forward message received from edge node to all the core nodes.
-            InboundMessageSource::Edge => self.publish_received_edge_message(&message, epoch),
-        }
-        // Bubble up to service for decapsulation and delaying.
-        self.report_message_to_service(message, epoch, source.metrics_type());
-    }
-
-    fn publish_received_edge_message(
-        &mut self,
-        msg: &EncapsulatedMessageWithVerifiedPublicHeader,
-        epoch: Epoch,
-    ) {
+    fn publish_received_edge_message(&mut self, msg: &EncapsulatedMessageWithVerifiedPublicHeader) {
         if let Err(e) = self
             .swarm
             .behaviour_mut()
             .blend
             .with_core_mut()
-            .publish_message_with_validated_header(msg, epoch)
+            .publish_message_with_validated_header_to_current_epoch(msg)
         {
-            // `InvalidEpoch` is expected here: verification runs off this task, so the
-            // epoch transition it belonged to can complete before the result comes back.
-            if matches!(e, SendError::InvalidEpoch) {
-                tracing::trace!(target: LOG_TARGET, "Dropping message for epoch {epoch:?}, which is no longer served, after its public header was verified.");
-            } else {
-                tracing::error!(target: LOG_TARGET, "Failed to publish message to blend network: {e:?}");
-            }
+            tracing::error!(target: LOG_TARGET, "Failed to publish message to blend network: {e:?}");
             metrics::outbound_publish_err();
         } else {
             metrics::outbound_publish_ok();
@@ -994,17 +809,16 @@ where
         tracing::trace!(target: LOG_TARGET, "Peer {peer_id} is healthy again");
     }
 
-    fn handle_blend_edge_behaviour_event(&self, blend_event: CoreToEdgeEvent) {
+    fn handle_blend_edge_behaviour_event(&mut self, blend_event: CoreToEdgeEvent) {
         match blend_event {
-            lb_blend::network::core::with_edge::behaviour::Event::Message(message) => {
-                // Edge nodes only ever send messages for the current epoch.
-                let epoch = self.current_epoch_info.epoch;
-                // The behaviour has verified the public header signature; the PoQ is
-                // verified before the message is relayed any further, off this task.
-                self.spawn_message_public_header_verification(
-                    message,
-                    epoch,
-                    InboundMessageSource::Edge,
+            lb_blend::network::core::with_edge::behaviour::Event::Message(msg) => {
+                // Forward message received from edge node to all the core nodes.
+                self.publish_received_edge_message(&msg);
+                // Bubble up to service for decapsulation and delaying.
+                self.report_message_to_service(
+                    msg,
+                    self.current_epoch_info.epoch,
+                    metrics::InboundMessageType::Edge,
                 );
             }
         }
@@ -1036,7 +850,7 @@ where
     Rng: RngCore,
     ObservationWindowProvider: IntervalStreamProvider<IntervalStream: Unpin + Send, IntervalItem = RangeInclusive<u64>>
         + 'static,
-    ProofsVerifier: ProofsVerifierTrait + Send + Sync + 'static,
+    ProofsVerifier: ProofsVerifierTrait + Clone + Send + Sync + 'static,
 {
     #[cfg(test)]
     #[expect(clippy::too_many_arguments, reason = "necessary for testing")]
@@ -1055,8 +869,11 @@ where
         peering_degree_check_clock: PeeringDegreeCheckClock,
     ) -> Self
     where
-        BehaviourConstructor:
-            FnOnce(PeerId, Membership<PeerId>) -> BlendBehaviour<ObservationWindowProvider>,
+        BehaviourConstructor: FnOnce(
+            PeerId,
+            Membership<PeerId>,
+        )
+            -> BlendBehaviour<ObservationWindowProvider, ProofsVerifier>,
         PeeringDegreeCheckClock: Stream<Item = ()> + Send + 'static,
     {
         use crate::test_utils::memory_test_swarm;
@@ -1064,9 +881,7 @@ where
         let membership = current_epoch_info.membership.clone();
         Self {
             incoming_message_sender,
-            current_epoch_info: share_epoch_verifier(current_epoch_info),
-            old_epoch_proofs_verifier: None,
-            pending_poq_verifications: FuturesUnordered::new(),
+            current_epoch_info,
             max_dial_attempts_per_connection,
             ongoing_dials: HashMap::new(),
             pending_retries: FuturesUnordered::new(),
@@ -1091,8 +906,9 @@ impl<Rng, ObservationWindowProvider, ProofsVerifier> Deref
 where
     ObservationWindowProvider: IntervalStreamProvider<IntervalStream: Unpin + Send, IntervalItem = RangeInclusive<u64>>
         + 'static,
+    ProofsVerifier: ProofsVerifierTrait + Clone + Send + Sync + 'static,
 {
-    type Target = Swarm<BlendBehaviour<ObservationWindowProvider>>;
+    type Target = Swarm<BlendBehaviour<ObservationWindowProvider, ProofsVerifier>>;
 
     fn deref(&self) -> &Self::Target {
         &self.swarm
@@ -1107,6 +923,7 @@ impl<Rng, ObservationWindowProvider, ProofsVerifier> core::ops::DerefMut
 where
     ObservationWindowProvider: IntervalStreamProvider<IntervalStream: Unpin + Send, IntervalItem = RangeInclusive<u64>>
         + 'static,
+    ProofsVerifier: ProofsVerifierTrait + Clone + Send + Sync + 'static,
 {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.swarm

--- a/services/blend/src/core/backends/libp2p/swarm.rs
+++ b/services/blend/src/core/backends/libp2p/swarm.rs
@@ -1,4 +1,5 @@
 use core::{
+    mem,
     num::{NonZeroU64, NonZeroUsize},
     ops::{Deref, RangeInclusive},
     pin::Pin,
@@ -10,8 +11,11 @@ use std::{
 
 use futures::{Stream, StreamExt as _, future::OptionFuture, stream::FuturesUnordered};
 use lb_blend::{
-    message::encap::validated::{
-        EncapsulatedMessageWithVerifiedPublicHeader, EncapsulatedMessageWithVerifiedSignature,
+    message::encap::{
+        ProofsVerifier as ProofsVerifierTrait,
+        validated::{
+            EncapsulatedMessageWithVerifiedPublicHeader, EncapsulatedMessageWithVerifiedSignature,
+        },
     },
     network::core::{
         NetworkBehaviourEvent,
@@ -58,12 +62,12 @@ use crate::{
 const FULL_MEMBERSHIP_RETRY_DELAY: Duration = Duration::from_mins(1);
 
 #[derive(Debug)]
-pub enum BlendSwarmMessage {
+pub enum BlendSwarmMessage<ProofsVerifier> {
     Publish {
         message: Box<EncapsulatedMessageWithVerifiedPublicHeader>,
         epoch: Epoch,
     },
-    StartNewEpoch(BackendEpochInfo<PeerId>),
+    StartNewEpoch(BackendEpochInfo<PeerId, ProofsVerifier>),
     CompleteEpochTransition,
     GetNetworkInfo {
         reply: oneshot::Sender<Option<NetworkInfo<PeerId>>>,
@@ -102,15 +106,19 @@ impl DialAttempt {
 type PendingRetries = FuturesUnordered<Pin<Box<dyn Future<Output = (PeerId, DialAttempt)> + Send>>>;
 type FullMembershipRetry = Option<Pin<Box<dyn Future<Output = ()> + Send>>>;
 
-pub struct BlendSwarm<Rng, ObservationWindowProvider>
+pub struct BlendSwarm<Rng, ObservationWindowProvider, ProofsVerifier>
 where
     ObservationWindowProvider: IntervalStreamProvider<IntervalStream: Unpin + Send, IntervalItem = RangeInclusive<u64>>
         + 'static,
 {
     swarm: Swarm<BlendBehaviour<ObservationWindowProvider>>,
-    swarm_messages_receiver: mpsc::Receiver<BlendSwarmMessage>,
-    incoming_message_sender: broadcast::Sender<(EncapsulatedMessageWithVerifiedSignature, Epoch)>,
-    current_epoch_info: BackendEpochInfo<PeerId>,
+    swarm_messages_receiver: mpsc::Receiver<BlendSwarmMessage<ProofsVerifier>>,
+    incoming_message_sender:
+        broadcast::Sender<(EncapsulatedMessageWithVerifiedPublicHeader, Epoch)>,
+    current_epoch_info: BackendEpochInfo<PeerId, ProofsVerifier>,
+    /// Verifier for the messages still arriving for the previous epoch, kept
+    /// until the epoch transition period is over.
+    old_epoch_proofs_verifier: Option<ProofsVerifier>,
     rng: Rng,
     max_dial_attempts_per_connection: NonZeroU64,
     ongoing_dials: HashMap<PeerId, DialAttempt>,
@@ -122,17 +130,18 @@ where
     peering_degree_check_clock: Pin<Box<dyn Stream<Item = ()> + Send>>,
 }
 
-pub struct SwarmParams<'config, Rng> {
+pub struct SwarmParams<'config, Rng, ProofsVerifier> {
     pub config: &'config BlendConfig<Libp2pBlendBackendSettings>,
-    pub current_epoch_info: BackendEpochInfo<PeerId>,
+    pub current_epoch_info: BackendEpochInfo<PeerId, ProofsVerifier>,
     pub rng: Rng,
-    pub swarm_message_receiver: mpsc::Receiver<BlendSwarmMessage>,
+    pub swarm_message_receiver: mpsc::Receiver<BlendSwarmMessage<ProofsVerifier>>,
     pub incoming_message_sender:
-        broadcast::Sender<(EncapsulatedMessageWithVerifiedSignature, Epoch)>,
+        broadcast::Sender<(EncapsulatedMessageWithVerifiedPublicHeader, Epoch)>,
     pub minimum_network_size: NonZeroUsize,
 }
 
-impl<Rng, ObservationWindowProvider> BlendSwarm<Rng, ObservationWindowProvider>
+impl<Rng, ObservationWindowProvider, ProofsVerifier>
+    BlendSwarm<Rng, ObservationWindowProvider, ProofsVerifier>
 where
     Rng: RngCore,
     ObservationWindowProvider: IntervalStreamProvider<IntervalStream: Unpin + Send, IntervalItem = RangeInclusive<u64>>
@@ -140,6 +149,7 @@ where
             &'c BlendConfig<Libp2pBlendBackendSettings>,
             &'c Membership<PeerId>,
         )> + 'static,
+    ProofsVerifier: ProofsVerifierTrait,
 {
     pub(super) fn new(
         SwarmParams {
@@ -149,7 +159,7 @@ where
             swarm_message_receiver: swarm_messages_receiver,
             incoming_message_sender,
             minimum_network_size,
-        }: SwarmParams<Rng>,
+        }: SwarmParams<Rng, ProofsVerifier>,
     ) -> Self {
         let listening_address = config.backend.listening_address.clone();
         let mut swarm = SwarmBuilder::with_existing_identity(config.keypair())
@@ -157,7 +167,15 @@ where
             .with_quic()
             .with_dns()
             .expect("DNS transport should be supported")
-            .with_behaviour(|_| BlendBehaviour::new(config, current_epoch_info.clone()))
+            .with_behaviour(|_| {
+                BlendBehaviour::new(
+                    config,
+                    (
+                        current_epoch_info.membership.clone(),
+                        current_epoch_info.epoch,
+                    ),
+                )
+            })
             .expect("Blend Behaviour should be built")
             .with_swarm_config(|cfg| {
                 // The idle timeout starts ticking once there are no active streams on a
@@ -178,6 +196,7 @@ where
             swarm_messages_receiver,
             incoming_message_sender,
             current_epoch_info,
+            old_epoch_proofs_verifier: None,
             rng,
             max_dial_attempts_per_connection: config.backend.max_dial_attempts_per_peer,
             ongoing_dials: HashMap::with_capacity(
@@ -195,11 +214,13 @@ where
     }
 }
 
-impl<Rng, ObservationWindowProvider> BlendSwarm<Rng, ObservationWindowProvider>
+impl<Rng, ObservationWindowProvider, ProofsVerifier>
+    BlendSwarm<Rng, ObservationWindowProvider, ProofsVerifier>
 where
     Rng: RngCore,
     ObservationWindowProvider:
         IntervalStreamProvider<IntervalStream: Unpin + Send, IntervalItem = RangeInclusive<u64>>,
+    ProofsVerifier: ProofsVerifierTrait,
 {
     /// Dial random peers from the membership list,
     /// excluding the peers with a negotiated connection in the ongoing epoch,
@@ -215,7 +236,7 @@ where
 
         // We need to clone else we would not be able to call `self.dial` below, which
         // requires access to `&mut self`.
-        let current_membership = self.current_epoch_info.0.clone();
+        let current_membership = self.current_epoch_info.membership.clone();
 
         let exclude_peers: HashSet<PeerId> = negotiated_peers
             .chain(self.swarm.behaviour().blocked_peers.blocked_peers())
@@ -281,7 +302,7 @@ where
     fn check_and_dial_new_peers_except(&mut self, except: &HashSet<PeerId>) {
         tracing::trace!(target: LOG_TARGET, ?except, "Checking if we need to dial new peers");
 
-        let membership_size = self.current_epoch_info.0.size();
+        let membership_size = self.current_epoch_info.membership.size();
         if membership_size < self.minimum_network_size.get() {
             tracing::warn!(target: LOG_TARGET, "Not dialing any peers because set of core nodes is smaller than the minimum network size. {membership_size} < {}", self.minimum_network_size.get());
             return;
@@ -337,10 +358,16 @@ where
     fn handle_blend_core_behaviour_event(&mut self, blend_event: CoreToCoreEvent) {
         match blend_event {
             lb_blend::network::core::with_core::behaviour::Event::Message { message, sender, epoch } => {
+                // The behaviour has verified the public header signature; the PoQ is
+                // verified here, before the message is relayed any further.
+                let Some(verified_message) = self.verify_message_public_header(*message, epoch, metrics::InboundMessageType::Core) else {
+                    tracing::trace!(target: LOG_TARGET, "Dropping message from core peer {sender:?} for epoch {epoch:?} because its public header failed verification.");
+                    return;
+                };
                 // Forward message received from node to all other core nodes.
-                self.forward_received_core_message(&message, sender, epoch);
+                self.forward_received_core_message(&verified_message, sender, epoch);
                 // Bubble up to service for decapsulation and delaying.
-                self.report_message_to_service(*message, epoch, metrics::InboundMessageType::Core);
+                self.report_message_to_service(verified_message, epoch, metrics::InboundMessageType::Core);
             }
             lb_blend::network::core::with_core::behaviour::Event::UnhealthyPeer(peer_id) => {
                 self.handle_unhealthy_peer(peer_id);
@@ -463,23 +490,28 @@ where
         }
     }
 
-    fn handle_swarm_message(&mut self, msg: BlendSwarmMessage) {
+    fn handle_swarm_message(&mut self, msg: BlendSwarmMessage<ProofsVerifier>) {
         match msg {
             BlendSwarmMessage::Publish { message, epoch } => {
-                self.handle_publish_swarm_message(*message, epoch);
+                self.handle_publish_swarm_message(&message, epoch);
             }
             BlendSwarmMessage::StartNewEpoch(new_epoch_info) => {
-                self.current_epoch_info = new_epoch_info;
-                self.swarm
-                    .behaviour_mut()
-                    .blend
-                    .start_new_epoch(self.current_epoch_info.clone());
+                let previous_epoch_info =
+                    mem::replace(&mut self.current_epoch_info, new_epoch_info);
+                // Messages for the previous epoch keep arriving during the transition
+                // period, so its verifier is kept around until the transition completes.
+                self.old_epoch_proofs_verifier = Some(previous_epoch_info.proofs_verifier);
+                self.swarm.behaviour_mut().blend.start_new_epoch((
+                    self.current_epoch_info.membership.clone(),
+                    self.current_epoch_info.epoch,
+                ));
                 self.ongoing_dials.clear();
                 self.pending_retries.clear();
                 self.pending_full_membership_retry = None;
                 self.check_and_dial_new_peers();
             }
             BlendSwarmMessage::CompleteEpochTransition => {
+                self.old_epoch_proofs_verifier = None;
                 self.swarm.behaviour_mut().blend.finish_epoch_transition();
             }
             BlendSwarmMessage::GetNetworkInfo { reply } => {
@@ -552,10 +584,12 @@ where
     }
 }
 
-impl<Rng, ObservationWindowProvider> BlendSwarm<Rng, ObservationWindowProvider>
+impl<Rng, ObservationWindowProvider, ProofsVerifier>
+    BlendSwarm<Rng, ObservationWindowProvider, ProofsVerifier>
 where
     ObservationWindowProvider:
         IntervalStreamProvider<IntervalStream: Unpin + Send, IntervalItem = RangeInclusive<u64>>,
+    ProofsVerifier: ProofsVerifierTrait,
 {
     /// It tries to dial the specified peer.
     ///
@@ -696,13 +730,51 @@ where
         }
     }
 
-    fn publish_received_edge_message(&mut self, msg: &EncapsulatedMessageWithVerifiedSignature) {
+    /// Verifies the `PoQ` of a message received from a peer, with the verifier
+    /// of the epoch the message belongs to.
+    ///
+    /// This is what gates the message from being relayed any further: the
+    /// behaviour only verifies the public header *signature*, and the resulting
+    /// [`EncapsulatedMessageWithVerifiedPublicHeader`] is the only thing the
+    /// forwarding functions accept, so a message that fails here — or that
+    /// belongs to an epoch we no longer have a verifier for — can neither be
+    /// relayed nor reported to the service.
+    fn verify_message_public_header(
+        &self,
+        message: EncapsulatedMessageWithVerifiedSignature,
+        epoch: Epoch,
+        message_type: metrics::InboundMessageType,
+    ) -> Option<EncapsulatedMessageWithVerifiedPublicHeader> {
+        let verifier = if epoch == self.current_epoch_info.epoch {
+            &self.current_epoch_info.proofs_verifier
+        } else if let Some(old_epoch_proofs_verifier) = &self.old_epoch_proofs_verifier {
+            old_epoch_proofs_verifier
+        } else {
+            tracing::debug!(target: LOG_TARGET, "Received message for epoch {epoch:?} with no verifier available. Dropping it.");
+            metrics::inbound_message_poq_verification_err(message_type);
+            return None;
+        };
+
+        message
+            .verify_proof_of_quota(verifier)
+            .inspect_err(|e| {
+                tracing::debug!(target: LOG_TARGET, "PoQ verification failed for message received for epoch {epoch:?}: {e:?}. Neither relaying nor processing it.");
+                metrics::inbound_message_poq_verification_err(message_type);
+            })
+            .ok()
+    }
+
+    fn publish_received_edge_message(
+        &mut self,
+        msg: &EncapsulatedMessageWithVerifiedPublicHeader,
+        epoch: Epoch,
+    ) {
         if let Err(e) = self
             .swarm
             .behaviour_mut()
             .blend
             .with_core_mut()
-            .publish_message_with_validated_signature_to_current_epoch(msg)
+            .publish_message_with_validated_header(msg, epoch)
         {
             tracing::error!(target: LOG_TARGET, "Failed to publish message to blend network: {e:?}");
             metrics::outbound_publish_err();
@@ -713,7 +785,7 @@ where
 
     fn forward_received_core_message(
         &mut self,
-        msg: &EncapsulatedMessageWithVerifiedSignature,
+        msg: &EncapsulatedMessageWithVerifiedPublicHeader,
         except: PeerId,
         epoch: Epoch,
     ) {
@@ -722,7 +794,7 @@ where
             .behaviour_mut()
             .blend
             .with_core_mut()
-            .forward_message_with_validated_signature(msg, except, epoch)
+            .forward_message_with_verified_public_header(msg, except, epoch)
         {
             // If we have a single connection, then we will always hit the `NoPeers` error.
             // In this case it's ok not to log such error, since this function is only
@@ -739,7 +811,7 @@ where
 
     fn report_message_to_service(
         &self,
-        msg: EncapsulatedMessageWithVerifiedSignature,
+        msg: EncapsulatedMessageWithVerifiedPublicHeader,
         epoch: Epoch,
         message_type: metrics::InboundMessageType,
     ) {
@@ -781,13 +853,25 @@ where
 
     fn handle_blend_edge_behaviour_event(&mut self, blend_event: CoreToEdgeEvent) {
         match blend_event {
-            lb_blend::network::core::with_edge::behaviour::Event::Message(msg) => {
+            lb_blend::network::core::with_edge::behaviour::Event::Message(message) => {
+                // Edge nodes only ever send messages for the current epoch.
+                let epoch = self.current_epoch_info.epoch;
+                // The behaviour has verified the public header signature; the PoQ is
+                // verified here, before the message is relayed any further.
+                let Some(verified_message) = self.verify_message_public_header(
+                    message,
+                    epoch,
+                    metrics::InboundMessageType::Edge,
+                ) else {
+                    tracing::trace!(target: LOG_TARGET, "Dropping message from edge peer for epoch {epoch:?} because its public header failed verification.");
+                    return;
+                };
                 // Forward message received from edge node to all the core nodes.
-                self.publish_received_edge_message(&msg);
+                self.publish_received_edge_message(&verified_message, epoch);
                 // Bubble up to service for decapsulation and delaying.
                 self.report_message_to_service(
-                    msg,
-                    self.current_epoch_info.1,
+                    verified_message,
+                    epoch,
                     metrics::InboundMessageType::Edge,
                 );
             }
@@ -796,7 +880,7 @@ where
 
     fn handle_publish_swarm_message(
         &mut self,
-        msg: EncapsulatedMessageWithVerifiedPublicHeader,
+        msg: &EncapsulatedMessageWithVerifiedPublicHeader,
         intended_epoch: Epoch,
     ) {
         if let Err(e) = self
@@ -814,23 +898,25 @@ where
     }
 }
 
-impl<Rng, ObservationWindowProvider> BlendSwarm<Rng, ObservationWindowProvider>
+impl<Rng, ObservationWindowProvider, ProofsVerifier>
+    BlendSwarm<Rng, ObservationWindowProvider, ProofsVerifier>
 where
     Rng: RngCore,
     ObservationWindowProvider: IntervalStreamProvider<IntervalStream: Unpin + Send, IntervalItem = RangeInclusive<u64>>
         + 'static,
+    ProofsVerifier: ProofsVerifierTrait,
 {
     #[cfg(test)]
     #[expect(clippy::too_many_arguments, reason = "necessary for testing")]
     pub fn new_test<BehaviourConstructor, PeeringDegreeCheckClock>(
         identity: &libp2p::identity::Keypair,
         behaviour_constructor: BehaviourConstructor,
-        swarm_messages_receiver: mpsc::Receiver<BlendSwarmMessage>,
+        swarm_messages_receiver: mpsc::Receiver<BlendSwarmMessage<ProofsVerifier>>,
         incoming_message_sender: broadcast::Sender<(
-            EncapsulatedMessageWithVerifiedSignature,
+            EncapsulatedMessageWithVerifiedPublicHeader,
             Epoch,
         )>,
-        current_epoch_info: BackendEpochInfo<PeerId>,
+        current_epoch_info: BackendEpochInfo<PeerId, ProofsVerifier>,
         rng: Rng,
         max_dial_attempts_per_connection: NonZeroU64,
         minimum_network_size: NonZeroUsize,
@@ -843,10 +929,11 @@ where
     {
         use crate::test_utils::memory_test_swarm;
 
-        let membership = current_epoch_info.0.clone();
+        let membership = current_epoch_info.membership.clone();
         Self {
             incoming_message_sender,
             current_epoch_info,
+            old_epoch_proofs_verifier: None,
             max_dial_attempts_per_connection,
             ongoing_dials: HashMap::new(),
             pending_retries: FuturesUnordered::new(),
@@ -866,7 +953,8 @@ where
 }
 
 // We implement `Deref` so we are able to call swarm methods on our own swarm.
-impl<Rng, ObservationWindowProvider> Deref for BlendSwarm<Rng, ObservationWindowProvider>
+impl<Rng, ObservationWindowProvider, ProofsVerifier> Deref
+    for BlendSwarm<Rng, ObservationWindowProvider, ProofsVerifier>
 where
     ObservationWindowProvider: IntervalStreamProvider<IntervalStream: Unpin + Send, IntervalItem = RangeInclusive<u64>>
         + 'static,
@@ -881,8 +969,8 @@ where
 #[cfg(test)]
 // We implement `DerefMut` only for tests, since we do not want to give people a
 // chance to bypass our API.
-impl<Rng, ObservationWindowProvider> core::ops::DerefMut
-    for BlendSwarm<Rng, ObservationWindowProvider>
+impl<Rng, ObservationWindowProvider, ProofsVerifier> core::ops::DerefMut
+    for BlendSwarm<Rng, ObservationWindowProvider, ProofsVerifier>
 where
     ObservationWindowProvider: IntervalStreamProvider<IntervalStream: Unpin + Send, IntervalItem = RangeInclusive<u64>>
         + 'static,

--- a/services/blend/src/core/backends/libp2p/tests/message_handling.rs
+++ b/services/blend/src/core/backends/libp2p/tests/message_handling.rs
@@ -2,7 +2,10 @@ use core::time::Duration;
 
 use libp2p_swarm_test::SwarmExt as _;
 use test_log::test;
-use tokio::{spawn, time::sleep};
+use tokio::{
+    spawn,
+    time::{sleep, timeout},
+};
 
 use crate::{
     core::backends::libp2p::{
@@ -57,9 +60,73 @@ async fn core_message_propagation() {
         .unwrap();
 
     // We test that swarm 1 publishes a message, sending it to swarm 2, the only
-    // swarm it is connected to. Then swarm 2 forwards it to swarm 3, which is not
-    // connected to swarm 1.
+    // swarm it is connected to. Then swarm 2 verifies its public header and
+    // forwards it to swarm 3, which is not connected to swarm 1.
     let (swarm_3_received_message, epoch) = swarm_3_message_receiver.recv().await.unwrap();
-    assert_eq!(swarm_3_received_message, message.into_inner().into());
+    assert_eq!(swarm_3_received_message, message.clone());
     assert_eq!(epoch, 1);
+}
+
+/// A message whose `PoQ` does not verify is neither relayed to the other core
+/// nodes nor bubbled up to the service. The forwarding functions only accept an
+/// `EncapsulatedMessageWithVerifiedPublicHeader`, so a node cannot amplify
+/// traffic it was unable to verify.
+#[test(tokio::test)]
+async fn message_with_invalid_poq_is_not_relayed() {
+    let (mut identities, peer_ids) = new_nodes_with_empty_address(3);
+    let TestSwarm {
+        swarm: mut swarm_1,
+        swarm_message_sender: swarm_1_message_sender,
+        ..
+    } = SwarmBuilder::new(identities.next().unwrap(), &peer_ids)
+        .build(|id, membership| BlendBehaviourBuilder::new(id, membership).build());
+    // The middle swarm rejects every `PoQ` it is asked to verify.
+    let TestSwarm {
+        swarm: mut swarm_2,
+        incoming_message_receiver: mut swarm_2_message_receiver,
+        ..
+    } = SwarmBuilder::new(identities.next().unwrap(), &peer_ids)
+        .with_rejecting_proofs_verifier()
+        .build(|id, membership| BlendBehaviourBuilder::new(id, membership).build());
+    let TestSwarm {
+        swarm: mut swarm_3,
+        incoming_message_receiver: mut swarm_3_message_receiver,
+        ..
+    } = SwarmBuilder::new(identities.next().unwrap(), &peer_ids)
+        .build(|id, membership| BlendBehaviourBuilder::new(id, membership).build());
+
+    let (swarm_2_address, _) = swarm_2.listen().await;
+    let (swarm_3_address, _) = swarm_3.listen().await;
+
+    swarm_1.dial_peer_at_addr(*swarm_2.local_peer_id(), swarm_2_address);
+    swarm_2.dial_peer_at_addr(*swarm_3.local_peer_id(), swarm_3_address);
+
+    spawn(async move { swarm_1.run().await });
+    spawn(async move { swarm_2.run().await });
+    spawn(async move { swarm_3.run().await });
+
+    // Wait for peers to establish connections with each other
+    sleep(Duration::from_secs(1)).await;
+
+    swarm_1_message_sender
+        .send(BlendSwarmMessage::Publish {
+            message: Box::new(TestEncapsulatedMessage::new(b"test-payload").clone()),
+            epoch: 1.into(),
+        })
+        .await
+        .unwrap();
+
+    // Swarm 2 drops the message on failed verification, so it never reaches swarm
+    // 3, which is only connected to swarm 2.
+    assert!(
+        timeout(Duration::from_secs(2), swarm_3_message_receiver.recv())
+            .await
+            .is_err(),
+        "A message whose PoQ failed to verify must not be relayed"
+    );
+    // Nor is it handed to swarm 2's own service.
+    assert!(
+        swarm_2_message_receiver.try_recv().is_err(),
+        "A message whose PoQ failed to verify must not be reported to the service"
+    );
 }

--- a/services/blend/src/core/backends/libp2p/tests/message_handling.rs
+++ b/services/blend/src/core/backends/libp2p/tests/message_handling.rs
@@ -2,10 +2,7 @@ use core::time::Duration;
 
 use libp2p_swarm_test::SwarmExt as _;
 use test_log::test;
-use tokio::{
-    spawn,
-    time::{sleep, timeout},
-};
+use tokio::{spawn, time::sleep};
 
 use crate::{
     core::backends::libp2p::{
@@ -65,68 +62,4 @@ async fn core_message_propagation() {
     let (swarm_3_received_message, epoch) = swarm_3_message_receiver.recv().await.unwrap();
     assert_eq!(swarm_3_received_message, message.clone());
     assert_eq!(epoch, 1);
-}
-
-/// A message whose `PoQ` does not verify is neither relayed to the other core
-/// nodes nor bubbled up to the service. The forwarding functions only accept an
-/// `EncapsulatedMessageWithVerifiedPublicHeader`, so a node cannot amplify
-/// traffic it was unable to verify.
-#[test(tokio::test)]
-async fn message_with_invalid_poq_is_not_relayed() {
-    let (mut identities, peer_ids) = new_nodes_with_empty_address(3);
-    let TestSwarm {
-        swarm: mut swarm_1,
-        swarm_message_sender: swarm_1_message_sender,
-        ..
-    } = SwarmBuilder::new(identities.next().unwrap(), &peer_ids)
-        .build(|id, membership| BlendBehaviourBuilder::new(id, membership).build());
-    // The middle swarm rejects every `PoQ` it is asked to verify.
-    let TestSwarm {
-        swarm: mut swarm_2,
-        incoming_message_receiver: mut swarm_2_message_receiver,
-        ..
-    } = SwarmBuilder::new(identities.next().unwrap(), &peer_ids)
-        .with_rejecting_proofs_verifier()
-        .build(|id, membership| BlendBehaviourBuilder::new(id, membership).build());
-    let TestSwarm {
-        swarm: mut swarm_3,
-        incoming_message_receiver: mut swarm_3_message_receiver,
-        ..
-    } = SwarmBuilder::new(identities.next().unwrap(), &peer_ids)
-        .build(|id, membership| BlendBehaviourBuilder::new(id, membership).build());
-
-    let (swarm_2_address, _) = swarm_2.listen().await;
-    let (swarm_3_address, _) = swarm_3.listen().await;
-
-    swarm_1.dial_peer_at_addr(*swarm_2.local_peer_id(), swarm_2_address);
-    swarm_2.dial_peer_at_addr(*swarm_3.local_peer_id(), swarm_3_address);
-
-    spawn(async move { swarm_1.run().await });
-    spawn(async move { swarm_2.run().await });
-    spawn(async move { swarm_3.run().await });
-
-    // Wait for peers to establish connections with each other
-    sleep(Duration::from_secs(1)).await;
-
-    swarm_1_message_sender
-        .send(BlendSwarmMessage::Publish {
-            message: Box::new(TestEncapsulatedMessage::new(b"test-payload").clone()),
-            epoch: 1.into(),
-        })
-        .await
-        .unwrap();
-
-    // Swarm 2 drops the message on failed verification, so it never reaches swarm
-    // 3, which is only connected to swarm 2.
-    assert!(
-        timeout(Duration::from_secs(2), swarm_3_message_receiver.recv())
-            .await
-            .is_err(),
-        "A message whose PoQ failed to verify must not be relayed"
-    );
-    // Nor is it handed to swarm 2's own service.
-    assert!(
-        swarm_2_message_receiver.try_recv().is_err(),
-        "A message whose PoQ failed to verify must not be reported to the service"
-    );
 }

--- a/services/blend/src/core/backends/libp2p/tests/redials.rs
+++ b/services/blend/src/core/backends/libp2p/tests/redials.rs
@@ -325,7 +325,7 @@ async fn core_epoch_rotation_clears_pending_retries() {
     let new_epoch_info = BackendEpochInfo {
         membership: Membership::new_without_local(&[]),
         epoch: 2.into(),
-        proofs_verifier: TestProofsVerifier::accepting(),
+        proofs_verifier: TestProofsVerifier,
     };
     swarm_message_sender
         .send(BlendSwarmMessage::StartNewEpoch(new_epoch_info))
@@ -403,7 +403,7 @@ async fn core_does_not_give_up_below_minimum_peering_degree() {
         .send(BlendSwarmMessage::StartNewEpoch(BackendEpochInfo {
             membership: new_membership,
             epoch: 2.into(),
-            proofs_verifier: TestProofsVerifier::accepting(),
+            proofs_verifier: TestProofsVerifier,
         }))
         .await
         .unwrap();

--- a/services/blend/src/core/backends/libp2p/tests/redials.rs
+++ b/services/blend/src/core/backends/libp2p/tests/redials.rs
@@ -10,10 +10,15 @@ use tokio::{
     time::{self, sleep, sleep_until},
 };
 
-use crate::core::backends::libp2p::{
-    core_swarm_test_utils::{SwarmExt as _, new_nodes_with_empty_address, update_nodes},
-    swarm::BlendSwarmMessage,
-    tests::utils::{BlendBehaviourBuilder, SwarmBuilder, TestSwarm, build_membership},
+use crate::core::backends::{
+    BackendEpochInfo,
+    libp2p::{
+        core_swarm_test_utils::{SwarmExt as _, new_nodes_with_empty_address, update_nodes},
+        swarm::BlendSwarmMessage,
+        tests::utils::{
+            BlendBehaviourBuilder, SwarmBuilder, TestProofsVerifier, TestSwarm, build_membership,
+        },
+    },
 };
 
 #[test(tokio::test)]
@@ -317,7 +322,11 @@ async fn core_epoch_rotation_clears_pending_retries() {
     assert_eq!(dialing_swarm.pending_retries_count(), 1);
 
     // Trigger a new epoch via the swarm message channel.
-    let new_epoch_info = (Membership::new_without_local(&[]), 2.into());
+    let new_epoch_info = BackendEpochInfo {
+        membership: Membership::new_without_local(&[]),
+        epoch: 2.into(),
+        proofs_verifier: TestProofsVerifier::accepting(),
+    };
     swarm_message_sender
         .send(BlendSwarmMessage::StartNewEpoch(new_epoch_info))
         .await
@@ -391,7 +400,11 @@ async fn core_does_not_give_up_below_minimum_peering_degree() {
     // peers to reach the minimum degree.
     let new_membership = build_membership(&nodes, Some(*dialing_swarm.local_peer_id()));
     swarm_message_sender
-        .send(BlendSwarmMessage::StartNewEpoch((new_membership, 2.into())))
+        .send(BlendSwarmMessage::StartNewEpoch(BackendEpochInfo {
+            membership: new_membership,
+            epoch: 2.into(),
+            proofs_verifier: TestProofsVerifier::accepting(),
+        }))
         .await
         .unwrap();
 

--- a/services/blend/src/core/backends/libp2p/tests/utils.rs
+++ b/services/blend/src/core/backends/libp2p/tests/utils.rs
@@ -45,25 +45,19 @@ use crate::{
     test_utils::PROTOCOL_NAME,
 };
 
-/// A `PoQ` verifier for the swarm tests, which either accepts or rejects every
-/// proof it is handed. The proof systems themselves are exercised elsewhere;
-/// here we only care about what the swarm does with the verification outcome.
+/// A `PoQ` verifier for the swarm tests, which accepts every proof it is
+/// handed.
+///
+/// What a node does with a *failed* verification is decided by the behaviour,
+/// so it is tested there rather than here.
 #[derive(Debug, Clone, Copy)]
-pub struct TestProofsVerifier {
-    accepts: bool,
-}
-
-impl TestProofsVerifier {
-    pub const fn accepting() -> Self {
-        Self { accepts: true }
-    }
-}
+pub struct TestProofsVerifier;
 
 impl ProofsVerifier for TestProofsVerifier {
     type Error = ();
 
     fn new(_public_inputs: PoQVerificationInputsMinusSigningKey) -> Self {
-        Self { accepts: true }
+        Self
     }
 
     fn verify_proof_of_quota(
@@ -71,9 +65,7 @@ impl ProofsVerifier for TestProofsVerifier {
         proof: ProofOfQuota,
         _signing_key: &lb_key_management_system_service::keys::Ed25519PublicKey,
     ) -> Result<VerifiedProofOfQuota, Self::Error> {
-        self.accepts
-            .then(|| VerifiedProofOfQuota::from_proof_of_quota_unchecked(proof))
-            .ok_or(())
+        Ok(VerifiedProofOfQuota::from_proof_of_quota_unchecked(proof))
     }
 
     fn verify_proof_of_selection(
@@ -81,9 +73,9 @@ impl ProofsVerifier for TestProofsVerifier {
         proof: ProofOfSelection,
         _inputs: &VerifyInputs,
     ) -> Result<VerifiedProofOfSelection, Self::Error> {
-        self.accepts
-            .then(|| VerifiedProofOfSelection::from_proof_of_selection_unchecked(proof))
-            .ok_or(())
+        Ok(VerifiedProofOfSelection::from_proof_of_selection_unchecked(
+            proof,
+        ))
     }
 }
 
@@ -149,7 +141,7 @@ impl SwarmBuilder {
         let public_info = BackendEpochInfo {
             membership: build_membership(membership, Some(identity.public().into())),
             epoch: 1.into(),
-            proofs_verifier: TestProofsVerifier::accepting(),
+            proofs_verifier: TestProofsVerifier,
         };
         Self {
             identity,
@@ -157,12 +149,6 @@ impl SwarmBuilder {
             max_dial_attempts: None,
             peering_degree_check_clock: None,
         }
-    }
-
-    /// Makes this swarm reject the `PoQ` of every message it receives.
-    pub const fn with_rejecting_proofs_verifier(mut self) -> Self {
-        self.public_info.proofs_verifier = TestProofsVerifier { accepts: false };
-        self
     }
 
     pub fn with_max_dial_attempts(mut self, max_dial_attempts: NonZeroU64) -> Self {
@@ -181,7 +167,11 @@ impl SwarmBuilder {
     ) -> TestSwarm
     where
         BehaviourConstructor:
-            FnOnce(PeerId, Membership<PeerId>) -> BlendBehaviour<TestObservationWindowProvider>,
+            FnOnce(
+                PeerId,
+                Membership<PeerId>,
+            )
+                -> BlendBehaviour<TestObservationWindowProvider, TestProofsVerifier>,
     {
         let (swarm_message_sender, swarm_message_receiver) = mpsc::channel(100);
         let (incoming_message_sender, incoming_message_receiver) = broadcast::channel(100);
@@ -213,6 +203,7 @@ pub struct BlendBehaviourBuilder {
     membership: Membership<PeerId>,
     observation_window: Option<(Duration, RangeInclusive<u64>)>,
     peering_degree: Option<RangeInclusive<usize>>,
+    proofs_verifier: TestProofsVerifier,
 }
 
 impl BlendBehaviourBuilder {
@@ -222,6 +213,7 @@ impl BlendBehaviourBuilder {
             membership,
             observation_window: None,
             peering_degree: None,
+            proofs_verifier: TestProofsVerifier,
         }
     }
 
@@ -239,7 +231,7 @@ impl BlendBehaviourBuilder {
         self
     }
 
-    pub fn build(self) -> BlendBehaviour<TestObservationWindowProvider> {
+    pub fn build(self) -> BlendBehaviour<TestObservationWindowProvider, TestProofsVerifier> {
         let observation_window_values = self
             .observation_window
             .unwrap_or((Duration::from_secs(1), u64::MIN..=u64::MAX));
@@ -265,6 +257,7 @@ impl BlendBehaviourBuilder {
                     interval: observation_window_values.0,
                 },
                 (self.membership, 1.into()),
+                self.proofs_verifier,
                 self.peer_id,
                 PROTOCOL_NAME,
             ),
@@ -314,7 +307,7 @@ pub trait SwarmExt: libp2p_swarm_test::SwarmExt {
 }
 
 #[async_trait]
-impl SwarmExt for Swarm<BlendBehaviour<TestObservationWindowProvider>> {
+impl SwarmExt for Swarm<BlendBehaviour<TestObservationWindowProvider, TestProofsVerifier>> {
     async fn listen_and_return_membership_entry(
         &mut self,
         addr: Option<Multiaddr>,

--- a/services/blend/src/core/backends/libp2p/tests/utils.rs
+++ b/services/blend/src/core/backends/libp2p/tests/utils.rs
@@ -5,13 +5,17 @@ use async_trait::async_trait;
 use futures::{Stream, StreamExt as _, stream::pending};
 use lb_blend::{
     message::{
-        crypto::key_ext::Ed25519SecretKeyExt as _,
-        encap::validated::EncapsulatedMessageWithVerifiedSignature,
+        crypto::{key_ext::Ed25519SecretKeyExt as _, proofs::PoQVerificationInputsMinusSigningKey},
+        encap::{ProofsVerifier, validated::EncapsulatedMessageWithVerifiedPublicHeader},
     },
     network::core::{
         Config, NetworkBehaviour,
         with_core::behaviour::{Config as CoreToCoreConfig, IntervalStreamProvider},
         with_edge::behaviour::Config as CoreToEdgeConfig,
+    },
+    proofs::{
+        quota::{ProofOfQuota, VerifiedProofOfQuota},
+        selection::{ProofOfSelection, VerifiedProofOfSelection, inputs::VerifyInputs},
     },
     scheduling::membership::{Membership, Node},
 };
@@ -41,13 +45,55 @@ use crate::{
     test_utils::PROTOCOL_NAME,
 };
 
-pub type InnerSwarm = BlendSwarm<BlakeRng, TestObservationWindowProvider>;
+/// A `PoQ` verifier for the swarm tests, which either accepts or rejects every
+/// proof it is handed. The proof systems themselves are exercised elsewhere;
+/// here we only care about what the swarm does with the verification outcome.
+#[derive(Debug, Clone, Copy)]
+pub struct TestProofsVerifier {
+    accepts: bool,
+}
+
+impl TestProofsVerifier {
+    pub const fn accepting() -> Self {
+        Self { accepts: true }
+    }
+}
+
+impl ProofsVerifier for TestProofsVerifier {
+    type Error = ();
+
+    fn new(_public_inputs: PoQVerificationInputsMinusSigningKey) -> Self {
+        Self { accepts: true }
+    }
+
+    fn verify_proof_of_quota(
+        &self,
+        proof: ProofOfQuota,
+        _signing_key: &lb_key_management_system_service::keys::Ed25519PublicKey,
+    ) -> Result<VerifiedProofOfQuota, Self::Error> {
+        self.accepts
+            .then(|| VerifiedProofOfQuota::from_proof_of_quota_unchecked(proof))
+            .ok_or(())
+    }
+
+    fn verify_proof_of_selection(
+        &self,
+        proof: ProofOfSelection,
+        _inputs: &VerifyInputs,
+    ) -> Result<VerifiedProofOfSelection, Self::Error> {
+        self.accepts
+            .then(|| VerifiedProofOfSelection::from_proof_of_selection_unchecked(proof))
+            .ok_or(())
+    }
+}
+
+pub type InnerSwarm = BlendSwarm<BlakeRng, TestObservationWindowProvider, TestProofsVerifier>;
 
 pub struct TestSwarm {
     pub swarm: InnerSwarm,
-    pub swarm_message_sender: mpsc::Sender<BlendSwarmMessage>,
+    pub swarm_message_sender: mpsc::Sender<BlendSwarmMessage<TestProofsVerifier>>,
     pub incoming_message_receiver:
-        broadcast::Receiver<(EncapsulatedMessageWithVerifiedSignature, Epoch)>,
+        broadcast::Receiver<(EncapsulatedMessageWithVerifiedPublicHeader, Epoch)>,
 }
 
 /// Generates `count` nodes with randomly generated identities and empty
@@ -93,23 +139,30 @@ pub fn build_membership(
 
 pub struct SwarmBuilder {
     identity: Keypair,
-    public_info: BackendEpochInfo<PeerId>,
+    public_info: BackendEpochInfo<PeerId, TestProofsVerifier>,
     max_dial_attempts: Option<NonZeroU64>,
     peering_degree_check_clock: Option<Pin<Box<dyn Stream<Item = ()> + Send>>>,
 }
 
 impl SwarmBuilder {
     pub fn new(identity: Keypair, membership: &[Node<PeerId>]) -> Self {
-        let public_info = (
-            build_membership(membership, Some(identity.public().into())),
-            1.into(),
-        );
+        let public_info = BackendEpochInfo {
+            membership: build_membership(membership, Some(identity.public().into())),
+            epoch: 1.into(),
+            proofs_verifier: TestProofsVerifier::accepting(),
+        };
         Self {
             identity,
             public_info,
             max_dial_attempts: None,
             peering_degree_check_clock: None,
         }
+    }
+
+    /// Makes this swarm reject the `PoQ` of every message it receives.
+    pub const fn with_rejecting_proofs_verifier(mut self) -> Self {
+        self.public_info.proofs_verifier = TestProofsVerifier { accepts: false };
+        self
     }
 
     pub fn with_max_dial_attempts(mut self, max_dial_attempts: NonZeroU64) -> Self {

--- a/services/blend/src/core/backends/mod.rs
+++ b/services/blend/src/core/backends/mod.rs
@@ -2,9 +2,7 @@ use std::{fmt::Debug, pin::Pin};
 
 use futures::Stream;
 use lb_blend::{
-    message::encap::validated::{
-        EncapsulatedMessageWithVerifiedPublicHeader, EncapsulatedMessageWithVerifiedSignature,
-    },
+    message::encap::validated::EncapsulatedMessageWithVerifiedPublicHeader,
     scheduling::membership::Membership,
 };
 use lb_chain_service::Epoch;
@@ -14,17 +12,30 @@ use crate::{core::settings::RunningBlendConfig as BlendConfig, message::NetworkI
 
 pub mod libp2p;
 
-pub type BackendEpochInfo<NodeId> = (Membership<NodeId>, Epoch);
+/// Everything the backend needs to know about an epoch.
+///
+/// The `PoQ` verifier travels with the membership and the epoch number because
+/// the backend verifies the public header of every message it receives — `PoQ`
+/// included — before relaying it to the rest of the network. Its inputs are
+/// epoch-specific, so a new verifier is handed over on every rotation, and the
+/// previous one is kept until [`BlendBackend::complete_epoch_transition`] to
+/// serve the messages still arriving for the old epoch.
+#[derive(Debug, Clone)]
+pub struct BackendEpochInfo<NodeId, ProofsVerifier> {
+    pub membership: Membership<NodeId>,
+    pub epoch: Epoch,
+    pub proofs_verifier: ProofsVerifier,
+}
 
 /// A trait for blend backends that send messages to the blend network.
 #[async_trait::async_trait]
-pub trait BlendBackend<NodeId, Rng, RuntimeServiceId> {
+pub trait BlendBackend<NodeId, Rng, ProofsVerifier, RuntimeServiceId> {
     type Settings: Clone + Debug + Send + Sync + 'static;
 
     fn new(
         service_config: BlendConfig<Self::Settings>,
         overwatch_handle: OverwatchHandle<RuntimeServiceId>,
-        current_epoch_info: BackendEpochInfo<NodeId>,
+        current_epoch_info: BackendEpochInfo<NodeId, ProofsVerifier>,
         rng: Rng,
     ) -> Self;
     fn shutdown(self);
@@ -35,13 +46,18 @@ pub trait BlendBackend<NodeId, Rng, RuntimeServiceId> {
         intended_epoch: Epoch,
     );
     /// Rotate epoch.
-    async fn rotate_epoch(&mut self, new_epoch_info: BackendEpochInfo<NodeId>);
-    /// Complete the epoch transition.
+    async fn rotate_epoch(&mut self, new_epoch_info: BackendEpochInfo<NodeId, ProofsVerifier>);
+    /// Complete the epoch transition, dropping the old epoch's state and its
+    /// `PoQ` verifier.
     async fn complete_epoch_transition(&mut self);
-    /// Listen to messages received from the blend network.
+    /// Listen to messages received from the blend network, along with the epoch
+    /// each of them belongs to.
+    ///
+    /// The backend yields only messages whose whole public header it has
+    /// verified, so the service does not have to verify the `PoQ` again.
     fn listen_to_incoming_messages(
         &mut self,
-    ) -> Pin<Box<dyn Stream<Item = (EncapsulatedMessageWithVerifiedSignature, Epoch)> + Send>>;
+    ) -> Pin<Box<dyn Stream<Item = (EncapsulatedMessageWithVerifiedPublicHeader, Epoch)> + Send>>;
 
     /// Return network info about the current blend peers.
     /// Returns `None` if the backend does not support this operation.

--- a/services/blend/src/core/mod.rs
+++ b/services/blend/src/core/mod.rs
@@ -223,7 +223,7 @@ where
     ProofsGenerator:
         CoreAndLeaderProofsGenerator<PreloadKMSBackendCorePoQGenerator<RuntimeServiceId>> + Send,
     SdpService: ServiceData<Message = SdpMessage> + Send,
-    ProofsVerifier: ProofsVerifierTrait + Clone + Send + Sync,
+    ProofsVerifier: ProofsVerifierTrait + Send + Sync,
     TimeBackend: lb_time_service::backends::TimeBackend + Send,
     ChainService: CryptarchiaServiceData<Tx: Send + Sync>,
     PolInfoProvider: PolInfoProviderTrait<RuntimeServiceId, Stream: Send + Unpin + 'static> + Send,
@@ -503,7 +503,7 @@ where
     Backend: BlendBackend<NodeId, BlakeRng, ProofsVerifier, RuntimeServiceId> + Sync,
     NetAdapter: NetworkAdapter<RuntimeServiceId>,
     ProofsGenerator: CoreAndLeaderProofsGenerator<KmsAdapter::CorePoQGenerator>,
-    ProofsVerifier: ProofsVerifierTrait + Clone,
+    ProofsVerifier: ProofsVerifierTrait,
     // To avoid bubbling up generics everywhere in the configs (current Overwatch limitation), we
     // know the final key ID type is a `String`, so we constraint the trait impl here instead.
     KmsAdapter: KmsPoQAdapter<RuntimeServiceId, KeyId = String, CorePoQGenerator: Clone + Send + Sync>
@@ -587,6 +587,12 @@ where
         current_epoch_public_info
     );
 
+    let current_epoch_poq_verification_inputs = PoQVerificationInputsMinusSigningKey {
+        core: current_epoch_public_info.poq_core_public_inputs,
+        leader: current_epoch_public_info.poq_leadership_public_inputs,
+        pow: PowInputs::unwired_placeholder(),
+    };
+
     let crypto_processor = CoreCryptographicProcessor::<
         _,
         KmsAdapter::CorePoQGenerator,
@@ -599,11 +605,7 @@ where
             non_ephemeral_encryption_key: blend_config.non_ephemeral_signing_key.derive_x25519(),
             num_blend_layers: blend_config.num_blend_layers,
         },
-        PoQVerificationInputsMinusSigningKey {
-            core: current_epoch_public_info.poq_core_public_inputs,
-            leader: current_epoch_public_info.poq_leadership_public_inputs,
-            pow: PowInputs::unwired_placeholder(),
-        },
+        current_epoch_poq_verification_inputs,
         current_epoch_core_poq_generator
             .expect("Core PoQ generator must be present at startup: the proxy service only launches CoreMode when the node is part of the core membership."),
         current_epoch_public_info.epoch,
@@ -684,7 +686,7 @@ where
             epoch: current_epoch_public_info.epoch,
             // The backend verifies the `PoQ` of every message it receives before
             // relaying it, so it needs its own verifier for the epoch.
-            proofs_verifier: crypto_processor.verifier().clone(),
+            proofs_verifier: ProofsVerifier::new(current_epoch_poq_verification_inputs),
         },
         BlakeRng::from_entropy(),
     );
@@ -784,7 +786,7 @@ where
     NetAdapter: NetworkAdapter<RuntimeServiceId> + Sync,
     ProofsGenerator: CoreAndLeaderProofsGenerator<CorePoQGenerator> + Send,
     CorePoQGenerator: Send + Sync,
-    ProofsVerifier: ProofsVerifierTrait + Clone + Send + Sync,
+    ProofsVerifier: ProofsVerifierTrait + Send + Sync,
     RuntimeServiceId: Sync + Send,
 {
     // An optional crypto processor to handle the old epoch during transition
@@ -997,7 +999,7 @@ where
     NodeId: Eq + Hash + Clone + Send,
     Rng: rand::Rng + Clone + Unpin,
     ProofsGenerator: CoreAndLeaderProofsGenerator<CorePoQGenerator>,
-    ProofsVerifier: ProofsVerifierTrait + Clone,
+    ProofsVerifier: ProofsVerifierTrait,
     Backend: BlendBackend<NodeId, BlakeRng, ProofsVerifier, RuntimeServiceId>,
 {
     match event {
@@ -1019,6 +1021,19 @@ where
             .expect("Reward epoch info must be created successfully. Panicking since the service cannot continue with this epoch");
             let (new_epoch_blending_token_collector, old_epoch_blending_token_collector) =
                 current_epoch_blending_token_collector.rotate_epoch(&new_reward_epoch_info);
+
+            let new_poq_verification_inputs = PoQVerificationInputsMinusSigningKey {
+                core: new_epoch_info.poq_core_public_inputs,
+                leader: new_epoch_info.poq_leadership_public_inputs,
+                pow: PowInputs::unwired_placeholder(),
+            };
+            backend
+                .rotate_epoch(BackendEpochInfo {
+                    membership: new_epoch_info.membership.clone(),
+                    epoch: new_epoch_info.epoch,
+                    proofs_verifier: ProofsVerifier::new(new_poq_verification_inputs),
+                })
+                .await;
 
             let new_scheduler_epoch_info = SchedulerEpochInfo {
                 core_quota: settings.epoch_core_quota(new_epoch_info.membership.size()),
@@ -1046,11 +1061,7 @@ where
                             .derive_x25519(),
                         num_blend_layers: settings.num_blend_layers,
                     },
-                    PoQVerificationInputsMinusSigningKey {
-                        core: new_epoch_info.poq_core_public_inputs,
-                        leader: new_epoch_info.poq_leadership_public_inputs,
-                        pow: PowInputs::unwired_placeholder(),
-                    },
+                    new_poq_verification_inputs,
                     core_poq_generator,
                     new_epoch_info.epoch,
                 ) {
@@ -1084,14 +1095,6 @@ where
                         };
                     }
                 };
-
-            backend
-                .rotate_epoch(BackendEpochInfo {
-                    membership: new_epoch_info.membership.clone(),
-                    epoch: new_epoch_info.epoch,
-                    proofs_verifier: new_processor.verifier().clone(),
-                })
-                .await;
 
             let (new_scheduler, old_scheduler) = current_scheduler
                 .rotate_epoch(new_scheduler_epoch_info, settings.scheduler_settings());

--- a/services/blend/src/core/mod.rs
+++ b/services/blend/src/core/mod.rs
@@ -1036,50 +1036,54 @@ where
                 };
             };
 
-            let new_processor = match CoreCryptographicProcessor::try_new_with_core_condition_check(
-                new_epoch_info.membership.clone(),
-                settings.minimum_network_size,
-                EpochCryptographicProcessorSettings {
-                    non_ephemeral_encryption_key: settings
-                        .non_ephemeral_signing_key
-                        .derive_x25519(),
-                    num_blend_layers: settings.num_blend_layers,
-                },
-                PoQVerificationInputsMinusSigningKey {
-                    core: new_epoch_info.poq_core_public_inputs,
-                    leader: new_epoch_info.poq_leadership_public_inputs,
-                    pow: PowInputs::unwired_placeholder(),
-                },
-                core_poq_generator,
-                new_epoch_info.epoch,
-            ) {
-                Ok(mut new_processor) => {
-                    if current_secret_info
-                        .as_ref()
-                        .is_some_and(|secret| secret.epoch == new_epoch_info.epoch)
-                    {
-                        // We consume the stream by `take()`ing only if the epochs match.
-                        let current_secret_info = current_secret_info
-                            .take()
-                            .expect("Secret PoL info presence checked above.");
-                        new_processor.set_epoch_private(
-                            current_secret_info.winning_pol_info_stream,
-                            new_epoch_info.epoch,
-                        );
+            let new_processor: CoreCryptographicProcessor<_, _, _, ProofsVerifier> =
+                match CoreCryptographicProcessor::try_new_with_core_condition_check(
+                    new_epoch_info.membership.clone(),
+                    settings.minimum_network_size,
+                    EpochCryptographicProcessorSettings {
+                        non_ephemeral_encryption_key: settings
+                            .non_ephemeral_signing_key
+                            .derive_x25519(),
+                        num_blend_layers: settings.num_blend_layers,
+                    },
+                    PoQVerificationInputsMinusSigningKey {
+                        core: new_epoch_info.poq_core_public_inputs,
+                        leader: new_epoch_info.poq_leadership_public_inputs,
+                        pow: PowInputs::unwired_placeholder(),
+                    },
+                    core_poq_generator,
+                    new_epoch_info.epoch,
+                ) {
+                    Ok(mut new_processor) => {
+                        if current_secret_info
+                            .as_ref()
+                            .is_some_and(|secret| secret.epoch == new_epoch_info.epoch)
+                        {
+                            // We consume the stream by `take()`ing only if the epochs match.
+                            let current_secret_info = current_secret_info
+                                .take()
+                                .expect("Secret PoL info presence checked above.");
+                            new_processor.set_epoch_private(
+                                current_secret_info.winning_pol_info_stream,
+                                new_epoch_info.epoch,
+                            );
+                        }
+                        new_processor
                     }
-                    new_processor
-                }
-                Err(e @ (Error::LocalIsNotCoreNode | Error::NetworkIsTooSmall(_))) => {
-                    tracing::info!(target: LOG_TARGET, "New membership does not satisfy the core node condition: {e:?}");
-                    return HandleEpochEventOutput::Retiring {
-                        old_crypto_processor: current_cryptographic_processor,
-                        old_scheduler: current_scheduler
-                            .rotate_epoch(new_scheduler_epoch_info, settings.scheduler_settings())
-                            .1,
-                        old_token_collector: old_epoch_blending_token_collector,
-                    };
-                }
-            };
+                    Err(e @ (Error::LocalIsNotCoreNode | Error::NetworkIsTooSmall(_))) => {
+                        tracing::info!(target: LOG_TARGET, "New membership does not satisfy the core node condition: {e:?}");
+                        return HandleEpochEventOutput::Retiring {
+                            old_crypto_processor: current_cryptographic_processor,
+                            old_scheduler: current_scheduler
+                                .rotate_epoch(
+                                    new_scheduler_epoch_info,
+                                    settings.scheduler_settings(),
+                                )
+                                .1,
+                            old_token_collector: old_epoch_blending_token_collector,
+                        };
+                    }
+                };
 
             backend
                 .rotate_epoch(BackendEpochInfo {

--- a/services/blend/src/core/mod.rs
+++ b/services/blend/src/core/mod.rs
@@ -18,12 +18,8 @@ use lb_blend::{
         Error as MessageError, PayloadType,
         crypto::proofs::PoQVerificationInputsMinusSigningKey,
         encap::{
-            ProofsVerifier as ProofsVerifierTrait,
-            encapsulated::EncapsulatedMessage,
-            validated::{
-                EncapsulatedMessageWithVerifiedPublicHeader,
-                EncapsulatedMessageWithVerifiedSignature,
-            },
+            ProofsVerifier as ProofsVerifierTrait, encapsulated::EncapsulatedMessage,
+            validated::EncapsulatedMessageWithVerifiedPublicHeader,
         },
         reward::{
             self, ActivityProof, BlendingToken, EpochBlendingTokenCollector,
@@ -78,6 +74,7 @@ use tracing::{debug, error, info};
 
 use crate::{
     core::{
+        backends::BackendEpochInfo,
         kms::{KmsPoQAdapter, PreloadKMSBackendCorePoQGenerator},
         processor::{
             CoreCryptographicProcessor, DecapsulatedMessageType, Error,
@@ -130,7 +127,7 @@ pub struct BlendService<
     StateStorage,
     RuntimeServiceId,
 > where
-    Backend: BlendBackend<NodeId, BlakeRng, RuntimeServiceId>,
+    Backend: BlendBackend<NodeId, BlakeRng, ProofsVerifier, RuntimeServiceId>,
     Network: NetworkAdapter<RuntimeServiceId>,
     StateStorage: RecoveryBackendTrait<
             RuntimeServiceId,
@@ -178,7 +175,7 @@ impl<
         RuntimeServiceId,
     >
 where
-    Backend: BlendBackend<NodeId, BlakeRng, RuntimeServiceId>,
+    Backend: BlendBackend<NodeId, BlakeRng, ProofsVerifier, RuntimeServiceId>,
     Network: NetworkAdapter<RuntimeServiceId>,
     StateStorage: RecoveryBackendTrait<
             RuntimeServiceId,
@@ -220,7 +217,7 @@ impl<
         RuntimeServiceId,
     >
 where
-    Backend: BlendBackend<NodeId, BlakeRng, RuntimeServiceId> + Send + Sync,
+    Backend: BlendBackend<NodeId, BlakeRng, ProofsVerifier, RuntimeServiceId> + Send + Sync,
     NodeId: membership::node_id::TryFrom + Clone + Debug + Send + Eq + Hash + Sync + 'static,
     Network: NetworkAdapter<RuntimeServiceId> + Send + Sync,
     ProofsGenerator:
@@ -503,10 +500,10 @@ async fn initialize<
 )
 where
     NodeId: Clone + Debug + Eq + Hash + Send + 'static,
-    Backend: BlendBackend<NodeId, BlakeRng, RuntimeServiceId> + Sync,
+    Backend: BlendBackend<NodeId, BlakeRng, ProofsVerifier, RuntimeServiceId> + Sync,
     NetAdapter: NetworkAdapter<RuntimeServiceId>,
     ProofsGenerator: CoreAndLeaderProofsGenerator<KmsAdapter::CorePoQGenerator>,
-    ProofsVerifier: ProofsVerifierTrait,
+    ProofsVerifier: ProofsVerifierTrait + Clone,
     // To avoid bubbling up generics everywhere in the configs (current Overwatch limitation), we
     // know the final key ID type is a `String`, so we constraint the trait impl here instead.
     KmsAdapter: KmsPoQAdapter<RuntimeServiceId, KeyId = String, CorePoQGenerator: Clone + Send + Sync>
@@ -682,10 +679,13 @@ where
     let backend = Backend::new(
         blend_config.clone(),
         overwatch_handle,
-        (
-            current_epoch_public_info.membership.clone(),
-            current_epoch_public_info.epoch,
-        ),
+        BackendEpochInfo {
+            membership: current_epoch_public_info.membership.clone(),
+            epoch: current_epoch_public_info.epoch,
+            // The backend verifies the `PoQ` of every message it receives before
+            // relaying it, so it needs its own verifier for the epoch.
+            proofs_verifier: crypto_processor.verifier().clone(),
+        },
         BlakeRng::from_entropy(),
     );
 
@@ -743,7 +743,7 @@ async fn run_event_loop<
 >(
     mut inbound_relay: impl Stream<Item = ServiceMessage<NodeId>> + Send + Unpin,
     blend_messages: &mut (
-             impl Stream<Item = (EncapsulatedMessageWithVerifiedSignature, Epoch)>
+             impl Stream<Item = (EncapsulatedMessageWithVerifiedPublicHeader, Epoch)>
              + Send
              + Unpin
              + 'static
@@ -780,11 +780,11 @@ async fn run_event_loop<
 where
     NodeId: Clone + Eq + Hash + Send + Sync + 'static,
     Rng: rand::Rng + Clone + Send + Unpin,
-    Backend: BlendBackend<NodeId, BlakeRng, RuntimeServiceId> + Sync + Send,
+    Backend: BlendBackend<NodeId, BlakeRng, ProofsVerifier, RuntimeServiceId> + Sync + Send,
     NetAdapter: NetworkAdapter<RuntimeServiceId> + Sync,
     ProofsGenerator: CoreAndLeaderProofsGenerator<CorePoQGenerator> + Send,
     CorePoQGenerator: Send + Sync,
-    ProofsVerifier: ProofsVerifierTrait + Send + Sync,
+    ProofsVerifier: ProofsVerifierTrait + Clone + Send + Sync,
     RuntimeServiceId: Sync + Send,
 {
     // An optional crypto processor to handle the old epoch during transition
@@ -896,7 +896,7 @@ async fn retire<
     CorePoQGenerator,
     RuntimeServiceId,
 >(
-    mut blend_messages: impl Stream<Item = EncapsulatedMessageWithVerifiedSignature>
+    mut blend_messages: impl Stream<Item = EncapsulatedMessageWithVerifiedPublicHeader>
     + Unpin
     + Send
     + 'static,
@@ -919,7 +919,7 @@ async fn retire<
 ) where
     NodeId: Clone + Eq + Hash + Send + Sync + 'static,
     Rng: rand::Rng + Clone + Send + Unpin,
-    Backend: BlendBackend<NodeId, BlakeRng, RuntimeServiceId> + Send + Sync,
+    Backend: BlendBackend<NodeId, BlakeRng, ProofsVerifier, RuntimeServiceId> + Send + Sync,
     NetAdapter: NetworkAdapter<RuntimeServiceId> + Send + Sync,
     ProofsGenerator: CoreAndLeaderProofsGenerator<CorePoQGenerator> + Send,
     CorePoQGenerator: Send + Sync,
@@ -997,8 +997,8 @@ where
     NodeId: Eq + Hash + Clone + Send,
     Rng: rand::Rng + Clone + Unpin,
     ProofsGenerator: CoreAndLeaderProofsGenerator<CorePoQGenerator>,
-    ProofsVerifier: ProofsVerifierTrait,
-    Backend: BlendBackend<NodeId, BlakeRng, RuntimeServiceId>,
+    ProofsVerifier: ProofsVerifierTrait + Clone,
+    Backend: BlendBackend<NodeId, BlakeRng, ProofsVerifier, RuntimeServiceId>,
 {
     match event {
         EpochEvent::NewEpoch(MaybeEmptyCoreEpochInfo::NonEmpty(core_epoch_info)) => {
@@ -1019,10 +1019,6 @@ where
             .expect("Reward epoch info must be created successfully. Panicking since the service cannot continue with this epoch");
             let (new_epoch_blending_token_collector, old_epoch_blending_token_collector) =
                 current_epoch_blending_token_collector.rotate_epoch(&new_reward_epoch_info);
-
-            backend
-                .rotate_epoch((new_epoch_info.membership.clone(), new_epoch_info.epoch))
-                .await;
 
             let new_scheduler_epoch_info = SchedulerEpochInfo {
                 core_quota: settings.epoch_core_quota(new_epoch_info.membership.size()),
@@ -1085,6 +1081,14 @@ where
                 }
             };
 
+            backend
+                .rotate_epoch(BackendEpochInfo {
+                    membership: new_epoch_info.membership.clone(),
+                    epoch: new_epoch_info.epoch,
+                    proofs_verifier: new_processor.verifier().clone(),
+                })
+                .await;
+
             let (new_scheduler, old_scheduler) = current_scheduler
                 .rotate_epoch(new_scheduler_epoch_info, settings.scheduler_settings());
             HandleEpochEventOutput::Transitioning {
@@ -1140,12 +1144,12 @@ where
 }
 
 /// Handles [`EpochEvent::TransitionPeriodExpired`].
-async fn handle_epoch_transition_expired<Backend, NodeId, Rng, RuntimeServiceId>(
+async fn handle_epoch_transition_expired<Backend, NodeId, Rng, ProofsVerifier, RuntimeServiceId>(
     backend: &mut Backend,
     blending_token_collector: OldEpochBlendingTokenCollector,
     sdp_relay: &OutboundRelay<SdpMessage>,
 ) where
-    Backend: BlendBackend<NodeId, Rng, RuntimeServiceId>,
+    Backend: BlendBackend<NodeId, Rng, ProofsVerifier, RuntimeServiceId>,
     NodeId: Eq + Hash + Clone + Send,
 {
     compute_and_submit_activity_proof(blending_token_collector, sdp_relay).await;
@@ -1328,11 +1332,12 @@ where
     state_updater.commit_changes()
 }
 
-/// Processes an incoming Blend message (with verified signature) received
-/// from a core or edge peer.
+/// Processes an incoming Blend message received from a core or edge peer.
 ///
-/// Decapsulation is attempted with the current or old epoch's cryptographic
-/// processor depending on the epoch the message is coming from.
+/// The backend has already verified the message's whole public header — `PoQ`
+/// included, which is what gated it from being relayed to the rest of the
+/// network — so all that is left here is to decapsulate it with the current or
+/// old epoch's cryptographic processor, depending on the epoch it comes from.
 fn handle_incoming_blend_message<
     NodeId,
     Rng,
@@ -1342,7 +1347,7 @@ fn handle_incoming_blend_message<
     ProofsVerifier,
     CorePoQGenerator,
 >(
-    (validated_encapsulated_message, epoch): (EncapsulatedMessageWithVerifiedSignature, Epoch),
+    (verified_message, epoch): (EncapsulatedMessageWithVerifiedPublicHeader, Epoch),
     scheduler: &mut EpochMessageScheduler<
         Rng,
         ProcessedMessage,
@@ -1367,11 +1372,7 @@ where
     ProofsVerifier: ProofsVerifierTrait,
 {
     if epoch == cryptographic_processor.epoch() {
-        let Some(output) = try_validate_and_decapsulate(
-            validated_encapsulated_message,
-            cryptographic_processor,
-            epoch,
-        ) else {
+        let Some(output) = try_decapsulate(verified_message, cryptographic_processor, epoch) else {
             return current_recovery_checkpoint;
         };
         handle_decapsulated_incoming_message_from_current_epoch(
@@ -1383,11 +1384,8 @@ where
     } else if let Some(old_cryptographic_processor) = old_epoch_cryptographic_processor
         && epoch == old_cryptographic_processor.epoch()
     {
-        let Some(output) = try_validate_and_decapsulate(
-            validated_encapsulated_message,
-            old_cryptographic_processor,
-            epoch,
-        ) else {
+        let Some(output) = try_decapsulate(verified_message, old_cryptographic_processor, epoch)
+        else {
             return current_recovery_checkpoint;
         };
         handle_decapsulated_incoming_message_from_old_epoch(
@@ -1403,11 +1401,10 @@ where
     }
 }
 
-/// Validates the `PoQ` of a received message and attempts recursive
-/// decapsulation. Returns `None` if validation or decapsulation fails (already
-/// logged).
-fn try_validate_and_decapsulate<NodeId, CorePoQGenerator, ProofsGenerator, ProofsVerifier>(
-    message: EncapsulatedMessageWithVerifiedSignature,
+/// Attempts recursive decapsulation of a message whose `PoQ` has already been
+/// verified. Returns `None` if decapsulation fails (already logged).
+fn try_decapsulate<NodeId, CorePoQGenerator, ProofsGenerator, ProofsVerifier>(
+    message: EncapsulatedMessageWithVerifiedPublicHeader,
     processor: &CoreCryptographicProcessor<
         NodeId,
         CorePoQGenerator,
@@ -1419,11 +1416,7 @@ fn try_validate_and_decapsulate<NodeId, CorePoQGenerator, ProofsGenerator, Proof
 where
     ProofsVerifier: ProofsVerifierTrait,
 {
-    let Ok(validated_message) = processor.validate_message_poq(message) else {
-        tracing::debug!(target: LOG_TARGET, "Received message for epoch {epoch} failed PoQ validation. Ignoring...");
-        return None;
-    };
-    match processor.decapsulate_message_recursive(validated_message) {
+    match processor.decapsulate_message_recursive(message) {
         Ok(output) => Some(output),
         Err(e) => {
             if matches!(e, MessageError::PrivateHeaderDeserializationFailed) {
@@ -1445,7 +1438,7 @@ fn handle_incoming_blend_message_from_old_epoch<
     ProofsVerifier,
     CorePoQGenerator,
 >(
-    validated_encapsulated_message: EncapsulatedMessageWithVerifiedSignature,
+    verified_message: EncapsulatedMessageWithVerifiedPublicHeader,
     scheduler: &mut OldEpochMessageScheduler<Rng, ProcessedMessage>,
     cryptographic_processor: &CoreCryptographicProcessor<
         NodeId,
@@ -1458,25 +1451,17 @@ fn handle_incoming_blend_message_from_old_epoch<
     NodeId: 'static,
     ProofsVerifier: ProofsVerifierTrait,
 {
-    match cryptographic_processor
-        .validate_message_poq(validated_encapsulated_message)
-        .and_then(|message_with_verified_header| {
-            cryptographic_processor.decapsulate_message_recursive(message_with_verified_header)
-        }) {
-        Ok(output) => {
-            let (_, blending_tokens) =
-                schedule_decapsulated_incoming_message(output, scheduler, cryptographic_processor);
-            for blending_token in blending_tokens {
-                blending_token_collector.collect(blending_token);
-            }
-        }
-        Err(e) => {
-            if matches!(e, MessageError::PrivateHeaderDeserializationFailed) {
-                tracing::trace!(target: LOG_TARGET, "Failed to decapsulate received message from old epoch due to deserialization error. This can happen when the message was intended for another node or when the message is malformed. Ignoring...");
-            } else {
-                tracing::debug!(target: LOG_TARGET, "Failed to decapsulate received message from old epoch: {e:?}");
-            }
-        }
+    let Some(output) = try_decapsulate(
+        verified_message,
+        cryptographic_processor,
+        cryptographic_processor.epoch(),
+    ) else {
+        return;
+    };
+    let (_, blending_tokens) =
+        schedule_decapsulated_incoming_message(output, scheduler, cryptographic_processor);
+    for blending_token in blending_tokens {
+        blending_token_collector.collect(blending_token);
     }
 }
 
@@ -1688,7 +1673,7 @@ async fn handle_release_round<
 where
     NodeId: Eq + Hash + 'static,
     Rng: RngCore + Send,
-    Backend: BlendBackend<NodeId, BlakeRng, RuntimeServiceId> + Sync,
+    Backend: BlendBackend<NodeId, BlakeRng, ProofsVerifier, RuntimeServiceId> + Sync,
     ProofsGenerator: CoreAndLeaderProofsGenerator<CorePoQGenerator>,
     ProofsVerifier: ProofsVerifierTrait,
     NetAdapter: NetworkAdapter<RuntimeServiceId> + Sync,
@@ -1760,7 +1745,14 @@ where
     state_updater.commit_changes()
 }
 
-async fn handle_release_round_for_old_epoch<NodeId, Rng, Backend, NetAdapter, RuntimeServiceId>(
+async fn handle_release_round_for_old_epoch<
+    NodeId,
+    Rng,
+    Backend,
+    NetAdapter,
+    ProofsVerifier,
+    RuntimeServiceId,
+>(
     processed_messages_to_release: Vec<ProcessedMessage>,
     rng: &mut Rng,
     backend: &Backend,
@@ -1769,7 +1761,7 @@ async fn handle_release_round_for_old_epoch<NodeId, Rng, Backend, NetAdapter, Ru
 ) where
     NodeId: Eq + Hash + 'static,
     Rng: RngCore + Send,
-    Backend: BlendBackend<NodeId, BlakeRng, RuntimeServiceId> + Sync,
+    Backend: BlendBackend<NodeId, BlakeRng, ProofsVerifier, RuntimeServiceId> + Sync,
     NetAdapter: NetworkAdapter<RuntimeServiceId> + Sync,
 {
     let mut futures = build_futures_to_release_processed_messages(
@@ -1820,6 +1812,7 @@ fn build_futures_to_release_processed_messages<
     NodeId,
     Backend,
     NetAdapter,
+    ProofsVerifier,
     RuntimeServiceId,
 >(
     processed_messages_to_release: Vec<ProcessedMessage>,
@@ -1830,7 +1823,7 @@ fn build_futures_to_release_processed_messages<
 ) -> Vec<BoxFuture<'fut, ()>>
 where
     NodeId: Eq + Hash + 'static,
-    Backend: BlendBackend<NodeId, BlakeRng, RuntimeServiceId> + Sync,
+    Backend: BlendBackend<NodeId, BlakeRng, ProofsVerifier, RuntimeServiceId> + Sync,
     NetAdapter: NetworkAdapter<RuntimeServiceId> + Sync,
 {
     processed_messages_to_release

--- a/services/blend/src/core/processor.rs
+++ b/services/blend/src/core/processor.rs
@@ -12,10 +12,7 @@ use lb_blend::{
             ProofsVerifier as ProofsVerifierTrait,
             decapsulated::{DecapsulatedMessage, DecapsulationOutput},
             encapsulated::EncapsulatedMessage,
-            validated::{
-                EncapsulatedMessageWithVerifiedPublicHeader,
-                EncapsulatedMessageWithVerifiedSignature,
-            },
+            validated::EncapsulatedMessageWithVerifiedPublicHeader,
         },
         reward::BlendingToken,
     },
@@ -145,14 +142,6 @@ where
         message: EncapsulatedMessage,
     ) -> Result<EncapsulatedMessageWithVerifiedPublicHeader, InnerError> {
         message.verify_public_header(self.verifier())
-    }
-
-    /// Validate the `PoQ` of an [`EncapsulatedMessageWithVerifiedSignature`].
-    pub fn validate_message_poq(
-        &self,
-        message: EncapsulatedMessageWithVerifiedSignature,
-    ) -> Result<EncapsulatedMessageWithVerifiedPublicHeader, InnerError> {
-        message.verify_proof_of_quota(self.verifier())
     }
 
     /// Semantically similar to the underlying

--- a/services/blend/src/core/service_components.rs
+++ b/services/blend/src/core/service_components.rs
@@ -44,7 +44,7 @@ impl<
         RuntimeServiceId,
     >
 where
-    Backend: BlendBackend<NodeId, BlakeRng, RuntimeServiceId>,
+    Backend: BlendBackend<NodeId, BlakeRng, ProofsVerifier, RuntimeServiceId>,
     Network: NetworkAdapter<RuntimeServiceId>,
     StateStorage: lb_services_utils::overwatch::recovery::RecoveryBackend<
             RuntimeServiceId,

--- a/services/blend/src/core/tests/mod.rs
+++ b/services/blend/src/core/tests/mod.rs
@@ -1,6 +1,6 @@
 mod utils;
 
-use futures::stream::repeat;
+use futures::{StreamExt as _, stream::repeat};
 use lb_blend::{
     message::reward::{ActivityProof, BlendingToken, EpochBlendingTokenCollector},
     proofs::{quota::VerifiedProofOfQuota, selection::VerifiedProofOfSelection},
@@ -1124,7 +1124,7 @@ async fn complete_old_epoch_after_main_loop_done() {
         .await;
 
         retire(
-            blend_message_stream,
+            blend_message_stream.map(|(msg, _)| msg),
             remaining_epoch_stream,
             backend,
             TestNetworkAdapter,
@@ -1271,7 +1271,7 @@ async fn stop_on_empty_epoch() {
         .await;
 
         retire(
-            blend_message_stream,
+            blend_message_stream.map(|(msg, _)| msg),
             remaining_epoch_stream,
             backend,
             TestNetworkAdapter,
@@ -1407,7 +1407,7 @@ async fn stop_on_non_empty_epoch_without_local_core_path() {
         .await;
 
         retire(
-            blend_message_stream,
+            blend_message_stream.map(|(msg, _)| msg),
             remaining_epoch_stream,
             backend,
             TestNetworkAdapter,

--- a/services/blend/src/core/tests/mod.rs
+++ b/services/blend/src/core/tests/mod.rs
@@ -1,6 +1,6 @@
 mod utils;
 
-use futures::{StreamExt as _, stream::repeat};
+use futures::stream::repeat;
 use lb_blend::{
     message::reward::{ActivityProof, BlendingToken, EpochBlendingTokenCollector},
     proofs::{quota::VerifiedProofOfQuota, selection::VerifiedProofOfSelection},
@@ -26,11 +26,11 @@ use crate::{
         state::ServiceState,
         tests::utils::{
             MockKmsAdapter, MockProofsVerifier, NodeId, TestBlendBackend, TestBlendBackendEvent,
-            TestNetworkAdapter, dummy_overwatch_resources, dummy_pol_private_inputs,
-            new_crypto_processor, new_epoch_info, new_membership, new_stream,
-            recorded_set_epoch_private_calls, reset_set_epoch_private_calls, reward_epoch_info,
-            scheduler_epoch_info, scheduler_settings, sdp_relay, settings, timing_settings,
-            wait_for_blend_backend_event,
+            TestNetworkAdapter, backend_epoch_info, dummy_overwatch_resources,
+            dummy_pol_private_inputs, new_crypto_processor, new_epoch_info, new_membership,
+            new_stream, recorded_set_epoch_private_calls, reset_set_epoch_private_calls,
+            reward_epoch_info, scheduler_epoch_info, scheduler_settings, sdp_relay, settings,
+            timing_settings, wait_for_blend_backend_event,
         },
     },
     epoch::{CoreEpochInfo, CoreEpochPublicInfo},
@@ -103,7 +103,7 @@ async fn test_handle_incoming_blend_message() {
     )
     .unwrap();
     let recovery_checkpoint = handle_incoming_blend_message(
-        (msg.clone().into(), 0.into()),
+        (msg.clone(), 0.into()),
         &mut scheduler,
         None,
         &processor,
@@ -149,7 +149,7 @@ async fn test_handle_incoming_blend_message() {
     )
     .unwrap();
     let recovery_checkpoint = handle_incoming_blend_message(
-        (msg.clone().into(), 0.into()),
+        (msg.clone(), 0.into()),
         &mut new_scheduler,
         Some(&mut scheduler),
         &new_processor,
@@ -187,7 +187,7 @@ async fn test_handle_incoming_blend_message() {
         .await
         .expect("encapsulation must succeed");
     let recovery_checkpoint = handle_incoming_blend_message(
-        (msg.into(), 1.into()),
+        (msg, 1.into()),
         &mut new_scheduler,
         Some(&mut scheduler),
         &new_processor,
@@ -233,7 +233,7 @@ async fn test_handle_incoming_blend_message() {
         .await
         .expect("encapsulation must succeed");
     let recovery_checkpoint = handle_incoming_blend_message(
-        (msg.into(), 2.into()),
+        (msg, 2.into()),
         &mut new_scheduler,
         Some(&mut scheduler),
         &new_processor,
@@ -348,7 +348,7 @@ async fn test_duplicate_decapsulated_replica_handled_gracefully() {
 
     // First replica: decapsulated and recorded as an unsent processed message.
     let recovery_checkpoint = handle_incoming_blend_message(
-        (replica_a.into(), epoch),
+        (replica_a, epoch),
         &mut scheduler,
         None,
         &processor,
@@ -365,7 +365,7 @@ async fn test_duplicate_decapsulated_replica_handled_gracefully() {
     // The insert into `unsent_processed_messages` returns `Err`, but it is now
     // treated as a known duplicate instead of panicking the task.
     let recovery_checkpoint = handle_incoming_blend_message(
-        (replica_b.into(), epoch),
+        (replica_b, epoch),
         &mut scheduler,
         None,
         &processor,
@@ -442,7 +442,7 @@ async fn test_handle_incoming_blend_message_with_invalid_poq() {
     // Signature is valid (built correctly) but PoQ will fail because the
     // MockProofsVerifier for epoch 1 expects epoch 1 proofs.
     drop(handle_incoming_blend_message(
-        (msg.into(), epoch_1),
+        (msg, epoch_1),
         &mut scheduler,
         None,
         &processor_1,
@@ -478,10 +478,10 @@ async fn test_handle_epoch_transition_expired() {
 
     // Create backend.
     let public_info = new_epoch_info(epoch, membership.clone(), &settings);
-    let mut backend = <TestBlendBackend as BlendBackend<_, _, _>>::new(
+    let mut backend = <TestBlendBackend as BlendBackend<_, _, _, _>>::new(
         settings.clone(),
         overwatch_handle.clone(),
-        (public_info.membership.clone(), public_info.epoch),
+        backend_epoch_info(&public_info),
         BlakeRng::from_entropy(),
     );
     let mut backend_event_receiver = backend.subscribe_to_events();
@@ -505,7 +505,7 @@ async fn test_handle_epoch_transition_expired() {
     let (sdp_relay, mut sdp_relay_receiver) = sdp_relay();
 
     // Call `handle_epoch_transition_expired`.
-    handle_epoch_transition_expired::<_, NodeId, BlakeRng, _>(
+    handle_epoch_transition_expired::<_, NodeId, BlakeRng, MockProofsVerifier, _>(
         &mut backend,
         token_collector,
         &sdp_relay,
@@ -562,10 +562,10 @@ async fn test_handle_epoch_event() {
         scheduler_settings(&settings.time, settings.num_blend_layers),
     );
     let token_collector = EpochBlendingTokenCollector::new(&reward_epoch_info(&public_info));
-    let mut backend = <TestBlendBackend as BlendBackend<_, _, _>>::new(
+    let mut backend = <TestBlendBackend as BlendBackend<_, _, _, _>>::new(
         settings.clone(),
         overwatch_handle.clone(),
-        (public_info.membership.clone(), public_info.epoch),
+        backend_epoch_info(&public_info),
         BlakeRng::from_entropy(),
     );
     let mut backend_event_receiver = backend.subscribe_to_events();
@@ -728,10 +728,10 @@ async fn test_handle_epoch_event_membership_change_rewires_backend_and_generator
         scheduler_settings(&settings.time, settings.num_blend_layers),
     );
     let token_collector = EpochBlendingTokenCollector::new(&reward_epoch_info(&public_info));
-    let mut backend = <TestBlendBackend as BlendBackend<_, _, _>>::new(
+    let mut backend = <TestBlendBackend as BlendBackend<_, _, _, _>>::new(
         settings.clone(),
         overwatch_handle.clone(),
-        (public_info.membership.clone(), public_info.epoch),
+        backend_epoch_info(&public_info),
         BlakeRng::from_entropy(),
     );
     let mut backend_event_receiver = backend.subscribe_to_events();
@@ -823,10 +823,10 @@ async fn transition_to_new_epoch_with_secret(secret_epoch: Epoch) -> Vec<Epoch> 
         scheduler_settings(&settings.time, settings.num_blend_layers),
     );
     let token_collector = EpochBlendingTokenCollector::new(&reward_epoch_info(&public_info));
-    let mut backend = <TestBlendBackend as BlendBackend<_, _, _>>::new(
+    let mut backend = <TestBlendBackend as BlendBackend<_, _, _, _>>::new(
         settings.clone(),
         overwatch_handle.clone(),
-        (public_info.membership.clone(), public_info.epoch),
+        backend_epoch_info(&public_info),
         BlakeRng::from_entropy(),
     );
     let (sdp_relay, _sdp_relay_receiver) = sdp_relay();
@@ -917,10 +917,10 @@ async fn test_handle_epoch_event_empty_epoch_retires() {
         scheduler_settings(&settings.time, settings.num_blend_layers),
     );
     let token_collector = EpochBlendingTokenCollector::new(&reward_epoch_info(&public_info));
-    let mut backend = <TestBlendBackend as BlendBackend<_, _, _>>::new(
+    let mut backend = <TestBlendBackend as BlendBackend<_, _, _, _>>::new(
         settings.clone(),
         overwatch_handle.clone(),
-        (public_info.membership.clone(), public_info.epoch),
+        backend_epoch_info(&public_info),
         BlakeRng::from_entropy(),
     );
     let (sdp_relay, _sdp_relay_receiver) = sdp_relay();
@@ -983,10 +983,10 @@ async fn test_handle_epoch_event_non_empty_without_local_core_path_retires() {
         scheduler_settings(&settings.time, settings.num_blend_layers),
     );
     let token_collector = EpochBlendingTokenCollector::new(&reward_epoch_info(&public_info));
-    let mut backend = <TestBlendBackend as BlendBackend<_, _, _>>::new(
+    let mut backend = <TestBlendBackend as BlendBackend<_, _, _, _>>::new(
         settings.clone(),
         overwatch_handle.clone(),
-        (public_info.membership.clone(), public_info.epoch),
+        backend_epoch_info(&public_info),
         BlakeRng::from_entropy(),
     );
     let (sdp_relay, _sdp_relay_receiver) = sdp_relay();
@@ -1124,7 +1124,7 @@ async fn complete_old_epoch_after_main_loop_done() {
         .await;
 
         retire(
-            blend_message_stream.map(|(msg, _)| msg),
+            blend_message_stream,
             remaining_epoch_stream,
             backend,
             TestNetworkAdapter,
@@ -1271,7 +1271,7 @@ async fn stop_on_empty_epoch() {
         .await;
 
         retire(
-            blend_message_stream.map(|(msg, _)| msg),
+            blend_message_stream,
             remaining_epoch_stream,
             backend,
             TestNetworkAdapter,
@@ -1407,7 +1407,7 @@ async fn stop_on_non_empty_epoch_without_local_core_path() {
         .await;
 
         retire(
-            blend_message_stream.map(|(msg, _)| msg),
+            blend_message_stream,
             remaining_epoch_stream,
             backend,
             TestNetworkAdapter,
@@ -1514,7 +1514,7 @@ async fn test_proof_generator_epoch_binding() {
     )
     .unwrap();
     drop(handle_incoming_blend_message(
-        (msg_0.clone().into(), epoch_0),
+        (msg_0.clone(), epoch_0),
         &mut scheduler_0,
         None,
         &generator_0,
@@ -1544,7 +1544,7 @@ async fn test_proof_generator_epoch_binding() {
     )
     .unwrap();
     drop(handle_incoming_blend_message(
-        (msg_1.clone().into(), epoch_0),
+        (msg_1.clone(), epoch_0),
         &mut scheduler_0_only,
         None,
         &generator_0,
@@ -1576,7 +1576,7 @@ async fn test_proof_generator_epoch_binding() {
     )
     .unwrap();
     drop(handle_incoming_blend_message(
-        (msg_1.into(), epoch_1),
+        (msg_1, epoch_1),
         &mut scheduler_1,
         None,
         &generator_1,

--- a/services/blend/src/core/tests/utils.rs
+++ b/services/blend/src/core/tests/utils.rs
@@ -6,13 +6,7 @@ use futures::Stream;
 use lb_blend::{
     message::{
         crypto::{key_ext::Ed25519SecretKeyExt as _, proofs::PoQVerificationInputsMinusSigningKey},
-        encap::{
-            ProofsVerifier,
-            validated::{
-                EncapsulatedMessageWithVerifiedPublicHeader,
-                EncapsulatedMessageWithVerifiedSignature,
-            },
-        },
+        encap::{ProofsVerifier, validated::EncapsulatedMessageWithVerifiedPublicHeader},
         reward,
     },
     proofs::{
@@ -150,16 +144,18 @@ pub struct TestBlendBackend {
 }
 
 #[async_trait]
-impl<NodeId, Rng> BlendBackend<NodeId, Rng, RuntimeServiceId> for TestBlendBackend
+impl<NodeId, Rng, ProofsVerifier> BlendBackend<NodeId, Rng, ProofsVerifier, RuntimeServiceId>
+    for TestBlendBackend
 where
     NodeId: Send + 'static,
+    ProofsVerifier: Send + 'static,
 {
     type Settings = ();
 
     fn new(
         _service_config: BlendConfig<Self::Settings>,
         _overwatch_handle: OverwatchHandle<RuntimeServiceId>,
-        _current_epoch_info: BackendEpochInfo<NodeId>,
+        _current_epoch_info: BackendEpochInfo<NodeId, ProofsVerifier>,
         _rng: Rng,
     ) -> Self {
         let (event_sender, _) = broadcast::channel(CHANNEL_SIZE);
@@ -173,11 +169,14 @@ where
         _intended_epoch: Epoch,
     ) {
     }
-    async fn rotate_epoch(&mut self, new_epoch_info: BackendEpochInfo<NodeId>) {
+
+    async fn rotate_epoch(&mut self, new_epoch_info: BackendEpochInfo<NodeId, ProofsVerifier>) {
         // Notify tests that the backend rotated to a new epoch, carrying the new
         // epoch and membership size so tests can assert the new membership was
         // propagated to the backend.
-        let (membership, epoch) = new_epoch_info;
+        let BackendEpochInfo {
+            membership, epoch, ..
+        } = new_epoch_info;
         // Ignore send errors: not all tests subscribe to backend events, and
         // `rotate_epoch` is also called right before a retirement (no subscriber).
         let _ = self.event_sender.send(TestBlendBackendEvent::EpochRotated {
@@ -195,7 +194,8 @@ where
 
     fn listen_to_incoming_messages(
         &mut self,
-    ) -> Pin<Box<dyn Stream<Item = (EncapsulatedMessageWithVerifiedSignature, Epoch)> + Send>> {
+    ) -> Pin<Box<dyn Stream<Item = (EncapsulatedMessageWithVerifiedPublicHeader, Epoch)> + Send>>
+    {
         unimplemented!()
     }
 
@@ -336,6 +336,22 @@ pub fn new_crypto_processor<CorePoQGenerator>(
         epoch_info.epoch,
     )
     .expect("crypto processor must be created successfully")
+}
+
+/// The [`BackendEpochInfo`] the service hands to the backend for an epoch,
+/// including the `PoQ` verifier the backend uses to check received messages.
+pub fn backend_epoch_info(
+    public_info: &CoreEpochPublicInfo<NodeId>,
+) -> BackendEpochInfo<NodeId, MockProofsVerifier> {
+    BackendEpochInfo {
+        membership: public_info.membership.clone(),
+        epoch: public_info.epoch,
+        proofs_verifier: MockProofsVerifier::new(PoQVerificationInputsMinusSigningKey {
+            core: public_info.poq_core_public_inputs,
+            leader: public_info.poq_leadership_public_inputs,
+            pow: PowInputs::unwired_placeholder(),
+        }),
+    }
 }
 
 pub fn new_epoch_info<BackendSettings>(

--- a/services/blend/src/edge/backends/libp2p/tests/message_handling.rs
+++ b/services/blend/src/edge/backends/libp2p/tests/message_handling.rs
@@ -70,9 +70,9 @@ async fn edge_message_propagation() {
     let (swarm_2_received_message, swarm_2_message_epoch) =
         core_swarm_2_incoming_message_receiver.recv().await.unwrap();
 
-    assert_eq!(swarm_1_received_message, message.clone().into());
+    assert_eq!(swarm_1_received_message, message.clone());
     assert_eq!(swarm_1_message_epoch, 1);
-    assert_eq!(swarm_2_received_message, message.clone().into());
+    assert_eq!(swarm_2_received_message, message.clone());
     assert_eq!(swarm_2_message_epoch, 1);
 }
 
@@ -137,19 +137,19 @@ async fn replication_factor() {
                 break;
             }
             swarm_1_received_message = core_swarm_1_incoming_message_receiver.recv() => {
-                assert_eq!(swarm_1_received_message.unwrap().0, message.clone().into());
+                assert_eq!(swarm_1_received_message.unwrap().0, message.clone());
                 assert!(!swarm_1_message_received);
                 received_messages += 1;
                 swarm_1_message_received = true;
             }
             swarm_2_received_message = core_swarm_2_incoming_message_receiver.recv() => {
-                assert_eq!(swarm_2_received_message.unwrap().0, message.clone().into());
+                assert_eq!(swarm_2_received_message.unwrap().0, message.clone());
                 assert!(!swarm_2_message_received);
                 received_messages += 1;
                 swarm_2_message_received = true;
             }
             swarm_3_received_message = core_swarm_3_incoming_message_receiver.recv() => {
-                assert_eq!(swarm_3_received_message.unwrap().0, message.clone().into());
+                assert_eq!(swarm_3_received_message.unwrap().0, message.clone());
                 assert!(!swarm_3_message_received);
                 received_messages += 1;
                 swarm_3_message_received = true;

--- a/services/blend/src/metrics.rs
+++ b/services/blend/src/metrics.rs
@@ -70,6 +70,17 @@ mod imp {
     pub fn inbound_messages_dropped(count: u64) {
         lb_tracing::increase_counter_u64!(blend_inbound_messages_dropped_total, count);
     }
+
+    /// Reports incoming messages that were dropped because their `PoQ` could
+    /// not be verified, and that were therefore neither relayed to the rest of
+    /// the network nor processed locally.
+    pub fn inbound_message_poq_verification_err(message_type: InboundMessageType) {
+        lb_tracing::increase_counter_u64!(
+            blend_inbound_messages_poq_verification_failed_total,
+            1,
+            message_type = message_type.to_str()
+        );
+    }
 }
 
 pub use imp::*;

--- a/services/blend/src/metrics.rs
+++ b/services/blend/src/metrics.rs
@@ -71,15 +71,10 @@ mod imp {
         lb_tracing::increase_counter_u64!(blend_inbound_messages_dropped_total, count);
     }
 
-    /// Reports incoming messages that were dropped because their `PoQ` could
-    /// not be verified, and that were therefore neither relayed to the rest of
-    /// the network nor processed locally.
-    pub fn inbound_message_poq_verification_err(message_type: InboundMessageType) {
-        lb_tracing::increase_counter_u64!(
-            blend_inbound_messages_poq_verification_failed_total,
-            1,
-            message_type = message_type.to_str()
-        );
+    /// Reports core peers blocked for spamming, labelled with what they were
+    /// caught doing — an invalid `PoQ` among the reasons.
+    pub fn core_peer_blocked(reason: &'static str) {
+        lb_tracing::increase_counter_u64!(blend_core_peers_blocked_total, 1, reason = reason);
     }
 }
 

--- a/services/blend/src/test_utils/libp2p.rs
+++ b/services/blend/src/test_utils/libp2p.rs
@@ -39,10 +39,6 @@ impl TestEncapsulatedMessage {
             .unwrap(),
         )
     }
-
-    pub fn into_inner(self) -> EncapsulatedMessageWithVerifiedPublicHeader {
-        self.0
-    }
 }
 
 impl Deref for TestEncapsulatedMessage {


### PR DESCRIPTION
## 1. What does this PR implement?

The new [empowering spec](https://app.notion.com/p/nomos-tech/EmPoWering-the-Logos-Blockchain-Proposal-37a261aa09df8071b28efabcbfc9dca6) requires Blend core nodes to validate PoQ before relaying messages to the rest of the network.

Since the Blend backend is already aware of epoch transitions, it was a relatively small change to add one more component, a verifier, to the set of values to be provided to the backend on new epochs.

This PR introduces one optimization not present in the old version: we do not verify PoQs directly on the swarm task, but we spawn proof verification on a blocking queue, returning to the service above only messages that pass the validation, and banning the peer that sends invalid PoQs.

## 2. Does the code have enough context to be clearly understood?

Yes.

## 3. Who are the specification authors and who is accountable for this PR?

@madxor spec, @ntn-x2 impl

## 4. Is the specification accurate and complete?

It's being updated as we move on with implementation.

## 5. Does the implementation introduce changes in the specification?

See above.