### PR TITLE
chore(chainsync): fix wrong log messages

### DIFF
--- a/consensus/cryptarchia-sync/src/libp2p/behaviour.rs
+++ b/consensus/cryptarchia-sync/src/libp2p/behaviour.rs
@@ -448,8 +448,8 @@ impl NetworkBehaviour for Behaviour {
                 Ok(request_stream) => {
                     self.handle_blocks_request_available(request_stream);
                 }
-                Err(e) => {
-                    error!("Error while processing block download request: {}", e);
+                Err(err) => {
+                    error!(%err, "failed to send a block download request");
                 }
             }
 
@@ -461,8 +461,8 @@ impl NetworkBehaviour for Behaviour {
                 Ok(request_stream) => {
                     self.handle_tip_request_available(request_stream);
                 }
-                Err(e) => {
-                    error!("Error while processing tip request: {}", e);
+                Err(err) => {
+                    error!(%err, "failed to send a tip request");
                 }
             }
 


### PR DESCRIPTION
## 1. What does this PR implement?

~~This PR is on top of @davidrusu's PR #3302.~~ Rebased on master, since the updated PR #3302 doesn't touch this file anymore.

I fixed wrong/ambigious log messages in the `cryptarchia-sync`. 

These logs are printed by a block requester, who **sends** a request to a block provider. However, the previous log messages could be interpreted as saying that the block provider failed to process a received request. That's not the case. This PR fixes the log messages to clarify that the block requester failed to **send** the request.

Also, many function names in this module are also confusing, in the same reason I mentioned above. In a next PR, I'm gonna rename all of them.

## 2. Does the code have enough context to be clearly understood?

Yes.

## 3. Who are the specification authors and who is accountable for this PR?

@youngjoon-lee @andrussal 

## 4. Is the specification accurate and complete?

yes.

## 5. Does the implementation introduce changes in the specification?

no

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
