### PR TITLE
refactor(operation): op code into trait

### DIFF
--- a/core/src/mantle/ledger.rs
+++ b/core/src/mantle/ledger.rs
@@ -50,6 +50,7 @@ pub mod verification_mode {
 
 pub trait ProvableOperation {
     type Proof;
+    const CODE: u8; // TODO: Compile time check that this is unique across all operations?
 }
 
 pub trait PreverifiableOperation<Mode: verification_mode::VerificationMode>:

--- a/core/src/mantle/ops/channel/channel_transfer.rs
+++ b/core/src/mantle/ops/channel/channel_transfer.rs
@@ -62,6 +62,7 @@ impl ProvableOperation for ChannelTransferOp {
     // `SignedOperationExecutionGas::gas_multiplier` below reads this proof's
     // signature count. If this changes, update that too.
     type Proof = ChannelMultiSigProof;
+    const CODE: u8 = 0x14;
 }
 
 impl OperationGas<MainnetGasProfile> for ChannelTransferOp {

--- a/core/src/mantle/ops/channel/config.rs
+++ b/core/src/mantle/ops/channel/config.rs
@@ -59,6 +59,7 @@ impl ProvableOperation for ChannelConfigOp {
     // `SignedOperationExecutionGas::gas_multiplier` below reads this proof's
     // signature count. If this changes, update that too.
     type Proof = ChannelMultiSigProof;
+    const CODE: u8 = 0x10;
 }
 
 impl OperationGas<MainnetGasProfile> for ChannelConfigOp {

--- a/core/src/mantle/ops/channel/deposit.rs
+++ b/core/src/mantle/ops/channel/deposit.rs
@@ -73,6 +73,7 @@ pub struct DepositExecutionContext {
 
 impl ProvableOperation for DepositOp {
     type Proof = ZkSignature;
+    const CODE: u8 = 0x12;
 }
 
 impl OperationGas<MainnetGasProfile> for DepositOp {

--- a/core/src/mantle/ops/channel/inscribe.rs
+++ b/core/src/mantle/ops/channel/inscribe.rs
@@ -89,6 +89,7 @@ pub struct InscriptionExecutionContext {
 
 impl ProvableOperation for InscriptionOp {
     type Proof = Ed25519Signature;
+    const CODE: u8 = 0x11;
 }
 
 impl OperationGas<MainnetGasProfile> for InscriptionOp {

--- a/core/src/mantle/ops/channel/withdraw.rs
+++ b/core/src/mantle/ops/channel/withdraw.rs
@@ -54,6 +54,7 @@ impl ProvableOperation for ChannelWithdrawOp {
     // `SignedOperationExecutionGas::gas_multiplier` below reads this proof's
     // signature count. If this changes, update that too.
     type Proof = ChannelMultiSigProof;
+    const CODE: u8 = 0x13;
 }
 
 impl OperationGas<MainnetGasProfile> for ChannelWithdrawOp {

--- a/core/src/mantle/ops/internal.rs
+++ b/core/src/mantle/ops/internal.rs
@@ -4,31 +4,33 @@ use super::{
     Op,
     channel::{config::ChannelConfigOp, deposit::DepositOp, inscribe::InscriptionOp},
     leader_claim::LeaderClaimOp,
-    op_codes,
     sdp::{SDPActiveOp, SDPDeclareOp, SDPWithdrawOp},
     serde_::OpWire,
     transfer::TransferOp,
 };
-use crate::mantle::ops::{
-    channel::{channel_transfer::ChannelTransferOp, withdraw::ChannelWithdrawOp},
-    pow::ClaimPowRewardOp,
+use crate::mantle::{
+    ledger::ProvableOperation as _,
+    ops::{
+        channel::{channel_transfer::ChannelTransferOp, withdraw::ChannelWithdrawOp},
+        pow::ClaimPowRewardOp,
+    },
 };
 
 /// Core set of supported Mantle operations and their serialization behaviour.
 #[derive(Serialize)]
 #[serde(untagged)]
 pub enum OpSer<'a> {
-    ChannelInscribe(OpWire<{ op_codes::INSCRIBE }, &'a InscriptionOp>),
-    ChannelConfig(OpWire<{ op_codes::CHANNEL_CONFIG }, &'a ChannelConfigOp>),
-    ChannelDeposit(OpWire<{ op_codes::CHANNEL_DEPOSIT }, &'a DepositOp>),
-    ChannelWithdraw(OpWire<{ op_codes::CHANNEL_WITHDRAW }, &'a ChannelWithdrawOp>),
-    ChannelTransfer(OpWire<{ op_codes::CHANNEL_TRANSFER }, &'a ChannelTransferOp>),
-    SDPDeclare(OpWire<{ op_codes::SDP_DECLARE }, &'a SDPDeclareOp>),
-    SDPWithdraw(OpWire<{ op_codes::SDP_WITHDRAW }, &'a SDPWithdrawOp>),
-    SDPActive(OpWire<{ op_codes::SDP_ACTIVE }, &'a SDPActiveOp>),
-    LeaderClaim(OpWire<{ op_codes::LEADER_CLAIM }, &'a LeaderClaimOp>),
-    Transfer(OpWire<{ op_codes::TRANSFER }, &'a TransferOp>),
-    ClaimPowReward(OpWire<{ op_codes::CLAIM_POW_REWARD }, &'a ClaimPowRewardOp>),
+    ChannelInscribe(OpWire<{ InscriptionOp::CODE }, &'a InscriptionOp>),
+    ChannelConfig(OpWire<{ ChannelConfigOp::CODE }, &'a ChannelConfigOp>),
+    ChannelDeposit(OpWire<{ DepositOp::CODE }, &'a DepositOp>),
+    ChannelWithdraw(OpWire<{ ChannelWithdrawOp::CODE }, &'a ChannelWithdrawOp>),
+    ChannelTransfer(OpWire<{ ChannelTransferOp::CODE }, &'a ChannelTransferOp>),
+    SDPDeclare(OpWire<{ SDPDeclareOp::CODE }, &'a SDPDeclareOp>),
+    SDPWithdraw(OpWire<{ SDPWithdrawOp::CODE }, &'a SDPWithdrawOp>),
+    SDPActive(OpWire<{ SDPActiveOp::CODE }, &'a SDPActiveOp>),
+    LeaderClaim(OpWire<{ LeaderClaimOp::CODE }, &'a LeaderClaimOp>),
+    Transfer(OpWire<{ TransferOp::CODE }, &'a TransferOp>),
+    ClaimPowReward(OpWire<{ ClaimPowRewardOp::CODE }, &'a ClaimPowRewardOp>),
 }
 
 impl<'a> From<&'a Op> for OpSer<'a> {
@@ -53,17 +55,17 @@ impl<'a> From<&'a Op> for OpSer<'a> {
 #[derive(Deserialize)]
 #[serde(untagged)]
 pub enum OpDe {
-    ChannelInscribe(OpWire<{ op_codes::INSCRIBE }, InscriptionOp>),
-    ChannelConfig(OpWire<{ op_codes::CHANNEL_CONFIG }, ChannelConfigOp>),
-    ChannelDeposit(OpWire<{ op_codes::CHANNEL_DEPOSIT }, DepositOp>),
-    ChannelWithdraw(OpWire<{ op_codes::CHANNEL_WITHDRAW }, ChannelWithdrawOp>),
-    ChannelTransfer(OpWire<{ op_codes::CHANNEL_TRANSFER }, ChannelTransferOp>),
-    SDPDeclare(OpWire<{ op_codes::SDP_DECLARE }, SDPDeclareOp>),
-    SDPWithdraw(OpWire<{ op_codes::SDP_WITHDRAW }, SDPWithdrawOp>),
-    SDPActive(OpWire<{ op_codes::SDP_ACTIVE }, SDPActiveOp>),
-    LeaderClaim(OpWire<{ op_codes::LEADER_CLAIM }, LeaderClaimOp>),
-    Transfer(OpWire<{ op_codes::TRANSFER }, TransferOp>),
-    ClaimPoWReward(OpWire<{ op_codes::CLAIM_POW_REWARD }, ClaimPowRewardOp>),
+    ChannelInscribe(OpWire<{ InscriptionOp::CODE }, InscriptionOp>),
+    ChannelConfig(OpWire<{ ChannelConfigOp::CODE }, ChannelConfigOp>),
+    ChannelDeposit(OpWire<{ DepositOp::CODE }, DepositOp>),
+    ChannelWithdraw(OpWire<{ ChannelWithdrawOp::CODE }, ChannelWithdrawOp>),
+    ChannelTransfer(OpWire<{ ChannelTransferOp::CODE }, ChannelTransferOp>),
+    SDPDeclare(OpWire<{ SDPDeclareOp::CODE }, SDPDeclareOp>),
+    SDPWithdraw(OpWire<{ SDPWithdrawOp::CODE }, SDPWithdrawOp>),
+    SDPActive(OpWire<{ SDPActiveOp::CODE }, SDPActiveOp>),
+    LeaderClaim(OpWire<{ LeaderClaimOp::CODE }, LeaderClaimOp>),
+    Transfer(OpWire<{ TransferOp::CODE }, TransferOp>),
+    ClaimPoWReward(OpWire<{ ClaimPowRewardOp::CODE }, ClaimPowRewardOp>),
 }
 
 impl From<OpDe> for Op {

--- a/core/src/mantle/ops/internal.rs
+++ b/core/src/mantle/ops/internal.rs
@@ -20,6 +20,7 @@ use crate::mantle::{
 #[derive(Serialize)]
 #[serde(untagged)]
 pub enum OpSer<'a> {
+    Transfer(OpWire<{ TransferOp::CODE }, &'a TransferOp>),
     ChannelInscribe(OpWire<{ InscriptionOp::CODE }, &'a InscriptionOp>),
     ChannelConfig(OpWire<{ ChannelConfigOp::CODE }, &'a ChannelConfigOp>),
     ChannelDeposit(OpWire<{ DepositOp::CODE }, &'a DepositOp>),
@@ -29,13 +30,13 @@ pub enum OpSer<'a> {
     SDPWithdraw(OpWire<{ SDPWithdrawOp::CODE }, &'a SDPWithdrawOp>),
     SDPActive(OpWire<{ SDPActiveOp::CODE }, &'a SDPActiveOp>),
     LeaderClaim(OpWire<{ LeaderClaimOp::CODE }, &'a LeaderClaimOp>),
-    Transfer(OpWire<{ TransferOp::CODE }, &'a TransferOp>),
     ClaimPowReward(OpWire<{ ClaimPowRewardOp::CODE }, &'a ClaimPowRewardOp>),
 }
 
 impl<'a> From<&'a Op> for OpSer<'a> {
     fn from(value: &'a Op) -> Self {
         match value {
+            Op::Transfer(op) => Self::Transfer(OpWire::new(op)),
             Op::ChannelInscribe(op) => Self::ChannelInscribe(OpWire::new(op)),
             Op::ChannelConfig(op) => Self::ChannelConfig(OpWire::new(op)),
             Op::ChannelDeposit(op) => Self::ChannelDeposit(OpWire::new(op)),
@@ -45,7 +46,6 @@ impl<'a> From<&'a Op> for OpSer<'a> {
             Op::SDPWithdraw(op) => Self::SDPWithdraw(OpWire::new(op)),
             Op::SDPActive(op) => Self::SDPActive(OpWire::new(op)),
             Op::LeaderClaim(op) => Self::LeaderClaim(OpWire::new(op)),
-            Op::Transfer(op) => Self::Transfer(OpWire::new(op)),
             Op::ClaimPowReward(op) => Self::ClaimPowReward(OpWire::new(op)),
         }
     }
@@ -55,8 +55,9 @@ impl<'a> From<&'a Op> for OpSer<'a> {
 #[derive(Deserialize)]
 #[serde(untagged)]
 pub enum OpDe {
-    ChannelInscribe(OpWire<{ InscriptionOp::CODE }, InscriptionOp>),
+    Transfer(OpWire<{ TransferOp::CODE }, TransferOp>),
     ChannelConfig(OpWire<{ ChannelConfigOp::CODE }, ChannelConfigOp>),
+    ChannelInscribe(OpWire<{ InscriptionOp::CODE }, InscriptionOp>),
     ChannelDeposit(OpWire<{ DepositOp::CODE }, DepositOp>),
     ChannelWithdraw(OpWire<{ ChannelWithdrawOp::CODE }, ChannelWithdrawOp>),
     ChannelTransfer(OpWire<{ ChannelTransferOp::CODE }, ChannelTransferOp>),
@@ -64,15 +65,15 @@ pub enum OpDe {
     SDPWithdraw(OpWire<{ SDPWithdrawOp::CODE }, SDPWithdrawOp>),
     SDPActive(OpWire<{ SDPActiveOp::CODE }, SDPActiveOp>),
     LeaderClaim(OpWire<{ LeaderClaimOp::CODE }, LeaderClaimOp>),
-    Transfer(OpWire<{ TransferOp::CODE }, TransferOp>),
-    ClaimPoWReward(OpWire<{ ClaimPowRewardOp::CODE }, ClaimPowRewardOp>),
+    ClaimPowReward(OpWire<{ ClaimPowRewardOp::CODE }, ClaimPowRewardOp>),
 }
 
 impl From<OpDe> for Op {
     fn from(value: OpDe) -> Self {
         match value {
-            OpDe::ChannelInscribe(w) => Self::ChannelInscribe(w.into_op()),
+            OpDe::Transfer(w) => Self::Transfer(w.into_op()),
             OpDe::ChannelConfig(w) => Self::ChannelConfig(w.into_op()),
+            OpDe::ChannelInscribe(w) => Self::ChannelInscribe(w.into_op()),
             OpDe::ChannelDeposit(w) => Self::ChannelDeposit(w.into_op()),
             OpDe::ChannelWithdraw(w) => Self::ChannelWithdraw(w.into_op()),
             OpDe::ChannelTransfer(w) => Self::ChannelTransfer(w.into_op()),
@@ -80,8 +81,7 @@ impl From<OpDe> for Op {
             OpDe::SDPWithdraw(w) => Self::SDPWithdraw(w.into_op()),
             OpDe::SDPActive(w) => Self::SDPActive(w.into_op()),
             OpDe::LeaderClaim(w) => Self::LeaderClaim(w.into_op()),
-            OpDe::Transfer(w) => Self::Transfer(w.into_op()),
-            OpDe::ClaimPoWReward(w) => Self::ClaimPowReward(w.into_op()),
+            OpDe::ClaimPowReward(w) => Self::ClaimPowReward(w.into_op()),
         }
     }
 }

--- a/core/src/mantle/ops/leader_claim.rs
+++ b/core/src/mantle/ops/leader_claim.rs
@@ -187,6 +187,7 @@ pub struct LeaderClaimExecutionContext {
 
 impl ProvableOperation for LeaderClaimOp {
     type Proof = Groth16LeaderClaimProof;
+    const CODE: u8 = 0x30;
 }
 
 impl OperationGas<MainnetGasProfile> for LeaderClaimOp {

--- a/core/src/mantle/ops/mod.rs
+++ b/core/src/mantle/ops/mod.rs
@@ -23,20 +23,6 @@ pub use crate::mantle::ops::{
 pub(crate) static OPERATION_ID_V1: LazyLock<Vec<u8>> =
     LazyLock::new(|| b"OPERATION_ID_V1".to_vec());
 
-pub(crate) mod op_codes {
-    pub const TRANSFER: u8 = 0x00;
-    pub const CHANNEL_CONFIG: u8 = 0x10;
-    pub const INSCRIBE: u8 = 0x11;
-    pub const CHANNEL_DEPOSIT: u8 = 0x12;
-    pub const CHANNEL_WITHDRAW: u8 = 0x13;
-    pub const CHANNEL_TRANSFER: u8 = 0x14;
-    pub const SDP_DECLARE: u8 = 0x20;
-    pub const SDP_WITHDRAW: u8 = 0x21;
-    pub const SDP_ACTIVE: u8 = 0x22;
-    pub const LEADER_CLAIM: u8 = 0x30;
-    pub const CLAIM_POW_REWARD: u8 = 0x40;
-}
-
 /// Mantle reference test-vector generators.
 ///
 /// This module does not assert library behaviour: it emits reference test

--- a/core/src/mantle/ops/op.rs
+++ b/core/src/mantle/ops/op.rs
@@ -6,6 +6,7 @@ use crate::{
     mantle::{
         GasProfile,
         gas::{Gas, OperationGas},
+        ledger::ProvableOperation as _,
         ops::{
             OPERATION_ID_V1,
             channel::{
@@ -14,7 +15,6 @@ use crate::{
             },
             internal::{OpDe, OpSer},
             leader_claim::LeaderClaimOp,
-            op_codes,
             pow::ClaimPowRewardOp,
             sdp::{SDPActiveOp, SDPDeclareOp, SDPWithdrawOp},
             transfer::TransferOp,
@@ -140,33 +140,33 @@ impl BinaryDecode for Op {
         let (input, opcode) = u8::decode(input, &())?;
 
         match opcode {
-            op_codes::INSCRIBE => InscriptionOp::decode(input, &())
+            InscriptionOp::CODE => InscriptionOp::decode(input, &())
                 .map(|(rest, op)| (rest, Self::ChannelInscribe(op))),
-            op_codes::CHANNEL_CONFIG => ChannelConfigOp::decode(input, &())
+            ChannelConfigOp::CODE => ChannelConfigOp::decode(input, &())
                 .map(|(rest, op)| (rest, Self::ChannelConfig(op))),
-            op_codes::CHANNEL_DEPOSIT => {
+            DepositOp::CODE => {
                 DepositOp::decode(input, &()).map(|(rest, op)| (rest, Self::ChannelDeposit(op)))
             }
-            op_codes::CHANNEL_WITHDRAW => ChannelWithdrawOp::decode(input, &())
+            ChannelWithdrawOp::CODE => ChannelWithdrawOp::decode(input, &())
                 .map(|(rest, op)| (rest, Self::ChannelWithdraw(op))),
-            op_codes::CHANNEL_TRANSFER => ChannelTransferOp::decode(input, &())
+            ChannelTransferOp::CODE => ChannelTransferOp::decode(input, &())
                 .map(|(rest, op)| (rest, Self::ChannelTransfer(op))),
-            op_codes::SDP_DECLARE => {
+            SDPDeclareOp::CODE => {
                 SDPDeclareOp::decode(input, &()).map(|(rest, op)| (rest, Self::SDPDeclare(op)))
             }
-            op_codes::SDP_WITHDRAW => {
+            SDPWithdrawOp::CODE => {
                 SDPWithdrawOp::decode(input, &()).map(|(rest, op)| (rest, Self::SDPWithdraw(op)))
             }
-            op_codes::SDP_ACTIVE => {
+            SDPActiveOp::CODE => {
                 SDPActiveOp::decode(input, &()).map(|(rest, op)| (rest, Self::SDPActive(op)))
             }
-            op_codes::LEADER_CLAIM => {
+            LeaderClaimOp::CODE => {
                 LeaderClaimOp::decode(input, &()).map(|(rest, op)| (rest, Self::LeaderClaim(op)))
             }
-            op_codes::TRANSFER => {
+            TransferOp::CODE => {
                 TransferOp::decode(input, &()).map(|(rest, op)| (rest, Self::Transfer(op)))
             }
-            op_codes::CLAIM_POW_REWARD => ClaimPowRewardOp::decode(input, &())
+            ClaimPowRewardOp::CODE => ClaimPowRewardOp::decode(input, &())
                 .map(|(rest, op)| (rest, Self::ClaimPowReward(op))),
             other => Err(DecodeError::unknown_discriminant::<Self>(u64::from(other))),
         }
@@ -222,17 +222,17 @@ impl Op {
 
     const fn code(&self) -> u8 {
         match self {
-            Self::ChannelInscribe(_) => op_codes::INSCRIBE,
-            Self::ChannelConfig(_) => op_codes::CHANNEL_CONFIG,
-            Self::ChannelDeposit(_) => op_codes::CHANNEL_DEPOSIT,
-            Self::ChannelWithdraw(_) => op_codes::CHANNEL_WITHDRAW,
-            Self::ChannelTransfer(_) => op_codes::CHANNEL_TRANSFER,
-            Self::SDPDeclare(_) => op_codes::SDP_DECLARE,
-            Self::SDPWithdraw(_) => op_codes::SDP_WITHDRAW,
-            Self::SDPActive(_) => op_codes::SDP_ACTIVE,
-            Self::LeaderClaim(_) => op_codes::LEADER_CLAIM,
-            Self::Transfer(_) => op_codes::TRANSFER,
-            Self::ClaimPowReward(_) => op_codes::CLAIM_POW_REWARD,
+            Self::ChannelInscribe(_) => InscriptionOp::CODE,
+            Self::ChannelConfig(_) => ChannelConfigOp::CODE,
+            Self::ChannelDeposit(_) => DepositOp::CODE,
+            Self::ChannelWithdraw(_) => ChannelWithdrawOp::CODE,
+            Self::ChannelTransfer(_) => ChannelTransferOp::CODE,
+            Self::SDPDeclare(_) => SDPDeclareOp::CODE,
+            Self::SDPWithdraw(_) => SDPWithdrawOp::CODE,
+            Self::SDPActive(_) => SDPActiveOp::CODE,
+            Self::LeaderClaim(_) => LeaderClaimOp::CODE,
+            Self::Transfer(_) => TransferOp::CODE,
+            Self::ClaimPowReward(_) => ClaimPowRewardOp::CODE,
         }
     }
 }

--- a/core/src/mantle/ops/pow.rs
+++ b/core/src/mantle/ops/pow.rs
@@ -273,6 +273,7 @@ impl ClaimPoWRewardExecutionContext {
 
 impl ProvableOperation for ClaimPowRewardOp {
     type Proof = NoOpProof;
+    const CODE: u8 = 0x40;
 }
 
 impl OperationGas<MainnetGasProfile> for ClaimPowRewardOp {

--- a/core/src/mantle/ops/sdp/active.rs
+++ b/core/src/mantle/ops/sdp/active.rs
@@ -35,6 +35,7 @@ pub struct SDPActiveExecutionContext {
 
 impl ProvableOperation for SDPActiveOp {
     type Proof = ZkSignature;
+    const CODE: u8 = 0x22;
 }
 
 impl OperationGas<MainnetGasProfile> for SDPActiveOp {

--- a/core/src/mantle/ops/sdp/declare.rs
+++ b/core/src/mantle/ops/sdp/declare.rs
@@ -159,6 +159,7 @@ pub struct SDPDeclareExecutionContext {
 
 impl ProvableOperation for SDPDeclareOp {
     type Proof = ZkAndEd25519Proof;
+    const CODE: u8 = 0x20;
 }
 
 impl OperationGas<MainnetGasProfile> for SDPDeclareOp {

--- a/core/src/mantle/ops/sdp/withdraw.rs
+++ b/core/src/mantle/ops/sdp/withdraw.rs
@@ -38,6 +38,7 @@ pub struct SDPWithdrawExecutionContext {
 
 impl ProvableOperation for SDPWithdrawOp {
     type Proof = ZkSignature;
+    const CODE: u8 = 0x21;
 }
 
 impl OperationGas<MainnetGasProfile> for SDPWithdrawOp {

--- a/core/src/mantle/ops/serde_.rs
+++ b/core/src/mantle/ops/serde_.rs
@@ -25,6 +25,8 @@ impl<'de, const CODE: u8> Deserialize<'de> for ConstU8<CODE> {
 }
 
 /// Shared `{ opcode, payload }` wire shape used in both directions.
+// TODO: If `Inner` is always a ProvableOperation, then we can leverage `: ProvableOperation` toOp
+//  satisfy the `CODE`.
 #[derive(Serialize, Deserialize)]
 pub struct OpWire<const CODE: u8, Inner> {
     opcode: ConstU8<CODE>,

--- a/core/src/mantle/ops/serde_.rs
+++ b/core/src/mantle/ops/serde_.rs
@@ -25,8 +25,6 @@ impl<'de, const CODE: u8> Deserialize<'de> for ConstU8<CODE> {
 }
 
 /// Shared `{ opcode, payload }` wire shape used in both directions.
-// TODO: If `Inner` is always a ProvableOperation, then we can leverage `: ProvableOperation` toOp
-//  satisfy the `CODE`.
 #[derive(Serialize, Deserialize)]
 pub struct OpWire<const CODE: u8, Inner> {
     opcode: ConstU8<CODE>,

--- a/core/src/mantle/ops/transfer.rs
+++ b/core/src/mantle/ops/transfer.rs
@@ -88,6 +88,7 @@ pub struct TransferValidationContext<'a> {
 
 impl ProvableOperation for TransferOp {
     type Proof = ZkSignature;
+    const CODE: u8 = 0x00;
 }
 
 impl OperationGas<MainnetGasProfile> for TransferOp {


### PR DESCRIPTION
## 1. What does this PR implement?
Move operation codes from the central `op_codes` module into an associated const on `ProvableOperation`, so each operation owns its own code.

## 2. Does the code have enough context to be clearly understood?
Yes

## 3. Who are the specification authors and who is accountable for this PR?
@strinnityk 

## 4. Is the specification accurate and complete?
N/A

## 5. Does the implementation introduce changes in the specification?
N/A

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [X] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [X] 2. Description added.
* [X] 3. Context and links to Specification document(s) added.
* [X] 4. Main contact(s) (developers and specification authors) added
* [X] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [X] 6. Link PR to a specific milestone.
* [X] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).