### PR TITLE
fix: epoch boundary unreleased data messages fix

### DIFF
--- a/blend/scheduling/src/message_scheduler/mod.rs
+++ b/blend/scheduling/src/message_scheduler/mod.rs
@@ -32,6 +32,68 @@ mod tests;
 
 const LOG_TARGET: &str = blend::scheduling::ROOT;
 
+/// Labels distinguishing the two schedulers in the round traces, since both are
+/// polled on every round for the duration of an epoch transition.
+const CURRENT_EPOCH: &str = "current epoch";
+const OLD_EPOCH: &str = "old epoch";
+
+/// The round-advancing logic shared by the current- and old-epoch schedulers.
+///
+/// Advances `round_clock`, then asks `poll_release_type` what is due for
+/// release this round: `Poll::Ready(None)` to end the stream, `Poll::Pending`
+/// for nothing, or `Poll::Ready(Some(_))` for the release type. A round is
+/// emitted whenever there is anything to send, which includes the case where
+/// the only thing pending is a queued data message.
+fn poll_round_info<ProcessedMessage, DataMessage>(
+    epoch: &str,
+    round_clock: &mut RoundClock,
+    data_messages: &mut Vec<DataMessage>,
+    cx: &mut Context<'_>,
+    poll_release_type: impl FnOnce(&mut Context<'_>) -> Poll<Option<RoundReleaseType<ProcessedMessage>>>,
+) -> Poll<Option<RoundInfo<ProcessedMessage, DataMessage>>>
+where
+    ProcessedMessage: Debug,
+    DataMessage: Debug,
+{
+    // We do not return anything if a new round has not elapsed.
+    let new_round = match round_clock.poll_next_unpin(cx) {
+        Poll::Pending => return Poll::Pending,
+        Poll::Ready(None) => return Poll::Ready(None),
+        Poll::Ready(Some(new_round)) => new_round,
+    };
+    trace!(target: LOG_TARGET, "New round {new_round} started for the {epoch}.");
+
+    // Determine the release type without consuming `data_messages` yet, so the
+    // early-return arms below cannot drop already-taken data messages.
+    let release_type = match poll_release_type(cx) {
+        Poll::Ready(None) => return Poll::Ready(None),
+        // Nothing else is due at this round, so we return `Ready` only if we have data
+        // messages to release. Else, we return `Pending`.
+        Poll::Pending => {
+            if data_messages.is_empty() {
+                // Awake to trigger a new round clock tick.
+                cx.waker().wake_by_ref();
+                return Poll::Pending;
+            }
+            None
+        }
+        Poll::Ready(Some(release_type)) => Some(release_type),
+    };
+
+    // Safe to take now: every path from here on emits the data messages.
+    let round_info = RoundInfo {
+        data_messages: take(data_messages),
+        release_type,
+    };
+    trace!(
+        target: LOG_TARGET,
+        data_messages = round_info.data_messages.len(),
+        release_type = ?round_info.release_type,
+        "emitting new round info for the {epoch}"
+    );
+    Poll::Ready(Some(round_info))
+}
+
 /// Trait for scheduling processed messages to be released in future rounds.
 pub trait ProcessedMessageScheduler<ProcessedMessage> {
     /// Add a new processed message to the release delayer component queue, for
@@ -50,11 +112,6 @@ pub struct EpochMessageScheduler<Rng, ProcessedMessage, DataMessage> {
     release_delayer: EpochProcessedMessageDelayer<RoundClock, Rng, ProcessedMessage>,
     /// The queue of data messages that are stored in between rounds.
     data_messages: Vec<DataMessage>,
-    /// Data messages inherited from the previous epoch, which had been queued
-    /// there but not released before it ended. They ride this scheduler's
-    /// release rounds so that the node keeps a single release schedule, but
-    /// they belong to the old epoch when it comes to publishing them.
-    old_epoch_data_messages: Vec<DataMessage>,
     /// The multi-consumer stream forked on each sub-stream.
     round_clock: RoundClock,
 }
@@ -105,36 +162,42 @@ where
             cover_traffic,
             release_delayer,
             data_messages: Vec::new(),
-            old_epoch_data_messages: Vec::new(),
             round_clock: Box::new(round_clock) as RoundClock,
         }
     }
 
-    pub fn consume(self) -> OldEpochMessageScheduler<Rng, ProcessedMessage> {
-        OldEpochMessageScheduler(self.release_delayer)
+    pub fn consume(self) -> OldEpochMessageScheduler<Rng, ProcessedMessage, DataMessage> {
+        let Self {
+            release_delayer,
+            data_messages,
+            round_clock,
+            ..
+        } = self;
+        OldEpochMessageScheduler {
+            release_delayer,
+            data_messages,
+            round_clock,
+        }
     }
 
     pub fn rotate_epoch(
         self,
         new_epoch_info: EpochInfo,
         settings: Settings,
-    ) -> (Self, OldEpochMessageScheduler<Rng, ProcessedMessage>) {
-        let Self {
-            release_delayer,
-            data_messages,
-            ..
-        } = self;
-        // Data messages queued in the current epoch but not yet released are carried
-        // over to the new epoch's scheduler, so the node keeps a single release
-        // schedule. They are kept apart from the new epoch's own data messages
-        // because they were encapsulated with the old epoch's `PoQ`, which only
-        // verifies against that epoch's public inputs: publishing them under the new
-        // epoch's number would make the receiver reject the proof and close us as a
-        // spammer. They go out to the old epoch's peers instead, and are dropped once
-        // the transition period expires and those peers are gone.
-        let mut new_scheduler = Self::new(new_epoch_info, release_delayer.rng().clone(), settings);
-        new_scheduler.old_epoch_data_messages = data_messages;
-        (new_scheduler, OldEpochMessageScheduler(release_delayer))
+    ) -> (
+        Self,
+        OldEpochMessageScheduler<Rng, ProcessedMessage, DataMessage>,
+    ) {
+        // Data messages queued but not released before the epoch ended stay with the
+        // old epoch's scheduler, alongside the processed messages it already drains,
+        // so each epoch's scheduler owns that epoch's traffic. They were encapsulated
+        // with the old epoch's `PoQ`, which only verifies against that epoch's public
+        // inputs: carrying them into the new epoch would publish them under the new
+        // epoch's number, and the receiver would reject the proof and close us as a
+        // spammer. They go out to the old epoch's peers instead, and whatever is
+        // still queued when the transition period expires is dropped with them.
+        let new_scheduler = Self::new(new_epoch_info, self.release_delayer.rng().clone(), settings);
+        (new_scheduler, self.consume())
     }
 
     /// Notify the cover message submodule that a new data message has been
@@ -158,7 +221,6 @@ impl<Rng, ProcessedMessage, DataMessage> EpochMessageScheduler<Rng, ProcessedMes
             cover_traffic,
             release_delayer,
             data_messages,
-            old_epoch_data_messages: Vec::new(),
             round_clock,
         }
     }
@@ -194,62 +256,35 @@ where
             release_delayer,
             round_clock,
             data_messages,
-            old_epoch_data_messages,
         } = &mut *self;
 
-        // We do not return anything if a new round has not elapsed.
-        let new_round = match round_clock.poll_next_unpin(cx) {
-            Poll::Pending => return Poll::Pending,
-            Poll::Ready(None) => return Poll::Ready(None),
-            Poll::Ready(Some(new_round)) => new_round,
-        };
-        trace!(target: LOG_TARGET, "New round {new_round} started.");
+        poll_round_info(CURRENT_EPOCH, round_clock, data_messages, cx, |cx| {
+            // We poll the sub-streams and return the right result accordingly. Both are
+            // polled unconditionally so that both register their waker.
+            let cover_traffic_output = cover_traffic.poll_next_unpin(cx);
+            let release_delayer_output = release_delayer.poll_next_unpin(cx);
 
-        // We poll the sub-stream and return the right result accordingly.
-        let cover_traffic_output = cover_traffic.poll_next_unpin(cx);
-        let release_delayer_output = release_delayer.poll_next_unpin(cx);
-
-        // Determine the release type without consuming `data_messages` yet, so the
-        // early-return arms below cannot drop already-taken data messages.
-        let release_type = match (cover_traffic_output, release_delayer_output) {
-            // Bubble up `Poll::Ready(None)` if any sub-stream returns it.
-            (Poll::Ready(None), _) | (_, Poll::Ready(None)) => return Poll::Ready(None),
-            // If none of the sub-streams is ready, we return `Ready` if we have data messages to
-            // release at this round. Else, we return `Pending`.
-            (Poll::Pending, Poll::Pending) => {
-                if data_messages.is_empty() && old_epoch_data_messages.is_empty() {
-                    // Awake to trigger a new round clock tick.
-                    cx.waker().wake_by_ref();
-                    return Poll::Pending;
+            match (cover_traffic_output, release_delayer_output) {
+                // Bubble up `Poll::Ready(None)` if any sub-stream returns it.
+                (Poll::Ready(None), _) | (_, Poll::Ready(None)) => Poll::Ready(None),
+                // Neither sub-stream is ready, so only queued data messages are due.
+                (Poll::Pending, Poll::Pending) => Poll::Pending,
+                // Cover message, no processed messages.
+                (Poll::Ready(Some(())), Poll::Pending) => {
+                    Poll::Ready(Some(RoundReleaseType::OnlyCoverMessage))
                 }
-                None
+                // Processed messages, no cover message.
+                (Poll::Pending, Poll::Ready(Some(processed_messages))) => Poll::Ready(Some(
+                    RoundReleaseType::OnlyProcessedMessages(processed_messages),
+                )),
+                // Cover and processed messages.
+                (Poll::Ready(Some(())), Poll::Ready(Some(processed_messages))) => {
+                    Poll::Ready(Some(RoundReleaseType::ProcessedAndCoverMessages(
+                        processed_messages,
+                    )))
+                }
             }
-            // Cover message, no processed messages.
-            (Poll::Ready(Some(())), Poll::Pending) => Some(RoundReleaseType::OnlyCoverMessage),
-            // Processed messages, no cover message.
-            (Poll::Pending, Poll::Ready(Some(processed_messages))) => {
-                Some(RoundReleaseType::OnlyProcessedMessages(processed_messages))
-            }
-            // Cover and processed messages.
-            (Poll::Ready(Some(())), Poll::Ready(Some(processed_messages))) => Some(
-                RoundReleaseType::ProcessedAndCoverMessages(processed_messages),
-            ),
-        };
-
-        // Safe to take now: every path from here on emits the data messages.
-        let round_info = RoundInfo {
-            data_messages: take(data_messages),
-            old_epoch_data_messages: take(old_epoch_data_messages),
-            release_type,
-        };
-        trace!(
-            target: LOG_TARGET,
-            data_messages = round_info.data_messages.len(),
-            old_epoch_data_messages = round_info.old_epoch_data_messages.len(),
-            release_type = ?round_info.release_type,
-            "emitting new round info"
-        );
-        Poll::Ready(Some(round_info))
+        })
     }
 }
 
@@ -275,38 +310,63 @@ impl Default for Settings {
 
 /// Message scheduler that is only for an old epoch during epoch transition.
 ///
-/// Unlike [`EpochMessageScheduler`], this supports only scheduling processed
-/// messages. Data messages cannot be scheduled, and it does not generate cover
-/// messages.
-pub struct OldEpochMessageScheduler<Rng, ProcessedMessage>(
-    EpochProcessedMessageDelayer<RoundClock, Rng, ProcessedMessage>,
-);
+/// It drains what the epoch left behind: the processed messages held by its
+/// release delayer, and the data messages that had been queued but not released
+/// when the epoch ended. No new data message can be queued on it, and it does
+/// not generate cover messages, so the release type it yields is never a cover
+/// one. Whatever is still queued when the transition period expires is dropped
+/// along with this scheduler.
+pub struct OldEpochMessageScheduler<Rng, ProcessedMessage, DataMessage> {
+    /// The module responsible for delaying the release of processed messages
+    /// that have not been fully decapsulated.
+    release_delayer: EpochProcessedMessageDelayer<RoundClock, Rng, ProcessedMessage>,
+    /// The data messages the old epoch had queued but not yet released.
+    data_messages: Vec<DataMessage>,
+    /// The multi-consumer stream forked on each sub-stream.
+    round_clock: RoundClock,
+}
 
-impl<Rng, ProcessedMessage> ProcessedMessageScheduler<ProcessedMessage>
-    for OldEpochMessageScheduler<Rng, ProcessedMessage>
+impl<Rng, ProcessedMessage, DataMessage> ProcessedMessageScheduler<ProcessedMessage>
+    for OldEpochMessageScheduler<Rng, ProcessedMessage, DataMessage>
 {
     fn schedule_processed_message(&mut self, message: ProcessedMessage) {
-        self.0.schedule_message(message);
+        self.release_delayer.schedule_message(message);
     }
 }
 
-impl<Rng, ProcessedMessage> Stream for OldEpochMessageScheduler<Rng, ProcessedMessage>
+impl<Rng, ProcessedMessage, DataMessage> Stream
+    for OldEpochMessageScheduler<Rng, ProcessedMessage, DataMessage>
 where
     Rng: rand::Rng + Unpin,
-    ProcessedMessage: Unpin,
+    ProcessedMessage: Debug + Unpin,
+    DataMessage: Debug + Unpin,
 {
-    type Item = Vec<ProcessedMessage>;
+    type Item = RoundInfo<ProcessedMessage, DataMessage>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        self.0.poll_next_unpin(cx)
+        let Self {
+            release_delayer,
+            data_messages,
+            round_clock,
+        } = &mut *self;
+
+        poll_round_info(OLD_EPOCH, round_clock, data_messages, cx, |cx| {
+            // The old epoch generates no cover traffic, so the only thing that can come
+            // due besides the leftover data messages is a batch of processed messages.
+            release_delayer
+                .poll_next_unpin(cx)
+                .map(|messages| messages.map(RoundReleaseType::OnlyProcessedMessages))
+        })
     }
 }
 
-impl<Rng, ProcessedMessage> OldEpochMessageScheduler<Rng, ProcessedMessage> {
+impl<Rng, ProcessedMessage, DataMessage>
+    OldEpochMessageScheduler<Rng, ProcessedMessage, DataMessage>
+{
     #[cfg(any(test, feature = "unsafe-test-functions"))]
     pub fn release_delayer(
         &self,
     ) -> &EpochProcessedMessageDelayer<RoundClock, Rng, ProcessedMessage> {
-        &self.0
+        &self.release_delayer
     }
 }

--- a/blend/scheduling/src/message_scheduler/mod.rs
+++ b/blend/scheduling/src/message_scheduler/mod.rs
@@ -50,6 +50,11 @@ pub struct EpochMessageScheduler<Rng, ProcessedMessage, DataMessage> {
     release_delayer: EpochProcessedMessageDelayer<RoundClock, Rng, ProcessedMessage>,
     /// The queue of data messages that are stored in between rounds.
     data_messages: Vec<DataMessage>,
+    /// Data messages inherited from the previous epoch, which had been queued
+    /// there but not released before it ended. They ride this scheduler's
+    /// release rounds so that the node keeps a single release schedule, but
+    /// they belong to the old epoch when it comes to publishing them.
+    old_epoch_data_messages: Vec<DataMessage>,
     /// The multi-consumer stream forked on each sub-stream.
     round_clock: RoundClock,
 }
@@ -100,6 +105,7 @@ where
             cover_traffic,
             release_delayer,
             data_messages: Vec::new(),
+            old_epoch_data_messages: Vec::new(),
             round_clock: Box::new(round_clock) as RoundClock,
         }
     }
@@ -118,16 +124,16 @@ where
             data_messages,
             ..
         } = self;
-        // Data messages queued in the current epoch but not yet released must be
-        // carried over to the new epoch's scheduler. Otherwise they would be
-        // silently dropped here (the `OldEpochMessageScheduler` only releases
-        // processed messages), and only re-sent on a full service restart from
-        // the recovery checkpoint. Re-queueing through `queue_data_message` also
-        // keeps the new epoch's cover-traffic accounting consistent.
+        // Data messages queued in the current epoch but not yet released are carried
+        // over to the new epoch's scheduler, so the node keeps a single release
+        // schedule. They are kept apart from the new epoch's own data messages
+        // because they were encapsulated with the old epoch's `PoQ`, which only
+        // verifies against that epoch's public inputs: publishing them under the new
+        // epoch's number would make the receiver reject the proof and close us as a
+        // spammer. They go out to the old epoch's peers instead, and are dropped once
+        // the transition period expires and those peers are gone.
         let mut new_scheduler = Self::new(new_epoch_info, release_delayer.rng().clone(), settings);
-        for message in data_messages {
-            new_scheduler.queue_data_message(message);
-        }
+        new_scheduler.old_epoch_data_messages = data_messages;
         (new_scheduler, OldEpochMessageScheduler(release_delayer))
     }
 
@@ -152,6 +158,7 @@ impl<Rng, ProcessedMessage, DataMessage> EpochMessageScheduler<Rng, ProcessedMes
             cover_traffic,
             release_delayer,
             data_messages,
+            old_epoch_data_messages: Vec::new(),
             round_clock,
         }
     }
@@ -187,6 +194,7 @@ where
             release_delayer,
             round_clock,
             data_messages,
+            old_epoch_data_messages,
         } = &mut *self;
 
         // We do not return anything if a new round has not elapsed.
@@ -209,7 +217,7 @@ where
             // If none of the sub-streams is ready, we return `Ready` if we have data messages to
             // release at this round. Else, we return `Pending`.
             (Poll::Pending, Poll::Pending) => {
-                if data_messages.is_empty() {
+                if data_messages.is_empty() && old_epoch_data_messages.is_empty() {
                     // Awake to trigger a new round clock tick.
                     cx.waker().wake_by_ref();
                     return Poll::Pending;
@@ -231,11 +239,13 @@ where
         // Safe to take now: every path from here on emits the data messages.
         let round_info = RoundInfo {
             data_messages: take(data_messages),
+            old_epoch_data_messages: take(old_epoch_data_messages),
             release_type,
         };
         trace!(
             target: LOG_TARGET,
             data_messages = round_info.data_messages.len(),
+            old_epoch_data_messages = round_info.old_epoch_data_messages.len(),
             release_type = ?round_info.release_type,
             "emitting new round info"
         );

--- a/blend/scheduling/src/message_scheduler/round_info.rs
+++ b/blend/scheduling/src/message_scheduler/round_info.rs
@@ -38,6 +38,11 @@ impl Display for Round {
 pub struct RoundInfo<ProcessedMessage, DataMessage> {
     /// The list of data messages to be released. This can happen at any round.
     pub data_messages: Vec<DataMessage>,
+    /// Data messages that were queued in the previous epoch but not released
+    /// before it ended. They are released on the same round as everything else,
+    /// but must be published to the old epoch's peers under the old epoch's
+    /// number, since that is what their `PoQ` verifies against.
+    pub old_epoch_data_messages: Vec<DataMessage>,
     /// Additional "types" of this round.
     pub release_type: Option<RoundReleaseType<ProcessedMessage>>,
 }

--- a/blend/scheduling/src/message_scheduler/round_info.rs
+++ b/blend/scheduling/src/message_scheduler/round_info.rs
@@ -38,11 +38,6 @@ impl Display for Round {
 pub struct RoundInfo<ProcessedMessage, DataMessage> {
     /// The list of data messages to be released. This can happen at any round.
     pub data_messages: Vec<DataMessage>,
-    /// Data messages that were queued in the previous epoch but not released
-    /// before it ended. They are released on the same round as everything else,
-    /// but must be published to the old epoch's peers under the old epoch's
-    /// number, since that is what their `PoQ` verifies against.
-    pub old_epoch_data_messages: Vec<DataMessage>,
     /// Additional "types" of this round.
     pub release_type: Option<RoundReleaseType<ProcessedMessage>>,
 }

--- a/blend/scheduling/src/message_scheduler/tests.rs
+++ b/blend/scheduling/src/message_scheduler/tests.rs
@@ -73,6 +73,7 @@ async fn no_substream_ready_with_data_messages() {
         scheduler.poll_next_unpin(&mut cx),
         Poll::Ready(Some(RoundInfo {
             data_messages: vec![1, 2],
+            old_epoch_data_messages: vec![],
             release_type: None
         }))
     );
@@ -106,6 +107,7 @@ async fn cover_traffic_substream_ready() {
         scheduler.poll_next_unpin(&mut cx),
         Poll::Ready(Some(RoundInfo {
             data_messages: vec![1],
+            old_epoch_data_messages: vec![],
             release_type: Some(RoundReleaseType::OnlyCoverMessage)
         }))
     );
@@ -137,6 +139,7 @@ async fn release_delayer_substream_ready() {
         scheduler.poll_next_unpin(&mut cx),
         Poll::Ready(Some(RoundInfo {
             data_messages: vec![2],
+            old_epoch_data_messages: vec![],
             release_type: Some(RoundReleaseType::OnlyProcessedMessages(vec![1]))
         }))
     );
@@ -169,6 +172,7 @@ async fn both_substreams_ready() {
         scheduler.poll_next_unpin(&mut cx),
         Poll::Ready(Some(RoundInfo {
             data_messages: vec![],
+            old_epoch_data_messages: vec![],
             release_type: Some(RoundReleaseType::ProcessedAndCoverMessages(vec![1]))
         }))
     );
@@ -208,6 +212,7 @@ async fn round_change() {
         scheduler.poll_next_unpin(&mut cx),
         Poll::Ready(Some(RoundInfo {
             data_messages: vec![],
+            old_epoch_data_messages: vec![],
             release_type: Some(RoundReleaseType::OnlyCoverMessage)
         }))
     );
@@ -222,6 +227,7 @@ async fn round_change() {
         scheduler.poll_next_unpin(&mut cx),
         Poll::Ready(Some(RoundInfo {
             data_messages: vec![3],
+            old_epoch_data_messages: vec![],
             release_type: None
         }))
     );
@@ -236,6 +242,7 @@ async fn round_change() {
         scheduler.poll_next_unpin(&mut cx),
         Poll::Ready(Some(RoundInfo {
             data_messages: vec![],
+            old_epoch_data_messages: vec![],
             release_type: Some(RoundReleaseType::OnlyProcessedMessages(vec![()]))
         }))
     );
@@ -243,7 +250,7 @@ async fn round_change() {
 }
 
 #[tokio::test]
-async fn rotate_epoch_carries_over_queued_data_messages() {
+async fn rotate_epoch_carries_over_queued_data_messages_as_old_epoch_ones() {
     let rng = BlakeRng::from_entropy();
     let rounds = [Round::from(0)];
     let scheduler = EpochMessageScheduler::<_, (), u32>::with_test_values(
@@ -260,7 +267,9 @@ async fn rotate_epoch_carries_over_queued_data_messages() {
         vec![1, 2],
     );
 
-    // Rotating into a new epoch must not silently drop the queued data messages.
+    // Rotating into a new epoch must not silently drop the queued data messages,
+    // but it must not treat them as the new epoch's own either: they carry the old
+    // epoch's `PoQ`, so they have to be published under the old epoch's number.
     let (new_scheduler, _old_scheduler) = scheduler.rotate_epoch(
         EpochInfo {
             core_quota: Quota::ONE,
@@ -269,5 +278,76 @@ async fn rotate_epoch_carries_over_queued_data_messages() {
         Settings::default(),
     );
 
-    assert_eq!(new_scheduler.data_messages, vec![1, 2]);
+    assert!(new_scheduler.data_messages.is_empty());
+    assert_eq!(new_scheduler.old_epoch_data_messages, vec![1, 2]);
+}
+
+#[tokio::test]
+async fn old_epoch_data_messages_are_released_on_the_same_round() {
+    let rng = BlakeRng::from_entropy();
+    let rounds = [Round::from(0)];
+    let mut scheduler = EpochMessageScheduler::<_, (), u32>::with_test_values(
+        // No cover messages to emit, tick will yield round `0`.
+        EpochCoverTraffic::with_test_values(Box::new(iter(rounds)), 0, 1.into(), rng.clone(), 0),
+        // Round `1` scheduled, so round `0` is not a release round for processed
+        // messages.
+        EpochProcessedMessageDelayer::with_test_values(
+            NonZeroU64::try_from(1).unwrap(),
+            1u128.into(),
+            rng,
+            Box::new(iter(rounds)),
+            vec![],
+        ),
+        Box::new(iter(rounds)),
+        vec![1],
+    );
+    scheduler.old_epoch_data_messages = vec![2, 3];
+    let mut cx = Context::from_waker(noop_waker_ref());
+
+    // Both queues drain in the same round info, so the node keeps a single release
+    // schedule across the transition.
+    assert_eq!(
+        scheduler.poll_next_unpin(&mut cx),
+        Poll::Ready(Some(RoundInfo {
+            data_messages: vec![1],
+            old_epoch_data_messages: vec![2, 3],
+            release_type: None
+        }))
+    );
+    assert!(scheduler.data_messages.is_empty());
+    assert!(scheduler.old_epoch_data_messages.is_empty());
+}
+
+#[tokio::test]
+async fn old_epoch_data_messages_alone_trigger_a_release() {
+    let rng = BlakeRng::from_entropy();
+    let rounds = [Round::from(0)];
+    let mut scheduler = EpochMessageScheduler::<_, (), u32>::with_test_values(
+        // No cover messages to emit, tick will yield round `0`.
+        EpochCoverTraffic::with_test_values(Box::new(iter(rounds)), 0, 1.into(), rng.clone(), 0),
+        // Round `1` scheduled, so round `0` is not a release round for processed
+        // messages.
+        EpochProcessedMessageDelayer::with_test_values(
+            NonZeroU64::try_from(1).unwrap(),
+            1u128.into(),
+            rng,
+            Box::new(iter(rounds)),
+            vec![],
+        ),
+        Box::new(iter(rounds)),
+        vec![],
+    );
+    // Nothing of our own to send, only leftovers from the previous epoch. They must
+    // still be flushed, else they would sit here until the transition expires.
+    scheduler.old_epoch_data_messages = vec![1];
+    let mut cx = Context::from_waker(noop_waker_ref());
+
+    assert_eq!(
+        scheduler.poll_next_unpin(&mut cx),
+        Poll::Ready(Some(RoundInfo {
+            data_messages: vec![],
+            old_epoch_data_messages: vec![1],
+            release_type: None
+        }))
+    );
 }

--- a/blend/scheduling/src/message_scheduler/tests.rs
+++ b/blend/scheduling/src/message_scheduler/tests.rs
@@ -13,7 +13,7 @@ use tokio_stream::iter;
 use crate::{
     cover_traffic::EpochCoverTraffic,
     message_scheduler::{
-        EpochMessageScheduler, Settings,
+        EpochMessageScheduler, OldEpochMessageScheduler, Settings,
         epoch_info::EpochInfo,
         round_info::{Round, RoundInfo, RoundReleaseType},
     },
@@ -73,7 +73,6 @@ async fn no_substream_ready_with_data_messages() {
         scheduler.poll_next_unpin(&mut cx),
         Poll::Ready(Some(RoundInfo {
             data_messages: vec![1, 2],
-            old_epoch_data_messages: vec![],
             release_type: None
         }))
     );
@@ -107,7 +106,6 @@ async fn cover_traffic_substream_ready() {
         scheduler.poll_next_unpin(&mut cx),
         Poll::Ready(Some(RoundInfo {
             data_messages: vec![1],
-            old_epoch_data_messages: vec![],
             release_type: Some(RoundReleaseType::OnlyCoverMessage)
         }))
     );
@@ -139,7 +137,6 @@ async fn release_delayer_substream_ready() {
         scheduler.poll_next_unpin(&mut cx),
         Poll::Ready(Some(RoundInfo {
             data_messages: vec![2],
-            old_epoch_data_messages: vec![],
             release_type: Some(RoundReleaseType::OnlyProcessedMessages(vec![1]))
         }))
     );
@@ -172,7 +169,6 @@ async fn both_substreams_ready() {
         scheduler.poll_next_unpin(&mut cx),
         Poll::Ready(Some(RoundInfo {
             data_messages: vec![],
-            old_epoch_data_messages: vec![],
             release_type: Some(RoundReleaseType::ProcessedAndCoverMessages(vec![1]))
         }))
     );
@@ -212,7 +208,6 @@ async fn round_change() {
         scheduler.poll_next_unpin(&mut cx),
         Poll::Ready(Some(RoundInfo {
             data_messages: vec![],
-            old_epoch_data_messages: vec![],
             release_type: Some(RoundReleaseType::OnlyCoverMessage)
         }))
     );
@@ -227,7 +222,6 @@ async fn round_change() {
         scheduler.poll_next_unpin(&mut cx),
         Poll::Ready(Some(RoundInfo {
             data_messages: vec![3],
-            old_epoch_data_messages: vec![],
             release_type: None
         }))
     );
@@ -242,7 +236,6 @@ async fn round_change() {
         scheduler.poll_next_unpin(&mut cx),
         Poll::Ready(Some(RoundInfo {
             data_messages: vec![],
-            old_epoch_data_messages: vec![],
             release_type: Some(RoundReleaseType::OnlyProcessedMessages(vec![()]))
         }))
     );
@@ -250,7 +243,7 @@ async fn round_change() {
 }
 
 #[tokio::test]
-async fn rotate_epoch_carries_over_queued_data_messages_as_old_epoch_ones() {
+async fn rotate_epoch_leaves_queued_data_messages_with_the_old_epoch() {
     let rng = BlakeRng::from_entropy();
     let rounds = [Round::from(0)];
     let scheduler = EpochMessageScheduler::<_, (), u32>::with_test_values(
@@ -268,9 +261,10 @@ async fn rotate_epoch_carries_over_queued_data_messages_as_old_epoch_ones() {
     );
 
     // Rotating into a new epoch must not silently drop the queued data messages,
-    // but it must not treat them as the new epoch's own either: they carry the old
-    // epoch's `PoQ`, so they have to be published under the old epoch's number.
-    let (new_scheduler, _old_scheduler) = scheduler.rotate_epoch(
+    // but it must not hand them to the new epoch either: they carry the old
+    // epoch's `PoQ`, so publishing them under the new epoch's number would get
+    // the proof rejected and this node closed as a spammer.
+    let (new_scheduler, old_scheduler) = scheduler.rotate_epoch(
         EpochInfo {
             core_quota: Quota::ONE,
             epoch: Epoch::new(0),
@@ -279,75 +273,70 @@ async fn rotate_epoch_carries_over_queued_data_messages_as_old_epoch_ones() {
     );
 
     assert!(new_scheduler.data_messages.is_empty());
-    assert_eq!(new_scheduler.old_epoch_data_messages, vec![1, 2]);
+    assert_eq!(old_scheduler.data_messages, vec![1, 2]);
+}
+
+/// Build an old-epoch scheduler whose round clock and release delayer both tick
+/// once, yielding round `0`.
+fn old_epoch_scheduler(
+    next_release_round: u128,
+    unreleased_processed_messages: Vec<u32>,
+    data_messages: Vec<u32>,
+) -> OldEpochMessageScheduler<BlakeRng, u32, u32> {
+    let rounds = [Round::from(0)];
+    OldEpochMessageScheduler {
+        release_delayer: EpochProcessedMessageDelayer::with_test_values(
+            NonZeroU64::try_from(1).unwrap(),
+            next_release_round.into(),
+            BlakeRng::from_entropy(),
+            Box::new(iter(rounds)),
+            unreleased_processed_messages,
+        ),
+        data_messages,
+        round_clock: Box::new(iter(rounds)),
+    }
 }
 
 #[tokio::test]
-async fn old_epoch_data_messages_are_released_on_the_same_round() {
-    let rng = BlakeRng::from_entropy();
-    let rounds = [Round::from(0)];
-    let mut scheduler = EpochMessageScheduler::<_, (), u32>::with_test_values(
-        // No cover messages to emit, tick will yield round `0`.
-        EpochCoverTraffic::with_test_values(Box::new(iter(rounds)), 0, 1.into(), rng.clone(), 0),
-        // Round `1` scheduled, so round `0` is not a release round for processed
-        // messages.
-        EpochProcessedMessageDelayer::with_test_values(
-            NonZeroU64::try_from(1).unwrap(),
-            1u128.into(),
-            rng,
-            Box::new(iter(rounds)),
-            vec![],
-        ),
-        Box::new(iter(rounds)),
-        vec![1],
-    );
-    scheduler.old_epoch_data_messages = vec![2, 3];
+async fn old_epoch_releases_leftover_data_messages_on_a_non_release_round() {
+    // Round `1` is scheduled for processed messages, so round `0` is not a release
+    // round for them. The leftover data messages must still go out: they are only
+    // deliverable while the old epoch's peers are still around.
+    let mut scheduler = old_epoch_scheduler(1, vec![], vec![1, 2]);
     let mut cx = Context::from_waker(noop_waker_ref());
 
-    // Both queues drain in the same round info, so the node keeps a single release
-    // schedule across the transition.
     assert_eq!(
         scheduler.poll_next_unpin(&mut cx),
         Poll::Ready(Some(RoundInfo {
-            data_messages: vec![1],
-            old_epoch_data_messages: vec![2, 3],
+            data_messages: vec![1, 2],
             release_type: None
         }))
     );
     assert!(scheduler.data_messages.is_empty());
-    assert!(scheduler.old_epoch_data_messages.is_empty());
 }
 
 #[tokio::test]
-async fn old_epoch_data_messages_alone_trigger_a_release() {
-    let rng = BlakeRng::from_entropy();
-    let rounds = [Round::from(0)];
-    let mut scheduler = EpochMessageScheduler::<_, (), u32>::with_test_values(
-        // No cover messages to emit, tick will yield round `0`.
-        EpochCoverTraffic::with_test_values(Box::new(iter(rounds)), 0, 1.into(), rng.clone(), 0),
-        // Round `1` scheduled, so round `0` is not a release round for processed
-        // messages.
-        EpochProcessedMessageDelayer::with_test_values(
-            NonZeroU64::try_from(1).unwrap(),
-            1u128.into(),
-            rng,
-            Box::new(iter(rounds)),
-            vec![],
-        ),
-        Box::new(iter(rounds)),
-        vec![],
-    );
-    // Nothing of our own to send, only leftovers from the previous epoch. They must
-    // still be flushed, else they would sit here until the transition expires.
-    scheduler.old_epoch_data_messages = vec![1];
+async fn old_epoch_is_pending_on_a_non_release_round_without_data_messages() {
+    let mut scheduler = old_epoch_scheduler(1, vec![], vec![]);
+    let mut cx = Context::from_waker(noop_waker_ref());
+
+    assert!(scheduler.poll_next_unpin(&mut cx).is_pending());
+}
+
+#[tokio::test]
+async fn old_epoch_releases_data_and_processed_messages_on_the_same_round() {
+    // Round `0` is a release round for processed messages, and there are leftover
+    // data messages queued as well. Both go out together, and never as a cover
+    // release type: the old epoch generates no cover traffic.
+    let mut scheduler = old_epoch_scheduler(0, vec![1], vec![2]);
     let mut cx = Context::from_waker(noop_waker_ref());
 
     assert_eq!(
         scheduler.poll_next_unpin(&mut cx),
         Poll::Ready(Some(RoundInfo {
-            data_messages: vec![],
-            old_epoch_data_messages: vec![1],
-            release_type: None
+            data_messages: vec![2],
+            release_type: Some(RoundReleaseType::OnlyProcessedMessages(vec![1]))
         }))
     );
+    assert!(scheduler.data_messages.is_empty());
 }

--- a/services/blend/src/core/mod.rs
+++ b/services/blend/src/core/mod.rs
@@ -776,7 +776,7 @@ async fn run_event_loop<
     mut recovery_checkpoint: ServiceState<Backend::Settings, NetAdapter::Settings>,
 ) -> (
     CoreCryptographicProcessor<NodeId, CorePoQGenerator, ProofsGenerator, ProofsVerifier>,
-    OldEpochMessageScheduler<Rng, ProcessedMessage>,
+    OldEpochMessageScheduler<Rng, ProcessedMessage, EncapsulatedMessageWithVerifiedPublicHeader>,
     OldEpochBlendingTokenCollector,
 )
 where
@@ -794,8 +794,13 @@ where
     let mut old_epoch_crypto_processor: Option<
         CoreCryptographicProcessor<NodeId, CorePoQGenerator, ProofsGenerator, ProofsVerifier>,
     > = None;
-    let mut old_epoch_message_scheduler: Option<OldEpochMessageScheduler<Rng, ProcessedMessage>> =
-        None;
+    let mut old_epoch_message_scheduler: Option<
+        OldEpochMessageScheduler<
+            Rng,
+            ProcessedMessage,
+            EncapsulatedMessageWithVerifiedPublicHeader,
+        >,
+    > = None;
     let mut latest_secret_pol_info: Option<PolEpochInfo> = None;
 
     loop {
@@ -829,7 +834,7 @@ where
             Some(round_info) = message_scheduler.next() => {
                 recovery_checkpoint = handle_release_round(round_info, &mut crypto_processor, rng, backend, network_adapter, recovery_checkpoint).await;
             }
-            Some((Some(processed_messages_to_release), previous_epoch)) = async {
+            Some((Some(round_info), previous_epoch)) = async {
                 match (&mut old_epoch_message_scheduler, old_epoch) {
                     (Some(old_scheduler), Some(old_epoch)) => {
                         Some((old_scheduler.next().await, old_epoch))
@@ -837,7 +842,7 @@ where
                     _ => None
                 }
             } => {
-                handle_release_round_for_old_epoch(processed_messages_to_release, rng, backend, network_adapter, previous_epoch).await;
+                handle_release_round_for_old_epoch(round_info, rng, backend, network_adapter, previous_epoch).await;
             }
             Some(pol_secret_info) = secret_pol_info_stream.next() => {
                 if current_epoch_info.epoch == pol_secret_info.epoch {
@@ -857,7 +862,7 @@ where
                         crypto_processor = new_crypto_processor;
                         old_epoch_crypto_processor = Some(old_crypto_processor);
                         message_scheduler = new_scheduler;
-                        old_epoch_message_scheduler = Some(old_scheduler);
+                        old_epoch_message_scheduler = Some(*old_scheduler);
                         current_epoch_info = new_epoch_info;
                         recovery_checkpoint = new_recovery_checkpoint;
                     },
@@ -875,7 +880,7 @@ where
                         tracing::info!(target: LOG_TARGET, "Exiting from the main event loop");
                         return (
                             old_crypto_processor,
-                            old_scheduler,
+                            *old_scheduler,
                             old_token_collector,
                         );
                     },
@@ -909,7 +914,11 @@ async fn retire<
     mut backend: Backend,
     network_adapter: NetAdapter,
     sdp_relay: OutboundRelay<SdpMessage>,
-    mut message_scheduler: OldEpochMessageScheduler<Rng, ProcessedMessage>,
+    mut message_scheduler: OldEpochMessageScheduler<
+        Rng,
+        ProcessedMessage,
+        EncapsulatedMessageWithVerifiedPublicHeader,
+    >,
     mut rng: Rng,
     mut blending_token_collector: OldEpochBlendingTokenCollector,
     crypto_processor: CoreCryptographicProcessor<
@@ -933,8 +942,8 @@ async fn retire<
             Some(incoming_message) = blend_messages.next() => {
                 handle_incoming_blend_message_from_old_epoch(incoming_message, &mut message_scheduler, &crypto_processor, &mut blending_token_collector);
             }
-            Some(processed_messages_to_release) = message_scheduler.next() => {
-                handle_release_round_for_old_epoch(processed_messages_to_release, &mut rng, &backend, &network_adapter, crypto_processor.epoch()).await;
+            Some(round_info) = message_scheduler.next() => {
+                handle_release_round_for_old_epoch(round_info, &mut rng, &backend, &network_adapter, crypto_processor.epoch()).await;
             }
             Some(EpochEvent::TransitionPeriodExpired) = remaining_epoch_stream.next() => {
                 handle_epoch_transition_expired(&mut backend, blending_token_collector, &sdp_relay).await;
@@ -1044,9 +1053,11 @@ where
                 tracing::info!(target: LOG_TARGET, "Local node is not part of new membership. Retiring from core.");
                 return HandleEpochEventOutput::Retiring {
                     old_crypto_processor: current_cryptographic_processor,
-                    old_scheduler: current_scheduler
-                        .rotate_epoch(new_scheduler_epoch_info, settings.scheduler_settings())
-                        .1,
+                    old_scheduler: Box::new(
+                        current_scheduler
+                            .rotate_epoch(new_scheduler_epoch_info, settings.scheduler_settings())
+                            .1,
+                    ),
                     old_token_collector: old_epoch_blending_token_collector,
                 };
             };
@@ -1085,12 +1096,14 @@ where
                         tracing::info!(target: LOG_TARGET, "New membership does not satisfy the core node condition: {e:?}");
                         return HandleEpochEventOutput::Retiring {
                             old_crypto_processor: current_cryptographic_processor,
-                            old_scheduler: current_scheduler
-                                .rotate_epoch(
-                                    new_scheduler_epoch_info,
-                                    settings.scheduler_settings(),
-                                )
-                                .1,
+                            old_scheduler: Box::new(
+                                current_scheduler
+                                    .rotate_epoch(
+                                        new_scheduler_epoch_info,
+                                        settings.scheduler_settings(),
+                                    )
+                                    .1,
+                            ),
                             old_token_collector: old_epoch_blending_token_collector,
                         };
                     }
@@ -1102,7 +1115,7 @@ where
                 new_crypto_processor: new_processor,
                 old_crypto_processor: current_cryptographic_processor,
                 new_scheduler,
-                old_scheduler,
+                old_scheduler: Box::new(old_scheduler),
                 new_recovery_checkpoint: ServiceState::with_epoch(
                     new_epoch_info.epoch,
                     new_epoch_blending_token_collector,
@@ -1129,7 +1142,7 @@ where
                 current_epoch_blending_token_collector.rotate_epoch(&new_reward_epoch_info);
             HandleEpochEventOutput::Retiring {
                 old_crypto_processor: current_cryptographic_processor,
-                old_scheduler: current_scheduler.consume(),
+                old_scheduler: Box::new(current_scheduler.consume()),
                 old_token_collector: old_epoch_blending_token_collector,
             }
         }
@@ -1195,7 +1208,13 @@ enum HandleEpochEventOutput<
             ProcessedMessage,
             EncapsulatedMessageWithVerifiedPublicHeader,
         >,
-        old_scheduler: OldEpochMessageScheduler<Rng, ProcessedMessage>,
+        old_scheduler: Box<
+            OldEpochMessageScheduler<
+                Rng,
+                ProcessedMessage,
+                EncapsulatedMessageWithVerifiedPublicHeader,
+            >,
+        >,
         new_epoch_info: CoreEpochPublicInfo<NodeId>,
         new_recovery_checkpoint: ServiceState<BackendSettings, NetworkSettings>,
     },
@@ -1213,7 +1232,13 @@ enum HandleEpochEventOutput<
     Retiring {
         old_crypto_processor:
             CoreCryptographicProcessor<NodeId, CorePoQGenerator, ProofsGenerator, ProofsVerifier>,
-        old_scheduler: OldEpochMessageScheduler<Rng, ProcessedMessage>,
+        old_scheduler: Box<
+            OldEpochMessageScheduler<
+                Rng,
+                ProcessedMessage,
+                EncapsulatedMessageWithVerifiedPublicHeader,
+            >,
+        >,
         old_token_collector: OldEpochBlendingTokenCollector,
     },
 }
@@ -1360,7 +1385,13 @@ fn handle_incoming_blend_message<
         ProcessedMessage,
         EncapsulatedMessageWithVerifiedPublicHeader,
     >,
-    old_epoch_scheduler: Option<&mut OldEpochMessageScheduler<Rng, ProcessedMessage>>,
+    old_epoch_scheduler: Option<
+        &mut OldEpochMessageScheduler<
+            Rng,
+            ProcessedMessage,
+            EncapsulatedMessageWithVerifiedPublicHeader,
+        >,
+    >,
     cryptographic_processor: &CoreCryptographicProcessor<
         NodeId,
         CorePoQGenerator,
@@ -1446,7 +1477,11 @@ fn handle_incoming_blend_message_from_old_epoch<
     CorePoQGenerator,
 >(
     verified_message: EncapsulatedMessageWithVerifiedPublicHeader,
-    scheduler: &mut OldEpochMessageScheduler<Rng, ProcessedMessage>,
+    scheduler: &mut OldEpochMessageScheduler<
+        Rng,
+        ProcessedMessage,
+        EncapsulatedMessageWithVerifiedPublicHeader,
+    >,
     cryptographic_processor: &CoreCryptographicProcessor<
         NodeId,
         CorePoQGenerator,
@@ -1541,7 +1576,11 @@ fn handle_decapsulated_incoming_message_from_old_epoch<
     ProofsVerifier,
 >(
     multi_layer_decapsulation_output: MultiLayerDecapsulationOutput,
-    scheduler: &mut OldEpochMessageScheduler<Rng, ProcessedMessage>,
+    scheduler: &mut OldEpochMessageScheduler<
+        Rng,
+        ProcessedMessage,
+        EncapsulatedMessageWithVerifiedPublicHeader,
+    >,
     recovery_checkpoint: ServiceState<BackendSettings, NetworkSettings>,
     old_cryptographic_processor: &CoreCryptographicProcessor<
         NodeId,
@@ -1664,7 +1703,6 @@ async fn handle_release_round<
 >(
     RoundInfo {
         data_messages,
-        old_epoch_data_messages,
         release_type,
     }: RoundInfo<ProcessedMessage, EncapsulatedMessageWithVerifiedPublicHeader>,
     cryptographic_processor: &mut CoreCryptographicProcessor<
@@ -1673,7 +1711,6 @@ async fn handle_release_round<
         ProofsGenerator,
         ProofsVerifier,
     >,
-    old_epoch: Option<Epoch>,
     rng: &mut Rng,
     backend: &Backend,
     network_adapter: &NetAdapter,
@@ -1711,25 +1748,6 @@ where
             },
         ).collect::<Vec<_>>();
 
-    // Data messages left over from the previous epoch go out on this same release
-    // round, but addressed to the old epoch's peers and tagged with the old epoch,
-    // because their `PoQ` only verifies against that epoch's public inputs. They
-    // are not tracked in this epoch's recovery state and do not consume this
-    // epoch's core quota, since they neither spend it nor reach current-epoch
-    // peers. Once the transition period has expired there is no old epoch left to
-    // publish to, so whatever remains is dropped here.
-    let old_epoch_data_count = old_epoch_data_messages.len();
-    let old_epoch_data_messages_relay_futures = old_epoch
-        .map(|old_epoch| {
-            old_epoch_data_messages
-                .into_iter()
-                .map(|data_message_to_blend| -> BoxFuture<'_, ()> {
-                    backend.publish(data_message_to_blend, old_epoch).boxed()
-                })
-                .collect::<Vec<_>>()
-        })
-        .unwrap_or_default();
-
     let processed_messages_relay_futures = build_futures_to_release_processed_messages(
         processed_messages,
         backend,
@@ -1740,7 +1758,6 @@ where
 
     let mut message_futures = data_messages_relay_futures
         .into_iter()
-        .chain(old_epoch_data_messages_relay_futures)
         .chain(processed_messages_relay_futures)
         .collect::<Vec<_>>();
 
@@ -1769,12 +1786,7 @@ where
 
     // Release all messages concurrently, and wait for all of them to be sent.
     join_all(message_futures).await;
-    log_release_window_summary(
-        data_count,
-        old_epoch_data_count,
-        processed_count,
-        cover_count,
-    );
+    log_release_window_summary(data_count, processed_count, cover_count);
 
     state_updater.commit_changes()
 }
@@ -1787,7 +1799,10 @@ async fn handle_release_round_for_old_epoch<
     ProofsVerifier,
     RuntimeServiceId,
 >(
-    processed_messages_to_release: Vec<ProcessedMessage>,
+    RoundInfo {
+        data_messages,
+        release_type,
+    }: RoundInfo<ProcessedMessage, EncapsulatedMessageWithVerifiedPublicHeader>,
     rng: &mut Rng,
     backend: &Backend,
     network_adapter: &NetAdapter,
@@ -1798,50 +1813,65 @@ async fn handle_release_round_for_old_epoch<
     Backend: BlendBackend<NodeId, BlakeRng, ProofsVerifier, RuntimeServiceId> + Sync,
     NetAdapter: NetworkAdapter<RuntimeServiceId> + Sync,
 {
-    let mut futures = build_futures_to_release_processed_messages(
-        processed_messages_to_release,
-        backend,
-        network_adapter,
-        None,
-        epoch,
-    );
+    // The old epoch never generates cover traffic, so the cover flag is always
+    // `false` here.
+    let (processed_messages, _) =
+        release_type.map_or_else(|| (vec![], false), RoundReleaseType::into_components);
+    let (data_count, processed_count) = (data_messages.len(), processed_messages.len());
+
+    // Data messages the epoch left unreleased carry its `PoQ`, which only verifies
+    // against that epoch's public inputs, so they are published under the old
+    // epoch's number and therefore to the peers still negotiated for it. They are
+    // not tracked in the new epoch's recovery state, which was reset on rotation,
+    // and they do not consume the new epoch's core quota, since they neither spend
+    // it nor reach current-epoch peers.
+    let data_messages_relay_futures =
+        data_messages
+            .into_iter()
+            .map(|data_message_to_blend| -> BoxFuture<'_, ()> {
+                backend.publish(data_message_to_blend, epoch).boxed()
+            });
+
+    let mut futures = data_messages_relay_futures
+        .chain(build_futures_to_release_processed_messages(
+            processed_messages,
+            backend,
+            network_adapter,
+            None,
+            epoch,
+        ))
+        .collect::<Vec<_>>();
     futures.shuffle(rng);
 
     // Release all messages concurrently, and wait for all of them to be sent.
-    let num_futures = futures.len();
     join_all(futures).await;
-    log_old_epoch_release_summary(num_futures);
+    log_old_epoch_release_summary(data_count, processed_count);
 }
 
-fn log_release_window_summary(
-    data_count: usize,
-    old_epoch_data_count: usize,
-    processed_count: usize,
-    cover_count: usize,
-) {
-    if data_count > 0 || old_epoch_data_count > 0 || processed_count > 0 {
+fn log_release_window_summary(data_count: usize, processed_count: usize, cover_count: usize) {
+    if data_count > 0 || processed_count > 0 {
         tracing::debug!(
             target: LOG_TARGET,
-            "Sent out {data_count} data, {old_epoch_data_count} old epoch data, {processed_count} processed and {cover_count} cover messages at this release window."
+            "Sent out {data_count} data, {processed_count} processed and {cover_count} cover messages at this release window."
         );
     } else {
         tracing::trace!(
             target: LOG_TARGET,
-            "Sent out {data_count} data, {old_epoch_data_count} old epoch data, {processed_count} processed and {cover_count} cover messages at this release window."
+            "Sent out {data_count} data, {processed_count} processed and {cover_count} cover messages at this release window."
         );
     }
 }
 
-fn log_old_epoch_release_summary(num_futures: usize) {
-    if num_futures > 0 {
+fn log_old_epoch_release_summary(data_count: usize, processed_count: usize) {
+    if data_count > 0 || processed_count > 0 {
         tracing::debug!(
             target: LOG_TARGET,
-            "Sent out {num_futures} processed messages at this release window for the old epoch"
+            "Sent out {data_count} data and {processed_count} processed messages at this release window for the old epoch"
         );
     } else {
         tracing::trace!(
             target: LOG_TARGET,
-            "Sent out {num_futures} processed messages at this release window for the old epoch"
+            "Sent out {data_count} data and {processed_count} processed messages at this release window for the old epoch"
         );
     }
 }

--- a/services/blend/src/core/mod.rs
+++ b/services/blend/src/core/mod.rs
@@ -1664,6 +1664,7 @@ async fn handle_release_round<
 >(
     RoundInfo {
         data_messages,
+        old_epoch_data_messages,
         release_type,
     }: RoundInfo<ProcessedMessage, EncapsulatedMessageWithVerifiedPublicHeader>,
     cryptographic_processor: &mut CoreCryptographicProcessor<
@@ -1672,6 +1673,7 @@ async fn handle_release_round<
         ProofsGenerator,
         ProofsVerifier,
     >,
+    old_epoch: Option<Epoch>,
     rng: &mut Rng,
     backend: &Backend,
     network_adapter: &NetAdapter,
@@ -1709,6 +1711,25 @@ where
             },
         ).collect::<Vec<_>>();
 
+    // Data messages left over from the previous epoch go out on this same release
+    // round, but addressed to the old epoch's peers and tagged with the old epoch,
+    // because their `PoQ` only verifies against that epoch's public inputs. They
+    // are not tracked in this epoch's recovery state and do not consume this
+    // epoch's core quota, since they neither spend it nor reach current-epoch
+    // peers. Once the transition period has expired there is no old epoch left to
+    // publish to, so whatever remains is dropped here.
+    let old_epoch_data_count = old_epoch_data_messages.len();
+    let old_epoch_data_messages_relay_futures = old_epoch
+        .map(|old_epoch| {
+            old_epoch_data_messages
+                .into_iter()
+                .map(|data_message_to_blend| -> BoxFuture<'_, ()> {
+                    backend.publish(data_message_to_blend, old_epoch).boxed()
+                })
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+
     let processed_messages_relay_futures = build_futures_to_release_processed_messages(
         processed_messages,
         backend,
@@ -1719,6 +1740,7 @@ where
 
     let mut message_futures = data_messages_relay_futures
         .into_iter()
+        .chain(old_epoch_data_messages_relay_futures)
         .chain(processed_messages_relay_futures)
         .collect::<Vec<_>>();
 
@@ -1747,7 +1769,12 @@ where
 
     // Release all messages concurrently, and wait for all of them to be sent.
     join_all(message_futures).await;
-    log_release_window_summary(data_count, processed_count, cover_count);
+    log_release_window_summary(
+        data_count,
+        old_epoch_data_count,
+        processed_count,
+        cover_count,
+    );
 
     state_updater.commit_changes()
 }
@@ -1786,16 +1813,21 @@ async fn handle_release_round_for_old_epoch<
     log_old_epoch_release_summary(num_futures);
 }
 
-fn log_release_window_summary(data_count: usize, processed_count: usize, cover_count: usize) {
-    if data_count > 0 || processed_count > 0 {
+fn log_release_window_summary(
+    data_count: usize,
+    old_epoch_data_count: usize,
+    processed_count: usize,
+    cover_count: usize,
+) {
+    if data_count > 0 || old_epoch_data_count > 0 || processed_count > 0 {
         tracing::debug!(
             target: LOG_TARGET,
-            "Sent out {data_count} data, {processed_count} processed and {cover_count} cover messages at this release window."
+            "Sent out {data_count} data, {old_epoch_data_count} old epoch data, {processed_count} processed and {cover_count} cover messages at this release window."
         );
     } else {
         tracing::trace!(
             target: LOG_TARGET,
-            "Sent out {data_count} data, {processed_count} processed and {cover_count} cover messages at this release window."
+            "Sent out {data_count} data, {old_epoch_data_count} old epoch data, {processed_count} processed and {cover_count} cover messages at this release window."
         );
     }
 }


### PR DESCRIPTION
## 1. What does this PR implement?

We are now validating PoQ before relaying messages, and invalid PoQs result in peer banning. This made an existing bug visible: when we rotate epoch, we used to move over the old epoch, unreleased data messages to the new epoch. This meant that the messages with the old epoch PoQ were propagated to new epoch's peers, which failed to verify the PoQ and hence would mark the sending peer as malicious.

This is now handled by keeping track of the old sessions data messages, which are carried over from the old epoch to the new epoch scheduler, and scheduled accordingly. We still maintain a single release schedule, but the old epoch messages are sent to the old epoch peers, and the new epoch messages are sent to the new epoch peers.

## 2. Does the code have enough context to be clearly understood?

Yes.

## 3. Who are the specification authors and who is accountable for this PR?

@ntn-x2 

## 4. Is the specification accurate and complete?

Yes.

## 5. Does the implementation introduce changes in the specification?

No.