### PR TITLE
feat(mantle): integrate ZK batch verification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4484,6 +4484,7 @@ dependencies = [
  "logos-blockchain-poseidon2",
  "logos-blockchain-utils",
  "logos-blockchain-utxotree",
+ "logos-blockchain-zksign",
  "multiaddr",
  "num-bigint",
  "rand 0.8.6",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -32,6 +32,7 @@ lb-pol                        = { workspace = true }
 lb-poseidon2                  = { workspace = true }
 lb-utils                      = { workspace = true }
 lb-utxotree                   = { workspace = true }
+lb-zksign                     = { workspace = true }
 multiaddr                     = { workspace = true }
 num-bigint                    = { workspace = true }
 rpds                          = { workspace = true }

--- a/core/src/mantle/batch.rs
+++ b/core/src/mantle/batch.rs
@@ -90,3 +90,139 @@ pub enum Error {
     #[error("deferred leader claim proof is malformed: {0}")]
     MalformedLeaderClaimProof(String),
 }
+
+#[cfg(test)]
+mod tests {
+    use lb_groth16::Fr;
+    use lb_key_management_system_keys::keys::{ZkKey, public_inputs_from_pks};
+    use lb_mmr::MerkleMountainRange;
+    use num_bigint::BigUint;
+
+    use super::*;
+    use crate::{
+        crypto::ZkHasher,
+        mantle::ops::leader_claim::{RewardsRoot, VoucherCm, VoucherNullifier, VoucherSecret},
+        proofs::leader_claim_proof::{
+            Groth16LeaderClaimProof, LeaderClaimPrivate, LeaderClaimPublic,
+        },
+    };
+
+    #[test]
+    fn verify_accepts_empty_batch() {
+        DeferredZkpVerifications::new()
+            .verify()
+            .expect("must succeed");
+    }
+
+    #[test]
+    fn verify_accepts_batch_of_valid_zk_signatures() {
+        [valid_zk_sig(7), valid_zk_sig(8), valid_zk_sig(9)]
+            .into_iter()
+            .collect::<DeferredZkpVerifications>()
+            .verify()
+            .expect("must succeed");
+    }
+
+    #[test]
+    fn verify_rejects_batch_containing_invalid_zk_signature() {
+        let err = [valid_zk_sig(7), invalid_zk_sig(8), valid_zk_sig(9)]
+            .into_iter()
+            .collect::<DeferredZkpVerifications>()
+            .verify()
+            .unwrap_err();
+        assert!(matches!(err, Error::InvalidZkSignatures));
+    }
+
+    #[test]
+    fn verify_accepts_batch_of_valid_leader_claims() {
+        [valid_leader_claim(7), valid_leader_claim(8)]
+            .into_iter()
+            .collect::<DeferredZkpVerifications>()
+            .verify()
+            .expect("must succeed");
+    }
+
+    #[test]
+    fn verify_rejects_batch_containing_invalid_leader_claim() {
+        let err = [valid_leader_claim(7), invalid_leader_claim(8)]
+            .into_iter()
+            .collect::<DeferredZkpVerifications>()
+            .verify()
+            .unwrap_err();
+        assert!(matches!(err, Error::InvalidLeaderClaimProofs));
+    }
+
+    #[test]
+    fn verify_rejects_invalid_leader_claim_alongside_valid_zk_signature() {
+        let err = [valid_zk_sig(7), invalid_leader_claim(8)]
+            .into_iter()
+            .collect::<DeferredZkpVerifications>()
+            .verify()
+            .unwrap_err();
+        assert!(matches!(err, Error::InvalidLeaderClaimProofs));
+    }
+
+    fn valid_zk_sig(message: u64) -> DeferredZkpVerification {
+        zk_sig(message, message)
+    }
+
+    fn invalid_zk_sig(message: u64) -> DeferredZkpVerification {
+        zk_sig(message + 1, message)
+    }
+
+    /// Signs `msg`, but pairs the proof with the public inputs the
+    /// verifier checks it against: those of `msg_for_input`.
+    /// If `msg != msg_for_input`, an invalid proof will be produced.
+    fn zk_sig(msg: u64, msg_for_input: u64) -> DeferredZkpVerification {
+        let key = ZkKey::from(BigUint::from(1u8));
+        let signature = ZkKey::multi_sign(std::slice::from_ref(&key), &Fr::from(msg)).unwrap();
+        let inputs =
+            public_inputs_from_pks(Fr::from(msg_for_input).into(), &[key.to_public_key()]).unwrap();
+
+        DeferredZkpVerification::ZkSig(*signature.as_proof(), inputs)
+    }
+
+    fn valid_leader_claim(voucher: u64) -> DeferredZkpVerification {
+        leader_claim(voucher, voucher)
+    }
+
+    fn invalid_leader_claim(voucher: u64) -> DeferredZkpVerification {
+        leader_claim(voucher + 1, voucher)
+    }
+
+    /// Proves a claim over the voucher of `secret`, but pairs the proof
+    /// with the nullifier the verifier checks it against: that of
+    /// `secret_for_input`.
+    /// If `secret != secret_for_input`, an invalid proof will be produced.
+    fn leader_claim(secret: u64, secret_for_input: u64) -> DeferredZkpVerification {
+        let voucher_secret = VoucherSecret::from(Fr::from(secret));
+        let (mmr, voucher_path) = MerkleMountainRange::<VoucherCm, ZkHasher>::new()
+            .push_with_paths(VoucherCm::from_secret(voucher_secret), &mut [])
+            .expect("MMR shouldn't be full");
+        let voucher_root = RewardsRoot::from(mmr.frontier_root());
+        let tx_hash = Fr::from(11u64);
+        let proof = Groth16LeaderClaimProof::prove(
+            LeaderClaimPrivate::try_new(
+                LeaderClaimPublic::new(
+                    VoucherNullifier::from_secret(voucher_secret).into(),
+                    voucher_root.into(),
+                    tx_hash,
+                ),
+                &voucher_path,
+                voucher_secret,
+            )
+            .expect("voucher path should match the PoC circuit height"),
+        )
+        .expect("proof generation should succeed");
+
+        DeferredZkpVerification::LeaderClaim(
+            *proof.proof(),
+            PoCVerifierInput::new(
+                VoucherNullifier::from_secret(VoucherSecret::from(Fr::from(secret_for_input)))
+                    .into(),
+                voucher_root.into(),
+                tx_hash,
+            ),
+        )
+    }
+}

--- a/core/src/mantle/batch.rs
+++ b/core/src/mantle/batch.rs
@@ -1,0 +1,92 @@
+use lb_poc::{PoCProof, PoCVerifierInput};
+use lb_zksign::{ZkSignProof, ZkSignVerifierInputs};
+
+/// A ZKP verification deferred while processing an operation.
+#[expect(
+    clippy::large_enum_variant,
+    reason = "This is short-lived; each is pushed into DeferredZkpVerifications almost immediately, \
+    which stores the two kinds in separate vectors. Also, most of them are the larger ZkSig variant."
+)]
+pub enum DeferredZkpVerification {
+    ZkSig(ZkSignProof, ZkSignVerifierInputs),
+    LeaderClaim(PoCProof, PoCVerifierInput),
+}
+
+/// ZKP verifications deferred while applying a block.
+#[derive(Default)]
+pub struct DeferredZkpVerifications {
+    zk_sigs: Vec<(ZkSignProof, ZkSignVerifierInputs)>,
+    leader_claims: Vec<(PoCProof, PoCVerifierInput)>,
+}
+
+impl DeferredZkpVerifications {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn push(&mut self, verification: DeferredZkpVerification) {
+        match verification {
+            DeferredZkpVerification::ZkSig(zk_sig, inputs) => self.zk_sigs.push((zk_sig, inputs)),
+            DeferredZkpVerification::LeaderClaim(proof, public) => {
+                self.leader_claims.push((proof, public));
+            }
+        }
+    }
+
+    pub fn extend(&mut self, other: Self) {
+        self.zk_sigs.extend(other.zk_sigs);
+        self.leader_claims.extend(other.leader_claims);
+    }
+
+    pub fn verify(self) -> Result<(), Error> {
+        Self::verify_zk_sigs(&self.zk_sigs)?;
+        Self::verify_leader_claims(&self.leader_claims)
+    }
+
+    fn verify_zk_sigs(zk_sigs: &[(ZkSignProof, ZkSignVerifierInputs)]) -> Result<(), Error> {
+        if zk_sigs.is_empty() {
+            return Ok(());
+        }
+
+        match lb_zksign::batch_verify(zk_sigs) {
+            Ok(true) => Ok(()),
+            Ok(false) => Err(Error::InvalidZkSignatures),
+            Err(e) => Err(Error::MalformedZkSignature(format!("{e:?}"))),
+        }
+    }
+
+    fn verify_leader_claims(proofs: &[(PoCProof, PoCVerifierInput)]) -> Result<(), Error> {
+        if proofs.is_empty() {
+            return Ok(());
+        }
+
+        match lb_poc::batch_verify(proofs) {
+            Ok(true) => Ok(()),
+            Ok(false) => Err(Error::InvalidLeaderClaimProofs),
+            Err(e) => Err(Error::MalformedLeaderClaimProof(format!("{e:?}"))),
+        }
+    }
+}
+
+impl FromIterator<DeferredZkpVerification> for DeferredZkpVerifications {
+    fn from_iter<T: IntoIterator<Item = DeferredZkpVerification>>(iter: T) -> Self {
+        let mut verifications = Self::new();
+        for verification in iter {
+            verifications.push(verification);
+        }
+        verifications
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("deferred ZkSignatures are invalid")]
+    InvalidZkSignatures,
+    #[error("deferred ZkSignature is malformed: {0}")]
+    MalformedZkSignature(String),
+    #[error("deferred leader claim proofs are invalid")]
+    InvalidLeaderClaimProofs,
+    #[error("deferred leader claim proof is malformed: {0}")]
+    MalformedLeaderClaimProof(String),
+}

--- a/core/src/mantle/ledger.rs
+++ b/core/src/mantle/ledger.rs
@@ -15,6 +15,7 @@ use crate::{
     crypto::{Hash, ZkHasher},
     events::TxEvent,
     mantle::{
+        batch::DeferredZkpVerification,
         channel::Channels,
         ops::{OpId, channel::ChannelId},
     },
@@ -70,7 +71,13 @@ pub trait VerifiableOperation<Mode: verification_mode::VerificationMode>:
     type Context<'a>;
     type Error;
 
-    fn verify(&self, proof: &Self::Proof, context: &Self::Context<'_>) -> Result<(), Self::Error>;
+    /// Performs stateful verifications, and returns a deferred ZKP verification
+    /// so that the caller can batch it.
+    fn verify(
+        &self,
+        proof: &Self::Proof,
+        context: &Self::Context<'_>,
+    ) -> Result<Option<DeferredZkpVerification>, Self::Error>;
 }
 
 pub trait ExecutableOperation {

--- a/core/src/mantle/mod.rs
+++ b/core/src/mantle/mod.rs
@@ -6,6 +6,7 @@ pub mod ops;
 pub mod traits;
 pub mod transactions;
 
+pub mod batch;
 mod channel_notes;
 mod fixtures;
 

--- a/core/src/mantle/ops/channel/channel_transfer.rs
+++ b/core/src/mantle/ops/channel/channel_transfer.rs
@@ -5,11 +5,13 @@ use crate::{
     events::TxEvent,
     mantle::{
         TxHash, Value,
+        batch::DeferredZkpVerification,
         channel::{Channels, Error},
         gas::{Gas, MainnetGasProfile, OperationGas, SignedOperationExecutionGas},
         ledger::{
             ExecutableOperation, Inputs, Outputs, PreverifiableOperation, ProvableOperation, Utxo,
-            Utxos, VerifiableOperation, verification_mode, verification_mode::VerificationMode,
+            Utxos, VerifiableOperation,
+            verification_mode::{self, VerificationMode},
         },
         ops::{
             OpId, SignedOp,
@@ -89,7 +91,11 @@ impl VerifiableOperation<verification_mode::StandardMode> for ChannelTransferOp 
     type Context<'a> = ChannelTransferValidationContext<'a>;
     type Error = Error;
 
-    fn verify(&self, proof: &Self::Proof, context: &Self::Context<'_>) -> Result<(), Self::Error> {
+    fn verify(
+        &self,
+        proof: &Self::Proof,
+        context: &Self::Context<'_>,
+    ) -> Result<Option<DeferredZkpVerification>, Self::Error> {
         verify_channel_multi_sig(
             &self.channel_id,
             proof,
@@ -134,7 +140,7 @@ impl VerifiableOperation<verification_mode::StandardMode> for ChannelTransferOp 
             });
         }
 
-        // Check the signatures
+        // Check the signatures. Don't defer this because ed25519 verification is cheap.
         for sig in signatures {
             if channel
                 .accredited_keys
@@ -147,7 +153,7 @@ impl VerifiableOperation<verification_mode::StandardMode> for ChannelTransferOp 
             }
         }
 
-        Ok(())
+        Ok(None)
     }
 }
 

--- a/core/src/mantle/ops/channel/config.rs
+++ b/core/src/mantle/ops/channel/config.rs
@@ -9,11 +9,12 @@ use crate::{
     events::TxEvent,
     mantle::{
         Value,
+        batch::DeferredZkpVerification,
         channel::{ChannelState, Channels, Error, SlotTimeframe, SlotTimeout},
         gas::{Gas, MainnetGasProfile, OperationGas, SignedOperationExecutionGas},
         ledger::{
             ExecutableOperation, PreverifiableOperation, ProvableOperation, VerifiableOperation,
-            verification_mode, verification_mode::VerificationMode,
+            verification_mode::{self, VerificationMode},
         },
         ops::SignedOp,
         transactions::{hash::TxHashView, states::VerificationState},
@@ -86,7 +87,11 @@ impl VerifiableOperation<verification_mode::StandardMode> for ChannelConfigOp {
     type Context<'a> = ChannelConfigValidationContext<'a>;
     type Error = Error;
 
-    fn verify(&self, proof: &Self::Proof, context: &Self::Context<'_>) -> Result<(), Self::Error> {
+    fn verify(
+        &self,
+        proof: &Self::Proof,
+        context: &Self::Context<'_>,
+    ) -> Result<Option<DeferredZkpVerification>, Self::Error> {
         // Check that the indexes are unique and there is the same number of proof and
         // index. This is enforced by the proof structure that enforces it.
 
@@ -101,7 +106,7 @@ impl VerifiableOperation<verification_mode::StandardMode> for ChannelConfigOp {
                 });
             }
 
-            // Check the signatures
+            // Check the signatures. Don't defer this because ed25519 verification is cheap.
             for signature in signatures {
                 if channel
                     .accredited_keys
@@ -119,7 +124,7 @@ impl VerifiableOperation<verification_mode::StandardMode> for ChannelConfigOp {
             }
         }
 
-        Ok(())
+        Ok(None)
     }
 }
 

--- a/core/src/mantle/ops/channel/deposit.rs
+++ b/core/src/mantle/ops/channel/deposit.rs
@@ -1,5 +1,5 @@
 use lb_codec::{BinaryCodec, BinaryEncode as _};
-use lb_key_management_system_keys::keys::{ZkPublicKey, ZkSignature};
+use lb_key_management_system_keys::keys::{ZkSignature, public_inputs_from_pks};
 use lb_utils::bounded::UpperBoundedVec;
 use serde::{Deserialize, Serialize};
 
@@ -7,12 +7,13 @@ use crate::{
     events::{DepositNote, DepositRecreatedNotes, TxEvent, TxEventPayload},
     mantle::{
         Value,
+        batch::DeferredZkpVerification,
         channel::{Channels, Error},
         gas::{Gas, MainnetGasProfile, OperationGas, SignedOperationExecutionGas},
         ledger::{
             ExecutableOperation, Inputs, InputsError, Outputs, PreverifiableOperation,
-            ProvableOperation, Utxos, VerifiableOperation, verification_mode,
-            verification_mode::VerificationMode,
+            ProvableOperation, Utxos, VerifiableOperation,
+            verification_mode::{self, VerificationMode},
         },
         ops::{OpId, SignedOp, channel::ChannelId},
         transactions::{
@@ -98,7 +99,11 @@ impl VerifiableOperation<verification_mode::StandardMode> for DepositOp {
     type Context<'a> = DepositValidationContext<'a>;
     type Error = Error;
 
-    fn verify(&self, proof: &Self::Proof, context: &Self::Context<'_>) -> Result<(), Self::Error> {
+    fn verify(
+        &self,
+        proof: &Self::Proof,
+        context: &Self::Context<'_>,
+    ) -> Result<Option<DeferredZkpVerification>, Self::Error> {
         // Check that the channel exist
         if !context.channels.channels.contains_key(&self.channel_id) {
             return Err(Error::ChannelNotFound {
@@ -113,13 +118,14 @@ impl VerifiableOperation<verification_mode::StandardMode> for DepositOp {
             context.utxos,
         )?;
 
-        // Check the signature
+        // Defer the proof verification, so that the caller can batch it.
         let public_keys = self.inputs.get_pk(context.utxos)?;
-        if !ZkPublicKey::verify_multi(&public_keys, context.tx_hash_view.as_fr(), proof) {
-            return Err(Error::InvalidSignature);
-        }
-
-        Ok(())
+        let inputs = public_inputs_from_pks((*context.tx_hash_view.as_fr()).into(), &public_keys)
+            .map_err(|_| Error::InvalidSignature)?;
+        Ok(Some(DeferredZkpVerification::ZkSig(
+            *proof.as_proof(),
+            inputs,
+        )))
     }
 }
 

--- a/core/src/mantle/ops/channel/inscribe.rs
+++ b/core/src/mantle/ops/channel/inscribe.rs
@@ -13,11 +13,12 @@ use crate::{
     events::TxEvent,
     mantle::{
         Value,
+        batch::DeferredZkpVerification,
         channel::{ChannelState, Channels, Error},
         gas::{Gas, MainnetGasProfile, OperationGas, SignedOperationExecutionGas},
         ledger::{
             ExecutableOperation, PreverifiableOperation, ProvableOperation, VerifiableOperation,
-            verification_mode, verification_mode::VerificationMode,
+            verification_mode::{self, VerificationMode},
         },
         ops::{SignedOp, channel::config::Keys},
         transactions::{hash::TxHashView, states::VerificationState},
@@ -116,7 +117,11 @@ impl VerifiableOperation<verification_mode::StandardMode> for InscriptionOp {
     type Context<'a> = InscriptionValidationContext<'a>;
     type Error = Error;
 
-    fn verify(&self, _proof: &Self::Proof, context: &Self::Context<'_>) -> Result<(), Self::Error> {
+    fn verify(
+        &self,
+        _proof: &Self::Proof,
+        context: &Self::Context<'_>,
+    ) -> Result<Option<DeferredZkpVerification>, Self::Error> {
         // Check if the channel exist otherwise the inscription is valid only if and
         // only if parent == ZERO
         if let Some(channel) = context.channels.channels.get(&self.channel_id).cloned() {
@@ -147,7 +152,8 @@ impl VerifiableOperation<verification_mode::StandardMode> for InscriptionOp {
             });
         }
 
-        Ok(())
+        // No deferred proof verification because it's cheap and done by `preverify`.
+        Ok(None)
     }
 }
 

--- a/core/src/mantle/ops/channel/withdraw.rs
+++ b/core/src/mantle/ops/channel/withdraw.rs
@@ -5,11 +5,13 @@ use crate::{
     events::TxEvent,
     mantle::{
         TxHash, Value,
+        batch::DeferredZkpVerification,
         channel::{Channels, Error},
         gas::{Gas, MainnetGasProfile, OperationGas, SignedOperationExecutionGas},
         ledger::{
             ExecutableOperation, Inputs, PreverifiableOperation, ProvableOperation, Utxos,
-            VerifiableOperation, verification_mode, verification_mode::VerificationMode,
+            VerifiableOperation,
+            verification_mode::{self, VerificationMode},
         },
         ops::{
             OpId, SignedOp,
@@ -78,7 +80,11 @@ impl VerifiableOperation<verification_mode::StandardMode> for ChannelWithdrawOp 
     type Context<'a> = WithdrawValidationContext<'a>;
     type Error = Error;
 
-    fn verify(&self, proof: &Self::Proof, context: &Self::Context<'_>) -> Result<(), Self::Error> {
+    fn verify(
+        &self,
+        proof: &Self::Proof,
+        context: &Self::Context<'_>,
+    ) -> Result<Option<DeferredZkpVerification>, Self::Error> {
         verify_channel_multi_sig(
             &self.channel_id,
             proof,
@@ -116,7 +122,7 @@ impl VerifiableOperation<verification_mode::StandardMode> for ChannelWithdrawOp 
             });
         }
 
-        // Check the signatures
+        // Check the signatures. Don't defer this because ed25519 verification is cheap.
         for sig in signatures {
             if channel
                 .accredited_keys
@@ -129,7 +135,7 @@ impl VerifiableOperation<verification_mode::StandardMode> for ChannelWithdrawOp 
             }
         }
 
-        Ok(())
+        Ok(None)
     }
 }
 

--- a/core/src/mantle/ops/leader_claim.rs
+++ b/core/src/mantle/ops/leader_claim.rs
@@ -3,6 +3,7 @@ use std::sync::LazyLock;
 use lb_codec::{BinaryCodec, BinaryEncode as _};
 use lb_groth16::{fr_from_bytes, fr_to_bytes, serde::serde_fr};
 use lb_key_management_system_keys::keys::ZkPublicKey;
+use lb_poc::PoCVerifierInput;
 use lb_poseidon2::{Digest, Fr, ZkHash};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -12,10 +13,12 @@ use crate::{
     events::{TxEvent, TxEventPayload},
     mantle::{
         Note, Utxo, Value,
+        batch::DeferredZkpVerification,
         gas::{Gas, MainnetGasProfile, OperationGas, SignedOperationExecutionGas},
         ledger::{
             ExecutableOperation, PreverifiableOperation, ProvableOperation, Utxos,
-            VerifiableOperation, verification_mode, verification_mode::VerificationMode,
+            VerifiableOperation,
+            verification_mode::{self, VerificationMode},
         },
         ops::{OpId, SignedOp},
         transactions::{
@@ -217,7 +220,11 @@ impl VerifiableOperation<verification_mode::StandardMode> for LeaderClaimOp {
     type Context<'a> = LeaderClaimVerificationContext<'a>;
     type Error = LeaderClaimError;
 
-    fn verify(&self, proof: &Self::Proof, context: &Self::Context<'_>) -> Result<(), Self::Error> {
+    fn verify(
+        &self,
+        proof: &Self::Proof,
+        context: &Self::Context<'_>,
+    ) -> Result<Option<DeferredZkpVerification>, Self::Error> {
         // Check that the nullifier isn't in the set
         if context.nullifiers.contains(&self.voucher_nullifier) {
             return Err(LeaderClaimError::DuplicatedVoucherNullifier);
@@ -228,16 +235,15 @@ impl VerifiableOperation<verification_mode::StandardMode> for LeaderClaimOp {
             return Err(LeaderClaimError::VouchersRootMismatch);
         }
 
-        // Check the proof of claim
-        if !proof.verify(&LeaderClaimPublic {
-            voucher_nullifier: self.voucher_nullifier.into(),
-            voucher_root: context.claimable_vouchers_root.0,
-            mantle_tx_hash: *context.tx_hash_view.as_fr(),
-        }) {
-            return Err(LeaderClaimError::InvalidPoC);
-        }
-
-        Ok(())
+        // Defer the proof verification, so that the caller can batch it.
+        Ok(Some(DeferredZkpVerification::LeaderClaim(
+            *proof.proof(),
+            PoCVerifierInput::new(
+                self.voucher_nullifier.into(),
+                context.claimable_vouchers_root.0,
+                *context.tx_hash_view.as_fr(),
+            ),
+        )))
     }
 }
 
@@ -287,7 +293,10 @@ mod tests {
     use lb_mmr::MerkleMountainRange;
 
     use super::*;
-    use crate::proofs::leader_claim_proof::LeaderClaimPrivate;
+    use crate::{
+        mantle::batch::{self, DeferredZkpVerifications},
+        proofs::leader_claim_proof::LeaderClaimPrivate,
+    };
 
     #[test]
     fn validate_accepts_valid_proof_of_claim() {
@@ -324,7 +333,14 @@ mod tests {
             tx_hash_view: &tx_hash_view,
         };
 
-        assert_eq!(op.verify(&proof, &context), Ok(()));
+        let deferred_zkp = op
+            .verify(&proof, &context)
+            .expect("stateful verification should succeed")
+            .expect("deferred ZKP verification should be returned");
+        std::iter::once(deferred_zkp)
+            .collect::<DeferredZkpVerifications>()
+            .verify()
+            .unwrap();
     }
 
     #[test]
@@ -427,9 +443,16 @@ mod tests {
         // The proof is verified against `op.voucher_nullifier`, which does not
         // match the proven voucher -> rejected. A voucher cannot be claimed under
         // a substituted nullifier.
-        assert_eq!(
-            op.verify(&proof, &context),
-            Err(LeaderClaimError::InvalidPoC)
-        );
+        let deferred_zkp = op
+            .verify(&proof, &context)
+            .expect("stateful verification should succeed")
+            .expect("deferred ZKP verification should be returned");
+        assert!(matches!(
+            std::iter::once(deferred_zkp)
+                .collect::<DeferredZkpVerifications>()
+                .verify()
+                .unwrap_err(),
+            batch::Error::InvalidLeaderClaimProofs
+        ));
     }
 }

--- a/core/src/mantle/ops/pow.rs
+++ b/core/src/mantle/ops/pow.rs
@@ -12,6 +12,7 @@ use crate::{
     events::{TxEvent, TxEventPayload},
     mantle::{
         Note, TxHash, Utxo, Value,
+        batch::DeferredZkpVerification,
         gas::{Gas, MainnetGasProfile, OperationGas},
         ledger::{
             ExecutableOperation, PreverifiableOperation, ProvableOperation, Utxos,
@@ -293,14 +294,18 @@ impl VerifiableOperation<verification_mode::StandardMode> for ClaimPowRewardOp {
     type Context<'a> = ClaimPoWRewardVerificationContext<'a>;
     type Error = ClaimPowRewardError;
 
-    fn verify(&self, _proof: &Self::Proof, context: &Self::Context<'_>) -> Result<(), Self::Error> {
+    fn verify(
+        &self,
+        _proof: &Self::Proof,
+        context: &Self::Context<'_>,
+    ) -> Result<Option<DeferredZkpVerification>, Self::Error> {
         context.are_pow_reward_enabled()?;
         context.accept_claim::<{ SLOT_WINDOW }>(self.block_hash)?;
         context.validate_current_epoch_nonce(self.epoch_nonce)?;
         let puzzle_ticket = self.get_puzzle_ticket();
         context.validate_difficulty_reward(puzzle_ticket)?;
         context.validate_double_claiming(puzzle_ticket)?;
-        Ok(())
+        Ok(None)
     }
 }
 
@@ -529,7 +534,12 @@ mod tests {
     fn validate_accepts_claim_with_current_epoch_nonce() {
         let nullifiers = HashTrieMapSync::new_sync();
         let ctx = accepting_context(&nullifiers);
-        assert_eq!(claim_op(CURRENT_EPOCH).verify(&NoOpProof, &ctx), Ok(()));
+        assert!(
+            claim_op(CURRENT_EPOCH)
+                .verify(&NoOpProof, &ctx)
+                .expect("stateful verification must succeed")
+                .is_none()
+        );
     }
 
     #[test]
@@ -538,7 +548,12 @@ mod tests {
         // stays claimable, so the previous epoch's nonce is also accepted.
         let nullifiers = HashTrieMapSync::new_sync();
         let ctx = accepting_context(&nullifiers);
-        assert_eq!(claim_op(PREVIOUS_EPOCH).verify(&NoOpProof, &ctx), Ok(()));
+        assert!(
+            claim_op(PREVIOUS_EPOCH)
+                .verify(&NoOpProof, &ctx)
+                .expect("stateful verification must succeed")
+                .is_none()
+        );
     }
 
     #[test]
@@ -547,8 +562,8 @@ mod tests {
         let ctx = accepting_context(&nullifiers);
         let op = claim_op(PREVIOUS_EPOCH - 1);
         assert_eq!(
-            op.verify(&NoOpProof, &ctx),
-            Err(ClaimPowRewardError::MismatchEpochNonce {
+            op.verify(&NoOpProof, &ctx).err().unwrap(),
+            ClaimPowRewardError::MismatchEpochNonce {
                 claim: op.epoch_nonce,
                 accepted: (
                     nonce_for_epoch(PREVIOUS_EPOCH),
@@ -566,8 +581,11 @@ mod tests {
         // pass, and this op's ticket is not zero.
         ctx.reward_difficulty = Fr::ZERO;
         assert_eq!(
-            claim_op(CURRENT_EPOCH).verify(&NoOpProof, &ctx),
-            Err(ClaimPowRewardError::InvalidPoWRewardTicket)
+            claim_op(CURRENT_EPOCH)
+                .verify(&NoOpProof, &ctx)
+                .err()
+                .unwrap(),
+            ClaimPowRewardError::InvalidPoWRewardTicket
         );
     }
 
@@ -581,8 +599,8 @@ mod tests {
         let mut ctx = accepting_context(&nullifiers);
         ctx.reward_difficulty = op.get_puzzle_ticket().into();
         assert_eq!(
-            op.verify(&NoOpProof, &ctx),
-            Err(ClaimPowRewardError::InvalidPoWRewardTicket)
+            op.verify(&NoOpProof, &ctx).err().unwrap(),
+            ClaimPowRewardError::InvalidPoWRewardTicket
         );
     }
 
@@ -593,8 +611,8 @@ mod tests {
             HashTrieMapSync::new_sync().insert(op.get_puzzle_ticket(), Slot::from(45u64));
         let ctx = accepting_context(&nullifiers);
         assert_eq!(
-            op.verify(&NoOpProof, &ctx),
-            Err(ClaimPowRewardError::DoubleClaimed)
+            op.verify(&NoOpProof, &ctx).err().unwrap(),
+            ClaimPowRewardError::DoubleClaimed
         );
     }
 

--- a/core/src/mantle/ops/pow.rs
+++ b/core/src/mantle/ops/pow.rs
@@ -569,7 +569,7 @@ mod tests {
                     nonce_for_epoch(PREVIOUS_EPOCH),
                     nonce_for_epoch(CURRENT_EPOCH)
                 ),
-            })
+            }
         );
     }
 

--- a/core/src/mantle/ops/sdp/active.rs
+++ b/core/src/mantle/ops/sdp/active.rs
@@ -1,5 +1,5 @@
 use lb_cryptarchia_engine::Epoch;
-use lb_key_management_system_keys::keys::{ZkPublicKey, ZkSignature};
+use lb_key_management_system_keys::keys::{ZkSignature, public_inputs_from_pks};
 use lb_log_targets::mantle;
 use tracing::info;
 
@@ -8,10 +8,12 @@ use crate::{
     events::TxEvent,
     mantle::{
         Value,
+        batch::DeferredZkpVerification,
         gas::{Gas, MainnetGasProfile, OperationGas, SignedOperationExecutionGas},
         ledger::{
             Declarations, ExecutableOperation, PreverifiableOperation, ProvableOperation,
-            VerifiableOperation, verification_mode, verification_mode::VerificationMode,
+            VerifiableOperation,
+            verification_mode::{self, VerificationMode},
         },
         ops::SignedOp,
         transactions::{hash::TxHashView, states::VerificationState},
@@ -56,7 +58,11 @@ impl VerifiableOperation<verification_mode::StandardMode> for SDPActiveOp {
     type Context<'a> = SDPActiveValidationContext<'a>;
     type Error = SdpError;
 
-    fn verify(&self, proof: &Self::Proof, context: &Self::Context<'_>) -> Result<(), Self::Error> {
+    fn verify(
+        &self,
+        proof: &Self::Proof,
+        context: &Self::Context<'_>,
+    ) -> Result<Option<DeferredZkpVerification>, Self::Error> {
         // Check the declaration exists
         let Some(declaration) = context.declarations.get(&self.declaration_id) else {
             return Err(SdpError::DeclarationNotFound(self.declaration_id));
@@ -81,12 +87,14 @@ impl VerifiableOperation<verification_mode::StandardMode> for SDPActiveOp {
             });
         }
 
-        // Check the signature over the `zk_id`
-        if !ZkPublicKey::verify_multi(&[declaration.zk_id], context.tx_hash_view.as_fr(), proof) {
-            return Err(SdpError::InvalidZkSignature);
-        }
-
-        Ok(())
+        // Defer the proof verification, so that the caller can batch it.
+        let inputs =
+            public_inputs_from_pks((*context.tx_hash_view.as_fr()).into(), &[declaration.zk_id])
+                .map_err(|_| SdpError::InvalidZkSignature)?;
+        Ok(Some(DeferredZkpVerification::ZkSig(
+            *proof.as_proof(),
+            inputs,
+        )))
     }
 }
 

--- a/core/src/mantle/ops/sdp/declare.rs
+++ b/core/src/mantle/ops/sdp/declare.rs
@@ -1,16 +1,18 @@
 use lb_cryptarchia_engine::Epoch;
-use lb_key_management_system_keys::keys::ZkPublicKey;
+use lb_key_management_system_keys::keys::public_inputs_from_pks;
 
 use super::{SDPDeclareOp, SdpError};
 use crate::{
     events::TxEvent,
     mantle::{
         Note, Value,
+        batch::DeferredZkpVerification,
         channel::Channels,
         gas::{Gas, MainnetGasProfile, OperationGas, SignedOperationExecutionGas},
         ledger::{
             Declarations, ExecutableOperation, PreverifiableOperation, ProvableOperation, Utxos,
-            VerifiableOperation, verification_mode, verification_mode::VerificationMode,
+            VerifiableOperation,
+            verification_mode::{self, VerificationMode},
         },
         ops::{SignedOp, ZkAndEd25519Proof},
         transactions::{hash::TxHashView, states::VerificationState},
@@ -180,21 +182,27 @@ impl VerifiableOperation<verification_mode::StandardMode> for SDPDeclareOp {
     type Context<'a> = SDPDeclareVerificationContext<'a>;
     type Error = SdpError;
 
-    fn verify(&self, proof: &Self::Proof, context: &Self::Context<'_>) -> Result<(), Self::Error> {
+    fn verify(
+        &self,
+        proof: &Self::Proof,
+        context: &Self::Context<'_>,
+    ) -> Result<Option<DeferredZkpVerification>, Self::Error> {
         // Check that the note exist
         let Some((utxo, _)) = context.utxo_tree.utxos().get(&self.locked_note_id) else {
             return Err(SdpError::InexistingNote(self.locked_note_id));
         };
 
-        // Ensure locked note exists and ownership over the locked note and `zk_id`
+        // Defer the ZKP verification, so that the caller can batch it.
+        // Ed25519 verification is done by `preverify`.
+        // Ensure locked note exists and ownership over the locked note and `zk_id`.
         let note = utxo.note;
-        if !ZkPublicKey::verify_multi(
+        let inputs = public_inputs_from_pks(
+            (*context.tx_hash_view.as_fr()).into(),
             &[note.pk, self.zk_id],
-            context.tx_hash_view.as_fr(),
-            &proof.zk_sig,
-        ) {
-            return Err(SdpError::InvalidZkSignature);
-        }
+        )
+        .map_err(|_| SdpError::InvalidZkSignature)?;
+        let deferred_verification =
+            DeferredZkpVerification::ZkSig(*proof.zk_sig.as_proof(), inputs);
 
         SDPDeclareValidationExt::validate(
             self,
@@ -203,7 +211,9 @@ impl VerifiableOperation<verification_mode::StandardMode> for SDPDeclareOp {
             context.declarations,
             context.locked_notes,
             context.min_stake,
-        )
+        )?;
+
+        Ok(Some(deferred_verification))
     }
 }
 
@@ -224,7 +234,11 @@ impl VerifiableOperation<verification_mode::GenesisMode> for SDPDeclareOp {
     type Context<'a> = SDPDeclareGenesisValidationContext<'a>;
     type Error = SdpError;
 
-    fn verify(&self, _proof: &Self::Proof, context: &Self::Context<'_>) -> Result<(), Self::Error> {
+    fn verify(
+        &self,
+        _proof: &Self::Proof,
+        context: &Self::Context<'_>,
+    ) -> Result<Option<DeferredZkpVerification>, Self::Error> {
         // Check that the note exist
         let Some((utxo, _)) = context.utxo_tree.utxos().get(&self.locked_note_id) else {
             return Err(SdpError::InexistingNote(self.locked_note_id));
@@ -238,7 +252,9 @@ impl VerifiableOperation<verification_mode::GenesisMode> for SDPDeclareOp {
             context.declarations,
             context.locked_notes,
             context.min_stake,
-        )
+        )?;
+
+        Ok(None)
     }
 }
 

--- a/core/src/mantle/ops/sdp/declare.rs
+++ b/core/src/mantle/ops/sdp/declare.rs
@@ -201,8 +201,6 @@ impl VerifiableOperation<verification_mode::StandardMode> for SDPDeclareOp {
             &[note.pk, self.zk_id],
         )
         .map_err(|_| SdpError::InvalidZkSignature)?;
-        let deferred_verification =
-            DeferredZkpVerification::ZkSig(*proof.zk_sig.as_proof(), inputs);
 
         SDPDeclareValidationExt::validate(
             self,
@@ -213,7 +211,10 @@ impl VerifiableOperation<verification_mode::StandardMode> for SDPDeclareOp {
             context.min_stake,
         )?;
 
-        Ok(Some(deferred_verification))
+        Ok(Some(DeferredZkpVerification::ZkSig(
+            *proof.zk_sig.as_proof(),
+            inputs,
+        )))
     }
 }
 

--- a/core/src/mantle/ops/sdp/withdraw.rs
+++ b/core/src/mantle/ops/sdp/withdraw.rs
@@ -1,5 +1,5 @@
 use lb_cryptarchia_engine::Epoch;
-use lb_key_management_system_keys::keys::{ZkPublicKey, ZkSignature};
+use lb_key_management_system_keys::keys::{ZkSignature, public_inputs_from_pks};
 use lb_log_targets::mantle;
 use tracing::debug;
 
@@ -8,10 +8,12 @@ use crate::{
     events::TxEvent,
     mantle::{
         Value,
+        batch::DeferredZkpVerification,
         gas::{Gas, MainnetGasProfile, OperationGas, SignedOperationExecutionGas},
         ledger::{
             Declarations, ExecutableOperation, PreverifiableOperation, ProvableOperation,
-            VerifiableOperation, verification_mode, verification_mode::VerificationMode,
+            VerifiableOperation,
+            verification_mode::{self, VerificationMode},
         },
         ops::SignedOp,
         transactions::{hash::TxHashView, states::VerificationState},
@@ -59,7 +61,11 @@ impl VerifiableOperation<verification_mode::StandardMode> for SDPWithdrawOp {
     type Context<'a> = SDPWithdrawValidationContext<'a>;
     type Error = SdpError;
 
-    fn verify(&self, proof: &Self::Proof, context: &Self::Context<'_>) -> Result<(), Self::Error> {
+    fn verify(
+        &self,
+        proof: &Self::Proof,
+        context: &Self::Context<'_>,
+    ) -> Result<Option<DeferredZkpVerification>, Self::Error> {
         // Check that the declaration exists
         let Some(declaration) = context.declarations.get(&self.declaration_id) else {
             return Err(SdpError::DeclarationNotFound(self.declaration_id));
@@ -93,20 +99,6 @@ impl VerifiableOperation<verification_mode::StandardMode> for SDPWithdrawOp {
             });
         }
 
-        // Ensure locked note pk and zk_id attached to this declaration authorized this
-        // Operation.
-        let note = context
-            .locked_notes
-            .get(&self.locked_note_id)
-            .expect("The Operation has been checked above");
-        if !ZkPublicKey::verify_multi(
-            &[note.pk, declaration.zk_id],
-            context.tx_hash_view.as_fr(),
-            proof,
-        ) {
-            return Err(SdpError::InvalidZkSignature);
-        }
-
         // Check that the nonce is greater than the previous one
         if self.nonce <= declaration.nonce {
             return Err(SdpError::InvalidNonce {
@@ -115,7 +107,22 @@ impl VerifiableOperation<verification_mode::StandardMode> for SDPWithdrawOp {
             });
         }
 
-        Ok(())
+        // Defer the proof verification, so that the caller can batch it.
+        // Ensure locked note pk and zk_id attached to this declaration authorized this
+        // Operation.
+        let note = context
+            .locked_notes
+            .get(&self.locked_note_id)
+            .expect("The Operation has been checked above");
+        let inputs = public_inputs_from_pks(
+            (*context.tx_hash_view.as_fr()).into(),
+            &[note.pk, declaration.zk_id],
+        )
+        .map_err(|_| SdpError::InvalidZkSignature)?;
+        Ok(Some(DeferredZkpVerification::ZkSig(
+            *proof.as_proof(),
+            inputs,
+        )))
     }
 }
 

--- a/core/src/mantle/ops/signed_op.rs
+++ b/core/src/mantle/ops/signed_op.rs
@@ -4,6 +4,7 @@ use crate::{
     events::TxEvent,
     mantle::{
         GasProfile,
+        batch::DeferredZkpVerification,
         gas::{Gas, OperationGas},
         ledger::{
             ExecutableOperation, Operation, PreverifiableOperation, ProvableOperation,
@@ -73,10 +74,13 @@ impl<T: VerifiableOperation<Mode>, Mode: VerificationMode> SignedOp<T, Preverifi
     pub fn verify(
         self,
         context: &T::Context<'_>,
-    ) -> Result<SignedOp<T, Verified, Mode>, (Self, T::Error)> {
+    ) -> Result<VerifiedSignedOp<T, Mode>, (Self, T::Error)> {
         let verify_result = self.operation.verify(&self.proof, context);
         match verify_result {
-            Ok(()) => Ok(self.into_state()),
+            Ok(deferred_zkp) => Ok(VerifiedSignedOp {
+                signed_op: self.into_state(),
+                deferred_zkp,
+            }),
             Err(error) => Err((self, error)),
         }
     }
@@ -102,4 +106,10 @@ where
     Mode: VerificationMode,
 {
     const GAS_COST: Gas = T::GAS_COST;
+}
+
+#[expect(dead_code, reason = "TODO: use SignedOp::verify")]
+pub struct VerifiedSignedOp<T: ProvableOperation, Mode: VerificationMode> {
+    signed_op: SignedOp<T, Verified, Mode>,
+    deferred_zkp: Option<DeferredZkpVerification>,
 }

--- a/core/src/mantle/ops/transfer.rs
+++ b/core/src/mantle/ops/transfer.rs
@@ -1,5 +1,5 @@
 use lb_codec::{BinaryCodec, BinaryEncode as _};
-use lb_key_management_system_keys::keys::{ZkPublicKey, ZkSignature};
+use lb_key_management_system_keys::keys::{ZkSignature, public_inputs_from_pks};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -7,12 +7,13 @@ use crate::{
     events::TxEvent,
     mantle::{
         Value,
+        batch::DeferredZkpVerification,
         channel::Channels,
         gas::{Gas, MainnetGasProfile, OperationGas, SignedOperationExecutionGas},
         ledger::{
             self, ExecutableOperation, Inputs, Outputs, PreverifiableOperation, ProvableOperation,
-            Utxo, Utxos, VerifiableOperation, verification_mode,
-            verification_mode::VerificationMode,
+            Utxo, Utxos, VerifiableOperation,
+            verification_mode::{self, VerificationMode},
         },
         ops::{OpId, SignedOp},
         transactions::{hash::TxHashView, states::VerificationState},
@@ -116,7 +117,11 @@ impl VerifiableOperation<verification_mode::StandardMode> for TransferOp {
     type Context<'a> = TransferValidationContext<'a>;
     type Error = TransferError;
 
-    fn verify(&self, proof: &Self::Proof, context: &Self::Context<'_>) -> Result<(), Self::Error> {
+    fn verify(
+        &self,
+        proof: &Self::Proof,
+        context: &Self::Context<'_>,
+    ) -> Result<Option<DeferredZkpVerification>, Self::Error> {
         // Validate Inputs
         self.inputs.validate_not_in_channel(
             context.locked_notes,
@@ -124,13 +129,14 @@ impl VerifiableOperation<verification_mode::StandardMode> for TransferOp {
             context.utxos,
         )?;
 
-        // Check the transfer Proof
+        // Defer the proof verification, so that the caller can batch it.
         let pks = self.inputs.get_pk(context.utxos)?;
-        if !ZkPublicKey::verify_multi(&pks, context.tx_hash_view.as_fr(), proof) {
-            return Err(TransferError::InvalidProof);
-        }
-
-        Ok(())
+        let inputs = public_inputs_from_pks((*context.tx_hash_view.as_fr()).into(), &pks)
+            .map_err(|_| TransferError::InvalidProof)?;
+        Ok(Some(DeferredZkpVerification::ZkSig(
+            *proof.as_proof(),
+            inputs,
+        )))
     }
 }
 
@@ -161,6 +167,7 @@ impl<State: VerificationState, Mode: VerificationMode> SignedOperationExecutionG
 #[cfg(test)]
 mod test {
     use lb_groth16::CompressedGroth16Proof;
+    use lb_key_management_system_keys::keys::ZkPublicKey;
     use lb_poseidon2::Fr;
     use num_bigint::BigUint;
 

--- a/core/src/mantle/transactions/signed_mantle_tx.rs
+++ b/core/src/mantle/transactions/signed_mantle_tx.rs
@@ -6,6 +6,7 @@ use crate::{
     crypto::{Digest as _, Hasher},
     mantle::{
         RawMantleTx, Value, VerificationError,
+        batch::DeferredZkpVerification,
         gas::{Gas, GasCost, GasOverflow, GasProfile, TxGasCalculator},
         ledger::{PreverifiableOperation, VerifiableOperation, verification_mode::StandardMode},
         ops::{
@@ -235,7 +236,7 @@ impl SignedMantleTx<Preverified> {
         proof: &OpProof,
         tx_hash_view: &TxHashView,
         helper: &impl OperationVerificationHelper,
-    ) -> Result<(), VerificationError> {
+    ) -> Result<Option<DeferredZkpVerification>, VerificationError> {
         match (op, proof) {
             (Op::ChannelInscribe(op), OpProof::Ed25519Sig(proof)) => {
                 let channel_inscribe_context = InscriptionValidationContext {

--- a/core/src/mantle/transactions/states.rs
+++ b/core/src/mantle/transactions/states.rs
@@ -6,7 +6,7 @@ pub trait VerificationState {}
 pub struct Unverified;
 impl VerificationState for Unverified {}
 
-/// Partially verified state of a Transaction/Operation
+/// Stateless-verified state of a Transaction/Operation
 ///
 /// This state indicates that the transaction has passed stateless checks. That
 /// is, checks that do not require access to the blockchain state, such as
@@ -15,7 +15,13 @@ impl VerificationState for Unverified {}
 pub struct Preverified;
 impl VerificationState for Preverified {}
 
-/// Fully verified state of a Transaction/Operation
+/// Stateful-verified state of a Transaction/Operation
+///
+/// This state indicates that the transaction has passed stateful checks, which
+/// require access to the blockchain state.
+/// ZK proof verifications are not included in this state, because they are
+/// deferred to the batch verification stage, which is performed after all
+/// transactions have been statefully verified.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Verified;
 impl VerificationState for Verified {}

--- a/core/src/mantle/transactions/verified_ops.rs
+++ b/core/src/mantle/transactions/verified_ops.rs
@@ -1,5 +1,6 @@
 use crate::mantle::{
     Op, OpProof, SignedMantleTx, VerificationError,
+    batch::DeferredZkpVerification,
     traits::Hashable as _,
     transactions::{
         OperationVerificationHelper, hash::TxHashView, mantle_tx::MantleTx as _,
@@ -46,24 +47,26 @@ impl<'tx> VerifiedOps<'tx> {
     pub fn next(
         &mut self,
         helper: &impl OperationVerificationHelper,
-    ) -> Option<Result<&'tx Op, VerificationError>> {
+    ) -> Option<Result<(&'tx Op, Option<DeferredZkpVerification>), VerificationError>> {
         let index = self.index;
         let op = self.ops.get(index)?;
         let proof = self
             .proofs
             .get(index)
             .expect("SignedMantleTx<Preverified> invariant: ops and proofs have the same length");
-        if let Err(error) = SignedMantleTx::<Preverified>::verify_stateful_op(
+        match SignedMantleTx::<Preverified>::verify_stateful_op(
             index,
             op,
             proof,
             &self.tx_hash_view,
             helper,
         ) {
-            return Some(Err(error));
+            Ok(deferred_zkp) => {
+                self.index += 1;
+                Some(Ok((op, deferred_zkp)))
+            }
+            Err(e) => Some(Err(e)),
         }
-        self.index += 1;
-        Some(Ok(op))
     }
 
     #[must_use]
@@ -151,10 +154,8 @@ mod tests {
 
         let verification_result = signed_tx.verified_ops().next(&helper).unwrap();
         assert_eq!(
-            verification_result,
-            Err(VerificationError::ChannelVerificationError(
-                Error::InvalidSignature
-            ))
+            verification_result.err().unwrap(),
+            VerificationError::ChannelVerificationError(Error::InvalidSignature)
         );
     }
 }

--- a/kms/keys/src/keys/mod.rs
+++ b/kms/keys/src/keys/mod.rs
@@ -16,7 +16,7 @@ pub use crate::keys::{
     },
     zk::{
         MAX_ZK_SIGNING_KEYS, PublicKey as ZkPublicKey, PublicKeys as ZkPublicKeys,
-        Signature as ZkSignature, UnsecuredZkKey, ZkKey,
+        Signature as ZkSignature, UnsecuredZkKey, ZkKey, public_inputs_from_pks,
     },
 };
 

--- a/kms/keys/src/keys/zk/mod.rs
+++ b/kms/keys/src/keys/zk/mod.rs
@@ -13,7 +13,9 @@ use crate::keys::{errors::KeyError, secured_key::SecuredKey};
 mod private;
 pub use self::private::SecretKey as UnsecuredZkKey;
 mod public;
-pub use self::public::{MAX_ZK_SIGNING_KEYS, PublicKey, PublicKeys};
+pub use self::public::{
+    MAX_ZK_SIGNING_KEYS, PublicKey, PublicKeys, inputs_from_pks as public_inputs_from_pks,
+};
 mod signature;
 pub use self::signature::Signature;
 

--- a/kms/keys/src/keys/zk/public.rs
+++ b/kms/keys/src/keys/zk/public.rs
@@ -41,7 +41,7 @@ impl PublicKey {
 
     #[must_use]
     pub fn verify_multi(pks: &[Self], data: &Fr, signature: &Signature) -> bool {
-        let inputs = match try_from_pks((*data).into(), pks) {
+        let inputs = match inputs_from_pks((*data).into(), pks) {
             Ok(inputs) => inputs,
             Err(e) => {
                 error!(target: LOG_TARGET, "Error building verifier inputs: {e:?}");
@@ -74,7 +74,10 @@ impl From<Fr> for PublicKey {
     }
 }
 
-fn try_from_pks(msg: Groth16Input, pks: &[PublicKey]) -> Result<ZkSignVerifierInputs, ZkSignError> {
+pub fn inputs_from_pks(
+    msg: Groth16Input,
+    pks: &[PublicKey],
+) -> Result<ZkSignVerifierInputs, ZkSignError> {
     if pks.len() > MAX_ZK_SIGNING_KEYS {
         return Err(ZkSignError::TooManyKeys(pks.len()));
     }

--- a/ledger/src/cryptarchia/mod.rs
+++ b/ledger/src/cryptarchia/mod.rs
@@ -992,15 +992,19 @@ pub mod tests {
             )?;
         let id = make_id(parent, slot, utxo);
         let proof = generate_proof(&ledger_state, &utxo, slot);
-        let (_, state, _) = ledger.prepare_update::<_, _, MainnetGasProfile>(
-            id,
-            parent,
-            slot,
-            &proof,
-            &UncleSlots::default(),
-            std::iter::empty::<&SignedMantleTx<Preverified>>(),
-        )?;
-        ledger.commit_update(id, state);
+        let update = ledger
+            .prepare_update::<_, _, MainnetGasProfile>(
+                id,
+                parent,
+                slot,
+                &proof,
+                &UncleSlots::default(),
+                std::iter::empty::<&SignedMantleTx<Preverified>>(),
+            )?
+            .verify_batch_proofs()
+            .map_err(|_| LedgerError::InvalidProof)?;
+
+        ledger.commit_update(update);
         Ok(id)
     }
 

--- a/ledger/src/cryptarchia/test/tsi_simulation.rs
+++ b/ledger/src/cryptarchia/test/tsi_simulation.rs
@@ -378,7 +378,7 @@ fn apply_block_to_ledger(
         .expect("epoch state update");
     let id = block_id(parent, slot);
     let proof = generate_proof(&parent_state, &utxo, slot);
-    let (_, state, _) = ledger
+    let update = ledger
         .prepare_update::<_, _, MainnetGasProfile>(
             id,
             parent,
@@ -387,7 +387,9 @@ fn apply_block_to_ledger(
             uncle_slots,
             std::iter::empty::<&SignedMantleTx<Preverified>>(),
         )
-        .expect("ledger update");
-    ledger.commit_update(id, state);
+        .expect("ledger update")
+        .verify_batch_proofs()
+        .expect("batch proof verification");
+    ledger.commit_update(update);
     id
 }

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -5,6 +5,7 @@ pub mod config;
 // - `mantle_ops`: our extensions in the form of Mantle operations, e.g. SDP.
 pub mod cryptarchia;
 pub mod mantle;
+mod update;
 
 use std::hash::Hash;
 
@@ -17,6 +18,7 @@ use lb_core::{
     events::{Events, HeaderEvent, TxEvent, TxEventPayload},
     mantle::{
         NoteId, Op, Utxo, Value, VerificationError,
+        batch::DeferredZkpVerifications,
         gas::{Gas, GasCost, GasOverflow, GasProfile},
         ledger::ExecutableOperation as _,
         ops::{
@@ -38,7 +40,10 @@ use mantle::LedgerState as MantleLedger;
 use rpds::HashTrieMapSync;
 use thiserror::Error;
 
-use crate::mantle::helpers::MantleOperationVerificationHelper;
+use crate::{
+    mantle::helpers::MantleOperationVerificationHelper,
+    update::{BatchVerifiedUpdate, PreparedUpdate},
+};
 
 const WINDOW_SIZE: usize = 120;
 
@@ -160,7 +165,7 @@ where
         proof: &LeaderProof,
         uncle_slots: &UncleSlots,
         txs: impl Iterator<Item = &'tx Tx>,
-    ) -> Result<(Id, LedgerState, Events), LedgerError<Id>>
+    ) -> Result<PreparedUpdate<Id>, LedgerError<Id>>
     where
         Tx: PreverifiedMantleTx<Context = GasPrices> + 'tx,
         LeaderProof: leader_proof::LeaderProof,
@@ -172,21 +177,17 @@ where
             .get(&parent_id)
             .ok_or(LedgerError::ParentNotFound(parent_id))?;
 
-        let (new_state, events) = parent_state.clone().try_update::<_, _, _, Profile>(
-            id,
-            slot,
-            proof,
-            uncle_slots,
-            txs,
-            &self.config,
-        )?;
+        let (new_state, events, deferred_zkps) = parent_state
+            .clone()
+            .try_update::<_, _, _, Profile>(id, slot, proof, uncle_slots, txs, &self.config)?;
 
-        Ok((id, new_state, events))
+        Ok(PreparedUpdate::new(id, new_state, events, deferred_zkps))
     }
 
     /// Commits a new [`LedgerState`] created by [`Self::prepare_update`].
-    pub fn commit_update(&mut self, id: Id, state: LedgerState) {
-        self.states.insert_mut(id, state);
+    pub fn commit_update(&mut self, update: BatchVerifiedUpdate<Id>) -> Events {
+        self.states.insert_mut(update.id, update.state);
+        update.events
     }
 
     pub fn state(&self, id: &Id) -> Option<&LedgerState> {
@@ -235,7 +236,7 @@ impl LedgerState {
         uncle_slots: &UncleSlots,
         txs: impl Iterator<Item = &'tx Tx>,
         config: &Config,
-    ) -> Result<(Self, Events), LedgerError<Id>>
+    ) -> Result<(Self, Events, DeferredZkpVerifications), LedgerError<Id>>
     where
         Tx: PreverifiedMantleTx<Context = GasPrices> + 'tx,
         LeaderProof: leader_proof::LeaderProof,
@@ -253,7 +254,7 @@ impl LedgerState {
         // block that is actually applied, contents included, belongs in the
         // epoch's average.
         let mut txs_in_block = 0u64;
-        let (mut state, tx_events) = state.try_apply_contents::<_, _, Profile>(
+        let (mut state, tx_events, deferred_zkp) = state.try_apply_contents::<_, _, Profile>(
             config,
             txs.inspect(|_| txs_in_block = txs_in_block.saturating_add(1)),
         )?;
@@ -272,7 +273,7 @@ impl LedgerState {
             .map(Into::into)
             .chain(tx_events.into_iter().map(Into::into))
             .collect::<Events>();
-        Ok((state, events))
+        Ok((state, events, deferred_zkp))
     }
 
     /// Apply header-related changed to the ledger state. These include
@@ -451,7 +452,7 @@ impl LedgerState {
         mut self,
         config: &Config,
         txs: impl Iterator<Item = &'tx Tx>,
-    ) -> Result<(Self, Vec<TxEvent>), LedgerError<Id>>
+    ) -> Result<(Self, Vec<TxEvent>, DeferredZkpVerifications), LedgerError<Id>>
     where
         Tx: PreverifiedMantleTx<Context = GasPrices> + 'tx,
     {
@@ -460,12 +461,15 @@ impl LedgerState {
         let mut total_fee_burned: GasCost = 0.into();
         let mut total_fee_tip: GasCost = 0.into();
         let mut tx_events = Vec::new();
+        let mut deferred_zkps = DeferredZkpVerifications::new();
 
         for tx in txs {
             let balance;
             let events;
-            (self, balance, events) = self.try_apply_tx::<_, _, Profile>(config, tx)?;
+            let deferred;
+            (self, balance, events, deferred) = self.try_apply_tx::<_, _, Profile>(config, tx)?;
             tx_events.extend(events);
+            deferred_zkps.extend(deferred);
 
             let gas_prices = GasPrices {
                 execution_base_gas_price: *self.cryptarchia_ledger.execution_base_fee(),
@@ -517,7 +521,7 @@ impl LedgerState {
         // Accumulate storage gas consumed so the storage market can update the
         // price at the next epoch rotation.
         self = self.add_storage_gas_consumed(total_block_storage_gas)?;
-        Ok((self, tx_events))
+        Ok((self, tx_events, deferred_zkps))
     }
 
     pub fn from_utxos(utxos: impl IntoIterator<Item = Utxo>, config: &Config) -> Self {
@@ -783,7 +787,7 @@ impl LedgerState {
         mut self,
         config: &Config,
         tx: &'tx Tx,
-    ) -> Result<(Self, Balance, Vec<TxEvent>), LedgerError<Id>>
+    ) -> Result<(Self, Balance, Vec<TxEvent>, DeferredZkpVerifications), LedgerError<Id>>
     where
         Tx: PreverifiedMantleTx + 'tx + MantleTxWithProofs<Context = GasPrices>,
     {
@@ -791,6 +795,7 @@ impl LedgerState {
 
         let mut balance: Balance = 0;
         let mut tx_events = Vec::new();
+        let mut deferred_zkps = DeferredZkpVerifications::new();
 
         loop {
             let helper = MantleOperationVerificationHelper::new(
@@ -798,9 +803,12 @@ impl LedgerState {
                 &self.cryptarchia_ledger,
                 config,
             );
-            let Some(op) = verified_ops.next(&helper).transpose()? else {
+            let Some((op, deferred_zkp)) = verified_ops.next(&helper).transpose()? else {
                 break;
             };
+            if let Some(deferred) = deferred_zkp {
+                deferred_zkps.push(deferred);
+            }
             (self, balance, tx_events) = self.try_apply_op::<_, Profile>(
                 op,
                 config,
@@ -810,7 +818,7 @@ impl LedgerState {
             )?;
         }
 
-        Ok((self, balance, tx_events))
+        Ok((self, balance, tx_events, deferred_zkps))
     }
 
     fn update_pow_reward_difficulty(&mut self, claims_in_block: u64) {
@@ -1087,7 +1095,7 @@ mod tests {
         );
 
         let new_id = [1; 32];
-        let (_, state, events) = ledger
+        let update = ledger
             .prepare_update::<_, _, MainnetGasProfile>(
                 new_id,
                 genesis_id,
@@ -1096,9 +1104,11 @@ mod tests {
                 &UncleSlots::default(),
                 std::iter::once(&tx),
             )
+            .unwrap()
+            .verify_batch_proofs()
             .unwrap();
+        let events = ledger.commit_update(update);
         assert!(events.is_empty());
-        ledger.commit_update(new_id, state);
 
         // Verify the transaction was applied
         let new_state = ledger.state(&new_id).unwrap();
@@ -1131,7 +1141,9 @@ mod tests {
         let result = state.try_apply_tx::<_, HeaderId, MainnetGasProfile>(&test_config, &tx);
         assert!(result.is_ok());
 
-        let (new_state, _, events) = result.unwrap();
+        let (new_state, _, events, deferred_zkps) = result.unwrap();
+        deferred_zkps.verify().unwrap();
+
         assert!(
             new_state
                 .mantle_ledger
@@ -1176,7 +1188,9 @@ mod tests {
         let result = state.try_apply_tx::<_, HeaderId, MainnetGasProfile>(&test_config, &tx);
         assert!(result.is_ok());
 
-        let (new_state, _, events) = result.unwrap();
+        let (new_state, _, events, deferred_zkps) = result.unwrap();
+        deferred_zkps.verify().unwrap();
+
         assert!(
             new_state
                 .mantle_ledger
@@ -1230,7 +1244,9 @@ mod tests {
         let ops = vec![Op::ChannelDeposit(deposit.clone())];
         let tx = create_multi_signed_tx(ops, vec![&Key::Zk(sk)]);
         let result = ledger_state.try_apply_tx::<_, HeaderId, MainnetGasProfile>(&test_config, &tx);
-        let (new_state, balance, events) = result.unwrap();
+        let (new_state, balance, events, deferred_zkps) = result.unwrap();
+        deferred_zkps.verify().unwrap();
+
         // The deposited note is consumed and re-created as a channel note under
         // a new NoteId.
         let deposited = Utxo::new(deposit.op_id(), 0, utxo.note).id();
@@ -1351,7 +1367,9 @@ mod tests {
             ledger_state.try_apply_tx::<_, HeaderId, MainnetGasProfile>(&test_config, &signed_tx);
         assert!(result.is_ok());
 
-        let (new_state, tx_balance, events) = result.unwrap();
+        let (new_state, tx_balance, events, deferred_zkps) = result.unwrap();
+        deferred_zkps.verify().unwrap();
+
         assert_eq!(tx_balance, 0);
         // The note is released from the channel and remains spendable in the ledger.
         assert!(
@@ -1489,7 +1507,8 @@ mod tests {
         let err = ledger_state
             .clone()
             .try_apply_tx::<_, HeaderId, MainnetGasProfile>(&test_config, &signed_tx)
-            .unwrap_err();
+            .err()
+            .unwrap();
         assert_eq!(
             err,
             LedgerError::VerificationError(VerificationError::ChannelVerificationError(
@@ -1863,7 +1882,8 @@ mod tests {
 
         let err = ledger
             .try_apply_contents::<_, HeaderId, MainnetGasProfile>(&config, std::iter::once(&tx))
-            .unwrap_err();
+            .err()
+            .unwrap();
         // The transaction should be rejected because the price indicated for execution
         // doesn't cover the base fee that cost 27 050
         assert_eq!(err, LedgerError::InsufficientBalance);
@@ -1902,7 +1922,7 @@ mod tests {
             .try_apply_contents::<_, HeaderId, MainnetGasProfile>(&config, std::iter::once(&tx));
         // The `unwrap` should succeed because the user pays at least the base fee of
         // 794
-        let (no_priority_fee_ledger, events) = result.unwrap();
+        let (no_priority_fee_ledger, events, _) = result.unwrap();
         assert!(events.is_empty());
 
         // The tx ays 1794 fees = 590 execution base fee + 1000 execution tip + 204
@@ -1920,7 +1940,7 @@ mod tests {
             .try_apply_contents::<_, HeaderId, MainnetGasProfile>(&config, std::iter::once(&tx));
         // The `unwrap` should succeed because the user pays at least the base fee of
         // 794
-        let (priority_fee_ledger, events) = result.unwrap();
+        let (priority_fee_ledger, events, _) = result.unwrap();
 
         assert_eq!(
             no_priority_fee_ledger
@@ -1958,7 +1978,7 @@ mod tests {
             .unwrap();
         assert!(storage_gas.into_inner() > 0);
 
-        let (applied, _) = ledger
+        let (applied, _, _) = ledger
             .try_apply_contents::<_, HeaderId, MainnetGasProfile>(&config, std::iter::once(&tx))
             .unwrap();
 
@@ -2063,7 +2083,8 @@ mod tests {
                     tx_hash_view: &tx_hash_view,
                 },
             )
-            .unwrap_err();
+            .err()
+            .unwrap();
         assert_eq!(err, LeaderClaimError::DuplicatedVoucherNullifier);
     }
 
@@ -2217,7 +2238,8 @@ mod tests {
 
             let err = state
                 .try_apply_tx::<_, HeaderId, MainnetGasProfile>(&config, &claim_tx())
-                .expect_err("claim should fail validation");
+                .err()
+                .expect("claim should fail validation");
 
             assert!(matches!(
                 err,
@@ -2236,7 +2258,8 @@ mod tests {
 
             let err = state
                 .try_apply_tx::<_, HeaderId, MainnetGasProfile>(&config, &claim_tx())
-                .expect_err("claim should fail validation");
+                .err()
+                .expect("claim should fail validation");
 
             assert!(matches!(
                 err,
@@ -2271,9 +2294,10 @@ mod tests {
             let pool_before = state.mantle_ledger.pow.reward_pool();
             let epoch_reward = state.mantle_ledger.pow.epoch_reward();
 
-            let (state, _balance, events) = state
+            let (state, _balance, events, deferred_zkps) = state
                 .try_apply_tx::<_, HeaderId, MainnetGasProfile>(&config, &claim_tx())
                 .expect("claim should validate and execute");
+            deferred_zkps.verify().unwrap();
 
             assert_eq!(
                 state.mantle_ledger.pow.reward_pool(),
@@ -2310,13 +2334,15 @@ mod tests {
             // Replaying the same solution is caught by the nullifier check
             // during tx-level validation.
             let (state, config) = claim_accepting_state();
-            let (state, _, _) = state
+            let (state, _, _, deferred_zkps) = state
                 .try_apply_tx::<_, HeaderId, MainnetGasProfile>(&config, &claim_tx())
                 .expect("first claim should succeed");
+            deferred_zkps.verify().unwrap();
 
             let err = state
                 .try_apply_tx::<_, HeaderId, MainnetGasProfile>(&config, &claim_tx())
-                .expect_err("second claim should be rejected");
+                .err()
+                .expect("second claim should be rejected");
 
             assert!(matches!(
                 err,

--- a/ledger/src/update.rs
+++ b/ledger/src/update.rs
@@ -43,3 +43,78 @@ pub struct BatchVerifiedUpdate<Id> {
     pub state: LedgerState,
     pub events: Events,
 }
+
+#[cfg(test)]
+mod tests {
+    use lb_core::{
+        events::{Event, HeaderEvent},
+        mantle::batch::DeferredZkpVerification,
+        sdp::{DeclarationId, ServiceType},
+    };
+    use lb_groth16::Fr;
+    use lb_key_management_system_keys::keys::{ZkKey, public_inputs_from_pks};
+    use num_bigint::BigUint;
+
+    use super::*;
+    use crate::cryptarchia::tests::{config, utxo};
+
+    const ID: [u8; 32] = [1; 32];
+
+    #[test]
+    fn verify_batch_proofs_carries_the_update_through() {
+        let state = LedgerState::from_utxos([utxo()], &config());
+        let utxos_root = state.latest_utxos().root();
+        let update = PreparedUpdate::new(
+            ID,
+            state,
+            Events::from(header_event()),
+            std::iter::once(valid_zk_sig()).collect(),
+        );
+
+        let update = update.verify_batch_proofs().expect("must succeed");
+        assert_eq!(update.id, ID);
+        assert_eq!(update.state.latest_utxos().root(), utxos_root);
+        assert_eq!(update.events.len(), 1);
+    }
+
+    #[test]
+    fn verify_batch_proofs_rejects_invalid_deferred_zkp() {
+        let update = PreparedUpdate::new(
+            ID,
+            LedgerState::from_utxos([utxo()], &config()),
+            Events::new(),
+            std::iter::once(invalid_zk_sig()).collect(),
+        );
+        assert!(matches!(
+            update.verify_batch_proofs(),
+            Err(batch::Error::InvalidZkSignatures)
+        ));
+    }
+
+    fn header_event() -> Event {
+        HeaderEvent::SdpNoteUnlocked {
+            note_id: utxo().id(),
+            service_type: ServiceType::BlendNetwork,
+            declaration_id: DeclarationId([2; 32]),
+        }
+        .into()
+    }
+
+    fn valid_zk_sig() -> DeferredZkpVerification {
+        zk_sig(1, 1)
+    }
+
+    fn invalid_zk_sig() -> DeferredZkpVerification {
+        zk_sig(1, 2)
+    }
+
+    /// If `msg == msg_for_input`, a valid sig is produced.
+    /// Otherwise, an invalid sig is produced.
+    fn zk_sig(msg: u64, msg_for_input: u64) -> DeferredZkpVerification {
+        let key = ZkKey::from(BigUint::from(1u8));
+        let signature = ZkKey::multi_sign(std::slice::from_ref(&key), &Fr::from(msg)).unwrap();
+        let inputs =
+            public_inputs_from_pks(Fr::from(msg_for_input).into(), &[key.to_public_key()]).unwrap();
+        DeferredZkpVerification::ZkSig(*signature.as_proof(), inputs)
+    }
+}

--- a/ledger/src/update.rs
+++ b/ledger/src/update.rs
@@ -1,0 +1,45 @@
+use lb_core::{
+    events::Events,
+    mantle::batch::{self, DeferredZkpVerifications},
+};
+
+use crate::LedgerState;
+
+pub struct PreparedUpdate<Id> {
+    id: Id,
+    state: LedgerState,
+    events: Events,
+    deferred_zkps: DeferredZkpVerifications,
+}
+
+impl<Id> PreparedUpdate<Id> {
+    #[must_use]
+    pub const fn new(
+        id: Id,
+        state: LedgerState,
+        events: Events,
+        deferred_zkps: DeferredZkpVerifications,
+    ) -> Self {
+        Self {
+            id,
+            state,
+            events,
+            deferred_zkps,
+        }
+    }
+
+    pub fn verify_batch_proofs(self) -> Result<BatchVerifiedUpdate<Id>, batch::Error> {
+        self.deferred_zkps.verify()?;
+        Ok(BatchVerifiedUpdate {
+            id: self.id,
+            state: self.state,
+            events: self.events,
+        })
+    }
+}
+
+pub struct BatchVerifiedUpdate<Id> {
+    pub id: Id,
+    pub state: LedgerState,
+    pub events: Events,
+}

--- a/services/chain/chain-leader/src/lib.rs
+++ b/services/chain/chain-leader/src/lib.rs
@@ -649,11 +649,21 @@ where
                         ledger_config,
                         iter::once(&tx),
                     ) {
-                    Ok((new_state, _events)) => {
-                        ledger_state = new_state;
-                        valid_txs.push(tx);
-                        applied_any = true;
-                    }
+                    Ok((new_state, _events, deferred_zkps)) => match deferred_zkps.verify() {
+                        Ok(()) => {
+                            ledger_state = new_state;
+                            valid_txs.push(tx);
+                            applied_any = true;
+                        }
+                        Err(err) => {
+                            tracing::trace!(
+                                tx = ?tx.hash(),
+                                %err,
+                                "deferred ZKP verification failed during block assembly",
+                            );
+                            still_pending.push(tx);
+                        }
+                    },
                     Err(err) => {
                         tracing::trace!(
                             "tx {:?} not (yet) applicable during block assembly: {:?}",

--- a/services/chain/chain-service/src/lib.rs
+++ b/services/chain/chain-service/src/lib.rs
@@ -119,6 +119,8 @@ pub enum Error {
     AwaitingGenesisTime,
     #[error("Invalid uncle {uncle}: {reason}")]
     InvalidUncle { uncle: HeaderId, reason: UncleError },
+    #[error("Batch ZKP verification error: {0}")]
+    BatchZkpVerification(#[from] lb_core::mantle::batch::Error),
 }
 
 struct InitializedCryptarchia {
@@ -396,8 +398,10 @@ impl Cryptarchia {
         // A block is valid only if every uncle it carries is valid.
         self.verify_uncles(block)?;
 
-        // A block number of this block if it's applied to the chain.
-        let (_, state, events) = self
+        // Apply the block to the ledger, and batch-verify ZK proofs.
+        // This ledger update is not finalized yet, and will be committed only after
+        // checking if the block is accepted by the consensus engine.
+        let update = self
             .ledger
             .prepare_update::<_, _, MainnetGasProfile>(
                 id,
@@ -413,7 +417,8 @@ impl Cryptarchia {
                     info: Box::new(self.info()),
                 },
                 err => Error::Ledger(err),
-            })?;
+            })?
+            .verify_batch_proofs()?;
 
         let (pruned_blocks, reorged_blocks) = self
             .consensus
@@ -426,7 +431,7 @@ impl Cryptarchia {
                 err => Error::Consensus(err),
             })?;
 
-        self.ledger.commit_update(id, state);
+        let events = self.ledger.commit_update(update);
 
         // Prune the ledger states of all the pruned blocks.
         self.prune_ledger_states(pruned_blocks.all());

--- a/services/chain/chain-service/src/tests/mod.rs
+++ b/services/chain/chain-service/src/tests/mod.rs
@@ -9,9 +9,18 @@ use futures::StreamExt as _;
 use lb_core::{
     block::{Block, BlockTransactions, UncleHeaders},
     mantle::{
-        Note, SignedMantleTx, Utxo,
-        ops::leader_claim::{VoucherCm, VoucherSecret},
-        transactions::states::Preverified,
+        Note, Op, OpProof, RawMantleTx, SignedMantleTx, TxGasCalculator as _, Utxo,
+        gas::MainnetGasProfile,
+        ledger::{Inputs, Outputs},
+        ops::{
+            leader_claim::{VoucherCm, VoucherSecret},
+            transfer::TransferOp,
+        },
+        traits::Hashable as _,
+        transactions::{
+            GasPrices,
+            states::{Preverified, Unverified},
+        },
     },
     proofs::leader_proof::{Groth16LeaderProof, LeaderPrivate, LeaderPublic, check_winning},
     sdp::ServiceParameters,
@@ -336,6 +345,67 @@ async fn process_block_does_not_mutate_state_when_storage_send_fails() {
     assert!(lib_rx.try_recv().is_err());
 }
 
+#[test]
+fn ledger_is_not_commited_if_block_contains_invalid_zkp() {
+    let config = ledger_config(NonZero::<u32>::new(1).unwrap());
+    let (zk_key, utxo) = utxo();
+    let genesis_id: HeaderId = [0; 32].into();
+    let mut cryptarchia = Cryptarchia::from_lib(
+        genesis_id,
+        LedgerState::from_utxos([utxo], &config),
+        genesis_id,
+        config,
+        lb_cryptarchia_engine::State::Bootstrapping,
+        Slot::new(0),
+        0,
+        UncleSlots::default(),
+    );
+
+    let fake_key = ZkKey::from(Fr::from(42u64));
+    assert_ne!(fake_key.to_public_key(), utxo.note.pk);
+    let (block, _) = try_build_block_with_transactions(
+        &cryptarchia,
+        genesis_id,
+        utxo,
+        &zk_key,
+        Slot::new(1),
+        UncleHeaders::empty(),
+        BlockTransactions::from([transfer_tx_with_fake_sig(utxo, &fake_key)]),
+    )
+    .expect("should find a winning slot");
+
+    let result = cryptarchia.try_apply_block(&block, block.header().slot());
+    assert!(matches!(result, Err(Error::BatchZkpVerification(_))));
+    assert!(
+        cryptarchia.ledger.state(&block.header().id()).is_none(),
+        "ledger state should not be committed"
+    );
+    assert_eq!(cryptarchia.tip(), genesis_id, "tip should not advance");
+}
+
+/// Creates a transfer tx with an fake sig.
+fn transfer_tx_with_fake_sig(utxo: Utxo, fake_key: &ZkKey) -> SignedMantleTx<Preverified> {
+    let mut output_note = Note::new(1, fake_key.to_public_key());
+    let fees = transfer_tx(utxo, output_note, fake_key)
+        .total_gas_cost::<MainnetGasProfile>(&GasPrices::default())
+        .unwrap();
+    output_note.value = utxo.note.value - fees.into_inner();
+
+    transfer_tx(utxo, output_note, fake_key)
+        .preverify()
+        .expect("a fake signature is only caught by the stateful checks")
+}
+
+fn transfer_tx(utxo: Utxo, output_note: Note, key: &ZkKey) -> SignedMantleTx<Unverified> {
+    let transfer_op = TransferOp::new(Inputs::new([utxo.id()]), Outputs::new([output_note]));
+    let mantle_tx = RawMantleTx([Op::Transfer(transfer_op)].into());
+    let ops_proofs = [OpProof::ZkSig(
+        ZkKey::multi_sign(std::slice::from_ref(key), &mantle_tx.hash().to_fr()).unwrap(),
+    )]
+    .into();
+    SignedMantleTx::new(mantle_tx, ops_proofs)
+}
+
 fn test_chain_with_next_block() -> (Cryptarchia, Block<SignedMantleTx<Preverified>>) {
     let k = 3.try_into().unwrap();
     let config = ledger_config(k);
@@ -420,7 +490,7 @@ pub fn ledger_config(security_param: NonZero<u32>) -> lb_ledger::Config {
     }
 }
 
-/// Builds a block by grinding through slots
+/// Builds a block with no trasaction by grinding through slots
 pub fn try_build_block(
     cryptarchia: &Cryptarchia,
     parent: HeaderId,
@@ -428,6 +498,27 @@ pub fn try_build_block(
     key: &ZkKey,
     start_slot: Slot,
     uncle_headers: UncleHeaders,
+) -> Option<(Block<SignedMantleTx<Preverified>>, Ed25519Key)> {
+    try_build_block_with_transactions(
+        cryptarchia,
+        parent,
+        utxo,
+        key,
+        start_slot,
+        uncle_headers,
+        BlockTransactions::empty(),
+    )
+}
+
+/// Builds a block carrying `transactions` by grinding through slots
+pub fn try_build_block_with_transactions(
+    cryptarchia: &Cryptarchia,
+    parent: HeaderId,
+    utxo: Utxo,
+    key: &ZkKey,
+    start_slot: Slot,
+    uncle_headers: UncleHeaders,
+    transactions: BlockTransactions<SignedMantleTx<Preverified>>,
 ) -> Option<(Block<SignedMantleTx<Preverified>>, Ed25519Key)> {
     let start_slot: u64 = start_slot.into();
     for slot in start_slot..=(start_slot + 1000) {
@@ -466,7 +557,7 @@ pub fn try_build_block(
             slot.into(),
             uncle_headers,
             proof,
-            BlockTransactions::empty(),
+            transactions,
             &signing_key,
         )
         .unwrap();


### PR DESCRIPTION
## 1. What does this PR implement?

Finally, we are integrating the Groth16 batch verification to the Mantle and the chain service.

This PR is not as large as it looks. I thought, it's better to open this as a single PR to keep the context cleanly. I will guide you how to review this.

Before starting, I'd like to mention that this PR is only for the "intra-block batching". It doesn't cover "inter-block batching" because that is much more complex, and I'm not sure if it's worth it right now.

Previously, we were verifying Groth16 proofs in the stateful verification step. 
```python
update = ledger.prepare_update(block):
    verify(tx1)       # proofs are verified here
    execute(tx1)
    verify(tx2)       # proofs are verified here
    execute(tx2)

engine.receive_block(block)

ledger.commit_update(update)
```

Now, we defer Groth16 proof verifications, and batch them at the end. 
```python
deferred = ledger.prepare_update(block):
    deferred1 = verify(tx1)       # proofs are "deferred"
    execute(tx1)
    deferred2 = verify(tx2)       # proofs are "deferred"
    execute(tx2)
    return [deferred1, deferred2]

update = batch_verify(deferred)   # this step has been added

engine.receive_block(block)

ledger.commit_update(update)      # this can be done only after `batch_verify`
```

This pseudocode is the key change. In the `prepare_update`, we gather deferred ZKP verifications. And then, we batch them. The `commit_update` cannot be called without the `update` which is produced only by `batch_verify`.
This pseudocode is implemented in `services/chain/chain-service/src/lib.rs`. I recommend to review this file first.

Two new modules are introduced to handle deferred verifications nicely:
- `core/src/mantle/batch.rs`
- `ledger/src/update.rs`

Other changes are just updating each `Op`'s stateful-verify function to just return a deferred proof, instead of verifying the proof.

NOTE: (especially for @strinnityk)
I didn't touch anything about the Tx/Op refactoring that you've been working on. Precisely, I didn't need to touch it because the batch verification is done in the block level, not in the tx level, as I described in the pseudocode above. 
But, what I want to highlight is that the `Verified` state doesn't mean that a tx has been "fully" verified anymore, because now the proof verification is deferred. I thought about renaming it (e.g. `StatefulVerified`, or so), but realized that it is not used anywhere yet. Currently, it seems that the codebase uses only `Preverified` state.
So, instead of touching anything about those "states", I just modified the doc comment of `Verified` to explain that the proof verifications are deferred. 

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@youngjoon-lee 
spec: @thomaslavaur 

## 4. Is the specification accurate and complete?

Yes

## 5. Does the implementation introduce changes in the specification?

No

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
