### PR TITLE
refactor(core): reuse the header validation for uncle validation

### DIFF
--- a/core/src/block/mod.rs
+++ b/core/src/block/mod.rs
@@ -49,18 +49,25 @@ pub type BlockNumber = u64;
 pub enum Error {
     #[error("Failed to serialize: {0}")]
     Serialisation(#[from] crate::codec::Error),
-    #[error("Signature error.")]
-    Signature,
+    #[error("Failed to verify header alone: {0}")]
+    Header(#[from] HeaderError),
     #[error("Body root mismatch: calculated body does not match header")]
     BodyRootMismatch,
     #[error("Signing key does not match the leader key in proof of leadership")]
     KeyMismatch,
-    #[error("Validation error: {0}")]
-    Validation(String),
     #[error(transparent)]
     BoundedError(#[from] BoundedError),
     #[error("Total storage size {size} exceeds maximum of {max} bytes")]
     ContentTooBig { size: usize, max: usize },
+}
+
+/// Why a header fails the checks that need the header alone.
+#[derive(Debug, thiserror::Error)]
+pub enum HeaderError {
+    #[error("Expected a non-genesis slot")]
+    GenesisSlot,
+    #[error("Signature error.")]
+    Signature,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, BinaryCodec)]
@@ -183,7 +190,7 @@ impl<Tx> Block<Tx> {
     {
         // 1. Non-genesis blocks only
         if slot == Slot::genesis() {
-            return Err(Error::Validation("expected non-genesis slot".to_owned()));
+            return Err(HeaderError::GenesisSlot.into());
         }
 
         // 2. Expected leader public key
@@ -241,24 +248,14 @@ impl<Tx> Block<Tx> {
     where
         Tx: Hashable<Hash = TxHash> + StorageSize,
     {
-        // 1. Non-genesis blocks only
-        if self.header.slot() == Slot::genesis() {
-            return Err(Error::Validation("expected non-genesis slot".to_owned()));
-        }
+        // 1. Checks that need the header alone
+        verify_header_alone(&self.header, &self.signature)?;
 
         // 2. Size is ok
         self.validate_total_transactions_size()?;
 
         // 3. Body root matches the carried uncle headers and transactions
         self.validate_body_root()?;
-
-        // 4. Signature is valid over the header bytes
-        let leader_public_key = self.header.leader_proof().leader_key();
-        let header_bytes = self.header.to_bytes()?;
-
-        leader_public_key
-            .verify(&header_bytes, &self.signature)
-            .map_err(|_| Error::Signature)?;
 
         Ok(self)
     }
@@ -341,6 +338,28 @@ impl<Tx> Block<Tx> {
             signature: self.signature,
         }
     }
+}
+
+/// The checks that the header and the signature over it settle on their own:
+/// the header's slot must not be the genesis one, and the signature must verify
+/// by the leader key.
+///
+/// This does not check `body_root` because it commits to a body this function
+/// does not have. It should be checked separately by the caller.
+pub fn verify_header_alone(
+    header: &Header,
+    signature: &Ed25519Signature,
+) -> Result<(), HeaderError> {
+    if header.slot() == Slot::genesis() {
+        return Err(HeaderError::GenesisSlot);
+    }
+
+    let header_bytes = header.to_bytes().map_err(|_| HeaderError::Signature)?;
+    header
+        .leader_proof()
+        .leader_key()
+        .verify(&header_bytes, signature)
+        .map_err(|_| HeaderError::Signature)
 }
 
 /// The commitment to a block body: its uncle headers and its txs
@@ -779,9 +798,10 @@ mod tests {
         )
         .unwrap_err();
 
-        assert!(
-            matches!(block_result, Error::Validation(msg) if msg == "expected non-genesis slot")
-        );
+        assert!(matches!(
+            block_result,
+            Error::Header(HeaderError::GenesisSlot)
+        ));
     }
 
     #[test]
@@ -822,7 +842,7 @@ mod tests {
         )
         .expect_err("genesis slot must be rejected by reconstruct path");
 
-        assert!(matches!(err, Error::Validation(msg) if msg == "expected non-genesis slot"));
+        assert!(matches!(err, Error::Header(HeaderError::GenesisSlot)));
     }
 
     /// The specification fixes the maximum proposal at 10,000 bytes:

--- a/core/src/block/uncle.rs
+++ b/core/src/block/uncle.rs
@@ -75,4 +75,8 @@ impl SignedHeader {
     pub const fn signature(&self) -> &Ed25519Signature {
         &self.signature
     }
+
+    pub fn verify(&self) -> Result<(), crate::block::HeaderError> {
+        crate::block::verify_header_alone(&self.header, &self.signature)
+    }
 }

--- a/services/chain/chain-service/src/uncle.rs
+++ b/services/chain/chain-service/src/uncle.rs
@@ -3,10 +3,8 @@
 use std::collections::HashSet;
 
 use lb_core::{
-    block::{Block, SignedHeader, UncleHeaders},
-    codec::SerializeOp as _,
+    block::{Block, HeaderError, SignedHeader, UncleHeaders},
     header::HeaderId,
-    proofs::leader_proof::LeaderProof as _,
 };
 use lb_cryptarchia_engine::Branch;
 
@@ -63,9 +61,13 @@ impl Cryptarchia {
         let window_start = slot.into_inner().saturating_sub(uncle_reference_window);
         self.verify_uncles_ancestry(block.uncle_headers(), parent, window_start)?;
 
-        // Each uncle's header signature and `PoL` must be valid.
+        // Each uncle's header (including its signature) must be valid,
+        // and its `PoL` must be valid.
         for uncle in block.uncle_headers().iter() {
-            self.verify_uncle_proofs(uncle)
+            uncle
+                .verify()
+                .map_err(UncleError::from)
+                .and_then(|()| self.verify_uncle_pol(uncle))
                 .map_err(|reason| Error::InvalidUncle {
                     uncle: uncle.header().id(),
                     reason,
@@ -122,20 +124,8 @@ impl Cryptarchia {
         Ok(())
     }
 
-    /// Verifies the signature and the leadership proof carried by an uncle.
-    fn verify_uncle_proofs(&self, uncle: &SignedHeader) -> Result<(), UncleError> {
-        // The signature must verify over the uncle's header, by its own leader.
-        let header_bytes = uncle
-            .header()
-            .to_bytes()
-            .map_err(|_| UncleError::InvalidSignature)?;
-        uncle
-            .header()
-            .leader_proof()
-            .leader_key()
-            .verify(&header_bytes, uncle.signature())
-            .map_err(|_| UncleError::InvalidSignature)?;
-
+    /// Verifies the leadership proof carried by an uncle.
+    fn verify_uncle_pol(&self, uncle: &SignedHeader) -> Result<(), UncleError> {
         // The proof of leadership must verify against the ledger state of the
         // uncle's parent, which must exist since the parent is on the chain.
         let parent_state = self
@@ -162,10 +152,21 @@ pub enum UncleError {
     ParentNotOnChain,
     #[error("on the chain that the block is extending")]
     OnChain,
+    #[error("at a slot no uncle can be proposed for")]
+    InvalidSlot,
     #[error("invalid header signature")]
     InvalidSignature,
     #[error("invalid proof of leadership")]
     InvalidProof,
+}
+
+impl From<HeaderError> for UncleError {
+    fn from(error: HeaderError) -> Self {
+        match error {
+            HeaderError::GenesisSlot => Self::InvalidSlot,
+            HeaderError::Signature => Self::InvalidSignature,
+        }
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## 1. What does this PR implement?

This is an additional refactoring on top of the series of uncle-ref PRs. We discussed about this refactoring in https://github.com/logos-blockchain/logos-blockchain/pull/3284#discussion_r3775549965, and I decided to open this separate PR since it's easier to read.

In [one](https://github.com/logos-blockchain/logos-blockchain/pull/3284) of the uncle-ref PRs, I wrote a function that verifies both header signature and PoL:
```
fn verify_uncle_proofs(&self, uncle: &SignedHeader) -> Result<(), UncleError> {
  // 1. verify `uncle.signature`
  // 2. verify `uncle.header.leadership_proof` with `self....parent_state`.
}
```
But, @davidrusu pointed out that we can probably use an existing function, instead of having this separate `verify_uncle_proofs` function.

That's a good point, and I investigated the codebase. But I found that we don't have any function that can replace the `verify_uncle_proofs` completely. It's because verifying `uncle.signature` is a stateless check that is performed when a `Block` is reconstructed, while the PoL verification is a stateful check that is done when we apply the block to the ledger.

Instead, in this PR, I refactored the existing stateless check little bit, and reused it to replace only the `step 1` in the `verify_uncle_proof`. By doing so, even if we add/change the stateless checks in the future, it automatically affects the uncle validation. 

What did I refactor in the stateless check? There were two mixed parts in the stateless check:
1. The checks that can be done only with a header alone.
2. The checks that require both header and body.
Those two were mixed in a single function. I factored out the `1` into a smaller function, so that we can reuse it for the uncle validation.

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@youngjoon-lee 

## 4. Is the specification accurate and complete?

Yes

## 5. Does the implementation introduce changes in the specification?

No

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
