### PR TITLE
test(zk): add benchmark for ZkSig batch verification

### DIFF
--- a/zk/proofs/zksign/Cargo.toml
+++ b/zk/proofs/zksign/Cargo.toml
@@ -34,5 +34,9 @@ rand         = { workspace = true }
 harness = false
 name    = "prove"
 
+[[bench]]
+harness = false
+name    = "verify"
+
 [lints]
 workspace = true

--- a/zk/proofs/zksign/benches/verify.rs
+++ b/zk/proofs/zksign/benches/verify.rs
@@ -1,0 +1,67 @@
+//! `ZkSign` verification benchmarks.
+//!
+//! Run with `cargo bench -p logos-blockchain-zksign --bench verify`.
+//!
+//! These measure the payoff of verifying a block's `ZkSign` proofs in a single
+//! batch instead of one at a time.
+
+use std::sync::LazyLock;
+
+use divan::counter::ItemsCount;
+use lb_groth16::Fr;
+use lb_poseidon2::{Digest as _, Poseidon2Bn254Hasher};
+use logos_blockchain_zksign::{
+    ZkSignPrivateKeysData, ZkSignProof, ZkSignVerifierInputs, ZkSignWitnessInputs, batch_verify,
+    prove, verify,
+};
+use num_bigint::BigUint;
+
+/// Batch sizes exercised by the batched and sequential verification
+/// benchmarks.
+///
+/// The largest batch size (1024) is the number of transactions a block can hold
+/// because most txs usually contain at least one `Transfer` operation to pay
+/// fees.
+const BATCH_SIZES: [usize; 6] = [1, 4, 16, 64, 256, 1024];
+
+/// Generate 1024 distinct proofs to be used for all the benchmarks.
+static PROOFS: LazyLock<Vec<(ZkSignProof, ZkSignVerifierInputs)>> = LazyLock::new(|| {
+    let n_proofs = BATCH_SIZES[BATCH_SIZES.len() - 1];
+    (0..n_proofs as u64)
+        .map(|index| {
+            let secret_keys: [Fr; 32] =
+                core::array::from_fn(|key| BigUint::from(index * 32 + key as u64 + 1).into());
+            let message_hash = Poseidon2Bn254Hasher::digest(&[BigUint::from(index).into()]);
+            prove(ZkSignWitnessInputs::from_witness_data_and_message_hash(
+                ZkSignPrivateKeysData::from(secret_keys),
+                message_hash,
+            ))
+            .unwrap()
+        })
+        .collect()
+});
+
+fn main() {
+    divan::main();
+}
+
+/// Verifies a batch of `batch_size` proofs.
+#[divan::bench(args = BATCH_SIZES)]
+fn bench_batch_verify(bencher: divan::Bencher, batch_size: usize) {
+    let batch = &PROOFS[..batch_size];
+    bencher
+        .counter(ItemsCount::new(batch_size))
+        .bench(|| assert!(divan::black_box(batch_verify(batch)).unwrap()));
+}
+
+/// Verifies `batch_size` proofs one at a time, as the baseline
+/// [`bench_batch_verify`] is compared against.
+#[divan::bench(args = BATCH_SIZES)]
+fn bench_sequential_verify(bencher: divan::Bencher, batch_size: usize) {
+    let batch = &PROOFS[..batch_size];
+    bencher.counter(ItemsCount::new(batch_size)).bench(|| {
+        for (proof, inputs) in batch {
+            assert!(divan::black_box(verify(proof, inputs)).unwrap());
+        }
+    });
+}


### PR DESCRIPTION
## 1. What does this PR implement?

I'm “preparing” integrating the groth16 batch verification to the codebase. I hope the PR title didn’t make you confused :)

This PR is the 1st step: A benchmark of ZkSignature batch verification.
We already have a benchmark for PoQ, but not for ZkSig.

Why for ZkSig? ZkSig is the most frequently used proof type, for various operations: Transfer, ChannelDeposit, SDPWithdraw, SDPActive, and also SDPDeclare (ZkAndEd25519Sigs). The other ZK proof we have for txs is only PoC (for LeaderClaim), but it is not used as frequent as the other operations.
So, batching ZkSigs would have the biggest impact.

The benchmark result is:
|n_proofs|sequential|batch|comparison|delta|
|---|---|---|---|--|
|1|2.84 ms|1.99 ms|1.43x|0.9 ms|
|4|11.35 ms|3.17 ms|3.57x|8 ms|
|16|45.39 ms|7.70 ms|5.90x|38 ms|
|64|181.6 ms|25.57 ms|7.10x|156 ms|
|256|726.1 ms|96.14 ms|7.55x|630 ms|
|1024|2.91 s|0.38 s|7.60x|2.53 s|

A side finding from the benchmark: the 7.6x is not purely the batching effect. 

You can see that the `batch` for `n_proofs = 1` is 1.43x faster than `sequential`. Since I don't have that much knowledge of ZK, I asked Claude why. It says that:

> `ark_groth16::prepare_inputs` folds the public inputs with a naive loop of individual scalar multiplications. On the other hand, our `groth16_batch_verify` does the same work with one Pippenger MSM.

I don't understand what this means, but I guess you guys have been already aware of it.

That says that we can simply replace the current `verify` calls in our codebase with `verify_batch`, and gain 1.43x performance improvement. But, I think, this is a separate topic.


## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@youngjoon-lee 
spec: @thomaslavaur 

## 4. Is the specification accurate and complete?

Yes

## 5. Does the implementation introduce changes in the specification?

No

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
