### PR TITLE
feat(api): extend deposit events with pk pairs

### DIFF
--- a/core/src/events/mod.rs
+++ b/core/src/events/mod.rs
@@ -1,4 +1,6 @@
 use bytes::Bytes;
+use lb_key_management_system_keys::keys::ZkPublicKey;
+use lb_utils::bounded::UpperBoundedVec;
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -6,7 +8,7 @@ use crate::{
     crypto::Hash,
     mantle::{
         NoteId, Utxo, Value,
-        ledger::BoundedInputs,
+        ledger::MAX_TRANSACTION_INPUTS,
         ops::{
             channel::{ChannelId, deposit::Metadata},
             leader_claim::VoucherNullifier,
@@ -98,9 +100,22 @@ impl TxEvent {
     }
 }
 
+/// A single channel note a deposit re-created from one of its inputs.
+///
+/// Carries the data a wallet needs to track and later select the note: its id,
+/// value, and owning public key. The public key is the depositor's — a deposit
+/// re-creates each input note unchanged inside the channel — so a withdrawal
+/// client can tell which key must authorize spending it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DepositNote {
+    pub note_id: NoteId,
+    pub value: Value,
+    pub pk: ZkPublicKey,
+}
+
 // A deposit re-creates one channel note per input, so the notes it emits carry
 // the same bound as its inputs.
-pub type DepositRecreatedNotes = BoundedInputs;
+pub type DepositRecreatedNotes = UpperBoundedVec<DepositNote, MAX_TRANSACTION_INPUTS>;
 
 /// Event payloads emitted while processing a transaction
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/core/src/events/mod.rs
+++ b/core/src/events/mod.rs
@@ -172,3 +172,88 @@ impl TryFrom<Events> for Bytes {
         events.to_bytes()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use lb_groth16::Fr;
+    use num_bigint::BigUint;
+
+    use super::*;
+
+    /// A deposit note with distinct, non-default id/value/pk so the round-trip
+    /// exercises every field rather than zero-valued defaults.
+    fn deposit_note(seed: u64, value: Value) -> DepositNote {
+        DepositNote {
+            note_id: NoteId::from(Fr::from(BigUint::from(seed))),
+            value,
+            pk: ZkPublicKey::from(Fr::from(BigUint::from(
+                seed.wrapping_mul(97).wrapping_add(3),
+            ))),
+        }
+    }
+
+    /// A `Deposit` payload carrying several notes must survive the events codec
+    /// round-trip. The wallet reads these notes off the block-events endpoint,
+    /// so a broken `DepositNote` (de)serialization would silently drop the
+    /// per-note value/pk data that channel-note tracking depends on.
+    #[test]
+    fn deposit_event_notes_survive_codec_round_trip() {
+        let expected_notes = vec![
+            deposit_note(11, 1),
+            deposit_note(22, 10_000),
+            deposit_note(33, u64::MAX),
+        ];
+        let notes: DepositRecreatedNotes = expected_notes
+            .clone()
+            .try_into()
+            .expect("note count is within the input bound");
+
+        let tx_hash = TxHash([1u8; 32]);
+        let op_id: Hash = [2u8; 32];
+        let channel_id = ChannelId::from([7u8; 32]);
+        let amount: Value = 424_242;
+        let metadata: Metadata = vec![9u8, 8, 7]
+            .try_into()
+            .expect("metadata is within the size bound");
+
+        let events = Events::from(Event::Tx(TxEvent::new(
+            tx_hash,
+            op_id,
+            TxEventPayload::Deposit {
+                channel_id,
+                amount,
+                metadata: metadata.clone(),
+                notes,
+            },
+        )));
+
+        let bytes: Bytes = events.try_into().expect("events serialize");
+        let decoded = Events::try_from(bytes).expect("events deserialize");
+
+        let mut iter = decoded.iter();
+        let event = iter.next().expect("one event round-trips");
+        assert!(iter.next().is_none(), "exactly one event round-trips");
+
+        let Event::Tx(TxEvent {
+            tx_hash: decoded_tx_hash,
+            op_id: decoded_op_id,
+            payload:
+                TxEventPayload::Deposit {
+                    channel_id: decoded_channel_id,
+                    amount: decoded_amount,
+                    metadata: decoded_metadata,
+                    notes: decoded_notes,
+                },
+        }) = event
+        else {
+            panic!("expected a deposit Tx event, got {event:?}");
+        };
+
+        assert_eq!(*decoded_tx_hash, tx_hash);
+        assert_eq!(*decoded_op_id, op_id);
+        assert_eq!(*decoded_channel_id, channel_id);
+        assert_eq!(*decoded_amount, amount);
+        assert_eq!(decoded_metadata.as_slice(), metadata.as_slice());
+        assert_eq!(decoded_notes.as_slice(), expected_notes.as_slice());
+    }
+}

--- a/core/src/mantle/channel.rs
+++ b/core/src/mantle/channel.rs
@@ -240,7 +240,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        events::TxEventPayload,
+        events::{DepositNote, TxEventPayload},
         mantle::{
             Note, Utxo, Value,
             ledger::Utxos,
@@ -423,7 +423,14 @@ mod tests {
         assert_eq!(*event_channel_id, deposit_op.channel_id);
         assert_eq!(*amount, utxo.note.value);
         assert_eq!(*metadata, deposit_op.metadata);
-        assert_eq!(notes.clone().into_inner(), vec![deposited]);
+        assert_eq!(
+            notes.clone().into_inner(),
+            vec![DepositNote {
+                note_id: deposited,
+                value: utxo.note.value,
+                pk: utxo.note.pk,
+            }]
+        );
     }
 
     #[test]

--- a/core/src/mantle/ops/channel/deposit.rs
+++ b/core/src/mantle/ops/channel/deposit.rs
@@ -4,7 +4,7 @@ use lb_utils::bounded::UpperBoundedVec;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    events::{DepositRecreatedNotes, TxEvent, TxEventPayload},
+    events::{DepositNote, DepositRecreatedNotes, TxEvent, TxEventPayload},
     mantle::{
         channel::{Channels, Error},
         ledger::{
@@ -128,12 +128,18 @@ impl ExecutableOperation for DepositOp {
         // Add the re-created notes to the ledger and register them as channel
         // notes.
         context.utxos = outputs.execute(context.utxos, self);
-        let mut note_ids = DepositRecreatedNotes::default();
+        let mut notes = DepositRecreatedNotes::default();
         for utxo in outputs.utxos(self) {
             context.channels = context
                 .channels
                 .register_channel_note(&utxo.id(), &self.channel_id)?;
-            note_ids.try_push(utxo.id()).map_err(InputsError::from)?;
+            notes
+                .try_push(DepositNote {
+                    note_id: utxo.id(),
+                    value: utxo.note.value,
+                    pk: utxo.note.pk,
+                })
+                .map_err(InputsError::from)?;
         }
 
         let events = std::iter::once(TxEvent::new(
@@ -143,7 +149,7 @@ impl ExecutableOperation for DepositOp {
                 channel_id: self.channel_id,
                 amount: amount_deposited,
                 metadata: self.metadata.clone(),
-                notes: note_ids,
+                notes,
             },
         ))
         .collect();

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -783,6 +783,7 @@ impl LedgerState {
 mod tests {
     use cryptarchia::tests::{config, generate_proof, utxo};
     use lb_core::{
+        events::DepositNote,
         mantle::{
             GasCalculator as _, Note, OpProof, RawMantleTx, SignedMantleTx,
             gas::MainnetGasConstants,
@@ -1238,7 +1239,14 @@ mod tests {
         assert_eq!(*event_channel_id, deposit.channel_id);
         assert_eq!(*amount, utxo.note.value);
         assert_eq!(*metadata, deposit.metadata);
-        assert_eq!(notes.as_slice(), &[deposited]);
+        assert_eq!(
+            notes.as_slice(),
+            &[DepositNote {
+                note_id: deposited,
+                value: utxo.note.value,
+                pk: utxo.note.pk,
+            }]
+        );
     }
 
     #[test]

--- a/tests/src/tests/mantle/channel.rs
+++ b/tests/src/tests/mantle/channel.rs
@@ -190,8 +190,10 @@ async fn channel_deposit() {
     assert_eq!(amount, deposit_amount);
     assert_eq!(metadata, deposit_op.metadata);
     // The deposit consumes its inputs and re-creates them as channel notes,
-    // one per input.
+    // one per input. The event carries each re-created note's id, value, and
+    // owning key, so the per-note values sum back to the deposit amount.
     assert_eq!(notes.len(), deposit_op.inputs.len());
+    assert_eq!(notes.iter().map(|note| note.value).sum::<u64>(), amount);
 
     let balance_after = get_wallet_balance(&validator.client, funding_pk).await;
     let spent = balance_before - balance_after;


### PR DESCRIPTION
## 1. What does this PR implement?

This PR extends the deposit events needed by: https://github.com/logos-blockchain/logos-blockchain/pull/3246. Please consult this PR and comments for the details.

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@pradovic 

## 4. Is the specification accurate and complete?
Yes

## 5. Does the implementation introduce changes in the specification?

No

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [ ] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [ ] 2. Description added.
* [ ] 3. Context and links to Specification document(s) added.
* [ ] 4. Main contact(s) (developers and specification authors) added
* [ ] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [ ] 6. Link PR to a specific milestone.
* [ ] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
