### PR TITLE
fix(chain): reject foreign-genesis IBD streams

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3948,6 +3948,7 @@ dependencies = [
  "logos-blockchain-chain-leader-service",
  "logos-blockchain-chain-service",
  "logos-blockchain-core",
+ "logos-blockchain-http-api-common",
  "logos-blockchain-ledger",
  "logos-blockchain-libp2p",
  "logos-blockchain-log-targets",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4278,6 +4278,7 @@ dependencies = [
  "overwatch",
  "rand 0.8.6",
  "serde",
+ "serde_json",
  "serde_with",
  "tempfile",
  "thiserror 2.0.18",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4163,6 +4163,7 @@ dependencies = [
  "logos-blockchain-key-management-system-keys",
  "logos-blockchain-node",
  "logos-blockchain-time-service",
+ "logos-blockchain-tx-service",
  "logos-blockchain-utils",
  "logos-blockchain-wallet-service",
  "multiaddr",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4278,7 +4278,6 @@ dependencies = [
  "overwatch",
  "rand 0.8.6",
  "serde",
- "serde_json",
  "serde_with",
  "tempfile",
  "thiserror 2.0.18",

--- a/c-bindings/Cargo.toml
+++ b/c-bindings/Cargo.toml
@@ -20,6 +20,7 @@ lb-http-api-common            = { workspace = true }
 lb-key-management-system-keys = { workspace = true }
 lb-node                       = { workspace = true }
 lb-time-service               = { workspace = true }
+lb-tx-service                 = { workspace = true }
 lb-utils                      = { workspace = true }
 lb-wallet-service             = { workspace = true }
 multiaddr                     = { workspace = true }

--- a/c-bindings/src/api/catalog.rs
+++ b/c-bindings/src/api/catalog.rs
@@ -1,0 +1,404 @@
+use std::{
+    ffi::{CString, c_char},
+    io::{Error, ErrorKind, Write},
+    num::NonZeroUsize,
+};
+
+use lb_api_service::http::{mantle, time};
+use lb_chain_service::Slot;
+use lb_node::{RocksBackend, RuntimeServiceId, SignedMantleTx, api::ApiProcessedBlockEvent};
+use serde::Serialize;
+
+use crate::{
+    LogosBlockchainNode, OperationStatus,
+    api::cryptarchia::get_cryptarchia_info_sync,
+    errors::OperationStatusCode,
+    result::{FfiStatusResult, StatusResult},
+    return_error_if_null_pointer, unwrap_or_return_error,
+};
+
+/// Matches the maximum page size accepted by the Inspector catalog reader.
+const MAX_FINALIZED_BLOCKS_RANGE_LIMIT: usize = 100;
+/// Matches the maximum direct range-response budget accepted by the Inspector.
+const MAX_FINALIZED_BLOCKS_RANGE_BYTES: usize = 64 * 1024 * 1024;
+
+struct BoundedJsonBuffer {
+    bytes: Vec<u8>,
+    limit: usize,
+    limit_exceeded: bool,
+}
+
+impl BoundedJsonBuffer {
+    fn new(limit: usize) -> Self {
+        Self {
+            bytes: Vec::with_capacity(limit.min(64 * 1024)),
+            limit,
+            limit_exceeded: false,
+        }
+    }
+}
+
+impl Write for BoundedJsonBuffer {
+    fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+        if bytes.len() > self.limit.saturating_sub(self.bytes.len()) {
+            self.limit_exceeded = true;
+            return Err(Error::new(
+                ErrorKind::WriteZero,
+                "JSON response exceeds its configured byte limit",
+            ));
+        }
+        self.bytes.extend_from_slice(bytes);
+        Ok(bytes.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+fn json_cstring<Value: Serialize>(
+    value: &Value,
+    label: &str,
+    max_bytes: usize,
+) -> StatusResult<CString> {
+    let mut buffer = BoundedJsonBuffer::new(max_bytes);
+    if let Err(error) = serde_json::to_writer(&mut buffer, value) {
+        let code = if buffer.limit_exceeded {
+            OperationStatusCode::ValidationError
+        } else {
+            OperationStatusCode::RuntimeError
+        };
+        return Err(OperationStatus::error(
+            code,
+            format!("Failed to serialize {label}: {error}"),
+        ));
+    }
+
+    CString::new(buffer.bytes).map_err(|error| {
+        OperationStatus::error(
+            OperationStatusCode::RuntimeError,
+            format!("Failed to create {label} C string: {error}"),
+        )
+    })
+}
+
+fn finalized_blocks_limit(
+    from_slot: u64,
+    to_slot: u64,
+    blocks_limit: u64,
+) -> StatusResult<NonZeroUsize> {
+    if from_slot > to_slot {
+        return Err(OperationStatus::error(
+            OperationStatusCode::ValidationError,
+            "from_slot must not be greater than to_slot.",
+        ));
+    }
+
+    let blocks_limit = usize::try_from(blocks_limit).map_err(|_| {
+        OperationStatus::error(
+            OperationStatusCode::ValidationError,
+            "blocks_limit overflow.",
+        )
+    })?;
+    let blocks_limit = NonZeroUsize::new(blocks_limit).ok_or_else(|| {
+        OperationStatus::error(
+            OperationStatusCode::ValidationError,
+            "blocks_limit must be greater than zero.",
+        )
+    })?;
+    if blocks_limit.get() > MAX_FINALIZED_BLOCKS_RANGE_LIMIT {
+        return Err(OperationStatus::error(
+            OperationStatusCode::ValidationError,
+            format!("blocks_limit exceeds {MAX_FINALIZED_BLOCKS_RANGE_LIMIT} finalized blocks."),
+        ));
+    }
+
+    Ok(blocks_limit)
+}
+
+fn ensure_finalized_range_within_lib(to_slot: u64, lib_slot: Slot) -> StatusResult<()> {
+    if Slot::new(to_slot) > lib_slot {
+        return Err(OperationStatus::error(
+            OperationStatusCode::ValidationError,
+            format!(
+                "to_slot {to_slot} exceeds captured LIB slot {}.",
+                u64::from(lib_slot)
+            ),
+        ));
+    }
+
+    Ok(())
+}
+
+pub(crate) fn get_time_info_sync(node: &LogosBlockchainNode) -> StatusResult<CString> {
+    let runtime_handle = node.get_runtime_handle();
+    let time_info = runtime_handle
+        .block_on(time::time_info::<lb_node::TimeService, RuntimeServiceId>(
+            node.get_overwatch_handle(),
+        ))
+        .map_err(|error| {
+            OperationStatus::error(
+                OperationStatusCode::RelayError,
+                format!("Failed to get time info: {error}"),
+            )
+        })?;
+
+    json_cstring(&time_info, "time info", MAX_FINALIZED_BLOCKS_RANGE_BYTES)
+}
+
+pub(crate) fn get_finalized_blocks_range_sync(
+    node: &LogosBlockchainNode,
+    from_slot: u64,
+    to_slot: u64,
+    blocks_limit: u64,
+) -> StatusResult<CString> {
+    let blocks_limit = finalized_blocks_limit(from_slot, to_slot, blocks_limit)?;
+    let chain_info = get_cryptarchia_info_sync(node)?;
+    ensure_finalized_range_within_lib(to_slot, chain_info.cryptarchia_info.lib_slot)?;
+    let runtime_handle = node.get_runtime_handle();
+    let blocks = runtime_handle
+        .block_on(mantle::get_blocks_in_slot_range_with_snapshot::<
+            SignedMantleTx,
+            RocksBackend,
+            RuntimeServiceId,
+        >(
+            node.get_overwatch_handle(),
+            Slot::new(from_slot),
+            Slot::new(to_slot),
+            false,
+            blocks_limit,
+            true,
+            &chain_info.cryptarchia_info,
+        ))
+        .map_err(|error| {
+            OperationStatus::error(
+                OperationStatusCode::RelayError,
+                format!("Failed to get finalized blocks range: {error}"),
+            )
+        })?;
+    let events: Vec<ApiProcessedBlockEvent> = blocks
+        .into_iter()
+        .map(ApiProcessedBlockEvent::from)
+        .collect();
+
+    json_cstring(
+        &events,
+        "finalized blocks range",
+        MAX_FINALIZED_BLOCKS_RANGE_BYTES,
+    )
+}
+
+/// Result type for [`get_time_info`]. On success, `value` is a pointer to a
+/// NUL-terminated JSON string matching `/time/info`.
+pub type FfiGetTimeInfoResult = FfiStatusResult<*mut c_char>;
+
+/// Reads the current time-service snapshot as JSON.
+///
+/// The result uses the existing C-string allocation contract and must be
+/// released with [`free_cstring`](super::free_cstring).
+///
+/// # Safety
+///
+/// `node` must be a valid, non-null [`LogosBlockchainNode`] pointer.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn get_time_info(node: *const LogosBlockchainNode) -> FfiGetTimeInfoResult {
+    return_error_if_null_pointer!(node);
+    // SAFETY: the public function contract requires a live, initialized node.
+    let node = unsafe { &*node };
+    let json_cstring = unwrap_or_return_error!(get_time_info_sync(node));
+    FfiGetTimeInfoResult::ok(json_cstring.into_raw())
+}
+
+/// Result type for [`get_finalized_blocks_range`]. On success, `value` is a
+/// pointer to a NUL-terminated JSON array of processed block events.
+pub type FfiGetFinalizedBlocksRangeResult = FfiStatusResult<*mut c_char>;
+
+/// Reads an ascending immutable block range from one finalized chain snapshot.
+///
+/// `blocks_limit` must be in `1..=100`; the function rejects a target above
+/// the captured LIB rather than silently changing the requested range. Each
+/// event has the same `{ block, tip, tip_slot, lib, lib_slot }` shape as the
+/// direct blocks-range API. The returned string must be released with
+/// [`free_cstring`](super::free_cstring).
+///
+/// # Safety
+///
+/// `node` must be a valid, non-null [`LogosBlockchainNode`] pointer.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn get_finalized_blocks_range(
+    node: *const LogosBlockchainNode,
+    from_slot: u64,
+    to_slot: u64,
+    blocks_limit: u64,
+) -> FfiGetFinalizedBlocksRangeResult {
+    return_error_if_null_pointer!(node);
+    // SAFETY: the public function contract requires a live, initialized node.
+    let node = unsafe { &*node };
+    let json_cstring = unwrap_or_return_error!(get_finalized_blocks_range_sync(
+        node,
+        from_slot,
+        to_slot,
+        blocks_limit,
+    ));
+    FfiGetFinalizedBlocksRangeResult::ok(json_cstring.into_raw())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+
+    use lb_core::{
+        block::{Block, BlockTransactions},
+        header::HeaderId,
+        proofs::leader_proof::Groth16LeaderProof,
+    };
+    use lb_key_management_system_keys::keys::Ed25519Key;
+
+    use super::*;
+
+    fn api_block(slot: u64, parent: HeaderId) -> Block<SignedMantleTx> {
+        let signing_key = Ed25519Key::from_bytes(&[0; 32]);
+        let mut proof = serde_json::to_value(Groth16LeaderProof::genesis())
+            .expect("genesis leader proof should serialize");
+        proof["leader_key"] = serde_json::to_value(signing_key.public_key())
+            .expect("leader public key should serialize");
+        let proof = serde_json::from_value(proof).expect("leader proof should serialize");
+
+        Block::<SignedMantleTx>::create(
+            parent,
+            Slot::new(slot),
+            proof,
+            BlockTransactions::empty(),
+            &signing_key,
+        )
+        .expect("test block should be constructible")
+    }
+
+    #[test]
+    fn finalized_range_rejects_reversed_slots() {
+        let result = finalized_blocks_limit(11, 10, 1);
+
+        assert!(matches!(
+            result,
+            Err(OperationStatus {
+                code: OperationStatusCode::ValidationError,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn finalized_range_rejects_zero_limit() {
+        let result = finalized_blocks_limit(0, 10, 0);
+
+        assert!(matches!(
+            result,
+            Err(OperationStatus {
+                code: OperationStatusCode::ValidationError,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn finalized_range_rejects_a_page_larger_than_the_catalog_contract() {
+        let result = finalized_blocks_limit(0, 100, 101);
+
+        assert!(matches!(
+            result,
+            Err(OperationStatus {
+                code: OperationStatusCode::ValidationError,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn finalized_range_accepts_the_catalog_page_limit() {
+        let result = finalized_blocks_limit(0, 100, 100);
+
+        assert!(matches!(result, Ok(limit) if limit.get() == 100));
+    }
+
+    #[test]
+    fn finalized_range_rejects_a_target_beyond_the_captured_lib() {
+        let result = ensure_finalized_range_within_lib(42, Slot::new(41));
+
+        assert!(matches!(
+            result,
+            Err(OperationStatus {
+                code: OperationStatusCode::ValidationError,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn bounded_json_serialization_rejects_an_oversized_result() {
+        let result = json_cstring(&"abcdef", "test result", 5);
+
+        assert!(matches!(
+            result,
+            Err(OperationStatus {
+                code: OperationStatusCode::ValidationError,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn finalized_range_serialization_preserves_processed_event_contract() {
+        let tip = HeaderId::from([9; 32]);
+        let lib = HeaderId::from([8; 32]);
+        let first_block = api_block(40, HeaderId::from([0; 32]));
+        let second_block = api_block(41, first_block.header().id());
+        let events = vec![
+            ApiProcessedBlockEvent {
+                block: first_block,
+                tip,
+                tip_slot: Slot::new(42),
+                lib,
+                lib_slot: Slot::new(41),
+            },
+            ApiProcessedBlockEvent {
+                block: second_block,
+                tip,
+                tip_slot: Slot::new(42),
+                lib,
+                lib_slot: Slot::new(41),
+            },
+        ];
+
+        let json = json_cstring(
+            &events,
+            "finalized blocks range",
+            MAX_FINALIZED_BLOCKS_RANGE_BYTES,
+        )
+        .expect("processed events should serialize");
+        let value: serde_json::Value =
+            serde_json::from_str(json.to_str().expect("JSON must be UTF-8"))
+                .expect("serialized events must be JSON");
+        let events = value.as_array().expect("range result must be an array");
+
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0]["block"]["header"]["slot"], 40);
+        assert_eq!(events[1]["block"]["header"]["slot"], 41);
+        for event in events {
+            let keys = event
+                .as_object()
+                .expect("each range item must be an object")
+                .keys()
+                .map(String::as_str)
+                .collect::<BTreeSet<_>>();
+            assert_eq!(
+                keys,
+                BTreeSet::from(["block", "tip", "tip_slot", "lib", "lib_slot"])
+            );
+            assert!(event["block"]["header"]["id"].is_string());
+            assert_eq!(event["tip"], serde_json::json!(tip));
+            assert_eq!(event["tip_slot"], 42);
+            assert_eq!(event["lib"], serde_json::json!(lib));
+            assert_eq!(event["lib_slot"], 41);
+        }
+    }
+}

--- a/c-bindings/src/api/catalog.rs
+++ b/c-bindings/src/api/catalog.rs
@@ -6,7 +6,10 @@ use std::{
 
 use lb_api_service::http::{mantle, time};
 use lb_chain_service::Slot;
-use lb_node::{RocksBackend, RuntimeServiceId, SignedMantleTx, api::ApiProcessedBlockEvent};
+use lb_core::mantle::{SignedMantleTx, transactions::states::Preverified};
+use lb_node::{
+    RocksBackend, RuntimeServiceId, api::serializers::blocks::ApiProcessedBlockEventOwned,
+};
 use serde::Serialize;
 
 use crate::{
@@ -158,7 +161,7 @@ pub(crate) fn get_finalized_blocks_range_sync(
     let runtime_handle = node.get_runtime_handle();
     let blocks = runtime_handle
         .block_on(mantle::get_blocks_in_slot_range_with_snapshot::<
-            SignedMantleTx,
+            SignedMantleTx<Preverified>,
             RocksBackend,
             RuntimeServiceId,
         >(
@@ -176,9 +179,9 @@ pub(crate) fn get_finalized_blocks_range_sync(
                 format!("Failed to get finalized blocks range: {error}"),
             )
         })?;
-    let events: Vec<ApiProcessedBlockEvent> = blocks
+    let events: Vec<ApiProcessedBlockEventOwned<Preverified>> = blocks
         .into_iter()
-        .map(ApiProcessedBlockEvent::from)
+        .map(ApiProcessedBlockEventOwned::from)
         .collect();
 
     json_cstring(
@@ -247,8 +250,9 @@ pub unsafe extern "C" fn get_finalized_blocks_range(
 mod tests {
     use std::collections::BTreeSet;
 
+    use lb_api_service::http::mantle::BlockWithChainState;
     use lb_core::{
-        block::{Block, BlockTransactions},
+        block::{Block, BlockTransactions, UncleHeaders},
         header::HeaderId,
         proofs::leader_proof::Groth16LeaderProof,
     };
@@ -256,7 +260,7 @@ mod tests {
 
     use super::*;
 
-    fn api_block(slot: u64, parent: HeaderId) -> Block<SignedMantleTx> {
+    fn api_block(slot: u64, parent: HeaderId) -> Block<SignedMantleTx<Preverified>> {
         let signing_key = Ed25519Key::from_bytes(&[0; 32]);
         let mut proof = serde_json::to_value(Groth16LeaderProof::genesis())
             .expect("genesis leader proof should serialize");
@@ -264,9 +268,10 @@ mod tests {
             .expect("leader public key should serialize");
         let proof = serde_json::from_value(proof).expect("leader proof should serialize");
 
-        Block::<SignedMantleTx>::create(
+        Block::<SignedMantleTx<Preverified>>::create(
             parent,
             Slot::new(slot),
+            UncleHeaders::empty(),
             proof,
             BlockTransactions::empty(),
             &signing_key,
@@ -353,20 +358,20 @@ mod tests {
         let first_block = api_block(40, HeaderId::from([0; 32]));
         let second_block = api_block(41, first_block.header().id());
         let events = vec![
-            ApiProcessedBlockEvent {
+            ApiProcessedBlockEventOwned::from(BlockWithChainState {
                 block: first_block,
                 tip,
                 tip_slot: Slot::new(42),
                 lib,
                 lib_slot: Slot::new(41),
-            },
-            ApiProcessedBlockEvent {
+            }),
+            ApiProcessedBlockEventOwned::from(BlockWithChainState {
                 block: second_block,
                 tip,
                 tip_slot: Slot::new(42),
                 lib,
                 lib_slot: Slot::new(41),
-            },
+            }),
         ];
 
         let json = json_cstring(

--- a/c-bindings/src/api/config.rs
+++ b/c-bindings/src/api/config.rs
@@ -151,6 +151,17 @@ pub fn generate_config_sync(args: EmbeddedInitArgs) -> OperationStatus {
     }
 }
 
+/// Generates a user config with an optional embedded-caller bootstrap-period
+/// override while preserving the existing `GenerateConfigArgs` ABI.
+#[must_use]
+pub fn generate_config_sync_with_bootstrap_period(
+    mut args: EmbeddedInitArgs,
+    prolonged_bootstrap_period_secs: Option<u64>,
+) -> OperationStatus {
+    args.prolonged_bootstrap_period_secs = prolonged_bootstrap_period_secs;
+    generate_config_sync(args)
+}
+
 /// Generates the user config file.
 ///
 /// # Arguments
@@ -171,6 +182,25 @@ pub fn generate_config_sync(args: EmbeddedInitArgs) -> OperationStatus {
 pub unsafe extern "C" fn generate_user_config(args: GenerateConfigArgs) -> OperationStatus {
     let init_args = EmbeddedInitArgs::from(args);
     generate_config_sync(init_args)
+}
+
+/// Generates a user config with an optional prolonged bootstrap period.
+///
+/// This entry point keeps the existing [`GenerateConfigArgs`] C ABI intact;
+/// callers that do not need an override should continue using
+/// [`generate_user_config`].
+///
+/// # Safety
+///
+/// `period_secs`, when non-null, must point to a valid `u64`.
+#[must_use]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn generate_user_config_with_bootstrap_period(
+    args: GenerateConfigArgs,
+    period_secs: *const u64,
+) -> OperationStatus {
+    let period = (!period_secs.is_null()).then(|| unsafe { *period_secs });
+    generate_config_sync_with_bootstrap_period(EmbeddedInitArgs::from(args), period)
 }
 
 /// Updates an existing user config file with keys from a keystore file,
@@ -471,5 +501,35 @@ mod test {
         let status = unsafe { migrate_user_config(migrated_c.as_ptr(), keystore_c.as_ptr()) };
         assert!(status.is_ok(), "Failed to migrate config: {status:?}");
         assert!(migrated_path.exists());
+    }
+
+    #[test]
+    fn embedded_bootstrap_period_override_is_written_to_user_config() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let config_path = temp_dir.path().join("user_config.yaml");
+        let keystore_path = temp_dir.path().join("keystore.yaml");
+
+        let status = generate_config_sync_with_bootstrap_period(
+            EmbeddedInitArgs {
+                output: config_path.clone(),
+                kms_file: Some(keystore_path),
+                ..Default::default()
+            },
+            Some(5),
+        );
+        assert!(status.is_ok(), "Failed to generate config: {status:?}");
+
+        let yaml =
+            std::fs::read_to_string(config_path).expect("Generated config should be readable");
+        let config: lb_node::config::UserConfig =
+            serde_yaml::from_str(&yaml).expect("Generated config should parse");
+        assert_eq!(
+            config
+                .cryptarchia
+                .service
+                .bootstrap
+                .prolonged_bootstrap_period,
+            std::time::Duration::from_secs(5)
+        );
     }
 }

--- a/c-bindings/src/api/cryptarchia.rs
+++ b/c-bindings/src/api/cryptarchia.rs
@@ -1,8 +1,3 @@
-use std::ffi::{CString, c_char};
-
-use lb_chain_service::api::CryptarchiaServiceApi;
-use lb_node::{RuntimeServiceId, generic_services::CryptarchiaService};
-
 use crate::{
     LogosBlockchainNode,
     api::free,
@@ -18,15 +13,14 @@ pub enum State {
     NotStarted = 0x2,
 }
 
-impl State {
-    const fn new(state: lb_chain_service::State, phase: lb_chain_service::PhaseTag) -> Self {
-        if matches!(phase, lb_chain_service::PhaseTag::AwaitingGenesisTime) {
-            return Self::NotStarted;
-        }
-
-        match state {
-            lb_chain_service::State::Bootstrapping => Self::Bootstrapping,
-            lb_chain_service::State::Online => Self::Online,
+impl From<lb_chain_service::ChainServiceMode> for State {
+    fn from(value: lb_chain_service::ChainServiceMode) -> Self {
+        match value {
+            lb_chain_service::ChainServiceMode::AwaitingStart => Self::NotStarted,
+            lb_chain_service::ChainServiceMode::Started(inner_state) => match inner_state {
+                lb_chain_service::State::Bootstrapping => Self::Bootstrapping,
+                lb_chain_service::State::Online => Self::Online,
+            },
         }
     }
 }
@@ -61,23 +55,84 @@ pub(crate) unsafe fn into_tx_hash(tx_hash: *const TxHash) -> lb_core::mantle::Tx
 #[repr(C)]
 pub struct CryptarchiaInfo {
     pub lib: HeaderId,
-    pub lib_slot: u64,
     pub tip: HeaderId,
     pub slot: u64,
     pub height: u64,
     pub mode: State,
+    // Appended to retain the offsets of existing fields. Callers that read
+    // this field must use a matching C library that allocates it.
+    pub genesis_id: HeaderId,
 }
 
-impl From<lb_chain_service::ChainServiceInfo> for CryptarchiaInfo {
-    fn from(value: lb_chain_service::ChainServiceInfo) -> Self {
-        Self {
+impl TryFrom<lb_chain_service::ChainServiceInfo> for CryptarchiaInfo {
+    type Error = OperationStatus;
+
+    fn try_from(value: lb_chain_service::ChainServiceInfo) -> Result<Self, Self::Error> {
+        let genesis_id = value.cryptarchia_info.genesis_id.ok_or_else(|| {
+            OperationStatus::error(
+                OperationStatusCode::RelayError,
+                "Cryptarchia info did not include a genesis identity.",
+            )
+        })?;
+
+        Ok(Self {
             lib: value.cryptarchia_info.lib.into(),
-            lib_slot: u64::from(value.cryptarchia_info.lib_slot),
             tip: value.cryptarchia_info.tip.into(),
             slot: u64::from(value.cryptarchia_info.slot),
             height: value.cryptarchia_info.height,
-            mode: State::new(value.cryptarchia_info.state, value.phase),
-        }
+            mode: State::from(value.mode),
+            genesis_id: genesis_id.into(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn conversion_preserves_genesis_identity() {
+        let genesis_id = lb_core::header::HeaderId::from([1; 32]);
+        let info = lb_chain_service::ChainServiceInfo {
+            cryptarchia_info: lb_chain_service::CryptarchiaInfo {
+                genesis_id: Some(genesis_id),
+                lib: lb_core::header::HeaderId::from([2; 32]),
+                lib_slot: lb_chain_service::Slot::new(3),
+                tip: lb_core::header::HeaderId::from([4; 32]),
+                slot: lb_chain_service::Slot::new(5),
+                height: 6,
+            },
+            mode: lb_chain_service::ChainServiceMode::Started(lb_chain_service::State::Online),
+        };
+
+        let ffi = CryptarchiaInfo::try_from(info).expect("genesis identity should be present");
+
+        assert_eq!(ffi.genesis_id, [1; 32]);
+    }
+
+    #[test]
+    fn conversion_rejects_missing_genesis_identity() {
+        let info = lb_chain_service::ChainServiceInfo {
+            cryptarchia_info: lb_chain_service::CryptarchiaInfo {
+                genesis_id: None,
+                lib: lb_core::header::HeaderId::from([2; 32]),
+                lib_slot: lb_chain_service::Slot::new(3),
+                tip: lb_core::header::HeaderId::from([4; 32]),
+                slot: lb_chain_service::Slot::new(5),
+                height: 6,
+            },
+            mode: lb_chain_service::ChainServiceMode::Started(lb_chain_service::State::Online),
+        };
+
+        let result = CryptarchiaInfo::try_from(info);
+
+        assert!(matches!(
+            result,
+            Err(OperationStatus {
+                code: OperationStatusCode::RelayError,
+                ..
+            })
+        ));
     }
 }
 
@@ -144,7 +199,7 @@ pub unsafe extern "C" fn get_cryptarchia_info(
     return_error_if_null_pointer!(node);
     let node = unsafe { &*node };
     let service_info = unwrap_or_return_error!(get_cryptarchia_info_sync(node));
-    let c_info = CryptarchiaInfo::from(service_info);
+    let c_info = unwrap_or_return_error!(CryptarchiaInfo::try_from(service_info));
 
     FfiCryptarchiaInfoResult::from_value(c_info)
 }
@@ -157,119 +212,4 @@ pub unsafe extern "C" fn get_cryptarchia_info(
 #[unsafe(no_mangle)]
 pub extern "C" fn free_cryptarchia_info(pointer: *mut CryptarchiaInfo) -> OperationStatus {
     free::<CryptarchiaInfo>(pointer)
-}
-
-/// Gets a block's events as a JSON string.
-///
-/// This is a synchronous wrapper around the asynchronous
-/// [`CryptarchiaServiceApi::get_block_events`] function.
-///
-/// # Arguments
-///
-/// - `node`: A [`LogosBlockchainNode`] instance.
-/// - `header_id`: The 32-byte header ID of the block whose events to fetch.
-///
-/// # Returns
-///
-/// A `Result` containing a JSON string of the block's events on success, or an
-/// [`OperationStatus`] error on failure. Returns
-/// [`OperationStatusCode::NotFound`] if no block with the given header ID
-/// exists.
-pub(crate) fn get_block_events_sync(
-    node: &LogosBlockchainNode,
-    header_id: HeaderId,
-) -> StatusResult<CString> {
-    let runtime_handle = node.get_runtime_handle();
-    let overwatch_handle = node.get_overwatch_handle();
-
-    let events = runtime_handle.block_on(async move {
-        let relay = overwatch_handle
-            .relay::<CryptarchiaService<RuntimeServiceId>>()
-            .await
-            .map_err(|e| {
-                OperationStatus::error(
-                    OperationStatusCode::RelayError,
-                    format!("Failed to get relay to CryptarchiaService: {e}"),
-                )
-            })?;
-        let api =
-            CryptarchiaServiceApi::<CryptarchiaService<RuntimeServiceId>, RuntimeServiceId>::new(
-                relay,
-            );
-        api.get_block_events(lb_core::header::HeaderId::from(header_id))
-            .await
-            .map_err(|e| {
-                OperationStatus::error(
-                    OperationStatusCode::ServiceError,
-                    format!("Failed to get block events: {e}"),
-                )
-            })
-    })?;
-
-    let events = events.ok_or_else(|| {
-        OperationStatus::error(
-            OperationStatusCode::NotFound,
-            format!("No block found for header id {header_id:?}"),
-        )
-    })?;
-
-    let json = serde_json::to_string(&events).map_err(|e| {
-        OperationStatus::error(
-            OperationStatusCode::RuntimeError,
-            format!("Failed to serialize block events: {e}"),
-        )
-    })?;
-
-    CString::new(json).map_err(|e| {
-        OperationStatus::error(
-            OperationStatusCode::RuntimeError,
-            format!("Failed to create CString: {e}"),
-        )
-    })
-}
-
-/// Result type for `get_block_events`. On success, `value` is a pointer to a
-/// NUL-terminated C string containing the JSON-serialized events.
-pub type FfiGetBlockEventsResult = FfiStatusResult<*mut c_char>;
-
-/// Get a block's events as a JSON string.
-///
-/// Returns the JSON-serialized events emitted by the block with the given
-/// 32-byte header ID.
-///
-/// # Arguments
-///
-/// - `node`: A non-null pointer to a [`LogosBlockchainNode`].
-/// - `header_id`: A non-null pointer to a 32-byte header ID.
-///
-/// # Returns
-///
-/// A [`FfiGetBlockEventsResult`] containing a pointer to an allocated C string
-/// (JSON events) on success, or an [`OperationStatus`] error on failure.
-/// Returns [`OperationStatusCode::NotFound`] if no block with the given header
-/// ID exists.
-///
-/// # Safety
-///
-/// This function is unsafe because it dereferences raw pointers.
-/// The caller must ensure that `node` is non-null and points to a valid
-/// [`LogosBlockchainNode`], and that `header_id` is non-null and points to at
-/// least 32 valid bytes.
-///
-/// # Memory Management
-///
-/// This function allocates memory for the output C string. The caller must
-/// free this memory using the [`free_cstring`](super::free_cstring) function.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn get_block_events(
-    node: *const LogosBlockchainNode,
-    header_id: *const HeaderId,
-) -> FfiGetBlockEventsResult {
-    return_error_if_null_pointer!(node);
-    return_error_if_null_pointer!(header_id);
-
-    let header_id = unsafe { *header_id };
-    let node = unsafe { &*node };
-    let json_cstring = unwrap_or_return_error!(get_block_events_sync(node, header_id));
-    FfiGetBlockEventsResult::ok(json_cstring.into_raw())
 }

--- a/c-bindings/src/api/cryptarchia.rs
+++ b/c-bindings/src/api/cryptarchia.rs
@@ -1,3 +1,8 @@
+use std::ffi::{CString, c_char};
+
+use lb_chain_service::api::CryptarchiaServiceApi;
+use lb_node::{RuntimeServiceId, generic_services::CryptarchiaService};
+
 use crate::{
     LogosBlockchainNode,
     api::free,
@@ -13,14 +18,15 @@ pub enum State {
     NotStarted = 0x2,
 }
 
-impl From<lb_chain_service::ChainServiceMode> for State {
-    fn from(value: lb_chain_service::ChainServiceMode) -> Self {
-        match value {
-            lb_chain_service::ChainServiceMode::AwaitingStart => Self::NotStarted,
-            lb_chain_service::ChainServiceMode::Started(inner_state) => match inner_state {
-                lb_chain_service::State::Bootstrapping => Self::Bootstrapping,
-                lb_chain_service::State::Online => Self::Online,
-            },
+impl State {
+    const fn new(state: lb_chain_service::State, phase: lb_chain_service::PhaseTag) -> Self {
+        if matches!(phase, lb_chain_service::PhaseTag::AwaitingGenesisTime) {
+            return Self::NotStarted;
+        }
+
+        match state {
+            lb_chain_service::State::Bootstrapping => Self::Bootstrapping,
+            lb_chain_service::State::Online => Self::Online,
         }
     }
 }
@@ -88,8 +94,8 @@ impl TryFrom<lb_chain_service::ChainServiceInfo> for CryptarchiaInfo {
     fn try_from(value: lb_chain_service::ChainServiceInfo) -> Result<Self, Self::Error> {
         let genesis_id = value.cryptarchia_info.genesis_id.ok_or_else(|| {
             OperationStatus::error(
-                OperationStatusCode::RelayError,
-                "Cryptarchia info did not include a genesis identity.",
+                OperationStatusCode::ValidationError,
+                "Cryptarchia info omitted its genesis identity; use a matching node and C library version.",
             )
         })?;
 
@@ -98,7 +104,7 @@ impl TryFrom<lb_chain_service::ChainServiceInfo> for CryptarchiaInfo {
             tip: value.cryptarchia_info.tip.into(),
             slot: u64::from(value.cryptarchia_info.slot),
             height: value.cryptarchia_info.height,
-            mode: State::from(value.mode),
+            mode: State::new(value.cryptarchia_info.state, value.phase),
             genesis_id: genesis_id.into(),
             lib_slot: u64::from(value.cryptarchia_info.lib_slot),
         })
@@ -120,8 +126,9 @@ mod tests {
                 tip: lb_core::header::HeaderId::from([4; 32]),
                 slot: lb_chain_service::Slot::new(5),
                 height: 6,
+                state: lb_chain_service::State::Online,
             },
-            mode: lb_chain_service::ChainServiceMode::Started(lb_chain_service::State::Online),
+            phase: lb_chain_service::PhaseTag::Following,
         };
 
         let ffi = CryptarchiaInfo::try_from(info).expect("genesis identity should be present");
@@ -139,8 +146,9 @@ mod tests {
                 tip: lb_core::header::HeaderId::from([4; 32]),
                 slot: lb_chain_service::Slot::new(5),
                 height: 6,
+                state: lb_chain_service::State::Online,
             },
-            mode: lb_chain_service::ChainServiceMode::Started(lb_chain_service::State::Online),
+            phase: lb_chain_service::PhaseTag::Following,
         };
 
         let result = CryptarchiaInfo::try_from(info);
@@ -148,7 +156,7 @@ mod tests {
         assert!(matches!(
             result,
             Err(OperationStatus {
-                code: OperationStatusCode::RelayError,
+                code: OperationStatusCode::ValidationError,
                 ..
             })
         ));
@@ -232,62 +240,74 @@ pub unsafe extern "C" fn get_cryptarchia_info(
 pub extern "C" fn free_cryptarchia_info(pointer: *mut CryptarchiaInfo) -> OperationStatus {
     free::<CryptarchiaInfo>(pointer)
 }
-<<<<<<< ours
-=======
 
-#[cfg(test)]
-mod tests {
-    use super::*;
+/// Gets a block's events as a JSON string.
+pub(crate) fn get_block_events_sync(
+    node: &LogosBlockchainNode,
+    header_id: HeaderId,
+) -> StatusResult<CString> {
+    let runtime_handle = node.get_runtime_handle();
+    let overwatch_handle = node.get_overwatch_handle();
 
-    #[test]
-    fn conversion_preserves_genesis_identity() {
-        let genesis_id = lb_core::header::HeaderId::from([1; 32]);
-        let info = lb_chain_service::ChainServiceInfo {
-            cryptarchia_info: lb_chain_service::CryptarchiaInfo {
-                genesis_id: Some(genesis_id),
-                lib: lb_core::header::HeaderId::from([2; 32]),
-                lib_slot: lb_chain_service::Slot::new(3),
-                tip: lb_core::header::HeaderId::from([4; 32]),
-                slot: lb_chain_service::Slot::new(5),
-                height: 6,
-            },
-            mode: lb_chain_service::ChainServiceMode::Started(lb_chain_service::State::Online),
-        };
-
-        let ffi = CryptarchiaInfo::try_from(info).expect("genesis identity should be present");
-
-        assert_eq!(ffi.genesis_id, [1; 32]);
-        assert_eq!(ffi.lib_slot, 3);
-    }
-
-    #[test]
-    fn cryptarchia_info_abi_version_matches_the_current_layout() {
-        assert_eq!(cryptarchia_info_abi_version(), CRYPTARCHIA_INFO_ABI_VERSION);
-    }
-
-    #[test]
-    fn conversion_rejects_missing_genesis_identity() {
-        let info = lb_chain_service::ChainServiceInfo {
-            cryptarchia_info: lb_chain_service::CryptarchiaInfo {
-                genesis_id: None,
-                lib: lb_core::header::HeaderId::from([2; 32]),
-                lib_slot: lb_chain_service::Slot::new(3),
-                tip: lb_core::header::HeaderId::from([4; 32]),
-                slot: lb_chain_service::Slot::new(5),
-                height: 6,
-            },
-            mode: lb_chain_service::ChainServiceMode::Started(lb_chain_service::State::Online),
-        };
-
-        let result = CryptarchiaInfo::try_from(info);
-
-        assert!(matches!(
-            result,
-            Err(OperationStatus {
-                code: OperationStatusCode::ValidationError,
-                ..
+    let events = runtime_handle.block_on(async move {
+        let relay = overwatch_handle
+            .relay::<CryptarchiaService<RuntimeServiceId>>()
+            .await
+            .map_err(|e| {
+                OperationStatus::error(
+                    OperationStatusCode::RelayError,
+                    format!("Failed to get relay to CryptarchiaService: {e}"),
+                )
+            })?;
+        let api =
+            CryptarchiaServiceApi::<CryptarchiaService<RuntimeServiceId>, RuntimeServiceId>::new(
+                relay,
+            );
+        api.get_block_events(lb_core::header::HeaderId::from(header_id))
+            .await
+            .map_err(|e| {
+                OperationStatus::error(
+                    OperationStatusCode::ServiceError,
+                    format!("Failed to get block events: {e}"),
+                )
             })
-        ));
-    }
+    })?;
+
+    let events = events.ok_or_else(|| {
+        OperationStatus::error(
+            OperationStatusCode::NotFound,
+            format!("No block found for header id {header_id:?}"),
+        )
+    })?;
+
+    let json = serde_json::to_string(&events).map_err(|e| {
+        OperationStatus::error(
+            OperationStatusCode::RuntimeError,
+            format!("Failed to serialize block events: {e}"),
+        )
+    })?;
+
+    CString::new(json).map_err(|e| {
+        OperationStatus::error(
+            OperationStatusCode::RuntimeError,
+            format!("Failed to create CString: {e}"),
+        )
+    })
 }
->>>>>>> theirs
+
+pub type FfiGetBlockEventsResult = FfiStatusResult<*mut c_char>;
+
+/// Get a block's events as a JSON string.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn get_block_events(
+    node: *const LogosBlockchainNode,
+    header_id: *const HeaderId,
+) -> FfiGetBlockEventsResult {
+    return_error_if_null_pointer!(node);
+    return_error_if_null_pointer!(header_id);
+
+    let header_id = unsafe { *header_id };
+    let node = unsafe { &*node };
+    let json_cstring = unwrap_or_return_error!(get_block_events_sync(node, header_id));
+    FfiGetBlockEventsResult::ok(json_cstring.into_raw())
+}

--- a/c-bindings/src/api/cryptarchia.rs
+++ b/c-bindings/src/api/cryptarchia.rs
@@ -111,58 +111,6 @@ impl TryFrom<lb_chain_service::ChainServiceInfo> for CryptarchiaInfo {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn conversion_preserves_genesis_identity() {
-        let genesis_id = lb_core::header::HeaderId::from([1; 32]);
-        let info = lb_chain_service::ChainServiceInfo {
-            cryptarchia_info: lb_chain_service::CryptarchiaInfo {
-                genesis_id: Some(genesis_id),
-                lib: lb_core::header::HeaderId::from([2; 32]),
-                lib_slot: lb_chain_service::Slot::new(3),
-                tip: lb_core::header::HeaderId::from([4; 32]),
-                slot: lb_chain_service::Slot::new(5),
-                height: 6,
-                state: lb_chain_service::State::Online,
-            },
-            phase: lb_chain_service::PhaseTag::Following,
-        };
-
-        let ffi = CryptarchiaInfo::try_from(info).expect("genesis identity should be present");
-
-        assert_eq!(ffi.genesis_id, [1; 32]);
-    }
-
-    #[test]
-    fn conversion_rejects_missing_genesis_identity() {
-        let info = lb_chain_service::ChainServiceInfo {
-            cryptarchia_info: lb_chain_service::CryptarchiaInfo {
-                genesis_id: None,
-                lib: lb_core::header::HeaderId::from([2; 32]),
-                lib_slot: lb_chain_service::Slot::new(3),
-                tip: lb_core::header::HeaderId::from([4; 32]),
-                slot: lb_chain_service::Slot::new(5),
-                height: 6,
-                state: lb_chain_service::State::Online,
-            },
-            phase: lb_chain_service::PhaseTag::Following,
-        };
-
-        let result = CryptarchiaInfo::try_from(info);
-
-        assert!(matches!(
-            result,
-            Err(OperationStatus {
-                code: OperationStatusCode::ValidationError,
-                ..
-            })
-        ));
-    }
-}
-
 /// Gets the current Cryptarchia info.
 ///
 /// This is a synchronous wrapper around the asynchronous
@@ -298,6 +246,11 @@ pub(crate) fn get_block_events_sync(
 pub type FfiGetBlockEventsResult = FfiStatusResult<*mut c_char>;
 
 /// Get a block's events as a JSON string.
+///
+/// # Safety
+///
+/// `node` and `header_id` must be non-null pointers to valid values. The
+/// pointed-to node must remain alive for the duration of this call.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn get_block_events(
     node: *const LogosBlockchainNode,
@@ -310,4 +263,56 @@ pub unsafe extern "C" fn get_block_events(
     let node = unsafe { &*node };
     let json_cstring = unwrap_or_return_error!(get_block_events_sync(node, header_id));
     FfiGetBlockEventsResult::ok(json_cstring.into_raw())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn conversion_preserves_genesis_identity() {
+        let genesis_id = lb_core::header::HeaderId::from([1; 32]);
+        let info = lb_chain_service::ChainServiceInfo {
+            cryptarchia_info: lb_chain_service::CryptarchiaInfo {
+                genesis_id: Some(genesis_id),
+                lib: lb_core::header::HeaderId::from([2; 32]),
+                lib_slot: lb_chain_service::Slot::new(3),
+                tip: lb_core::header::HeaderId::from([4; 32]),
+                slot: lb_chain_service::Slot::new(5),
+                height: 6,
+                state: lb_chain_service::State::Online,
+            },
+            phase: lb_chain_service::PhaseTag::Following,
+        };
+
+        let ffi = CryptarchiaInfo::try_from(info).expect("genesis identity should be present");
+
+        assert_eq!(ffi.genesis_id, [1; 32]);
+    }
+
+    #[test]
+    fn conversion_rejects_missing_genesis_identity() {
+        let info = lb_chain_service::ChainServiceInfo {
+            cryptarchia_info: lb_chain_service::CryptarchiaInfo {
+                genesis_id: None,
+                lib: lb_core::header::HeaderId::from([2; 32]),
+                lib_slot: lb_chain_service::Slot::new(3),
+                tip: lb_core::header::HeaderId::from([4; 32]),
+                slot: lb_chain_service::Slot::new(5),
+                height: 6,
+                state: lb_chain_service::State::Online,
+            },
+            phase: lb_chain_service::PhaseTag::Following,
+        };
+
+        let result = CryptarchiaInfo::try_from(info);
+
+        assert!(matches!(
+            result,
+            Err(OperationStatus {
+                code: OperationStatusCode::ValidationError,
+                ..
+            })
+        ));
+    }
 }

--- a/c-bindings/src/api/cryptarchia.rs
+++ b/c-bindings/src/api/cryptarchia.rs
@@ -62,6 +62,24 @@ pub struct CryptarchiaInfo {
     // Appended to retain the offsets of existing fields. Callers that read
     // this field must use a matching C library that allocates it.
     pub genesis_id: HeaderId,
+    // Appended to retain the offsets of the version-one layout. Callers that
+    // read this field must use a matching C library that allocates it.
+    pub lib_slot: u64,
+}
+
+/// Version of the `CryptarchiaInfo` C ABI layout.
+///
+/// Consumers must check this before dereferencing a value returned by
+/// [`get_cryptarchia_info`]. Increment it whenever that layout changes.
+pub const CRYPTARCHIA_INFO_ABI_VERSION: u32 = 2;
+
+/// Gets the version of the `CryptarchiaInfo` C ABI layout.
+///
+/// Consumers use this to reject incompatible libraries before reading a
+/// `CryptarchiaInfo` allocation.
+#[unsafe(no_mangle)]
+pub const extern "C" fn cryptarchia_info_abi_version() -> u32 {
+    CRYPTARCHIA_INFO_ABI_VERSION
 }
 
 impl TryFrom<lb_chain_service::ChainServiceInfo> for CryptarchiaInfo {
@@ -82,6 +100,7 @@ impl TryFrom<lb_chain_service::ChainServiceInfo> for CryptarchiaInfo {
             height: value.cryptarchia_info.height,
             mode: State::from(value.mode),
             genesis_id: genesis_id.into(),
+            lib_slot: u64::from(value.cryptarchia_info.lib_slot),
         })
     }
 }
@@ -213,3 +232,62 @@ pub unsafe extern "C" fn get_cryptarchia_info(
 pub extern "C" fn free_cryptarchia_info(pointer: *mut CryptarchiaInfo) -> OperationStatus {
     free::<CryptarchiaInfo>(pointer)
 }
+<<<<<<< ours
+=======
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn conversion_preserves_genesis_identity() {
+        let genesis_id = lb_core::header::HeaderId::from([1; 32]);
+        let info = lb_chain_service::ChainServiceInfo {
+            cryptarchia_info: lb_chain_service::CryptarchiaInfo {
+                genesis_id: Some(genesis_id),
+                lib: lb_core::header::HeaderId::from([2; 32]),
+                lib_slot: lb_chain_service::Slot::new(3),
+                tip: lb_core::header::HeaderId::from([4; 32]),
+                slot: lb_chain_service::Slot::new(5),
+                height: 6,
+            },
+            mode: lb_chain_service::ChainServiceMode::Started(lb_chain_service::State::Online),
+        };
+
+        let ffi = CryptarchiaInfo::try_from(info).expect("genesis identity should be present");
+
+        assert_eq!(ffi.genesis_id, [1; 32]);
+        assert_eq!(ffi.lib_slot, 3);
+    }
+
+    #[test]
+    fn cryptarchia_info_abi_version_matches_the_current_layout() {
+        assert_eq!(cryptarchia_info_abi_version(), CRYPTARCHIA_INFO_ABI_VERSION);
+    }
+
+    #[test]
+    fn conversion_rejects_missing_genesis_identity() {
+        let info = lb_chain_service::ChainServiceInfo {
+            cryptarchia_info: lb_chain_service::CryptarchiaInfo {
+                genesis_id: None,
+                lib: lb_core::header::HeaderId::from([2; 32]),
+                lib_slot: lb_chain_service::Slot::new(3),
+                tip: lb_core::header::HeaderId::from([4; 32]),
+                slot: lb_chain_service::Slot::new(5),
+                height: 6,
+            },
+            mode: lb_chain_service::ChainServiceMode::Started(lb_chain_service::State::Online),
+        };
+
+        let result = CryptarchiaInfo::try_from(info);
+
+        assert!(matches!(
+            result,
+            Err(OperationStatus {
+                code: OperationStatusCode::ValidationError,
+                ..
+            })
+        ));
+    }
+}
+>>>>>>> theirs

--- a/c-bindings/src/api/diagnostics.rs
+++ b/c-bindings/src/api/diagnostics.rs
@@ -2,7 +2,7 @@ use std::ffi::{CString, c_char};
 
 use lb_core::{
     header::HeaderId as CoreHeaderId,
-    mantle::{SignedMantleTx, Transaction},
+    mantle::{SignedMantleTx, traits::Hashable, transactions::states::Preverified},
 };
 use lb_node::RuntimeServiceId;
 use lb_tx_service::storage::adapters::RocksStorageAdapter;
@@ -86,7 +86,10 @@ fn get_mantle_metrics_sync(node: &LogosBlockchainNode) -> StatusResult<CString> 
     let runtime_handle = node.get_runtime_handle();
     let metrics = runtime_handle
         .block_on(lb_api_service::http::mantle::mantle_mempool_metrics::<
-            RocksStorageAdapter<SignedMantleTx, <SignedMantleTx as Transaction>::Hash>,
+            RocksStorageAdapter<
+                SignedMantleTx<Preverified>,
+                <SignedMantleTx<Preverified> as Hashable>::Hash,
+            >,
             RuntimeServiceId,
         >(node.get_overwatch_handle()))
         .map_err(|error| {

--- a/c-bindings/src/api/diagnostics.rs
+++ b/c-bindings/src/api/diagnostics.rs
@@ -1,0 +1,195 @@
+use std::ffi::{CString, c_char};
+
+use lb_core::{
+    header::HeaderId as CoreHeaderId,
+    mantle::{SignedMantleTx, Transaction},
+};
+use lb_node::RuntimeServiceId;
+use lb_tx_service::storage::adapters::RocksStorageAdapter;
+use serde::Serialize;
+
+use crate::{
+    LogosBlockchainNode,
+    api::cryptarchia::HeaderId,
+    errors::{OperationStatus, OperationStatusCode},
+    result::{FfiStatusResult, StatusResult},
+    return_error_if_null_pointer, unwrap_or_return_error,
+};
+
+/// Result type for diagnostic reads. On success, `value` is an allocated
+/// NUL-terminated C string containing JSON. Callers free it with
+/// [`free_cstring`](super::free_cstring).
+pub type FfiDiagnosticJsonResult = FfiStatusResult<*mut c_char>;
+
+fn serialize_json<Value>(value: &Value, operation: &str) -> StatusResult<CString>
+where
+    Value: Serialize,
+{
+    let json = serde_json::to_string(value).map_err(|error| {
+        OperationStatus::error(
+            OperationStatusCode::RuntimeError,
+            format!("Failed to serialize {operation}: {error}"),
+        )
+    })?;
+
+    CString::new(json).map_err(|error| {
+        OperationStatus::error(
+            OperationStatusCode::RuntimeError,
+            format!("Failed to create C string for {operation}: {error}"),
+        )
+    })
+}
+
+fn get_cryptarchia_headers_sync(
+    node: &LogosBlockchainNode,
+    from_descendant: Option<HeaderId>,
+    to_ancestor: Option<HeaderId>,
+) -> StatusResult<CString> {
+    let runtime_handle = node.get_runtime_handle();
+    let headers = runtime_handle
+        .block_on(lb_api_service::http::consensus::cryptarchia_headers::<
+            RuntimeServiceId,
+        >(
+            node.get_overwatch_handle(),
+            from_descendant.map(CoreHeaderId::from),
+            to_ancestor.map(CoreHeaderId::from),
+        ))
+        .map_err(|error| {
+            OperationStatus::error(
+                OperationStatusCode::RelayError,
+                format!("Failed to get cryptarchia headers: {error}"),
+            )
+        })?;
+
+    serialize_json(&headers, "cryptarchia headers")
+}
+
+fn get_network_info_sync(node: &LogosBlockchainNode) -> StatusResult<CString> {
+    let runtime_handle = node.get_runtime_handle();
+    let network_info = runtime_handle
+        .block_on(
+            lb_api_service::http::libp2p::libp2p_info::<RuntimeServiceId>(
+                node.get_overwatch_handle(),
+            ),
+        )
+        .map_err(|error| {
+            OperationStatus::error(
+                OperationStatusCode::RelayError,
+                format!("Failed to get network information: {error}"),
+            )
+        })?;
+
+    serialize_json(&network_info, "network information")
+}
+
+fn get_mantle_metrics_sync(node: &LogosBlockchainNode) -> StatusResult<CString> {
+    let runtime_handle = node.get_runtime_handle();
+    let metrics = runtime_handle
+        .block_on(lb_api_service::http::mantle::mantle_mempool_metrics::<
+            RocksStorageAdapter<SignedMantleTx, <SignedMantleTx as Transaction>::Hash>,
+            RuntimeServiceId,
+        >(node.get_overwatch_handle()))
+        .map_err(|error| {
+            OperationStatus::error(
+                OperationStatusCode::RelayError,
+                format!("Failed to get Mantle metrics: {error}"),
+            )
+        })?;
+
+    serialize_json(&metrics, "Mantle metrics")
+}
+
+/// Gets bounded Cryptarchia header identifiers as a JSON array.
+///
+/// A null `from_descendant` or `to_ancestor` represents the corresponding
+/// omitted direct-node query parameter. The result has the same data shape as
+/// the node's Cryptarchia headers endpoint.
+///
+/// # Safety
+///
+/// `node` must point to a live [`LogosBlockchainNode`] allocated by this
+/// library. When non-null, `from_descendant` and `to_ancestor` must each point
+/// to a readable, initialized 32-byte [`HeaderId`] for the duration of this
+/// call. The returned `value` must be freed with
+/// [`free_cstring`](super::free_cstring).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn get_cryptarchia_headers(
+    node: *const LogosBlockchainNode,
+    from_descendant: *const HeaderId,
+    to_ancestor: *const HeaderId,
+) -> FfiDiagnosticJsonResult {
+    return_error_if_null_pointer!(node);
+    // SAFETY: the public function contract requires a live, aligned,
+    // initialized LogosBlockchainNode whenever `node` is non-null.
+    let node = unsafe { &*node };
+    let from_descendant = if from_descendant.is_null() {
+        None
+    } else {
+        // SAFETY: a non-null optional header pointer is required by the public
+        // function contract to reference one initialized HeaderId.
+        Some(unsafe { *from_descendant })
+    };
+    let to_ancestor = if to_ancestor.is_null() {
+        None
+    } else {
+        // SAFETY: a non-null optional header pointer is required by the public
+        // function contract to reference one initialized HeaderId.
+        Some(unsafe { *to_ancestor })
+    };
+    let value = unwrap_or_return_error!(get_cryptarchia_headers_sync(
+        node,
+        from_descendant,
+        to_ancestor,
+    ));
+    FfiDiagnosticJsonResult::ok(value.into_raw())
+}
+
+/// Gets Libp2p network information as JSON.
+///
+/// # Safety
+///
+/// `node` must point to a live [`LogosBlockchainNode`] allocated by this
+/// library. The returned `value` must be freed with
+/// [`free_cstring`](super::free_cstring).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn get_network_info(
+    node: *const LogosBlockchainNode,
+) -> FfiDiagnosticJsonResult {
+    return_error_if_null_pointer!(node);
+    // SAFETY: the public function contract requires a live, aligned,
+    // initialized LogosBlockchainNode whenever `node` is non-null.
+    let node = unsafe { &*node };
+    let value = unwrap_or_return_error!(get_network_info_sync(node));
+    FfiDiagnosticJsonResult::ok(value.into_raw())
+}
+
+/// Gets Mantle mempool metrics as JSON.
+///
+/// # Safety
+///
+/// `node` must point to a live [`LogosBlockchainNode`] allocated by this
+/// library. The returned `value` must be freed with
+/// [`free_cstring`](super::free_cstring).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn get_mantle_metrics(
+    node: *const LogosBlockchainNode,
+) -> FfiDiagnosticJsonResult {
+    return_error_if_null_pointer!(node);
+    // SAFETY: the public function contract requires a live, aligned,
+    // initialized LogosBlockchainNode whenever `node` is non-null.
+    let node = unsafe { &*node };
+    let value = unwrap_or_return_error!(get_mantle_metrics_sync(node));
+    FfiDiagnosticJsonResult::ok(value.into_raw())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::serialize_json;
+
+    #[test]
+    fn diagnostic_json_is_a_c_string() {
+        let value = serialize_json(&serde_json::json!({"peers": 2}), "test diagnostic")
+            .expect("serializable JSON must be representable as a C string");
+        assert_eq!(value.to_bytes_with_nul(), b"{\"peers\":2}\0");
+    }
+}

--- a/c-bindings/src/api/mod.rs
+++ b/c-bindings/src/api/mod.rs
@@ -2,6 +2,7 @@ pub mod blend;
 pub mod channel;
 pub mod config;
 pub mod cryptarchia;
+pub mod diagnostics;
 pub mod keys;
 pub mod leader;
 pub mod lifecycle;

--- a/c-bindings/src/api/mod.rs
+++ b/c-bindings/src/api/mod.rs
@@ -1,5 +1,6 @@
 pub mod blend;
 pub mod channel;
+pub mod catalog;
 pub mod config;
 pub mod cryptarchia;
 pub mod diagnostics;

--- a/c-bindings/src/api/mod.rs
+++ b/c-bindings/src/api/mod.rs
@@ -1,6 +1,6 @@
 pub mod blend;
-pub mod channel;
 pub mod catalog;
+pub mod channel;
 pub mod config;
 pub mod cryptarchia;
 pub mod diagnostics;

--- a/c-bindings/src/api/time.rs
+++ b/c-bindings/src/api/time.rs
@@ -102,7 +102,9 @@ pub type FfiTimeInfoResult = FfiStatusResult<*mut TimeInfo>;
 /// This function allocates memory for the output [`TimeInfo`] struct. The
 /// caller must free this memory using the [`free_time_info`] function.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn get_time_info(node: *const LogosBlockchainNode) -> FfiTimeInfoResult {
+pub unsafe extern "C" fn get_time_info_struct(
+    node: *const LogosBlockchainNode,
+) -> FfiTimeInfoResult {
     return_error_if_null_pointer!(node);
     let node = unsafe { &*node };
     let time_info = unwrap_or_return_error!(get_time_info_sync(node));

--- a/flake.nix
+++ b/flake.nix
@@ -61,6 +61,7 @@
             src = craneLib.path ./.;
             filter = path: type:
               (pkgs.lib.hasSuffix "nodes/node/binary/src/config/deployment/settings.yaml" path) ||
+              (pkgs.lib.hasSuffix ".hex" path) ||
               (craneLib.filterCargoSources path type);
           };
           crateName = craneLib.crateNameFromCargoToml { inherit src; };

--- a/nodes/node/binary/src/api/handlers.rs
+++ b/nodes/node/binary/src/api/handlers.rs
@@ -16,7 +16,6 @@ use lb_api_service::http::{
     consensus::{self, Cryptarchia},
     libp2p, mantle, mempool,
     storage::StorageAdapter,
-    time,
 };
 use lb_blend_service::message::ProxyServiceMessage;
 use lb_chain_broadcast_service::BlockBroadcastService;
@@ -38,6 +37,7 @@ use lb_core::{
     },
 };
 use lb_http_api_common::{
+    TimeInfo,
     bodies::{
         blend::JoinBlendRequestBody,
         channel::{ChannelDepositRequestBody, ChannelDepositResponseBody},
@@ -66,6 +66,7 @@ use lb_tx_service::{
     MempoolMsg, TxMempoolService, backend::Mempool,
     network::adapters::libp2p::Libp2pAdapter as MempoolNetworkAdapter,
 };
+use lb_time_service::TimeServiceMessage;
 use lb_wallet_service::api::{WalletApi, WalletServiceData};
 use overwatch::{
     overwatch::handle::OverwatchHandle,

--- a/nodes/node/binary/src/api/handlers.rs
+++ b/nodes/node/binary/src/api/handlers.rs
@@ -2048,6 +2048,7 @@ mod tests {
 
     fn chain_info() -> CryptarchiaInfo {
         CryptarchiaInfo {
+            genesis_id: Some(HeaderId::from([1; 32])),
             lib: HeaderId::from([2; 32]),
             slot: Slot::new(TIP_SLOT),
             lib_slot: Slot::new(LIB_SLOT),
@@ -2059,6 +2060,7 @@ mod tests {
 
     fn small_chain() -> CryptarchiaInfo {
         CryptarchiaInfo {
+            genesis_id: Some(HeaderId::from([1; 32])),
             lib: HeaderId::from([2; 32]),
             slot: Slot::new(100),
             lib_slot: Slot::new(0),

--- a/nodes/node/binary/src/api/handlers.rs
+++ b/nodes/node/binary/src/api/handlers.rs
@@ -62,11 +62,11 @@ use lb_sdp_service::{
 use lb_storage_service::{
     StorageService, api::chain::StorageChainApi, backends::rocksdb::RocksBackend,
 };
+use lb_time_service::TimeServiceMessage;
 use lb_tx_service::{
     MempoolMsg, TxMempoolService, backend::Mempool,
     network::adapters::libp2p::Libp2pAdapter as MempoolNetworkAdapter,
 };
-use lb_time_service::TimeServiceMessage;
 use lb_wallet_service::api::{WalletApi, WalletServiceData};
 use overwatch::{
     overwatch::handle::OverwatchHandle,

--- a/nodes/node/binary/src/api/handlers.rs
+++ b/nodes/node/binary/src/api/handlers.rs
@@ -16,6 +16,7 @@ use lb_api_service::http::{
     consensus::{self, Cryptarchia},
     libp2p, mantle, mempool,
     storage::StorageAdapter,
+    time,
 };
 use lb_blend_service::message::ProxyServiceMessage;
 use lb_chain_broadcast_service::BlockBroadcastService;
@@ -37,7 +38,6 @@ use lb_core::{
     },
 };
 use lb_http_api_common::{
-    TimeInfo,
     bodies::{
         blend::JoinBlendRequestBody,
         channel::{ChannelDepositRequestBody, ChannelDepositResponseBody},
@@ -62,7 +62,6 @@ use lb_sdp_service::{
 use lb_storage_service::{
     StorageService, api::chain::StorageChainApi, backends::rocksdb::RocksBackend,
 };
-use lb_time_service::TimeServiceMessage;
 use lb_tx_service::{
     MempoolMsg, TxMempoolService, backend::Mempool,
     network::adapters::libp2p::Libp2pAdapter as MempoolNetworkAdapter,

--- a/nodes/node/binary/src/api/mod.rs
+++ b/nodes/node/binary/src/api/mod.rs
@@ -1,6 +1,7 @@
 pub mod backend;
 mod errors;
 pub mod handlers;
+pub use serializers::blocks::ApiProcessedBlockEvent;
 mod openapi;
 mod queries;
 mod responses;

--- a/nodes/node/binary/src/cli/mod.rs
+++ b/nodes/node/binary/src/cli/mod.rs
@@ -211,6 +211,13 @@ pub struct EmbeddedInitArgs {
     /// empty, regardless of any peers passed via `--initial-peers`/`-p`.
     pub skip_ibd: bool,
 
+    /// Optional prolonged bootstrap period override, in seconds.
+    ///
+    /// This is used by embedded callers that need a bounded transition from
+    /// IBD completion to the online state. Omitting it preserves the normal
+    /// one-hour node default.
+    pub prolonged_bootstrap_period_secs: Option<u64>,
+
     /// Log filter directives to write into the generated config, e.g.
     /// `warn,logos_blockchain=debug,libp2p_gossipsub::behaviour=error`.
     pub log_filter: Option<String>,
@@ -240,6 +247,8 @@ impl From<EmbeddedInitArgs> for InitArgs {
             Some(BlendCoreConfig::default_listening_address(args.blend_port));
 
         init_args.cryptarchia.skip_ibd = args.skip_ibd;
+        init_args.cryptarchia.prolonged_bootstrap_period_secs =
+            args.prolonged_bootstrap_period_secs;
         init_args.api.addr = Some(args.http_addr);
         init_args.state.path.clone_from(&args.state_path);
         init_args.storage_path.clone_from(&args.storage_path);
@@ -264,6 +273,7 @@ impl Default for EmbeddedInitArgs {
             storage_path: None,
             logs_path: None,
             skip_ibd: false,
+            prolonged_bootstrap_period_secs: None,
             log_filter: None,
             kms_file: None,
         }

--- a/nodes/node/binary/src/config/deployment/mod.rs
+++ b/nodes/node/binary/src/config/deployment/mod.rs
@@ -57,4 +57,22 @@ mod tests {
         let as_str = serde_yaml::to_string(&settings).unwrap();
         let _recovered: DeploymentSettings = serde_yaml::from_str(&as_str).unwrap();
     }
+
+    #[test]
+    fn default_uses_deployed_testnet_protocols() {
+        let settings = DeploymentSettings::default();
+
+        assert_eq!(
+            settings.network.chain_sync_protocol_name.to_string(),
+            "/logos-blockchain-testnet-0.2.1/chainsync/1.0.0"
+        );
+        assert_eq!(
+            settings.network.kademlia_protocol_name.to_string(),
+            "/logos-blockchain-testnet-0.2.1/kad/1.0.0"
+        );
+        assert_eq!(
+            settings.network.identify_protocol_name.to_string(),
+            "/logos-blockchain-testnet-0.2.1/identify/1.0.0"
+        );
+    }
 }

--- a/nodes/node/binary/src/config/deployment/settings.yaml
+++ b/nodes/node/binary/src/config/deployment/settings.yaml
@@ -2,8 +2,8 @@ blend:
   common:
     num_blend_layers: 1
     minimum_network_size: 2
-    protocol_name: /logos-blockchain/blend/X.Y.Z
-    data_replication_factor: 0
+    protocol_name: /logos-blockchain-testnet-0.2.1/blend/1.0.0
+    data_replication_factor: 1
   core:
     scheduler:
       cover:
@@ -14,19 +14,19 @@ blend:
     normalization_constant: 1.03
     activity_threshold_sensitivity: 1
 network:
-  kademlia_protocol_name: /logos-blockchain/kad/X.Y.Z
-  identify_protocol_name: /logos-blockchain/identify/X.Y.Z
-  chain_sync_protocol_name: /logos-blockchain/chainsync/X.Y.Z
+  kademlia_protocol_name: /logos-blockchain-testnet-0.2.1/kad/1.0.0
+  identify_protocol_name: /logos-blockchain-testnet-0.2.1/identify/1.0.0
+  chain_sync_protocol_name: /logos-blockchain-testnet-0.2.1/chainsync/1.0.0
 cryptarchia:
   epoch_config:
     epoch_stake_distribution_stabilization: 3
     epoch_period_nonce_buffer: 3
     epoch_period_nonce_stabilization: 4
-  security_param: 30
+  security_param: 120
   slot_activation_coeff:
     numerator: 1
-    denominator: 20
-  learning_rate: 0.5
+    denominator: 30
+  learning_rate: 1.0
   window_absorption_parameter: 12
   sdp_config:
     service_params:
@@ -34,15 +34,15 @@ cryptarchia:
         inactivity_period: 2
         epoch: 0
     min_stake:
-      threshold: 1
+      threshold: 1000000000
       timestamp: 0
-  gossipsub_protocol: /logos-blockchain/cryptarchia/X.Y.Z
+  gossipsub_protocol: /logos-blockchain-testnet-0.2.1/cryptarchia/1.0.0
   genesis_block:
     header:
       version: Bedrock
       parent_block: '0000000000000000000000000000000000000000000000000000000000000000'
       slot: 0
-      body_root: 'f9403475ca1264e8d8dd9512ea1bcee1e90f139beaf209c0d71e206ec9d8a310'
+      body_root: '14c92872cfb1e338c43235511335d23a0b8f00d4ed1e27a98f9d09a295bd3efd'
       proof_of_leadership:
         proof: '0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
         entropy_contribution: '0000000000000000000000000000000000000000000000000000000000000000'
@@ -53,25 +53,356 @@ cryptarchia:
     transactions:
     - mantle_tx:
         ops:
-          - opcode: 0
-            payload:
-              inputs: []
-              outputs: []
-          - opcode: 17
-            payload:
-              channel_id: '0000000000000000000000000000000000000000000000000000000000000000'
-              inscription: '10000000000000007374616e64616c6f6e652d6c6f63616c9169fe692d2ddf918544bca603c5a291c7dd1b902d6769ff4b00021506780e075c06051a'
-              parent: '0000000000000000000000000000000000000000000000000000000000000000'
-              signer: '0000000000000000000000000000000000000000000000000000000000000000'
+        - opcode: 0
+          payload:
+            inputs: []
+            outputs:
+            - value: 100000000000000
+              pk: '376ee6dc1fdb8ee8ae315aa1046c636121bd1133e83adf0de3c2fafa41b4ac1c'
+            - value: 200000000000000
+              pk: '859d98b2eb9f6253bf908ca2b1fc445b517b7cb5e7b6280e2c1da4f19304c71d'
+            - value: 200000000000000
+              pk: '17f531bfab29cef706b1c6ca26d23ad9aa8906f7965237312a36ca502761241b'
+            - value: 1000000000
+              pk: '6b2bcd3029fba573cff0c332dc4de7430faf5e261383d693d8dbb5b97665660a'
+            - value: 100000000000000
+              pk: b1c7d3eff60e03588e9f9a4a21a15faecd0406b21f81d3c90a50a42d2253cc0d
+            - value: 200000000000000
+              pk: '7215983b8b7440c7bc61a8252f1d6cb5f6cd2c8e098b9dc17a43145af93d1900'
+            - value: 200000000000000
+              pk: '3738bd8f382d7227b7f6339e49ebb65d1a046188361216e60d17a256fac1dc00'
+            - value: 1000000000
+              pk: ae9a47f76c9a2c00c40310cc82a1da9f5292af9ee223b898c38478c85fd39515
+            - value: 100000000000000
+              pk: dc3d17f010bf7742e5df5257df434a6e5f8dcbb95549ea6fe571c27cd75c4901
+            - value: 200000000000000
+              pk: '670b1a36742173c0310ec3ffb352afe8430d938619334ce57a8fb2bcd24dca1e'
+            - value: 200000000000000
+              pk: e03ad89b26f2321916f78c3e02abc693879341dcf0427cde62f0793f7944c20c
+            - value: 1000000000
+              pk: '4114009ea9da81c5fcb680eca33129fb3fe166af733d25a23ac2da567ee84c19'
+            - value: 100000000000000
+              pk: '9e14d1a30241297fb0133e3f3ffd72dce7363b4b680ce7953849dec5b46aac15'
+            - value: 200000000000000
+              pk: '605199d3e793d342f1f0457c0ada288efc61d455e3b576e70af14b1651a08c06'
+            - value: 200000000000000
+              pk: '2cf55928c4bfe673b2395100c377c70aa716791233b680ba7775e9b589311b0b'
+            - value: 1000000000
+              pk: '4d705c711b7c99fc041576c0c5412934cd86f3369d88c9f451e786c0e396fb1c'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 8000000000000
+              pk: '5eae3b5cbd9eaf070b54158b6a670aaa1abb52d65ccaa0436c2a2137282ade04'
+            - value: 18446744073709551615
+              pk: c2a6a4a0981d5bdcf8ddeb8d7934fd8c5510efeb1053f613b45871670b6f7b19
+        - opcode: 17
+          payload:
+            channel_id: '0000000000000000000000000000000000000000000000000000000000000000'
+            inscription: '05302e322e3190fb726a2d2ddf918544bca603c5a291c7dd1b902d6769ff4b00021506780e075c06051a'
+            parent: '0000000000000000000000000000000000000000000000000000000000000000'
+            signer: '0000000000000000000000000000000000000000000000000000000000000000'
+        - opcode: 32
+          payload:
+            service_type: BN
+            locators:
+            - /ip4/65.109.51.37/udp/3400/quic-v1
+            provider_id: '59c662860b737f4e2515599adb3434856db8070b373a449ff66955ad3da6b473'
+            zk_id: '6b2bcd3029fba573cff0c332dc4de7430faf5e261383d693d8dbb5b97665660a'
+            locked_note_id: '44e03d8e7c4e4df2ccbbc2ec06862688610b558a7ef5466ad7ce8b656341d826'
+        - opcode: 32
+          payload:
+            service_type: BN
+            locators:
+            - /ip4/65.109.51.37/udp/3401/quic-v1
+            provider_id: '7fce82aa171b349a40f2a98ce9a05b5db62415adfd3ab4ffea6f214443d5909d'
+            zk_id: ae9a47f76c9a2c00c40310cc82a1da9f5292af9ee223b898c38478c85fd39515
+            locked_note_id: '4f992361ddeee887907e5ec3ef3105bbfc04665519342ce4618a04c07a9bab14'
+        - opcode: 32
+          payload:
+            service_type: BN
+            locators:
+            - /ip4/65.109.51.37/udp/3402/quic-v1
+            provider_id: da8060ee71506bcbf1ac50973ad6dedc3a6cae69139b9d12bfd9c80c4785f6b0
+            zk_id: '4114009ea9da81c5fcb680eca33129fb3fe166af733d25a23ac2da567ee84c19'
+            locked_note_id: da256d2a4934ad2d87bc16e44750af8fa257bdc00d92f2866f027b41bf580e1e
+        - opcode: 32
+          payload:
+            service_type: BN
+            locators:
+            - /ip4/65.109.51.37/udp/50002/quic-v1
+            provider_id: f6807fc50fbd4ef5f7fe1aaef037ee78d23233e60de802da36bfbb64215800fe
+            zk_id: '4d705c711b7c99fc041576c0c5412934cd86f3369d88c9f451e786c0e396fb1c'
+            locked_note_id: '3727cd76de980d961911a4926bd5b0d42b67327fa06920cb96f47fe2b54a1d01'
       ops_proofs:
-        - !ZkSig
+      - !ZkSig
+        pi_a: '0000000000000000000000000000000000000000000000000000000000000000'
+        pi_b: '00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
+        pi_c: '0000000000000000000000000000000000000000000000000000000000000000'
+      - !Ed25519Sig '00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
+      - !ZkAndEd25519Sigs
+        zk_sig:
           pi_a: '0000000000000000000000000000000000000000000000000000000000000000'
           pi_b: '00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
           pi_c: '0000000000000000000000000000000000000000000000000000000000000000'
-        - !Ed25519Sig '00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
-  faucet_pk: '0000000000000000000000000000000000000000000000000000000000000000'
+        ed25519_sig: '00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
+      - !ZkAndEd25519Sigs
+        zk_sig:
+          pi_a: '0000000000000000000000000000000000000000000000000000000000000000'
+          pi_b: '00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
+          pi_c: '0000000000000000000000000000000000000000000000000000000000000000'
+        ed25519_sig: '00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
+      - !ZkAndEd25519Sigs
+        zk_sig:
+          pi_a: '0000000000000000000000000000000000000000000000000000000000000000'
+          pi_b: '00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
+          pi_c: '0000000000000000000000000000000000000000000000000000000000000000'
+        ed25519_sig: '00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
+      - !ZkAndEd25519Sigs
+        zk_sig:
+          pi_a: '0000000000000000000000000000000000000000000000000000000000000000'
+          pi_b: '00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
+          pi_c: '0000000000000000000000000000000000000000000000000000000000000000'
+        ed25519_sig: '00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
+  faucet_pk: c2a6a4a0981d5bdcf8ddeb8d7934fd8c5510efeb1053f613b45871670b6f7b19
 time:
   slot_duration: '1.000000000'
 mempool:
-  pubsub_topic: /logos-blockchain/mempool/X.Y.Z
-  tx_ttl: '86400.000000000'
+  pubsub_topic: /logos-blockchain-testnet-0.2.1/mempool/1.0.0

--- a/nodes/node/binary/src/config/mod.rs
+++ b/nodes/node/binary/src/config/mod.rs
@@ -267,6 +267,11 @@ pub struct CryptarchiaArgs {
     /// empty, regardless of any peers passed via `--net-initial-peers`/`-p`.
     #[clap(long = "skip-ibd", default_value_t = false)]
     pub skip_ibd: bool,
+
+    /// Override the prolonged bootstrap period for embedded configuration
+    /// generation. CLI callers keep the node default when omitted.
+    #[clap(skip)]
+    pub prolonged_bootstrap_period_secs: Option<u64>,
 }
 
 #[derive(Parser, Debug, Default, Clone, Copy)]
@@ -478,11 +483,16 @@ pub const fn update_cryptarchia(
 ) {
     let CryptarchiaArgs {
         cryptarchia_funding_pk: funding_pk,
+        prolonged_bootstrap_period_secs,
         ..
     } = cryptarchia_args;
 
     if let Some(pk) = funding_pk {
         cryptarchia.set_funding_pk(pk);
+    }
+
+    if let Some(period_secs) = prolonged_bootstrap_period_secs {
+        cryptarchia.service.bootstrap.prolonged_bootstrap_period = Duration::from_secs(period_secs);
     }
 }
 

--- a/services/api/Cargo.toml
+++ b/services/api/Cargo.toml
@@ -21,6 +21,7 @@ lb-chain-broadcast-service = { workspace = true }
 lb-chain-leader-service    = { workspace = true }
 lb-chain-service           = { features = ["openapi"], workspace = true }
 lb-core                    = { workspace = true }
+lb-http-api-common         = { workspace = true }
 lb-ledger                  = { workspace = true }
 lb-libp2p                  = { workspace = true }
 lb-log-targets             = { workspace = true }

--- a/services/api/src/http/mod.rs
+++ b/services/api/src/http/mod.rs
@@ -7,3 +7,4 @@ pub mod mantle;
 pub mod mempool;
 pub mod sdp;
 pub mod storage;
+pub mod time;

--- a/services/api/src/http/time.rs
+++ b/services/api/src/http/time.rs
@@ -1,0 +1,64 @@
+use std::fmt::{Debug, Display};
+
+use lb_http_api_common::TimeInfo;
+use lb_time_service::TimeServiceMessage;
+use overwatch::{
+    overwatch::handle::OverwatchHandle,
+    services::{AsServiceId, ServiceData},
+};
+use tokio::sync::oneshot;
+
+use crate::http::DynError;
+
+fn map_time_info(service_info: &lb_time_service::TimeServiceInfo) -> TimeInfo {
+    TimeInfo {
+        slot_duration_ms: service_info.slot_duration_ms,
+        genesis_time_unix_ms: service_info.genesis_time_unix_ms,
+        current_slot: u64::from(service_info.current_slot),
+        current_epoch: u32::from(service_info.current_epoch),
+    }
+}
+
+/// Returns the current time-service snapshot in the same shape as `/time/info`.
+pub async fn time_info<TimeService, RuntimeServiceId>(
+    handle: &OverwatchHandle<RuntimeServiceId>,
+) -> Result<TimeInfo, DynError>
+where
+    TimeService: ServiceData<Message = TimeServiceMessage>,
+    RuntimeServiceId: Debug + Send + Sync + Display + 'static + AsServiceId<TimeService>,
+{
+    let relay = handle.relay::<TimeService>().await?;
+    let (sender, receiver) = oneshot::channel();
+    relay
+        .send(TimeServiceMessage::Info { sender })
+        .await
+        .map_err(|(error, _)| error)?;
+    let service_info = receiver.await?.map_err(std::io::Error::other)?;
+
+    Ok(map_time_info(&service_info))
+}
+
+#[cfg(test)]
+mod tests {
+    use lb_chain_service::{Epoch, Slot};
+    use lb_time_service::TimeServiceInfo;
+
+    use super::map_time_info;
+
+    #[test]
+    fn time_info_preserves_the_service_snapshot_fields() {
+        let service_info = TimeServiceInfo {
+            slot_duration_ms: 1_000,
+            genesis_time_unix_ms: 1_700_000_000_000,
+            current_slot: Slot::new(42),
+            current_epoch: Epoch::new(7),
+        };
+
+        let info = map_time_info(&service_info);
+
+        assert_eq!(info.slot_duration_ms, 1_000);
+        assert_eq!(info.genesis_time_unix_ms, 1_700_000_000_000);
+        assert_eq!(info.current_slot, 42);
+        assert_eq!(info.current_epoch, 7);
+    }
+}

--- a/services/chain/chain-network/src/bootstrap/ibd.rs
+++ b/services/chain/chain-network/src/bootstrap/ibd.rs
@@ -204,6 +204,13 @@ where
                     ))) => {
                         debug!(?header_id, "block already applied; continuing");
                     }
+                    Err(Error::BlockProcessing(err)) if is_foreign_chain_parent_missing(&err) => {
+                        warn!(
+                            ?err,
+                            "discarding block download from a peer on a different chain"
+                        );
+                        downloader.cancel_active_download();
+                    }
                     Err(err) => {
                         warn!(?err, "failed to process block; cancelling the download");
                         downloader.cancel_active_download();
@@ -243,6 +250,27 @@ where
         .flatten()
         .collect())
     }
+}
+
+/// A peer can remain connected across a Testnet redeployment and answer the
+/// chainsync protocol with blocks from the previous genesis. While the local
+/// node is still bootstrapping, its LIB remains the local genesis. A missing
+/// parent from a stream that does not point at that genesis is therefore
+/// conclusive evidence of a foreign chain; retrying the stream only repeats
+/// the same stale peer response. Once LIB advances, keep the existing
+/// recoverable behavior because a missing parent can be a normal fork.
+fn is_foreign_chain_parent_missing(err: &ChainError) -> bool {
+    let ChainError::Cryptarchia(lb_chain_service::api::ApiError::ParentMissing { parent, info }) =
+        err
+    else {
+        return false;
+    };
+
+    let Some(genesis_id) = info.genesis_id else {
+        return false;
+    };
+
+    info.lib == genesis_id && *parent != genesis_id
 }
 
 /// Calls [`fetch_tips`] with exponential backoff to not overload the configured
@@ -374,6 +402,72 @@ mod tests {
 
     use super::*;
     use crate::network::BoxedStream;
+
+    fn parent_missing_error(
+        genesis_id: Option<HeaderId>,
+        parent: HeaderId,
+        lib: HeaderId,
+        height: u64,
+    ) -> ChainError {
+        ChainError::Cryptarchia(lb_chain_service::api::ApiError::ParentMissing {
+            parent,
+            info: Box::new(CryptarchiaInfo {
+                genesis_id,
+                lib,
+                lib_slot: Slot::from(0),
+                tip: HeaderId::from([4; 32]),
+                slot: Slot::from(0),
+                height,
+                state: lb_chain_service::State::Bootstrapping,
+            }),
+        })
+    }
+
+    #[test]
+    fn foreign_parent_missing_is_terminal_during_partial_bootstrap() {
+        let genesis = HeaderId::from([1; 32]);
+
+        assert!(is_foreign_chain_parent_missing(&parent_missing_error(
+            Some(genesis),
+            HeaderId::from([2; 32]),
+            genesis,
+            4_000,
+        )));
+    }
+
+    #[test]
+    fn local_genesis_parent_missing_remains_retryable() {
+        let genesis = HeaderId::from([1; 32]);
+
+        assert!(!is_foreign_chain_parent_missing(&parent_missing_error(
+            Some(genesis),
+            genesis,
+            genesis,
+            4_000,
+        )));
+    }
+
+    #[test]
+    fn parent_missing_after_lib_advance_remains_retryable() {
+        let genesis = HeaderId::from([1; 32]);
+
+        assert!(!is_foreign_chain_parent_missing(&parent_missing_error(
+            Some(genesis),
+            HeaderId::from([2; 32]),
+            HeaderId::from([3; 32]),
+            4_000,
+        )));
+    }
+
+    #[test]
+    fn legacy_chain_identity_does_not_trigger_foreign_rejection() {
+        assert!(!is_foreign_chain_parent_missing(&parent_missing_error(
+            None,
+            HeaderId::from([2; 32]),
+            HeaderId::from([1; 32]),
+            4_000,
+        )));
+    }
 
     #[tokio::test]
     async fn no_peers_configured() {

--- a/services/chain/chain-service/Cargo.toml
+++ b/services/chain/chain-service/Cargo.toml
@@ -46,6 +46,7 @@ lb-network-service            = { workspace = true }
 lb-storage-service            = { features = ["rocksdb-backend"], workspace = true }
 lb-utxotree                   = { workspace = true }
 rand                          = { workspace = true }
+serde_json                    = { workspace = true }
 tempfile                      = { workspace = true }
 
 [features]

--- a/services/chain/chain-service/Cargo.toml
+++ b/services/chain/chain-service/Cargo.toml
@@ -46,7 +46,6 @@ lb-network-service            = { workspace = true }
 lb-storage-service            = { features = ["rocksdb-backend"], workspace = true }
 lb-utxotree                   = { workspace = true }
 rand                          = { workspace = true }
-serde_json                    = { workspace = true }
 tempfile                      = { workspace = true }
 
 [features]

--- a/services/chain/chain-service/src/lib.rs
+++ b/services/chain/chain-service/src/lib.rs
@@ -234,6 +234,11 @@ pub struct ChainServiceInfo {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct CryptarchiaInfo {
+    /// Stable chain identity when supplied by the node. Legacy HTTP nodes omit
+    /// this field, in which case consumers must not infer it from a partial
+    /// block history.
+    #[serde(default)]
+    pub genesis_id: Option<HeaderId>,
     pub lib: HeaderId,
     pub lib_slot: Slot,
     pub tip: HeaderId,
@@ -337,6 +342,7 @@ impl Cryptarchia {
         let lib_branch = self.lib_branch();
 
         CryptarchiaInfo {
+            genesis_id: Some(self.genesis_id),
             lib: lib_branch.id(),
             lib_slot: lib_branch.slot(),
             tip: tip_branch.id(),

--- a/zone-sdk/src/test_support.rs
+++ b/zone-sdk/src/test_support.rs
@@ -142,6 +142,7 @@ impl adapter::Node for MockNode {
     async fn consensus_info(&self) -> Result<ChainServiceInfo, lb_common_http_client::Error> {
         Ok(ChainServiceInfo {
             cryptarchia_info: CryptarchiaInfo {
+                genesis_id: None,
                 lib: self.lib,
                 lib_slot: self.lib_slot,
                 tip: self.tip,


### PR DESCRIPTION
> Note: This PR was sent by an automated agent by mistake on this repository, drifted from a task to sync upstream changes on experimental forks of several logos repositories, and instead it created a PR here. 

## Summary

- reject IBD streams that report a foreign genesis while preserving the local genesis
- restore the embedded Testnet deployment profile and deployed protocol identifiers
- expose the current catalog and diagnostic C bindings used by the module consumer

## Validation

- workspace formatting, dependency checks, Clippy, and focused deployment/IBD tests pass
- C library package builds with the deployed Testnet chainsync protocol
- consumer module package-profile validation passes

Related: logos-blockchain-module#47