### PR TITLE
fix(tx): Add missing OpDe for claimopreward

### DIFF
--- a/core/src/mantle/ops/internal.rs
+++ b/core/src/mantle/ops/internal.rs
@@ -63,6 +63,7 @@ pub enum OpDe {
     SDPActive(OpWire<SDP_ACTIVE, SDPActiveOp>),
     LeaderClaim(OpWire<LEADER_CLAIM, LeaderClaimOp>),
     Transfer(OpWire<TRANSFER, TransferOp>),
+    ClaimPoWReward(OpWire<CLAIM_POW_REWARD, ClaimPowRewardOp>),
 }
 
 impl From<OpDe> for Op {
@@ -78,6 +79,7 @@ impl From<OpDe> for Op {
             OpDe::SDPActive(w) => Self::SDPActive(w.into_op()),
             OpDe::LeaderClaim(w) => Self::LeaderClaim(w.into_op()),
             OpDe::Transfer(w) => Self::Transfer(w.into_op()),
+            OpDe::ClaimPoWReward(w) => Self::ClaimPowReward(w.into_op()),
         }
     }
 }


### PR DESCRIPTION
## 1. What does this PR implement?

Adds a missing OpDe (deserializer) variant for the pow claim operation

## 2. Does the code have enough context to be clearly understood?

Quite simple.

## 3. Who are the specification authors and who is accountable for this PR?

@danielSanchezQ @strinnityk 

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

N/A

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
