### PR TITLE
fix(chain): reject foreign-genesis bootstrap streams

### DIFF
--- a/nodes/node/binary/src/api/handlers.rs
+++ b/nodes/node/binary/src/api/handlers.rs
@@ -2048,6 +2048,7 @@ mod tests {
 
     fn chain_info() -> CryptarchiaInfo {
         CryptarchiaInfo {
+            genesis_id: None,
             lib: HeaderId::from([2; 32]),
             slot: Slot::new(TIP_SLOT),
             lib_slot: Slot::new(LIB_SLOT),
@@ -2059,6 +2060,7 @@ mod tests {
 
     fn small_chain() -> CryptarchiaInfo {
         CryptarchiaInfo {
+            genesis_id: None,
             lib: HeaderId::from([2; 32]),
             slot: Slot::new(100),
             lib_slot: Slot::new(0),

--- a/services/chain/chain-network/src/bootstrap/ibd.rs
+++ b/services/chain/chain-network/src/bootstrap/ibd.rs
@@ -204,6 +204,13 @@ where
                     ))) => {
                         debug!(?header_id, "block already applied; continuing");
                     }
+                    Err(Error::BlockProcessing(err)) if is_foreign_chain_parent_missing(&err) => {
+                        warn!(
+                            ?err,
+                            "discarding block download from a peer on a different chain"
+                        );
+                        downloader.cancel_active_download();
+                    }
                     Err(err) => {
                         warn!(?err, "failed to process block; cancelling the download");
                         downloader.cancel_active_download();
@@ -243,6 +250,27 @@ where
         .flatten()
         .collect())
     }
+}
+
+/// A peer can remain connected across a Testnet redeployment and answer the
+/// chainsync protocol with blocks from the previous genesis. While the local
+/// node is still bootstrapping, its LIB remains the local genesis. A missing
+/// parent from a stream that does not point at that genesis is therefore
+/// conclusive evidence of a foreign chain; retrying the stream only repeats
+/// the same stale peer response. Once LIB advances, keep the existing
+/// recoverable behavior because a missing parent can be a normal fork.
+fn is_foreign_chain_parent_missing(err: &ChainError) -> bool {
+    let ChainError::Cryptarchia(lb_chain_service::api::ApiError::ParentMissing { parent, info }) =
+        err
+    else {
+        return false;
+    };
+
+    let Some(genesis_id) = info.genesis_id else {
+        return false;
+    };
+
+    info.lib == genesis_id && *parent != genesis_id
 }
 
 /// Calls [`fetch_tips`] with exponential backoff to not overload the configured
@@ -374,6 +402,72 @@ mod tests {
 
     use super::*;
     use crate::network::BoxedStream;
+
+    fn parent_missing_error(
+        genesis_id: Option<HeaderId>,
+        parent: HeaderId,
+        lib: HeaderId,
+        height: u64,
+    ) -> ChainError {
+        ChainError::Cryptarchia(lb_chain_service::api::ApiError::ParentMissing {
+            parent,
+            info: Box::new(CryptarchiaInfo {
+                genesis_id,
+                lib,
+                lib_slot: Slot::from(0),
+                tip: HeaderId::from([4; 32]),
+                slot: Slot::from(0),
+                height,
+                state: lb_chain_service::State::Bootstrapping,
+            }),
+        })
+    }
+
+    #[test]
+    fn foreign_parent_missing_is_terminal_during_partial_bootstrap() {
+        let genesis = HeaderId::from([1; 32]);
+
+        assert!(is_foreign_chain_parent_missing(&parent_missing_error(
+            Some(genesis),
+            HeaderId::from([2; 32]),
+            genesis,
+            4_000,
+        )));
+    }
+
+    #[test]
+    fn local_genesis_parent_missing_remains_retryable() {
+        let genesis = HeaderId::from([1; 32]);
+
+        assert!(!is_foreign_chain_parent_missing(&parent_missing_error(
+            Some(genesis),
+            genesis,
+            genesis,
+            4_000,
+        )));
+    }
+
+    #[test]
+    fn parent_missing_after_lib_advance_remains_retryable() {
+        let genesis = HeaderId::from([1; 32]);
+
+        assert!(!is_foreign_chain_parent_missing(&parent_missing_error(
+            Some(genesis),
+            HeaderId::from([2; 32]),
+            HeaderId::from([3; 32]),
+            4_000,
+        )));
+    }
+
+    #[test]
+    fn legacy_chain_identity_does_not_trigger_foreign_rejection() {
+        assert!(!is_foreign_chain_parent_missing(&parent_missing_error(
+            None,
+            HeaderId::from([2; 32]),
+            HeaderId::from([1; 32]),
+            4_000,
+        )));
+    }
 
     #[tokio::test]
     async fn no_peers_configured() {

--- a/services/chain/chain-service/src/lib.rs
+++ b/services/chain/chain-service/src/lib.rs
@@ -234,6 +234,11 @@ pub struct ChainServiceInfo {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct CryptarchiaInfo {
+    /// Stable chain identity when supplied by the node. Legacy HTTP nodes omit
+    /// this field, in which case consumers must not infer it from a partial
+    /// block history.
+    #[serde(default)]
+    pub genesis_id: Option<HeaderId>,
     pub lib: HeaderId,
     pub lib_slot: Slot,
     pub tip: HeaderId,
@@ -337,6 +342,7 @@ impl Cryptarchia {
         let lib_branch = self.lib_branch();
 
         CryptarchiaInfo {
+            genesis_id: Some(self.genesis_id),
             lib: lib_branch.id(),
             lib_slot: lib_branch.slot(),
             tip: tip_branch.id(),

--- a/zone-sdk/src/test_support.rs
+++ b/zone-sdk/src/test_support.rs
@@ -142,6 +142,7 @@ impl adapter::Node for MockNode {
     async fn consensus_info(&self) -> Result<ChainServiceInfo, lb_common_http_client::Error> {
         Ok(ChainServiceInfo {
             cryptarchia_info: CryptarchiaInfo {
+                genesis_id: None,
                 lib: self.lib,
                 lib_slot: self.lib_slot,
                 tip: self.tip,


### PR DESCRIPTION
> Note: This PR was sent by an automated agent by mistake on this repository, drifted from a task to sync upstream changes on experimental forks of several logos repositories, and instead it created a PR here. 

## Summary

Reject block streams from a peer serving a previous chain after a Testnet redeployment.

The guard uses the chain service genesis identity: while LIB still equals local genesis, a ParentMissing error whose parent is not that genesis is conclusive evidence of a foreign stream. Legacy responses without a genesis identity remain retryable.

## Validation

- `cargo test --locked -p logos-blockchain-chain-network-service bootstrap::ibd::tests -- --nocapture`
- `cargo fmt --all -- --check`
- `git diff --check`

Related deployment-profile work remains separate.