### PR TITLE
feat: add HTTP API for running node version

### DIFF
--- a/deployment/nginx/static/run/index.html.template
+++ b/deployment/nginx/static/run/index.html.template
@@ -23,6 +23,8 @@
                 <a href="https://$ENV_TITLE_STRING.blockchain.logos.co/node/0/network/info" target="_blank">Network Info</a>
                 <span class="divider">|</span>
                 <a href="https://$ENV_TITLE_STRING.blockchain.logos.co/node/0/blend/info" target="_blank">Blend Info</a>
+                <span class="divider">|</span>
+                <a href="https://$ENV_TITLE_STRING.blockchain.logos.co/node/0/version" target="_blank">Node Version</a>
             </div>
         </li>
 
@@ -34,6 +36,8 @@
                 <a href="https://$ENV_TITLE_STRING.blockchain.logos.co/node/1/network/info" target="_blank">Network Info</a>
                 <span class="divider">|</span>
                 <a href="https://$ENV_TITLE_STRING.blockchain.logos.co/node/1/blend/info" target="_blank">Blend Info</a>
+                <span class="divider">|</span>
+                <a href="https://$ENV_TITLE_STRING.blockchain.logos.co/node/1/version" target="_blank">Node Version</a>
             </div>
         </li>
 
@@ -45,6 +49,8 @@
                 <a href="https://$ENV_TITLE_STRING.blockchain.logos.co/node/2/network/info" target="_blank">Network Info</a>
                 <span class="divider">|</span>
                 <a href="https://$ENV_TITLE_STRING.blockchain.logos.co/node/2/blend/info" target="_blank">Blend Info</a>
+                <span class="divider">|</span>
+                <a href="https://$ENV_TITLE_STRING.blockchain.logos.co/node/2/version" target="_blank">Node Version</a>
             </div>
         </li>
 
@@ -56,6 +62,8 @@
                 <a href="https://$ENV_TITLE_STRING.blockchain.logos.co/node/3/network/info" target="_blank">Network Info</a>
                 <span class="divider">|</span>
                 <a href="https://$ENV_TITLE_STRING.blockchain.logos.co/node/3/blend/info" target="_blank">Blend Info</a>
+                <span class="divider">|</span>
+                <a href="https://$ENV_TITLE_STRING.blockchain.logos.co/node/3/version" target="_blank">Node Version</a>
             </div>
         </li>
     </ul>

--- a/nodes/api-common/src/paths.rs
+++ b/nodes/api-common/src/paths.rs
@@ -17,6 +17,7 @@ pub const SDP_POST_DECLARATION: &str = "/sdp/declaration";
 pub const SDP_POST_ACTIVITY: &str = "/sdp/activity";
 pub const SDP_POST_WITHDRAWAL: &str = "/sdp/withdrawal";
 pub const SDP_POST_SET_DECLARATION_ID: &str = "/sdp/set-declaration-id";
+pub const NODE_VERSION: &str = "/version";
 pub const LEADER_CLAIM: &str = "/leader/claim";
 pub const LEADER_CLAIM_VOUCHERS: &str = "/leader/claim/vouchers";
 

--- a/nodes/node/binary/src/api/backend.rs
+++ b/nodes/node/binary/src/api/backend.rs
@@ -47,7 +47,7 @@ use super::handlers::{
     add_tx, blend_info, block, block_events, blocks_range_stream, blocks_stream,
     cryptarchia_headers, cryptarchia_info, cryptarchia_lib_stream, dial_peer, get_gas_prices,
     get_sdp_declarations, get_sdp_snapshot, immutable_blocks, libp2p_info, mantle_metrics,
-    mantle_status, mempool_view, time_info, transaction, wallet,
+    mantle_status, mempool_view, time_info, transaction, version, wallet,
 };
 use crate::{
     BlendService, TracingService, WalletService,
@@ -210,6 +210,7 @@ where
 
         let app = Router::new()
             .merge(SwaggerUi::new("/swagger-ui").url("/api-docs/openapi.json", ApiDoc::openapi()))
+            .route(paths::NODE_VERSION, routing::get(version))
             .route(
                 paths::MANTLE_METRICS,
                 routing::get(mantle_metrics::<MempoolStorageAdapter, RuntimeServiceId>),

--- a/nodes/node/binary/src/api/handlers.rs
+++ b/nodes/node/binary/src/api/handlers.rs
@@ -474,6 +474,21 @@ where
     >(&handle, items))
 }
 
+#[utoipa::path(
+    get,
+    path = paths::NODE_VERSION,
+    responses(
+        (status = 200, description = "Version of the running node, e.g. `0.1.2 (abcdefaa)`", body = String),
+    )
+)]
+#[expect(
+    clippy::unused_async,
+    reason = "Axum handlers are required to be async."
+)]
+pub async fn version() -> Response {
+    Json(crate::version::node_version()).into_response()
+}
+
 #[derive(Deserialize)]
 pub struct CryptarchiaInfoQuery {
     from: Option<HeaderId>,

--- a/nodes/node/binary/src/api/handlers.rs
+++ b/nodes/node/binary/src/api/handlers.rs
@@ -481,10 +481,6 @@ where
         (status = 200, description = "Version of the running node, e.g. `0.1.2 (abcdefaa)`", body = String),
     )
 )]
-#[expect(
-    clippy::unused_async,
-    reason = "Axum handlers are required to be async."
-)]
 pub async fn version() -> Response {
     Json(crate::version::node_version()).into_response()
 }

--- a/nodes/node/binary/src/api/openapi.rs
+++ b/nodes/node/binary/src/api/openapi.rs
@@ -5,6 +5,7 @@ use utoipa::OpenApi;
 #[derive(OpenApi)]
 #[openapi(
     paths(
+        crate::api::handlers::version,
         crate::api::handlers::mantle_metrics,
         crate::api::handlers::mantle_status,
         crate::api::handlers::cryptarchia_info,

--- a/nodes/node/binary/src/cli/mod.rs
+++ b/nodes/node/binary/src/cli/mod.rs
@@ -26,15 +26,16 @@ use crate::{
         update_api, update_blend, update_cryptarchia, update_network, update_sdp, update_state,
         update_tracing,
     },
+    version::{HEAD_COMMIT_HASH, HEAD_TAG_NAME, PKG_VERSION, PROFILE, RUSTC_VERSION, TARGET},
 };
 
 fn long_version() -> String {
-    let head_commit_hash = env!("HEAD_COMMIT_HASH");
-    let head_tag_name = env!("HEAD_TAG_NAME");
-    let pkg_version = env!("PKG_VERSION");
-    let target = env!("TARGET");
-    let profile = env!("PROFILE");
-    let rustc_version = env!("RUSTC_VERSION");
+    let head_commit_hash = HEAD_COMMIT_HASH;
+    let head_tag_name = HEAD_TAG_NAME;
+    let pkg_version = PKG_VERSION;
+    let target = TARGET;
+    let profile = PROFILE;
+    let rustc_version = RUSTC_VERSION;
 
     let commit_line = match (head_commit_hash, head_tag_name) {
         (commit_hash, tag_name) if !commit_hash.is_empty() && !tag_name.is_empty() => {

--- a/nodes/node/binary/src/lib.rs
+++ b/nodes/node/binary/src/lib.rs
@@ -3,6 +3,7 @@ pub mod cli;
 pub mod config;
 pub mod generic_services;
 pub mod panic;
+pub mod version;
 
 pub mod global_allocators;
 

--- a/nodes/node/binary/src/version.rs
+++ b/nodes/node/binary/src/version.rs
@@ -1,0 +1,20 @@
+//! Version and build information, baked in at compile time by `build.rs`.
+
+pub(crate) const HEAD_COMMIT_HASH: &str = env!("HEAD_COMMIT_HASH");
+pub(crate) const HEAD_TAG_NAME: &str = env!("HEAD_TAG_NAME");
+pub(crate) const PKG_VERSION: &str = env!("PKG_VERSION");
+pub(crate) const TARGET: &str = env!("TARGET");
+pub(crate) const PROFILE: &str = env!("PROFILE");
+pub(crate) const RUSTC_VERSION: &str = env!("RUSTC_VERSION");
+
+/// Version of the running binary, with the commit it was built from.
+///
+/// The commit is omitted when the binary is not built from a git checkout.
+#[must_use]
+pub fn node_version() -> String {
+    if HEAD_COMMIT_HASH.is_empty() {
+        PKG_VERSION.to_owned()
+    } else {
+        format!("{PKG_VERSION} ({HEAD_COMMIT_HASH})")
+    }
+}

--- a/nodes/node/http-client/src/lib.rs
+++ b/nodes/node/http-client/src/lib.rs
@@ -31,7 +31,7 @@ use lb_http_api_common::{
     paths::{
         BLEND_JOIN_NETWORK, BLOCK_EVENTS, BLOCKS, BLOCKS_DETAIL, BLOCKS_RANGE_STREAM,
         BLOCKS_STREAM, CHANNEL, CRYPTARCHIA_INFO, CRYPTARCHIA_LIB_STREAM, LEADER_CLAIM_VOUCHERS,
-        MANTLE_GAS_PRICES, MEMPOOL_ADD_TX, SDP_POST_DECLARATION, TIME_INFO,
+        MANTLE_GAS_PRICES, MEMPOOL_ADD_TX, NODE_VERSION, SDP_POST_DECLARATION, TIME_INFO,
         wallet::{BALANCE, FUND, TRANSACTIONS_TRANSFER_FUNDS},
     },
     queries::BlocksStreamQuery,
@@ -295,6 +295,14 @@ impl CommonHttpClient {
             .join(SDP_POST_DECLARATION.trim_start_matches('/'))
             .map_err(Error::Url)?;
         self.post(request_url, declaration).await
+    }
+
+    /// Get the version of the node, e.g. `0.1.2 (abcdefaa)`.
+    pub async fn get_node_version(&self, base_url: Url) -> Result<String, Error> {
+        let request_url = base_url
+            .join(NODE_VERSION.trim_start_matches('/'))
+            .map_err(Error::Url)?;
+        self.get::<(), String>(request_url, None).await
     }
 
     /// Get consensus info (tip, height, etc.)


### PR DESCRIPTION
## 1. What does this PR implement?

Simple HTTP GET endpoint to return the version (as in the crate version) and the optional commit tag of the running node. This is useful for example in our web dashboards to get the version of the nodes running a specific devnet or testnet environment, and for clients to know whether a node supports a specific HTTP endpoint that was introduced at a specific version, for instance.

## 2. Does the code have enough context to be clearly understood?

Yes.

## 3. Who are the specification authors and who is accountable for this PR? TRh

@ntn-x2 

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

No.