### PR TITLE
chore: update toolchain to Rust 1.98

### DIFF
--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions-rs/toolchain@88dc2356392166efad76775c878094f4e83ff746  # Version 1.0.6
         with:
           # The same version must be used in the `.pre-commit-config.yaml` file
-          toolchain: nightly-2026-05-22
+          toolchain: nightly-2026-07-05
           profile: minimal
           components: rustfmt
           override: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
         # We're running `fmt` with `--all` and `pass_filenames: false` to format the entire workspace at once.
         # Otherwise, `pre-commit` passes staged files one by one, which can lead to inconsistent results
         # due to, presumably, the lack of full workspace context.
-        entry: cargo +nightly-2026-05-22 fmt
+        entry: cargo +nightly-2026-07-05 fmt
         pass_filenames: false
       - id: clippy
         name: cargo clippy

--- a/blend/message/src/message/payload.rs
+++ b/blend/message/src/message/payload.rs
@@ -176,7 +176,6 @@ impl BinaryDecode for PaddedPayloadBody {
 
 #[cfg(test)]
 mod tests {
-    use lb_codec::{BinaryDecode as _, BinaryEncode as _};
     use serde::Serialize;
     use serde_with::serde_as;
 

--- a/blend/scheduling/src/epoch.rs
+++ b/blend/scheduling/src/epoch.rs
@@ -123,7 +123,6 @@ where
 
 #[cfg(test)]
 mod tests {
-    use futures::StreamExt as _;
     use tokio::time::{Instant, interval};
     use tokio_stream::wrappers::IntervalStream;
 

--- a/core/src/mantle/transactions/mantle_tx.rs
+++ b/core/src/mantle/transactions/mantle_tx.rs
@@ -246,8 +246,6 @@ where
 }
 #[cfg(test)]
 mod tests {
-    use lb_codec::BinaryEncode as _;
-
     use super::*;
 
     #[test]

--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -5,7 +5,7 @@
 # ===========================
 # BUILD IMAGE
 # ===========================
-FROM rust:1.97.1-slim-bookworm AS builder
+FROM rust:1.98.0-slim-bookworm AS builder
 
 WORKDIR /logos-blockchain
 COPY . .

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,7 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
 
     rust-overlay = {
-      url = "github:oxalica/rust-overlay/b99d48435bc3e34309d2c7ae6f7d45e77a156c38";
+      url = "github:oxalica/rust-overlay/89abdfd661ea493cde2f73d7b1332cb34150aa43";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
@@ -48,7 +48,7 @@
           overlays = [ rust-overlay.overlays.default ];
         };
 
-      rustVersion = "1.97.1";
+      rustVersion = "1.98.0";
     in
     {
       packages = forAll (

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -2075,7 +2075,7 @@ mod tests {
                 pow::{ClaimPowRewardError, ClaimPowRewardOp, PowTarget},
             },
         };
-        use lb_groth16::{AdditiveGroup as _, fr_from_mod_bytes};
+        use lb_groth16::fr_from_mod_bytes;
 
         use super::*;
         use crate::mantle::pow::ClaimPoWConstants;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -8,6 +8,6 @@
 # * .github/workflows/code-check.yml (fmt job)
 # * .pre-commit-config.yml (fmt hook)
 # Then, if there is any new allow-by-default rustc lint introduced/stabilized, add it to the respective entry in our `config.toml`.
-channel = "1.97.1"
+channel = "1.98.0"
 # Even if clippy should be included in the default profile, in some cases it is not installed. So we force it with an explicit declaration.
 components = ["clippy"]

--- a/services/chain/chain-network/src/bootstrap/ibd.rs
+++ b/services/chain/chain-network/src/bootstrap/ibd.rs
@@ -344,6 +344,7 @@ pub struct AllPeersFailed;
 
 #[cfg(test)]
 mod tests {
+    use core::future::ready;
     use std::{
         collections::HashMap,
         iter::empty,
@@ -660,31 +661,36 @@ mod tests {
     }
 
     impl IbdBlockProcessor<Block> for MockBlockProcessor {
-        async fn info(&self) -> Result<CryptarchiaInfo, Error> {
-            Ok(self.cryptarchia.info())
+        fn info(&self) -> impl Future<Output = Result<CryptarchiaInfo, Error>> {
+            ready(Ok(self.cryptarchia.info()))
         }
 
-        async fn process_block(&mut self, block: Block) -> Result<(), Error> {
+        fn process_block(&mut self, block: Block) -> impl Future<Output = Result<(), Error>> {
             if self.cryptarchia.has_block(&block.id) {
-                return Err(Error::BlockProcessing(ChainError::Cryptarchia(
+                return ready(Err(Error::BlockProcessing(ChainError::Cryptarchia(
                     lb_chain_service::api::ApiError::AlreadyApplied(block.id),
-                )));
+                ))));
             }
 
-            self.cryptarchia
-                .consensus
-                .receive_block(block.id, block.parent, block.slot, UncleSlots::default())
-                .map_err(|e| {
-                    self.process_block_failures.fetch_add(1, Ordering::SeqCst);
-                    Error::BlockProcessing(ChainError::InvalidBlock(format!(
-                        "Consensus error: {e:?}"
-                    )))
-                })?;
-            Ok(())
+            ready(
+                self.cryptarchia
+                    .consensus
+                    .receive_block(block.id, block.parent, block.slot, UncleSlots::default())
+                    .map_err(|e| {
+                        self.process_block_failures.fetch_add(1, Ordering::SeqCst);
+                        Error::BlockProcessing(ChainError::InvalidBlock(format!(
+                            "Consensus error: {e:?}"
+                        )))
+                    })
+                    .map(|_| ()),
+            )
         }
 
-        async fn has_processed_block(&self, header: HeaderId) -> Result<bool, Error> {
-            Ok(self.cryptarchia.has_block(&header))
+        fn has_processed_block(
+            &self,
+            header: HeaderId,
+        ) -> impl Future<Output = Result<bool, Error>> {
+            ready(Ok(self.cryptarchia.has_block(&header)))
         }
     }
 

--- a/services/chain/chain-service/src/sync/block_provider.rs
+++ b/services/chain/chain-service/src/sync/block_provider.rs
@@ -585,7 +585,6 @@ where
 mod tests {
     use std::{collections::BTreeMap, num::NonZero};
 
-    use futures::StreamExt as _;
     use lb_core::{
         block::{BlockTransactions, UncleHeaders},
         codec::DeserializeOp as _,

--- a/tests/testing_framework/assets/runtime/Dockerfile.cfgsync
+++ b/tests/testing_framework/assets/runtime/Dockerfile.cfgsync
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM rust:1.97.1-slim-bookworm AS builder
+FROM rust:1.98.0-slim-bookworm AS builder
 
 WORKDIR /logos-blockchain-testing
 COPY --from=logos_blockchain_testing . /logos-blockchain-testing

--- a/tests/testing_framework/assets/runtime/Dockerfile.node
+++ b/tests/testing_framework/assets/runtime/Dockerfile.node
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 # check=skip=SecretsUsedInArgOrEnv
 
-FROM rust:1.97.1-slim-bookworm AS cfgsync-builder
+FROM rust:1.98.0-slim-bookworm AS cfgsync-builder
 
 WORKDIR /logos-blockchain-testing
 COPY --from=logos_blockchain_testing . /logos-blockchain-testing
@@ -14,7 +14,7 @@ RUN cargo build --locked --release \
     -p cfgsync-runtime \
     --bin cfgsync-client
 
-FROM rust:1.97.1-slim-bookworm AS builder
+FROM rust:1.98.0-slim-bookworm AS builder
 
 WORKDIR /workspace
 COPY . .

--- a/tests/testing_framework/src/framework/local/provisioning.rs
+++ b/tests/testing_framework/src/framework/local/provisioning.rs
@@ -903,7 +903,6 @@ fn initial_peers_for_dynamic_node(
 #[cfg(test)]
 mod tests {
     use flate2::{Compression, write::GzEncoder};
-    use testing_framework_runner_local::LocalDeployerEnv as _;
 
     use super::*;
     use crate::node::configs::deployment::DeploymentBuilder;

--- a/tests/testing_framework/src/lib.rs
+++ b/tests/testing_framework/src/lib.rs
@@ -68,6 +68,5 @@ pub mod prelude {
 #[must_use]
 pub fn is_truthy_env(key: &str) -> bool {
     std::env::var(key)
-        .ok()
-        .is_some_and(|value| matches!(value.as_str(), "1" | "true" | "TRUE" | "yes" | "YES"))
+        .is_ok_and(|value| matches!(value.as_str(), "1" | "true" | "TRUE" | "yes" | "YES"))
 }

--- a/tools/config/src/time.rs
+++ b/tools/config/src/time.rs
@@ -34,8 +34,7 @@ pub fn set_time_config() -> GeneralTimeConfig {
 
 fn is_truthy_env(key: &str) -> bool {
     std::env::var(key)
-        .ok()
-        .is_some_and(|value| matches!(value.as_str(), "1" | "true" | "TRUE" | "yes" | "YES"))
+        .is_ok_and(|value| matches!(value.as_str(), "1" | "true" | "TRUE" | "yes" | "YES"))
 }
 
 #[must_use]

--- a/zone-sdk/src/sequencer/block_fetch.rs
+++ b/zone-sdk/src/sequencer/block_fetch.rs
@@ -980,7 +980,7 @@ mod tests {
             channel::{SlotTimeframe, SlotTimeout},
             ledger::{Inputs, Outputs},
             ops::{
-                OpId as _, OpProof,
+                OpProof,
                 channel::{
                     channel_transfer::ChannelTransferOp,
                     config::{ChannelConfigOp, Keys},

--- a/zone-sdk/src/sequencer/state.rs
+++ b/zone-sdk/src/sequencer/state.rs
@@ -1180,7 +1180,7 @@ impl TxState {
 mod tests {
     use lb_core::mantle::{
         Op::ChannelInscribe, RawMantleTx, ops::channel::inscribe::InscriptionOp,
-        traits::Hashable as _, transactions::OpsProofs,
+        transactions::OpsProofs,
     };
     use lb_key_management_system_service::keys::Ed25519PublicKey;
 

--- a/zone-sdk/src/sequencer/zone_sequencer.rs
+++ b/zone-sdk/src/sequencer/zone_sequencer.rs
@@ -1,3 +1,4 @@
+use core::future::ready;
 use std::{
     collections::{HashSet, VecDeque},
     sync::{
@@ -701,18 +702,18 @@ where
     // requires transferring a channel  note to that key, which needs the
     // sequencer to track the channel's notes.
     #[expect(
-        clippy::unused_async,
+        clippy::unused_self,
         clippy::needless_pass_by_ref_mut,
         reason = "Signature kept for the flow that will replace this stub."
     )]
-    pub(super) async fn do_publish_atomic_withdraw(
+    pub(super) fn do_publish_atomic_withdraw(
         &mut self,
         _inscribe: Inscription,
         _withdraws: Vec<WithdrawArg>,
-    ) -> Result<(PublishResult, SequencerCheckpoint), Error> {
-        Err(Error::Network(
+    ) -> impl Future<Output = Result<(PublishResult, SequencerCheckpoint), Error>> {
+        ready(Err(Error::Network(
             "atomic withdraw is unsupported until channel notes are tracked".into(),
-        ))
+        )))
     }
 
     //     pub(super) async fn do_publish_atomic_withdraw(


### PR DESCRIPTION
## 1. What does this PR implement?

Update to [Rust 1.98](https://blog.rust-lang.org/2026/08/20/Rust-1.98.0/).

Most important change is around the [`unused_async_trait_impl` lint](https://rust-lang.github.io/rust-clippy/rust-1.98.0/index.html#unused_async_trait_impl), which recommends not using the `async` keyword for functions that do not have any `await` inside of them, but use the `impl Future` return type to reduce the underlying state machine size and complexity.