### PR TITLE
feat: change priority fee to be a percentage

### DIFF
--- a/c-bindings/src/api/wallet.rs
+++ b/c-bindings/src/api/wallet.rs
@@ -1471,7 +1471,7 @@ pub(crate) fn wallet_fund_tx_sync(
                 request.tx_builder,
                 request.change_public_key,
                 request.funding_public_keys,
-                request.priority_fee,
+                request.priority_fee_percent,
             )
             .await
             .map_err(|error| {
@@ -1547,8 +1547,15 @@ pub type FfiWalletFundResult = FfiStatusResult<*mut c_char>;
 ///
 /// The request and response are JSON strings with the exact same schemas as
 /// the node's `POST /wallet/fund` HTTP request and response bodies. The
-/// optional `priority_fee` field (default 0) is left as excess balance above
-/// the mandatory fee, paid to the block producer as the execution tip.
+/// optional `priority_fee_percent` field (default 0) is interpreted as a
+/// percentage of the final mandatory fee, including execution and storage
+/// cost. The rounded-up percentage is reserved as excess balance above that
+/// fee; only the unused reserve is paid to the block producer as the effective
+/// priority tip. The Zone SDK and TUI default to 12%, a practical reserve
+/// intended to absorb normal fee movement, including approximately one
+/// storage-market epoch increase at normal price levels. This is not a
+/// protocol guarantee at very low prices or when execution fees also rise
+/// materially; integer storage-price arithmetic can make 1 become 2.
 ///
 /// # Arguments
 ///

--- a/core/src/mantle/transactions/builder.rs
+++ b/core/src/mantle/transactions/builder.rs
@@ -140,9 +140,7 @@ impl MantleTxBuilder {
     }
 
     /// Return a positive change output while reserving the requested
-    /// percentage of the final transaction's mandatory fee. The dummy output
-    /// makes the mandatory fee calculation include the change output before
-    /// the percentage is calculated.
+    /// percentage of the final transaction's mandatory fee.
     pub fn return_change<G: GasProfile>(
         self,
         context: &MantleTxContext,
@@ -153,10 +151,7 @@ impl MantleTxBuilder {
         // is based on the final transaction shape.
         let candidate = self.with_dummy_change_note()?;
         let mandatory_fee = candidate.minimum_gas_cost::<G>(context)?.into_inner();
-        let priority_fee_amount = Self::priority_fee_amount(mandatory_fee, priority_fee_percent)?;
-        let required_fee = mandatory_fee
-            .checked_add(priority_fee_amount)
-            .ok_or(GasOverflow)?;
+        let required_fee = Self::required_fee(mandatory_fee, priority_fee_percent)?;
         let available_change = self.net_balance() - i128::from(required_fee);
 
         match available_change.cmp(&1) {
@@ -171,15 +166,6 @@ impl MantleTxBuilder {
                     value: change,
                     pk: change_pk,
                 })?;
-
-                let final_mandatory_fee =
-                    tx_with_change.minimum_gas_cost::<G>(context)?.into_inner();
-                let final_priority_fee_amount =
-                    Self::priority_fee_amount(final_mandatory_fee, priority_fee_percent)?;
-                let final_required_fee = final_mandatory_fee
-                    .checked_add(final_priority_fee_amount)
-                    .ok_or(GasOverflow)?;
-                assert_eq!(tx_with_change.net_balance(), i128::from(final_required_fee));
 
                 Ok(Some(tx_with_change))
             }
@@ -267,11 +253,18 @@ impl MantleTxBuilder {
         priority_fee_percent: u64,
     ) -> Result<i128, TxBuilderError> {
         let mandatory_fee = self.minimum_gas_cost::<G>(context)?.into_inner();
-        let priority_fee_amount = Self::priority_fee_amount(mandatory_fee, priority_fee_percent)?;
-        let required_fee = mandatory_fee
-            .checked_add(priority_fee_amount)
-            .ok_or(GasOverflow)?;
+        let required_fee = Self::required_fee(mandatory_fee, priority_fee_percent)?;
         Ok(self.net_balance() - i128::from(required_fee))
+    }
+
+    fn required_fee(
+        mandatory_fee: Value,
+        priority_fee_percent: u64,
+    ) -> Result<Value, TxBuilderError> {
+        let priority_fee_amount = Self::priority_fee_amount(mandatory_fee, priority_fee_percent)?;
+        mandatory_fee
+            .checked_add(priority_fee_amount)
+            .ok_or_else(|| GasOverflow.into())
     }
 
     /// Calculates the priority fee amount for a mandatory fee using integer
@@ -705,5 +698,21 @@ mod tests {
         assert_eq!(MantleTxBuilder::priority_fee_amount(8, 12).unwrap(), 1);
         assert_eq!(MantleTxBuilder::priority_fee_amount(9, 12).unwrap(), 2);
         assert_eq!(MantleTxBuilder::priority_fee_amount(100, 101).unwrap(), 101);
+    }
+
+    #[test]
+    fn priority_fee_percentage_handles_u64_boundaries() {
+        assert_eq!(
+            MantleTxBuilder::priority_fee_amount(u64::MAX, 100).unwrap(),
+            u64::MAX
+        );
+        assert!(matches!(
+            MantleTxBuilder::priority_fee_amount(u64::MAX, 101),
+            Err(TxBuilderError::GasOverflow(_))
+        ));
+        assert!(matches!(
+            MantleTxBuilder::required_fee(u64::MAX, 100),
+            Err(TxBuilderError::GasOverflow(_))
+        ));
     }
 }

--- a/core/src/mantle/transactions/builder.rs
+++ b/core/src/mantle/transactions/builder.rs
@@ -139,41 +139,47 @@ impl MantleTxBuilder {
         Ok(self)
     }
 
-    /// `priority_fee` is deliberately left unreturned: the resulting excess
-    /// balance above the mandatory fee is the transaction's execution tip.
+    /// Return a positive change output while reserving the requested
+    /// percentage of the final transaction's mandatory fee. The dummy output
+    /// makes the mandatory fee calculation include the change output before
+    /// the percentage is calculated.
     pub fn return_change<G: GasProfile>(
         self,
         context: &MantleTxContext,
         change_pk: ZkPublicKey,
-        priority_fee: Value,
+        priority_fee_percent: u64,
     ) -> Result<Option<Self>, TxBuilderError> {
-        // Calculate the funding delta with a dummy change note to account for
-        // the gas cost increase from adding the output
-        let delta_with_change = self.with_dummy_change_note()?.funding_delta::<G>(context)?;
-        let delta_target = i128::from(priority_fee);
+        // Calculate the mandatory fee with a dummy change note so the reserve
+        // is based on the final transaction shape.
+        let candidate = self.with_dummy_change_note()?;
+        let mandatory_fee = candidate.minimum_gas_cost::<G>(context)?.into_inner();
+        let priority_fee_amount = Self::priority_fee_amount(mandatory_fee, priority_fee_percent)?;
+        let required_fee = mandatory_fee
+            .checked_add(priority_fee_amount)
+            .ok_or(GasOverflow)?;
+        let available_change = self.net_balance() - i128::from(required_fee);
 
-        match delta_with_change.cmp(&delta_target) {
-            Ordering::Less | Ordering::Equal => {
-                // NOTE: the `Equal` is important here since we
-                // cannot create zero-valued outputs.
-
-                // The increase in cost due to the change note means
-                // we have insufficient funds, need more UTXO's.
+        match available_change.cmp(&1) {
+            Ordering::Less => {
+                // The change output would be zero-valued or unaffordable, so
+                // the caller must try a larger set of funding inputs.
                 Ok(None)
             }
-            Ordering::Greater => {
-                // We have enough balance to cover the increase in cost from the change
-                // note. Use return_change which properly accounts for the gas cost
-                // increase from adding the change output.
-                let change = u64::try_from(delta_with_change - delta_target)
-                    .expect("Positive delta must fit in u64");
-
+            Ordering::Equal | Ordering::Greater => {
+                let change = u64::try_from(available_change).expect("change must fit in u64");
                 let tx_with_change = self.add_ledger_output(Note {
                     value: change,
                     pk: change_pk,
                 })?;
 
-                assert_eq!(tx_with_change.funding_delta::<G>(context)?, delta_target);
+                let final_mandatory_fee =
+                    tx_with_change.minimum_gas_cost::<G>(context)?.into_inner();
+                let final_priority_fee_amount =
+                    Self::priority_fee_amount(final_mandatory_fee, priority_fee_percent)?;
+                let final_required_fee = final_mandatory_fee
+                    .checked_add(final_priority_fee_amount)
+                    .ok_or(GasOverflow)?;
+                assert_eq!(tx_with_change.net_balance(), i128::from(final_required_fee));
 
                 Ok(Some(tx_with_change))
             }
@@ -251,6 +257,34 @@ impl MantleTxBuilder {
         context: &MantleTxContext,
     ) -> Result<i128, TxBuilderError> {
         Ok(self.net_balance() - i128::from(self.minimum_gas_cost::<G>(context)?.into_inner()))
+    }
+
+    /// Returns the balance remaining after the mandatory fee and the
+    /// percentage-based priority fee reserve.
+    pub fn funding_delta_with_priority_fee<G: GasProfile>(
+        &self,
+        context: &MantleTxContext,
+        priority_fee_percent: u64,
+    ) -> Result<i128, TxBuilderError> {
+        let mandatory_fee = self.minimum_gas_cost::<G>(context)?.into_inner();
+        let priority_fee_amount = Self::priority_fee_amount(mandatory_fee, priority_fee_percent)?;
+        let required_fee = mandatory_fee
+            .checked_add(priority_fee_amount)
+            .ok_or(GasOverflow)?;
+        Ok(self.net_balance() - i128::from(required_fee))
+    }
+
+    /// Calculates the priority fee amount for a mandatory fee using integer
+    /// arithmetic, rounding up to the next whole fee unit.
+    fn priority_fee_amount(
+        mandatory_fee: Value,
+        priority_fee_percent: u64,
+    ) -> Result<Value, TxBuilderError> {
+        let numerator = u128::from(mandatory_fee)
+            .checked_mul(u128::from(priority_fee_percent))
+            .and_then(|value| value.checked_add(99))
+            .ok_or(GasOverflow)?;
+        Value::try_from(numerator / 100).map_err(|_| GasOverflow.into())
     }
 
     /// Returns all note IDs already consumed or locked by this transaction,
@@ -662,5 +696,14 @@ mod tests {
             "should contain transfer input"
         );
         assert_eq!(consumed_or_locked.len(), 4);
+    }
+
+    #[test]
+    fn priority_fee_percentage_rounds_up_without_a_cap() {
+        assert_eq!(MantleTxBuilder::priority_fee_amount(0, 12).unwrap(), 0);
+        assert_eq!(MantleTxBuilder::priority_fee_amount(1, 12).unwrap(), 1);
+        assert_eq!(MantleTxBuilder::priority_fee_amount(8, 12).unwrap(), 1);
+        assert_eq!(MantleTxBuilder::priority_fee_amount(9, 12).unwrap(), 2);
+        assert_eq!(MantleTxBuilder::priority_fee_amount(100, 101).unwrap(), 101);
     }
 }

--- a/core/src/mantle/transactions/builder.rs
+++ b/core/src/mantle/transactions/builder.rs
@@ -150,9 +150,8 @@ impl MantleTxBuilder {
         // Calculate the mandatory fee with a dummy change note so the reserve
         // is based on the final transaction shape.
         let candidate = self.with_dummy_change_note()?;
-        let mandatory_fee = candidate.minimum_gas_cost::<G>(context)?.into_inner();
-        let required_fee = Self::required_fee(mandatory_fee, priority_fee_percent)?;
-        let available_change = self.net_balance() - i128::from(required_fee);
+        let available_change =
+            candidate.funding_delta_with_priority_fee::<G>(context, priority_fee_percent)?;
 
         match available_change.cmp(&1) {
             Ordering::Less => {

--- a/deployment/tui-zone/src/cli.rs
+++ b/deployment/tui-zone/src/cli.rs
@@ -103,14 +103,20 @@ pub struct NodeKeyArgs {
     #[arg(long, default_value_t = 1_000_000, env = "MAX_TX_FEE")]
     pub max_tx_fee: u64,
 
-    /// Execution tip paid on top of the mandatory fee when funding via
-    /// `--funding-pk`; capped by `--max-tx-fee`.
+    /// Percentage of the final mandatory fee reserved when funding via
+    /// `--funding-pk`. The percentage covers execution plus storage cost; only
+    /// unused reserve becomes an effective priority tip. The 12% default is a
+    /// practical reserve for normal fee movement, including approximately one
+    /// storage-market epoch at normal price levels, not a protocol guarantee
+    /// at very low prices or when execution fees also rise materially. Storage
+    /// prices use integer arithmetic, so 1 can become 2. Capped in total by
+    /// `--max-tx-fee`.
     #[arg(
         long,
-        default_value_t = lb_zone_sdk::sequencer::FundingConfig::DEFAULT_PRIORITY_FEE,
-        env = "PRIORITY_FEE"
+        default_value_t = lb_zone_sdk::sequencer::FundingConfig::DEFAULT_PRIORITY_FEE_PERCENT,
+        env = "PRIORITY_FEE_PERCENT"
     )]
-    pub priority_fee: u64,
+    pub priority_fee_percent: u64,
 }
 
 #[derive(Args, Debug)]

--- a/deployment/tui-zone/src/run_commands/utils.rs
+++ b/deployment/tui-zone/src/run_commands/utils.rs
@@ -341,7 +341,7 @@ pub fn funding_config(args: &NodeKeyArgs) -> RunResult<FundingConfig> {
     Ok(FundingConfig {
         funding_pk: decode_zk_public_key_hex(&args.funding_pk)?,
         max_tx_fee: args.max_tx_fee.into(),
-        priority_fee: args.priority_fee,
+        priority_fee_percent: args.priority_fee_percent,
     })
 }
 

--- a/nodes/api-common/src/bodies/wallet.rs
+++ b/nodes/api-common/src/bodies/wallet.rs
@@ -149,7 +149,7 @@ pub mod fund {
     use lb_core::{
         header::HeaderId,
         mantle::{
-            OpProof, Value,
+            OpProof,
             gas::GasCost,
             transactions::{RawMantleTx, builder::MantleTxBuilder},
         },
@@ -163,9 +163,21 @@ pub mod fund {
         pub tx_builder: MantleTxBuilder,
         pub change_public_key: ZkPublicKey,
         pub funding_public_keys: Vec<ZkPublicKey>,
+        /// Absolute hard cap on the final funded transaction fee.
         pub max_tx_fee: GasCost,
+        /// Percentage of the final mandatory fee reserved as a priority fee.
+        /// The percentage applies to the complete mandatory fee (execution
+        /// plus storage), not to storage alone. Only the unused reserve is an
+        /// effective priority tip. The default used by the Zone SDK and TUI
+        /// is 12%, a practical reserve intended to absorb normal fee movement,
+        /// including approximately one storage-market epoch increase at
+        /// normal price levels. It is not a protocol guarantee at very low
+        /// prices or when execution fees also rise materially. Storage prices
+        /// use integer arithmetic, so a low price can jump proportionally more
+        /// (for example, 1 to 2). `0` funds exactly to the mandatory fee; the
+        /// value is not capped at 100.
         #[serde(default)]
-        pub priority_fee: Value,
+        pub priority_fee_percent: u64,
     }
 
     #[derive(Serialize, Deserialize)]

--- a/nodes/node/binary/src/api/handlers.rs
+++ b/nodes/node/binary/src/api/handlers.rs
@@ -93,6 +93,18 @@ use crate::{
 
 const TARGET: &str = node::api::ROOT;
 
+fn validate_max_tx_fee(
+    tx_fee: lb_core::mantle::gas::GasCost,
+    max_tx_fee: lb_core::mantle::gas::GasCost,
+) -> Result<(), DynError> {
+    if tx_fee > max_tx_fee {
+        return Err(overwatch::DynError::from(format!(
+            "tx_fee({tx_fee}) exceeds max_tx_fee({max_tx_fee})"
+        )));
+    }
+    Ok(())
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DialPeerRequestBody {
     pub addr: Multiaddr,
@@ -1001,12 +1013,7 @@ where
             .await?;
 
         let tx_fee = funded_tx_builder.tx_fee()?;
-        if tx_fee > req.max_tx_fee {
-            return Err(overwatch::DynError::from(format!(
-                "tx_fee({tx_fee}) exceeds max_tx_fee({})",
-                req.max_tx_fee
-            )));
-        }
+        validate_max_tx_fee(tx_fee, req.max_tx_fee)?;
 
         let signed_tx = wallet.sign_tx(Some(tip), funded_tx_builder).await?.response;
         let tx_hash = signed_tx.hash();
@@ -1025,7 +1032,7 @@ where
         >(&handle, signed_tx, Hashable::hash)
         .await?;
 
-        Ok(ChannelDepositResponseBody { hash: tx_hash })
+        Ok::<_, overwatch::DynError>(ChannelDepositResponseBody { hash: tx_hash })
     })
 }
 
@@ -1977,17 +1984,12 @@ pub mod wallet {
                     req.tx_builder,
                     req.change_public_key,
                     req.funding_public_keys,
-                    req.priority_fee,
+                    req.priority_fee_percent,
                 )
                 .await?;
 
             let tx_fee = funded_tx_builder.tx_fee()?;
-            if tx_fee > req.max_tx_fee {
-                return Err(overwatch::DynError::from(format!(
-                    "tx_fee({tx_fee}) exceeds max_tx_fee({})",
-                    req.max_tx_fee
-                )));
-            }
+            validate_max_tx_fee(tx_fee, req.max_tx_fee)?;
 
             // Owners of the funding inputs, in input order — the ledger
             // verifies the transfer proof against this exact list.
@@ -2027,11 +2029,12 @@ mod tests {
         header::HeaderId,
         mantle::{
             channel::{ChannelState, SlotTimeframe, SlotTimeout},
+            gas::GasCost,
             ops::channel::{Ed25519PublicKey, MsgId, config::Keys},
         },
     };
 
-    use super::channel_response;
+    use super::{channel_response, validate_max_tx_fee};
     use crate::api::{
         errors::BlocksStreamWindowError, handlers::resolve_blocks_stream_window,
         queries::BlocksStreamRequest,
@@ -2114,6 +2117,18 @@ mod tests {
         let response = channel_response(Err(DynError::from("channel backend failed".to_owned())));
 
         assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    #[test]
+    fn max_tx_fee_rejects_a_percentage_funded_final_fee() {
+        let mandatory_fee: u64 = 794;
+        let priority_fee_percent: u64 = 12;
+        let priority_fee_amount = (mandatory_fee * priority_fee_percent).div_ceil(100);
+        let funded_tx_fee = GasCost::new(mandatory_fee + priority_fee_amount);
+
+        let error = validate_max_tx_fee(funded_tx_fee, GasCost::new(mandatory_fee + 95))
+            .expect_err("the percentage reserve should be included in the hard cap");
+        assert!(error.to_string().contains("exceeds max_tx_fee"));
     }
 
     fn request(

--- a/nodes/node/http-client/src/lib.rs
+++ b/nodes/node/http-client/src/lib.rs
@@ -592,8 +592,9 @@ impl CommonHttpClient {
 
     /// Post a request to fund a transaction from the node's wallet.
     ///
-    /// The node adds fee inputs and change from its own wallet, signs only
-    /// the appended fee transfer, and returns the funded (still unsigned)
+    /// The node adds fee inputs and change from its own wallet, reserving the
+    /// request's percentage-based priority-fee reserve, then signs only the
+    /// appended fee transfer and returns the funded (still unsigned)
     /// transaction together with the transfer proof.
     pub async fn fund_tx(
         &self,

--- a/services/wallet/src/api.rs
+++ b/services/wallet/src/api.rs
@@ -134,13 +134,17 @@ where
         Ok(rx.await??)
     }
 
+    /// Fund a transaction, reserving `priority_fee_percent` percent of its
+    /// final mandatory fee as a priority reserve. The mandatory fee includes
+    /// execution and storage cost; only the unused reserve becomes an
+    /// effective priority tip. The percentage is not capped at 100.
     pub async fn fund_tx(
         &self,
         tip: Option<HeaderId>,
         tx_builder: MantleTxBuilder,
         change_pk: ZkPublicKey,
         funding_pks: Vec<ZkPublicKey>,
-        priority_fee: Value,
+        priority_fee_percent: u64,
     ) -> Result<TipResponse<MantleTxBuilder>, WalletApiError> {
         let (resp_tx, rx) = oneshot::channel();
 
@@ -150,7 +154,7 @@ where
                 tx_builder,
                 change_pk,
                 funding_pks,
-                priority_fee,
+                priority_fee_percent,
                 resp_tx,
             })
             .await?;

--- a/services/wallet/src/lib.rs
+++ b/services/wallet/src/lib.rs
@@ -158,7 +158,9 @@ pub enum WalletMsg {
         tx_builder: MantleTxBuilder,
         change_pk: ZkPublicKey,
         funding_pks: Vec<ZkPublicKey>,
-        priority_fee: Value,
+        /// Percentage of the final mandatory fee reserved as a priority-fee
+        /// reserve; only the unused reserve becomes the effective tip.
+        priority_fee_percent: u64,
         resp_tx: Sender<Result<TipResponse<MantleTxBuilder>, WalletServiceError>>,
     },
     BuildLeaderClaimTx {
@@ -535,7 +537,7 @@ where
                 tx_builder,
                 change_pk,
                 funding_pks,
-                priority_fee,
+                priority_fee_percent,
                 resp_tx,
             } => {
                 let tip = match Self::msg_tip_or_latest(tip, cryptarchia).await {
@@ -563,7 +565,7 @@ where
                     change_pk,
                     funding_pks,
                     &context,
-                    priority_fee,
+                    priority_fee_percent,
                 ) {
                     Ok(funded) => funded,
                     Err(err) => {

--- a/services/wallet/src/states.rs
+++ b/services/wallet/src/states.rs
@@ -6,7 +6,7 @@ use std::{
 use lb_core::{
     header::HeaderId,
     mantle::{
-        GasProfile, NoteId, Value,
+        GasProfile, NoteId,
         ops::leader_claim::{VoucherCm, VoucherNullifier},
         transactions::{MantleTxBuilder, MantleTxContext},
     },
@@ -358,8 +358,10 @@ impl<'u> ServiceState<'u> {
     }
 
     /// Fund `tx_builder` from the wallet's UTXOs at `tip`, excluding notes
-    /// already reserved for in-flight transactions. `priority_fee` is left
-    /// as excess balance above the mandatory fee (the execution tip).
+    /// already reserved for in-flight transactions. `priority_fee_percent`
+    /// reserves that percentage of the final mandatory fee, including both
+    /// execution and storage cost. Only the unused reserve becomes an
+    /// effective priority tip, and the percentage is not capped at 100.
     pub fn fund_tx<G: GasProfile>(
         &self,
         tip: HeaderId,
@@ -367,7 +369,7 @@ impl<'u> ServiceState<'u> {
         change_pk: ZkPublicKey,
         funding_pks: impl IntoIterator<Item = impl Borrow<ZkPublicKey>>,
         context: &MantleTxContext,
-        priority_fee: Value,
+        priority_fee_percent: u64,
     ) -> Result<MantleTxBuilder, WalletError> {
         self.wallet.fund_tx::<G>(
             tip,
@@ -376,7 +378,7 @@ impl<'u> ServiceState<'u> {
             funding_pks,
             context,
             &self.pending_notes.note_ids(),
-            priority_fee,
+            priority_fee_percent,
         )
     }
 

--- a/tests/cucumber_tests/features/fees.feature
+++ b/tests/cucumber_tests/features/fees.feature
@@ -70,7 +70,7 @@ Feature: Fees
       | NODE_1    | 2             | WALLET_2A   |              |
       | NODE_1    | 3             | WALLET_3A   |              |
     When node "NODE_1" is at height 1 in 180 seconds
-    And I prepare a wallet-funded self-transfer with priority fee percentage 50 from wallet "WALLET_3A" via node "NODE_1" as "BUFFERED"
+    And I prepare a wallet-funded self-transfer with a 50% priority fee reserve from wallet "WALLET_3A" via node "NODE_1" as "BUFFERED"
     And I submit an exactly funded self-transfer from wallet "WALLET_1A" via node "NODE_1" as "TRAFFIC_A"
     And I submit an exactly funded self-transfer from wallet "WALLET_2A" via node "NODE_1" as "TRAFFIC_B"
     And I record per-block gas prices on node "NODE_1" for 125 slots in 300 seconds

--- a/tests/cucumber_tests/features/fees.feature
+++ b/tests/cucumber_tests/features/fees.feature
@@ -48,9 +48,10 @@ Feature: Fees
   # usage; price viability is covered by ledger market-liveness tests. With
   # k=3 and f=1/2 below, each epoch is 60 slots long. The traffic transactions
   # use zero tip because tips do not drive prices. A separate transaction is
-  # prepared with positive fee headroom before the storage-price update and
-  # submitted afterwards to show that it remains valid as the effective tip
-  # absorbs the higher mandatory fee.
+  # prepared through /wallet/fund with a percentage reserve before the
+  # storage-price update and submitted afterwards to show that the effective
+  # reserve absorbs the higher mandatory fee. The acceptance reserve is 50%
+  # because genesis storage price 1 can double to 2 under integer pricing.
   @fees_ci
   Scenario: Execution and storage gas prices respond according to the fee market rules
     Given the cluster uses cryptarchia security parameter 3
@@ -69,7 +70,7 @@ Feature: Fees
       | NODE_1    | 2             | WALLET_2A   |              |
       | NODE_1    | 3             | WALLET_3A   |              |
     When node "NODE_1" is at height 1 in 180 seconds
-    And I prepare a self-transfer with a 1000 LGO tip from wallet "WALLET_3A" via node "NODE_1" as "BUFFERED"
+    And I prepare a wallet-funded self-transfer with priority fee percentage 50 from wallet "WALLET_3A" via node "NODE_1" as "BUFFERED"
     And I submit an exactly funded self-transfer from wallet "WALLET_1A" via node "NODE_1" as "TRAFFIC_A"
     And I submit an exactly funded self-transfer from wallet "WALLET_2A" via node "NODE_1" as "TRAFFIC_B"
     And I record per-block gas prices on node "NODE_1" for 125 slots in 300 seconds
@@ -78,7 +79,7 @@ Feature: Fees
     And recorded gas prices cross a 60-slot epoch boundary
     And recorded execution gas prices follow the execution market spec reference
     And recorded storage gas prices respond to network usage
-    And transaction "BUFFERED" prepared with a 1000 LGO tip remains funded with a smaller tip at current prices on node "NODE_1"
+    And transaction "BUFFERED" prepared with a 50% priority fee reserve remains funded with a smaller reserve at current prices on node "NODE_1"
     When I submit prepared transaction "BUFFERED" via node "NODE_1"
     Then transaction "BUFFERED" is included on node "NODE_1" in 60 seconds
     Then I stop all nodes

--- a/tests/src/common/fee_spec.rs
+++ b/tests/src/common/fee_spec.rs
@@ -46,6 +46,17 @@ pub const SPEC_BASE_FEE_DENOMINATOR: u128 = 12_773_840;
 /// Gas Cost Determination v1.5.1: a transfer costs 590 gas.
 pub const SPEC_TRANSFER_GAS: u64 = 590;
 
+/// Computes a percentage reserve with checked widened arithmetic and integer
+/// ceiling, matching the transaction funding rule.
+pub fn priority_fee_amount(mandatory_fee: u64, priority_fee_percent: u64) -> Result<u64, String> {
+    let numerator = u128::from(mandatory_fee)
+        .checked_mul(u128::from(priority_fee_percent))
+        .and_then(|value| value.checked_add(99))
+        .ok_or_else(|| "priority fee percentage arithmetic overflowed".to_owned())?;
+    u64::try_from(numerator / 100)
+        .map_err(|_| "priority fee percentage result does not fit in u64".to_owned())
+}
+
 /// The spec's execution price update, written out from the spec document.
 #[derive(Debug, Clone)]
 pub struct ExecutionMarketReference {

--- a/tests/src/cucumber/steps/fees/actions.rs
+++ b/tests/src/cucumber/steps/fees/actions.rs
@@ -12,13 +12,17 @@ use lb_core::{
         SignedMantleTx,
         gas::{GasCost, MainnetGasProfile, TxGasCalculator as _},
         traits::Hashable as _,
-        transactions::{GasPrices, builder::MantleTxBuilder},
+        transactions::{GasPrices, builder::MantleTxBuilder, states::Preverified},
     },
 };
 use lb_http_api_common::{
-    bodies::wallet::{fund::WalletFundRequestBody, transfer_funds::WalletTransferFundsRequestBody},
+    bodies::wallet::{
+        fund::{WalletFundRequestBody, WalletFundResponseBody},
+        transfer_funds::WalletTransferFundsRequestBody,
+    },
     queries::{BlockFilter, BlockSortOrder, BlocksStreamQuery},
 };
+use lb_key_management_system_service::keys::ZkPublicKey;
 use lb_testing_framework::{NodeHttpClient, configs::wallet::WalletAccount};
 use tokio::time::timeout;
 use tracing::info;
@@ -69,9 +73,7 @@ pub async fn prepare_self_transfer_with_tip(
     Ok(())
 }
 
-/// Funds a self-transfer through `/wallet/fund` with a percentage reserve,
-/// keeps it unsigned by the caller, and records the initial fee arithmetic at
-/// the exact funding tip for the epoch-crossing assertion.
+/// Funds a self-transfer through `/wallet/fund` with a percentage reserve.
 pub async fn prepare_wallet_funded_self_transfer_with_priority_fee(
     world: &mut CucumberWorld,
     step: &Step,
@@ -83,6 +85,37 @@ pub async fn prepare_wallet_funded_self_transfer_with_priority_fee(
     let account = user_wallet_account(world, step, wallet_name)?;
     let client = world.resolve_node_http_client(node_name)?;
     let funding_pk = account.public_key();
+    let (response, prices) =
+        fund_self_transfer(&client, step, funding_pk, priority_fee_percent).await?;
+    let signed_tx = assemble_funded_transaction(response, step)?;
+    let prepared_fee =
+        record_prepared_priority_fee(world, step, &signed_tx, &prices, priority_fee_percent)?;
+
+    info!(
+        target: TARGET,
+        "Prepared wallet-funded self-transfer `{transaction_alias}` ({:?}) from wallet \
+         '{wallet_name}' with {priority_fee_percent}% reserve: mandatory={}, reserve={}, funded={}, \
+         prices execution={} storage={}",
+        signed_tx.hash(),
+        prepared_fee.initial_mandatory_fee,
+        prepared_fee.initial_reserve,
+        prepared_fee.funded_fee,
+        prices.execution_base_gas_price.into_inner(),
+        prices.storage_gas_price.into_inner(),
+    );
+
+    world.remember_prepared_priority_fee(transaction_alias.clone(), prepared_fee);
+    world.remember_prepared_transaction(transaction_alias, signed_tx);
+
+    Ok(())
+}
+
+async fn fund_self_transfer(
+    client: &NodeHttpClient,
+    step: &Step,
+    funding_pk: ZkPublicKey,
+    priority_fee_percent: u64,
+) -> Result<(WalletFundResponseBody, GasPrices), StepError> {
     let response = client
         .fund_tx(WalletFundRequestBody {
             tip: None,
@@ -108,11 +141,20 @@ pub async fn prepare_wallet_funded_self_transfer_with_priority_fee(
                 step.value
             ),
         })?;
-    let prices = GasPrices {
-        execution_base_gas_price: prices_at_funding_tip.execution_base_gas_price,
-        storage_gas_price: prices_at_funding_tip.storage_gas_price,
-    };
 
+    Ok((
+        response,
+        GasPrices {
+            execution_base_gas_price: prices_at_funding_tip.execution_base_gas_price,
+            storage_gas_price: prices_at_funding_tip.storage_gas_price,
+        },
+    ))
+}
+
+fn assemble_funded_transaction(
+    response: WalletFundResponseBody,
+    step: &Step,
+) -> Result<SignedMantleTx<Preverified>, StepError> {
     let transfer_proof = response
         .transfer_proof
         .ok_or_else(|| StepError::LogicalError {
@@ -121,16 +163,25 @@ pub async fn prepare_wallet_funded_self_transfer_with_priority_fee(
                 step.value
             ),
         })?;
-    let signed_tx = SignedMantleTx::new(response.funded_tx, [transfer_proof].into())
+    SignedMantleTx::new(response.funded_tx, [transfer_proof].into())
         .preverify()
         .map_err(|source| StepError::StepFail {
             message: format!(
                 "Step `{}` error: percentage-funded self-transfer failed verification: {source}",
                 step.value
             ),
-        })?;
+        })
+}
+
+fn record_prepared_priority_fee(
+    world: &CucumberWorld,
+    step: &Step,
+    signed_tx: &SignedMantleTx<Preverified>,
+    prices: &GasPrices,
+    priority_fee_percent: u64,
+) -> Result<PreparedPriorityFee, StepError> {
     let initial_mandatory_fee = signed_tx
-        .total_gas_cost::<MainnetGasProfile>(&prices)
+        .total_gas_cost::<MainnetGasProfile>(prices)
         .map_err(|source| StepError::StepFail {
             message: format!(
                 "Step `{}` error: initial mandatory fee calculation failed: {source}",
@@ -144,10 +195,11 @@ pub async fn prepare_wallet_funded_self_transfer_with_priority_fee(
                 message: format!("Step `{}` error: {message}", step.value),
             },
         )?;
-    let funded_fee = fee_spec::net_balance_against(&world.genesis_block_utxos, &signed_tx)
-        .map_err(|message| StepError::StepFail {
+    let funded_fee = fee_spec::net_balance_against(&world.genesis_block_utxos, signed_tx).map_err(
+        |message| StepError::StepFail {
             message: format!("Step `{}` error: {message}", step.value),
-        })?;
+        },
+    )?;
     let expected_funded_fee = initial_mandatory_fee
         .checked_add(initial_reserve)
         .ok_or_else(|| StepError::StepFail {
@@ -166,30 +218,14 @@ pub async fn prepare_wallet_funded_self_transfer_with_priority_fee(
         });
     }
 
-    info!(
-        target: TARGET,
-        "Prepared wallet-funded self-transfer `{transaction_alias}` ({:?}) from wallet \
-         '{wallet_name}' with {priority_fee_percent}% reserve: mandatory={initial_mandatory_fee}, \
-         reserve={initial_reserve}, funded={funded_fee}, prices execution={} storage={}",
-        signed_tx.hash(),
-        prices.execution_base_gas_price.into_inner(),
-        prices.storage_gas_price.into_inner(),
-    );
-
-    world.remember_prepared_priority_fee(
-        transaction_alias.clone(),
-        PreparedPriorityFee {
-            percent: priority_fee_percent,
-            initial_mandatory_fee,
-            initial_reserve,
-            funded_fee,
-            initial_execution_price: prices.execution_base_gas_price.into_inner(),
-            initial_storage_price: prices.storage_gas_price.into_inner(),
-        },
-    );
-    world.remember_prepared_transaction(transaction_alias, signed_tx);
-
-    Ok(())
+    Ok(PreparedPriorityFee {
+        percent: priority_fee_percent,
+        initial_mandatory_fee,
+        initial_reserve,
+        funded_fee,
+        initial_execution_price: prices.execution_base_gas_price.into_inner(),
+        initial_storage_price: prices.storage_gas_price.into_inner(),
+    })
 }
 
 /// Submits a previously prepared transaction and records its hash under the

--- a/tests/src/cucumber/steps/fees/actions.rs
+++ b/tests/src/cucumber/steps/fees/actions.rs
@@ -8,10 +8,15 @@ use futures::{StreamExt as _, future::join_all};
 use lb_common_http_client::ApiBlock;
 use lb_core::{
     header::HeaderId,
-    mantle::{traits::Hashable as _, transactions::GasPrices},
+    mantle::{
+        SignedMantleTx,
+        gas::{GasCost, MainnetGasProfile, TxGasCalculator as _},
+        traits::Hashable as _,
+        transactions::{GasPrices, builder::MantleTxBuilder},
+    },
 };
 use lb_http_api_common::{
-    bodies::wallet::transfer_funds::WalletTransferFundsRequestBody,
+    bodies::wallet::{fund::WalletFundRequestBody, transfer_funds::WalletTransferFundsRequestBody},
     queries::{BlockFilter, BlockSortOrder, BlocksStreamQuery},
 };
 use lb_testing_framework::{NodeHttpClient, configs::wallet::WalletAccount};
@@ -23,7 +28,7 @@ use crate::{
     cucumber::{
         error::{StepError, StepResult},
         steps::TARGET,
-        world::{CucumberWorld, WalletType},
+        world::{CucumberWorld, PreparedPriorityFee, WalletType},
     },
 };
 
@@ -59,6 +64,129 @@ pub async fn prepare_self_transfer_with_tip(
         prices.execution_base_gas_price, prices.storage_gas_price,
     );
 
+    world.remember_prepared_transaction(transaction_alias, signed_tx);
+
+    Ok(())
+}
+
+/// Funds a self-transfer through `/wallet/fund` with a percentage reserve,
+/// keeps it unsigned by the caller, and records the initial fee arithmetic at
+/// the exact funding tip for the epoch-crossing assertion.
+pub async fn prepare_wallet_funded_self_transfer_with_priority_fee(
+    world: &mut CucumberWorld,
+    step: &Step,
+    wallet_name: &str,
+    node_name: &str,
+    transaction_alias: String,
+    priority_fee_percent: u64,
+) -> StepResult {
+    let account = user_wallet_account(world, step, wallet_name)?;
+    let client = world.resolve_node_http_client(node_name)?;
+    let funding_pk = account.public_key();
+    let response = client
+        .fund_tx(WalletFundRequestBody {
+            tip: None,
+            tx_builder: MantleTxBuilder::new(),
+            change_public_key: funding_pk,
+            funding_public_keys: vec![funding_pk],
+            max_tx_fee: GasCost::new(u64::MAX),
+            priority_fee_percent,
+        })
+        .await
+        .map_err(|source| StepError::StepFail {
+            message: format!(
+                "Step `{}` error: percentage-funded transaction request failed: {source}",
+                step.value
+            ),
+        })?;
+    let prices_at_funding_tip = client
+        .gas_prices(Some(response.tip))
+        .await
+        .map_err(|source| StepError::StepFail {
+            message: format!(
+                "Step `{}` error: gas prices at funding tip request failed: {source}",
+                step.value
+            ),
+        })?;
+    let prices = GasPrices {
+        execution_base_gas_price: prices_at_funding_tip.execution_base_gas_price,
+        storage_gas_price: prices_at_funding_tip.storage_gas_price,
+    };
+
+    let transfer_proof = response
+        .transfer_proof
+        .ok_or_else(|| StepError::LogicalError {
+            message: format!(
+                "Step `{}` error: percentage-funded self-transfer did not return a transfer proof",
+                step.value
+            ),
+        })?;
+    let signed_tx = SignedMantleTx::new(response.funded_tx, [transfer_proof].into())
+        .preverify()
+        .map_err(|source| StepError::StepFail {
+            message: format!(
+                "Step `{}` error: percentage-funded self-transfer failed verification: {source}",
+                step.value
+            ),
+        })?;
+    let initial_mandatory_fee = signed_tx
+        .total_gas_cost::<MainnetGasProfile>(&prices)
+        .map_err(|source| StepError::StepFail {
+            message: format!(
+                "Step `{}` error: initial mandatory fee calculation failed: {source}",
+                step.value
+            ),
+        })?
+        .into_inner();
+    let initial_reserve =
+        fee_spec::priority_fee_amount(initial_mandatory_fee, priority_fee_percent).map_err(
+            |message| StepError::StepFail {
+                message: format!("Step `{}` error: {message}", step.value),
+            },
+        )?;
+    let funded_fee = fee_spec::net_balance_against(&world.genesis_block_utxos, &signed_tx)
+        .map_err(|message| StepError::StepFail {
+            message: format!("Step `{}` error: {message}", step.value),
+        })?;
+    let expected_funded_fee = initial_mandatory_fee
+        .checked_add(initial_reserve)
+        .ok_or_else(|| StepError::StepFail {
+            message: format!(
+                "Step `{}` error: funded fee arithmetic overflowed",
+                step.value
+            ),
+        })?;
+    if funded_fee != expected_funded_fee {
+        return Err(StepError::StepFail {
+            message: format!(
+                "Step `{}` error: funded fee {funded_fee} does not equal mandatory fee \
+                 {initial_mandatory_fee} plus {priority_fee_percent}% reserve {initial_reserve}",
+                step.value
+            ),
+        });
+    }
+
+    info!(
+        target: TARGET,
+        "Prepared wallet-funded self-transfer `{transaction_alias}` ({:?}) from wallet \
+         '{wallet_name}' with {priority_fee_percent}% reserve: mandatory={initial_mandatory_fee}, \
+         reserve={initial_reserve}, funded={funded_fee}, prices execution={} storage={}",
+        signed_tx.hash(),
+        prices.execution_base_gas_price.into_inner(),
+        prices.storage_gas_price.into_inner(),
+    );
+
+    world.remember_prepared_priority_fee(
+        transaction_alias.clone(),
+        PreparedPriorityFee {
+            percent: priority_fee_percent,
+            initial_mandatory_fee,
+            initial_reserve,
+            funded_fee,
+            initial_execution_price: prices.execution_base_gas_price.into_inner(),
+            initial_storage_price: prices.storage_gas_price.into_inner(),
+        },
+    );
     world.remember_prepared_transaction(transaction_alias, signed_tx);
 
     Ok(())

--- a/tests/src/cucumber/steps/fees/assertions.rs
+++ b/tests/src/cucumber/steps/fees/assertions.rs
@@ -4,7 +4,10 @@
 use std::time::Duration;
 
 use cucumber::gherkin::Step;
-use lb_core::{header::HeaderId, mantle::gas::GasPrice};
+use lb_core::{
+    header::HeaderId,
+    mantle::gas::{GasPrice, MainnetGasProfile, TxGasCalculator as _},
+};
 use tracing::info;
 
 use crate::{
@@ -158,6 +161,86 @@ pub async fn prepared_transaction_tip_absorbed_fee_increase(
         target: TARGET,
         "Transaction `{transaction_alias}` remains funded after its effective tip fell from \
          {original_tip} to {remaining_tip}",
+    );
+
+    Ok(())
+}
+
+/// Recalculates the mandatory fee of a percentage-funded transaction at the
+/// current prices and verifies that the price increase consumed part of its
+/// original reserve without making it underfunded.
+pub async fn prepared_transaction_percentage_reserve_absorbed_fee_increase(
+    world: &CucumberWorld,
+    step: &Step,
+    transaction_alias: &str,
+    configured_percent: u64,
+    node_name: &str,
+) -> StepResult {
+    let prepared_fee = world.resolve_prepared_priority_fee(transaction_alias)?;
+    if prepared_fee.percent != configured_percent {
+        return Err(StepError::StepFail {
+            message: format!(
+                "Step `{}` error: transaction `{transaction_alias}` was prepared with {}%, \
+                 expected {configured_percent}%",
+                step.value, prepared_fee.percent
+            ),
+        });
+    }
+
+    let signed_tx = world.resolve_prepared_transaction(transaction_alias)?;
+    let client = world.resolve_node_http_client(node_name)?;
+    let prices = actions::live_gas_prices(&client, step).await?;
+    let current_mandatory_fee = signed_tx
+        .total_gas_cost::<MainnetGasProfile>(&prices)
+        .map_err(|source| StepError::StepFail {
+            message: format!(
+                "Step `{}` error: current mandatory fee calculation failed: {source}",
+                step.value
+            ),
+        })?
+        .into_inner();
+    let remaining_reserve = prepared_fee
+        .funded_fee
+        .checked_sub(current_mandatory_fee)
+        .ok_or_else(|| StepError::StepFail {
+            message: format!(
+                "Step `{}` error: transaction `{transaction_alias}` is underfunded: \
+                 funded fee {}, current mandatory fee {}",
+                step.value, prepared_fee.funded_fee, current_mandatory_fee
+            ),
+        })?;
+
+    if remaining_reserve >= prepared_fee.initial_reserve {
+        return Err(StepError::StepFail {
+            message: format!(
+                "Step `{}` error: transaction `{transaction_alias}` reserve did not shrink: \
+                 initial mandatory={}, initial reserve={}, funded={}, current mandatory={}, \
+                 remaining reserve={}",
+                step.value,
+                prepared_fee.initial_mandatory_fee,
+                prepared_fee.initial_reserve,
+                prepared_fee.funded_fee,
+                current_mandatory_fee,
+                remaining_reserve,
+            ),
+        });
+    }
+
+    info!(
+        target: TARGET,
+        "Transaction `{transaction_alias}` retained a smaller effective reserve: \
+         {}% of initial mandatory {} => reserve {}, funded {}; prices execution {} -> {}, \
+         storage {} -> {}; current mandatory {}, remaining reserve {}",
+        prepared_fee.percent,
+        prepared_fee.initial_mandatory_fee,
+        prepared_fee.initial_reserve,
+        prepared_fee.funded_fee,
+        prepared_fee.initial_execution_price,
+        prices.execution_base_gas_price.into_inner(),
+        prepared_fee.initial_storage_price,
+        prices.storage_gas_price.into_inner(),
+        current_mandatory_fee,
+        remaining_reserve,
     );
 
     Ok(())

--- a/tests/src/cucumber/steps/fees/steps.rs
+++ b/tests/src/cucumber/steps/fees/steps.rs
@@ -198,6 +198,29 @@ async fn step_prepare_self_transfer_with_tip(
     .await
 }
 
+#[when(
+    expr = "I prepare a wallet-funded self-transfer with priority fee percentage {int} from \
+            wallet {string} via node {string} as {string}"
+)]
+async fn step_prepare_wallet_funded_self_transfer_with_priority_fee(
+    world: &mut CucumberWorld,
+    step: &Step,
+    priority_fee_percent: u64,
+    wallet_name: String,
+    node_name: String,
+    transaction_alias: String,
+) -> StepResult {
+    actions::prepare_wallet_funded_self_transfer_with_priority_fee(
+        world,
+        step,
+        &wallet_name,
+        &node_name,
+        transaction_alias,
+        priority_fee_percent,
+    )
+    .await
+}
+
 #[when(expr = "I submit prepared transaction {string} via node {string}")]
 async fn step_submit_prepared_transaction(
     world: &mut CucumberWorld,
@@ -228,6 +251,31 @@ async fn step_prepared_transaction_tip_absorbed_fee_increase(
         step,
         &transaction_alias,
         original_tip,
+        &node_name,
+    )
+    .await
+}
+
+#[then(
+    expr = "transaction {string} prepared with a {int}% priority fee reserve remains funded \
+            with a smaller reserve at current prices on node {string}"
+)]
+#[expect(
+    clippy::needless_pass_by_ref_mut,
+    reason = "cucumber step entrypoints must take `&mut World`"
+)]
+async fn step_prepared_transaction_percentage_reserve_absorbed_fee_increase(
+    world: &mut CucumberWorld,
+    step: &Step,
+    transaction_alias: String,
+    configured_percent: u64,
+    node_name: String,
+) -> StepResult {
+    assertions::prepared_transaction_percentage_reserve_absorbed_fee_increase(
+        world,
+        step,
+        &transaction_alias,
+        configured_percent,
         &node_name,
     )
     .await

--- a/tests/src/cucumber/steps/fees/steps.rs
+++ b/tests/src/cucumber/steps/fees/steps.rs
@@ -199,7 +199,7 @@ async fn step_prepare_self_transfer_with_tip(
 }
 
 #[when(
-    expr = "I prepare a wallet-funded self-transfer with priority fee percentage {int} from \
+    expr = "I prepare a wallet-funded self-transfer with a {int}% priority fee reserve from \
             wallet {string} via node {string} as {string}"
 )]
 async fn step_prepare_wallet_funded_self_transfer_with_priority_fee(

--- a/tests/src/cucumber/steps/manual_zone/actions.rs
+++ b/tests/src/cucumber/steps/manual_zone/actions.rs
@@ -64,7 +64,7 @@ const SEQUENCER_READY_TIMEOUT: Duration = Duration::from_mins(2);
 const SEQUENCER_READY_POLL_TIMEOUT: Duration = Duration::from_secs(10);
 const SEQUENCER_READY_HEIGHT_ADVANCE_TIMEOUT: Duration = Duration::from_secs(30);
 const ZONE_SECURITY_PARAM: u32 = 5;
-const ZONE_TEST_PRIORITY_FEE: u64 = 400;
+const ZONE_TEST_PRIORITY_FEE_PERCENT: u64 = 12;
 
 pub(super) enum DriveMode {
     Passive {
@@ -752,7 +752,7 @@ fn sequencer_funding(
     Ok(FundingConfig {
         funding_pk,
         max_tx_fee: GasCost::new(u64::MAX),
-        priority_fee: ZONE_TEST_PRIORITY_FEE,
+        priority_fee_percent: ZONE_TEST_PRIORITY_FEE_PERCENT,
     })
 }
 

--- a/tests/src/cucumber/steps/manual_zone/support.rs
+++ b/tests/src/cucumber/steps/manual_zone/support.rs
@@ -982,7 +982,7 @@ pub async fn replay_finalized_history(
     let funding = FundingConfig {
         funding_pk: lb_groth16::Fr::from(1u64).into(),
         max_tx_fee: GasCost::new(u64::MAX),
-        priority_fee: FundingConfig::DEFAULT_PRIORITY_FEE,
+        priority_fee_percent: FundingConfig::DEFAULT_PRIORITY_FEE_PERCENT,
     };
     let mut sequencer = ZoneSequencer::init(reader.channel_id, keygen(), node, funding, None);
 
@@ -1488,7 +1488,7 @@ async fn build_funded_custom_tx(
     let response = node_client
         .fund_tx(WalletFundRequestBody {
             tip: None,
-            priority_fee: 0,
+            priority_fee_percent: 0,
             tx_builder,
             change_public_key: funding_pk,
             funding_public_keys: vec![funding_pk],

--- a/tests/src/cucumber/steps/wallet_fund.rs
+++ b/tests/src/cucumber/steps/wallet_fund.rs
@@ -510,7 +510,7 @@ async fn fund_via_node(
             change_public_key: funding_pk,
             funding_public_keys: vec![funding_pk],
             max_tx_fee: GasCost::new(u64::MAX),
-            priority_fee: 0,
+            priority_fee_percent: 0,
         })
         .await
         .map_err(|source| StepError::StepFail {

--- a/tests/src/cucumber/world.rs
+++ b/tests/src/cucumber/world.rs
@@ -905,6 +905,9 @@ pub struct CucumberWorld {
     pub submission_outcomes: HashMap<String, Result<(), String>>,
     /// Manual: Exact signed transactions prepared for later submission.
     pub prepared_transactions: HashMap<String, SignedMantleTx<Preverified>>,
+    /// Manual: Initial fee arithmetic for percentage-funded transactions
+    /// prepared by the fee-market steps.
+    pub prepared_priority_fees: HashMap<String, PreparedPriorityFee>,
     /// Manual: Transaction hashes observed in blocks by the wallet scanner.
     pub observed_transaction_hashes: SharedObservedTransactionHashes,
     /// Manual: Background wallet scanner diagnostics state.
@@ -1100,6 +1103,7 @@ impl Debug for CucumberWorld {
             .field("submitted_transactions", &self.submitted_transactions.len())
             .field("submission_outcomes", &self.submission_outcomes.len())
             .field("prepared_transactions", &self.prepared_transactions.len())
+            .field("prepared_priority_fees", &self.prepared_priority_fees.len())
             .field(
                 "observed_transaction_hashes",
                 &self.observed_transaction_hashes_len(),
@@ -1191,6 +1195,17 @@ pub struct GenesisTokens {
     /// The total amount of tokens allocated to this account in the genesis
     /// configuration.
     pub token_amount: u64,
+}
+
+/// Fee values captured when a percentage-funded transaction is prepared.
+#[derive(Clone, Debug)]
+pub struct PreparedPriorityFee {
+    pub percent: u64,
+    pub initial_mandatory_fee: u64,
+    pub initial_reserve: u64,
+    pub funded_fee: u64,
+    pub initial_execution_price: u64,
+    pub initial_storage_price: u64,
 }
 
 /// A scenario wallet is either user-owned or backed by a node wallet key.
@@ -2001,6 +2016,21 @@ impl CucumberWorld {
         signed_tx: SignedMantleTx<Preverified>,
     ) {
         self.prepared_transactions.insert(alias, signed_tx);
+    }
+
+    pub fn remember_prepared_priority_fee(&mut self, alias: String, fee: PreparedPriorityFee) {
+        self.prepared_priority_fees.insert(alias, fee);
+    }
+
+    pub fn resolve_prepared_priority_fee(
+        &self,
+        alias: &str,
+    ) -> Result<&PreparedPriorityFee, StepError> {
+        self.prepared_priority_fees
+            .get(alias)
+            .ok_or(StepError::LogicalError {
+                message: format!("Prepared priority fee alias '{alias}' not found in world state"),
+            })
     }
 
     pub fn resolve_prepared_transaction(

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -231,9 +231,10 @@ impl WalletState {
             .collect()
     }
 
-    /// Funds the transaction so its excess balance is exactly
-    /// `priority_fee` above the mandatory fee — the excess is the
-    /// transaction's execution tip. `0` funds to the exact minimum.
+    /// Funds the transaction so its excess balance is exactly the requested
+    /// percentage of the final mandatory fee. Only the unused reserve becomes
+    /// the transaction's effective priority tip. `0` funds to the exact
+    /// minimum.
     pub fn fund_tx<G: GasProfile>(
         &self,
         tx_builder: &MantleTxBuilder,
@@ -241,7 +242,7 @@ impl WalletState {
         pks: impl IntoIterator<Item = impl Borrow<ZkPublicKey>>,
         context: &MantleTxContext,
         excluded_notes: &HashSet<NoteId>,
-        priority_fee: Value,
+        priority_fee_percent: u64,
     ) -> Result<MantleTxBuilder, WalletError> {
         // Get all UTXOs owned by the provided PKs, excluding the following notes:
         // - Notes that are being consumed/locked by the tx
@@ -263,22 +264,21 @@ impl WalletState {
         // Consume large valued notes first to ensure we converge.
         utxos.sort_by_key(|utxo| -i128::from(utxo.note.value));
 
-        // The funding target: the tx's excess balance over the mandatory fee
-        // must end up exactly at `priority_fee` (the execution tip).
-        let delta_target = i128::from(priority_fee);
-
         // The transaction may already be funded before we add any of the
         // wallet's UTXOs, for example when it pays no fee or the caller already
         // supplied inputs. In that case we must not pull in an extra input (and
         // the change note it would require).
-        match tx_builder.funding_delta::<G>(context)?.cmp(&delta_target) {
+        match tx_builder
+            .funding_delta_with_priority_fee::<G>(context, priority_fee_percent)?
+            .cmp(&0)
+        {
             Ordering::Equal => return Ok(tx_builder.clone()),
             Ordering::Greater => {
-                if let Some(tx_with_change) =
-                    tx_builder
-                        .clone()
-                        .return_change::<G>(context, change_pk, priority_fee)?
-                {
+                if let Some(tx_with_change) = tx_builder.clone().return_change::<G>(
+                    context,
+                    change_pk,
+                    priority_fee_percent,
+                )? {
                     return Ok(tx_with_change);
                 }
                 // The change note costs more than the surplus covers, so fall
@@ -292,9 +292,10 @@ impl WalletState {
                 .clone()
                 .extend_ledger_inputs(utxos[..=i].iter().copied())?;
 
-            let funding_delta = funded_tx_builder.funding_delta::<G>(context)?;
+            let funding_delta = funded_tx_builder
+                .funding_delta_with_priority_fee::<G>(context, priority_fee_percent)?;
 
-            match funding_delta.cmp(&delta_target) {
+            match funding_delta.cmp(&0) {
                 Ordering::Less => {
                     // Insufficient funds, need more UTXO's.
                 }
@@ -307,9 +308,11 @@ impl WalletState {
                     // We have enough balance, but we need to introduce a change note.
                     // The change note will slightly increase the storage cost of the tx so there is
                     // a chance that we will not be able to fund the tx with the change note.
-                    if let Some(tx_with_change) =
-                        funded_tx_builder.return_change::<G>(context, change_pk, priority_fee)?
-                    {
+                    if let Some(tx_with_change) = funded_tx_builder.return_change::<G>(
+                        context,
+                        change_pk,
+                        priority_fee_percent,
+                    )? {
                         // We were able to fund the tx with change note added.
                         return Ok(tx_with_change);
                     }
@@ -799,7 +802,7 @@ where
         funding_pks: impl IntoIterator<Item = impl Borrow<ZkPublicKey>>,
         context: &MantleTxContext,
         excluded_notes: &HashSet<NoteId>,
-        priority_fee: Value,
+        priority_fee_percent: u64,
     ) -> Result<MantleTxBuilder, WalletError> {
         self.wallet_state_at(tip)?.fund_tx::<G>(
             tx_builder,
@@ -807,7 +810,7 @@ where
             funding_pks,
             context,
             excluded_notes,
-            priority_fee,
+            priority_fee_percent,
         )
     }
 
@@ -1436,7 +1439,12 @@ mod tests {
                 .into_inner()
         );
         assert_eq!(794, funded_tx_builder.net_balance());
-        assert_eq!(0, funded_tx_builder.funding_delta::<Gas>(&context).unwrap());
+        assert_eq!(
+            0,
+            funded_tx_builder
+                .funding_delta_with_priority_fee::<Gas>(&context, 0)
+                .unwrap()
+        );
 
         let funded_tx = funded_tx_builder.build().unwrap();
 
@@ -1457,7 +1465,7 @@ mod tests {
     }
 
     #[test]
-    fn test_fund_tx_with_priority_fee() {
+    fn test_fund_tx_with_priority_fee_percentage() {
         let alice = pk(1);
         let utxo = Utxo::new(tx_hash(0), 0, Note::new(5000, alice));
         let ledger_state = LedgerState::from_utxos([utxo], &ledger_config());
@@ -1472,7 +1480,14 @@ mod tests {
             leader_reward_amount: 0,
         };
         let tx_builder = MantleTxBuilder::new();
-        let priority_fee = 200;
+        let priority_fee_percent = 12;
+        let mandatory_fee_without_change = tx_builder
+            .clone()
+            .add_ledger_input(Utxo::new(tx_hash(1), 0, Note::new(0, alice)))
+            .unwrap()
+            .minimum_gas_cost::<Gas>(&context)
+            .unwrap()
+            .into_inner();
 
         let funded_tx_builder = wallet_state
             .fund_tx::<Gas>(
@@ -1481,31 +1496,37 @@ mod tests {
                 [alice],
                 &context,
                 &HashSet::new(),
-                priority_fee,
+                priority_fee_percent,
             )
             .unwrap();
 
-        // The tip is left as excess balance above the mandatory fee.
-        let gas_cost = funded_tx_builder
+        // The final mandatory fee includes the change output, and the tip is
+        // the rounded-up percentage of that final fee.
+        let mandatory_fee = funded_tx_builder
             .minimum_gas_cost::<Gas>(&context)
             .unwrap()
             .into_inner();
+        assert_eq!(mandatory_fee_without_change, 754);
+        assert_eq!(mandatory_fee, 794);
+        let priority_fee_amount = (mandatory_fee * priority_fee_percent).div_ceil(100);
         assert_eq!(
-            i128::from(gas_cost + priority_fee),
+            i128::from(mandatory_fee + priority_fee_amount),
             funded_tx_builder.net_balance()
         );
         assert_eq!(
-            i128::from(priority_fee),
-            funded_tx_builder.funding_delta::<Gas>(&context).unwrap()
+            0,
+            funded_tx_builder
+                .funding_delta_with_priority_fee::<Gas>(&context, priority_fee_percent)
+                .unwrap()
         );
 
-        // The change output shrank by exactly the tip.
+        // The change output shrank by the mandatory fee and percentage tip.
         let funded_tx = funded_tx_builder.build().unwrap();
         if let Op::Transfer(transfer_op) = &funded_tx.ops()[funded_tx.ops().len() - 1] {
             assert_eq!(
                 transfer_op.outputs,
                 Outputs::new([Note {
-                    value: 5000 - gas_cost - priority_fee,
+                    value: 5000 - mandatory_fee - priority_fee_amount,
                     pk: alice,
                 }])
             );

--- a/zone-sdk/BRIDGING.md
+++ b/zone-sdk/BRIDGING.md
@@ -45,7 +45,7 @@ let node = NodeHttpClient::new(
 let funding = FundingConfig {
     funding_pk,
     max_tx_fee: 1_000_000.into(),
-    priority_fee: FundingConfig::DEFAULT_PRIORITY_FEE,
+    priority_fee_percent: FundingConfig::DEFAULT_PRIORITY_FEE_PERCENT,
 };
 let mut sequencer = ZoneSequencer::init(channel_id, signing_key, node, funding, None);
 
@@ -53,6 +53,16 @@ let mut sequencer = ZoneSequencer::init(channel_id, signing_key, node, funding, 
 // publishing the first inscription creates the channel just-in-time.
 let (result, checkpoint) = sequencer.handle().publish(genesis_zone_block)?;
 ```
+
+`priority_fee_percent` is a percentage reserve over the complete mandatory
+fee, which consists of execution plus storage cost. Only the reserve left
+after the transaction's final mandatory fee is charged becomes the effective
+priority tip. The Zone SDK default is 12%: a practical reserve intended to
+absorb normal fee movement, including approximately one storage-market epoch
+increase under normal price levels. It is not a protocol guarantee at very low
+prices or when execution fees also rise materially. Storage prices use integer
+arithmetic, so low prices can make proportionally larger jumps (for example,
+1 to 2); 12% is therefore a safety margin, not a guaranteed one-epoch bound.
 
 To override other sequencer settings, build the config explicitly —
 `SequencerConfig::new(funding)` fills in the defaults for everything else:

--- a/zone-sdk/src/sequencer/tx_builder.rs
+++ b/zone-sdk/src/sequencer/tx_builder.rs
@@ -49,7 +49,9 @@ where
             change_public_key: funding.funding_pk,
             funding_public_keys: vec![funding.funding_pk],
             max_tx_fee: funding.max_tx_fee,
-            priority_fee: funding.priority_fee,
+            // The public request field is a percentage of the final
+            // mandatory fee, not an absolute fee amount.
+            priority_fee_percent: funding.priority_fee_percent,
         })
         .await
         .map_err(|e| Error::Network(format!("funding failed: {e}")))?;
@@ -279,4 +281,26 @@ pub(super) fn prepare_tx(
 
 pub(super) fn sign_tx(tx_hash: TxHash, signing_key: &Ed25519Key) -> Ed25519Signature {
     signing_key.sign_payload(tx_hash.as_signing_bytes().as_ref())
+}
+
+#[cfg(test)]
+mod tests {
+    use tokio::sync::mpsc;
+
+    use super::*;
+    use crate::test_support::{MockNode, funding_config};
+
+    #[tokio::test]
+    async fn funding_path_passes_priority_fee_as_a_percentage() {
+        let (priority_fees_tx, mut priority_fees_rx) = mpsc::channel(1);
+        let node = MockNode {
+            funding_priority_fees: Some(priority_fees_tx),
+            ..MockNode::default()
+        };
+        let funding = funding_config();
+
+        fund_ops(&node, &funding, Vec::new()).await.unwrap();
+
+        assert_eq!(priority_fees_rx.recv().await, Some(12));
+    }
 }

--- a/zone-sdk/src/sequencer/types.rs
+++ b/zone-sdk/src/sequencer/types.rs
@@ -134,16 +134,23 @@ impl ChannelUpdateTx {
 pub struct FundingConfig {
     /// The node wallet key that pays transaction fees.
     pub funding_pk: ZkPublicKey,
-    /// Hard cap on the fee of a single transaction.
+    /// Absolute hard cap on the fee of a single funded transaction.
     pub max_tx_fee: GasCost,
-    /// Execution tip paid on top of the mandatory fee when funding a
-    /// transaction. [`Self::max_tx_fee`] caps the total.
-    pub priority_fee: Value,
+    /// Percentage of the final mandatory fee reserved as a priority reserve
+    /// when funding a transaction. The mandatory fee is execution plus
+    /// storage cost, and only the unused reserve becomes an effective tip.
+    /// The 12% default is a practical reserve intended to absorb normal fee
+    /// movement, including approximately one storage-market epoch increase
+    /// at normal price levels. It is not a protocol guarantee at very low
+    /// prices or when execution fees also rise materially: storage prices use
+    /// integer arithmetic, so a low price can jump proportionally more (for
+    /// example, 1 to 2). [`Self::max_tx_fee`] caps the total.
+    pub priority_fee_percent: u64,
 }
 
 impl FundingConfig {
-    /// Default execution tip.
-    pub const DEFAULT_PRIORITY_FEE: Value = 200;
+    /// Default percentage reserve for normal fee movement.
+    pub const DEFAULT_PRIORITY_FEE_PERCENT: Value = 12;
 }
 
 /// Configuration for the zone sequencer.

--- a/zone-sdk/src/test_support.rs
+++ b/zone-sdk/src/test_support.rs
@@ -36,6 +36,7 @@ use tokio::sync::{mpsc, watch};
 use crate::{
     ZoneMessage,
     adapter::{self, BoxStream},
+    sequencer::FundingConfig,
 };
 
 /// One scripted `block_stream` connection: serve `events`, then `then`.
@@ -85,6 +86,8 @@ pub struct MockNode {
     pub up: Option<watch::Receiver<bool>>,
     /// Receives every `post_transaction` tx.
     pub posted: Option<mpsc::Sender<SignedMantleTx<Unverified>>>,
+    /// Receives the priority-fee percentages from funding requests.
+    pub funding_priority_fees: Option<mpsc::Sender<u64>>,
 }
 
 impl Default for MockNode {
@@ -103,6 +106,7 @@ impl Default for MockNode {
             zone_messages: Vec::new(),
             up: None,
             posted: None,
+            funding_priority_fees: None,
         }
     }
 }
@@ -261,6 +265,12 @@ impl adapter::Node for MockNode {
         &self,
         request: WalletFundRequestBody,
     ) -> Result<WalletFundResponseBody, lb_common_http_client::Error> {
+        if let Some(priority_fees) = &self.funding_priority_fees {
+            priority_fees
+                .send(request.priority_fee_percent)
+                .await
+                .expect("funding percentage receiver alive");
+        }
         // Fee-less passthrough: build the request's ops unchanged, as the
         // node would at zero gas price.
         Ok(WalletFundResponseBody {
@@ -276,11 +286,11 @@ impl adapter::Node for MockNode {
 /// Funding config backed by a fixture key; [`MockNode::fund_tx`] ignores it
 /// and returns the ops unchanged.
 #[must_use]
-pub fn funding_config() -> crate::sequencer::FundingConfig {
-    crate::sequencer::FundingConfig {
+pub fn funding_config() -> FundingConfig {
+    FundingConfig {
         funding_pk: lb_groth16::Fr::from(1u64).into(),
         max_tx_fee: GasCost::new(u64::MAX),
-        priority_fee: crate::sequencer::FundingConfig::DEFAULT_PRIORITY_FEE,
+        priority_fee_percent: FundingConfig::DEFAULT_PRIORITY_FEE_PERCENT,
     }
 }
 


### PR DESCRIPTION
## 1. What does this PR implement?

Changed the absolute `priority_fee` to `priority_fee_percent`, an integer percentage of the final mandatory transaction fee:

- 0 funds exactly to the mandatory fee.
- 12 reserves `ceil(mandatory_fee × 12 / 100)`.
- Percentages are uncapped and calculated with checked integer arithmetic.
- Percentage calculation uses the final funded transaction candidate, including change-output gas.
- `max_tx_fee` remains an absolute cap on the final funded transaction fee.

**Updated surfaces**

- Core wallet funding and `MantleTxBuilder::return_change`
- Wallet service API and funding messages
- `/wallet/fund` schema and documentation
- Zone SDK funding configuration and requests
- TUI `--priority-fee-percent` / `PRIORITY_FEE_PERCENT`
- C bindings and documentation
- Zone SDK/test-support call sites
- Default Zone SDK/TUI reserve changed from an absolute 200 to 12%

**Tests**

Added coverage for:

- Zero percentage funding
- 12% fee reserve
- Integer `ceil` rounding and small fees
- Final mandatory fee including change output
- Percentages above 100
- `max_tx_fee` rejection including the percentage reserve
- Zone SDK funding request propagation
- Cucumber coverage proving a percentage reserve absorbs a fee increase across epoch boundaries and the same prepared transaction remain valid.

**Notes:** 
- This PR is an indirect replacement for #3288. 
- Related [discussion](https://discordapp.com/channels/973324189794697286/1536655245403361363).

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@hansieodendaal, @davidrusu 

## 4. Is the specification accurate and complete?

Yes

## 5. Does the implementation introduce changes in the specification?

No

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [X] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [X] 2. Description added.
* [X] 3. Context and links to Specification document(s) added.
* [X] 4. Main contact(s) (developers and specification authors) added
* [X] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [X] 6. Link PR to a specific milestone.
* [X] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
