### PR TITLE
fix(pow): Fix epoch nonce usage for pow

### DIFF
--- a/core/src/mantle/ops/pow.rs
+++ b/core/src/mantle/ops/pow.rs
@@ -1,6 +1,6 @@
 use ark_ff::Zero as _;
 use lb_codec::{BinaryCodec, BinaryEncode as _};
-use lb_cryptarchia_engine::{Epoch, Slot};
+use lb_cryptarchia_engine::Slot;
 use lb_groth16::{Fr, fr_from_mod_bytes, serde::serde_fr};
 use lb_key_management_system_keys::keys::ZkPublicKey;
 use rpds::HashTrieMapSync;
@@ -97,7 +97,8 @@ pub enum ClaimPowRewardError {
     #[error("Mismatch epoch nonce ({claim:?}), accepted {accepted:?}")]
     MismatchEpochNonce {
         claim: ZkHash,
-        accepted: (Epoch, Epoch),
+        /// The (previous, current) epoch nonces a claim may match.
+        accepted: (ZkHash, ZkHash),
     },
     #[error("Invalid PoW reward ticket")]
     InvalidPoWRewardTicket,
@@ -124,10 +125,13 @@ pub struct ClaimPoWRewardVerificationContext<'a> {
     pub epoch_pow_reward: PowReward,
     /// `R_PoW`: current balance of the `PoW` reward pool.
     pub epoch_reward_pool: PowReward,
-    /// Nonce of the current epoch.
-    pub current_epoch: Epoch,
-    /// Nonce of the previous epoch, also accepted for claims.
-    pub previous_epoch: Epoch,
+    /// Randomness nonce of the current epoch (the same value
+    /// proof-of-leadership uses), against which a claim's `epoch_nonce` is
+    /// matched.
+    pub current_epoch_nonce: ZkHash,
+    /// Randomness nonce of the previous epoch, also accepted for claims mined
+    /// just before an epoch boundary and claimed just after it.
+    pub previous_epoch_nonce: ZkHash,
     /// Slots of known blocks, used to check the claim's block is within
     /// the acceptance window.
     pub blocks_slot: HashTrieMapSync<Hash, Slot>,
@@ -168,28 +172,20 @@ impl ClaimPoWRewardVerificationContext<'_> {
         Ok(())
     }
 
-    /// Epoch nonce must match the current epoch or the previous epoch nonce
+    /// Epoch nonce must match the current epoch or the previous epoch nonce.
     fn validate_current_epoch_nonce(
         &self,
         claim_epoch_nonce: ZkHash,
     ) -> Result<(), ClaimPowRewardError> {
-        let previous_epoch_nonce = ZkHasher::digest(&[fr_from_mod_bytes(
-            &self.previous_epoch.into_inner().to_le_bytes(),
-        )]);
-        if claim_epoch_nonce == previous_epoch_nonce {
-            return Ok(());
-        }
-
-        let current_epoch_nonce = ZkHasher::digest(&[fr_from_mod_bytes(
-            &self.current_epoch.into_inner().to_le_bytes(),
-        )]);
-        if claim_epoch_nonce == current_epoch_nonce {
+        if claim_epoch_nonce == self.current_epoch_nonce
+            || claim_epoch_nonce == self.previous_epoch_nonce
+        {
             return Ok(());
         }
 
         Err(ClaimPowRewardError::MismatchEpochNonce {
             claim: claim_epoch_nonce,
-            accepted: (self.previous_epoch, self.current_epoch),
+            accepted: (self.previous_epoch_nonce, self.current_epoch_nonce),
         })
     }
 
@@ -358,8 +354,8 @@ mod tests {
             pow_nullifiers: nullifiers,
             epoch_pow_reward,
             epoch_reward_pool,
-            current_epoch: 0.into(),
-            previous_epoch: 0.into(),
+            current_epoch_nonce: nonce_for_epoch(0),
+            previous_epoch_nonce: nonce_for_epoch(0),
             blocks_slot: HashTrieMapSync::new_sync(),
         }
     }
@@ -403,7 +399,8 @@ mod tests {
     const PREVIOUS_EPOCH: u32 = 4;
     const CLAIM_BLOCK_HASH: Hash = [1u8; 32];
 
-    /// The epoch nonce `validate_current_epoch_nonce` derives for an epoch.
+    /// A distinct, deterministic stand-in epoch nonce, so tests can build
+    /// claims and contexts for different epochs without a real ledger.
     fn nonce_for_epoch(epoch: u32) -> ZkHash {
         ZkHasher::digest(&[fr_from_mod_bytes(&epoch.to_le_bytes())])
     }
@@ -428,8 +425,8 @@ mod tests {
             pow_nullifiers: nullifiers,
             epoch_pow_reward: 10,
             epoch_reward_pool: 1_000,
-            current_epoch: CURRENT_EPOCH.into(),
-            previous_epoch: PREVIOUS_EPOCH.into(),
+            current_epoch_nonce: nonce_for_epoch(CURRENT_EPOCH),
+            previous_epoch_nonce: nonce_for_epoch(PREVIOUS_EPOCH),
             blocks_slot: std::iter::once((CLAIM_BLOCK_HASH, Slot::from(45u64))).collect(),
         }
     }
@@ -544,7 +541,10 @@ mod tests {
             op.verify(&NoOpProof, &ctx),
             Err(ClaimPowRewardError::MismatchEpochNonce {
                 claim: op.epoch_nonce,
-                accepted: (PREVIOUS_EPOCH.into(), CURRENT_EPOCH.into()),
+                accepted: (
+                    nonce_for_epoch(PREVIOUS_EPOCH),
+                    nonce_for_epoch(CURRENT_EPOCH)
+                ),
             })
         );
     }

--- a/core/src/mantle/transactions/signed_mantle_tx.rs
+++ b/core/src/mantle/transactions/signed_mantle_tx.rs
@@ -345,8 +345,8 @@ impl SignedMantleTx<Preverified> {
                     pow_nullifiers: helper.get_pow_nullifiers(),
                     epoch_pow_reward: helper.get_epoch_pow_reward(),
                     epoch_reward_pool: helper.get_pow_reward_pool(),
-                    current_epoch: helper.get_epoch(),
-                    previous_epoch: helper.get_previous_epoch(),
+                    current_epoch_nonce: helper.get_current_epoch_nonce(),
+                    previous_epoch_nonce: helper.get_previous_epoch_nonce(),
                     blocks_slot: helper.get_blocks_slot(),
                 };
                 claim_pow_op

--- a/core/src/mantle/transactions/verification_helper.rs
+++ b/core/src/mantle/transactions/verification_helper.rs
@@ -3,7 +3,7 @@ use lb_key_management_system_keys::keys::Ed25519PublicKey;
 use rpds::HashTrieMapSync;
 
 use crate::{
-    crypto::Hash,
+    crypto::{Hash, ZkHash},
     mantle::{
         VerificationError,
         channel::Channels,
@@ -56,9 +56,8 @@ pub trait OperationVerificationHelper {
     ) -> Result<Ed25519PublicKey, VerificationError>;
 
     // `PoW` claim validation inputs, one per
-    // [`ClaimPoWRewardVerificationContext`] field. The current epoch comes from
-    // [`Self::get_epoch`] and the current block slot from
-    // [`Self::get_block_slot`].
+    // [`ClaimPoWRewardVerificationContext`] field. The current block slot comes
+    // from [`Self::get_block_slot`].
     //
     // [`ClaimPoWRewardVerificationContext`]: crate::mantle::ops::pow::ClaimPoWRewardVerificationContext
 
@@ -75,9 +74,13 @@ pub trait OperationVerificationHelper {
     /// `R_PoW`: current balance of the `PoW` reward pool.
     fn get_pow_reward_pool(&self) -> PowReward;
 
-    /// The epoch preceding [`Self::get_epoch`], whose nonce is also accepted
-    /// for claims mined just before an epoch boundary.
-    fn get_previous_epoch(&self) -> Epoch;
+    /// Randomness nonce of the current epoch, against which a claim's
+    /// `epoch_nonce` is matched.
+    fn get_current_epoch_nonce(&self) -> ZkHash;
+
+    /// Randomness nonce of the epoch preceding [`Self::get_epoch`], also
+    /// accepted for claims mined just before an epoch boundary.
+    fn get_previous_epoch_nonce(&self) -> ZkHash;
 
     /// Slots of the blocks a claim may anchor to, keyed by block hash;
     /// used for the window-of-acceptance check.
@@ -92,7 +95,7 @@ pub mod test_utils {
     use rpds::{HashTrieMapSync, HashTrieSetSync};
 
     use crate::{
-        crypto::Hash,
+        crypto::{Hash, ZkHash},
         mantle::{
             Utxo, VerificationError,
             channel::Channels,
@@ -122,7 +125,8 @@ pub mod test_utils {
         pow_nullifiers: HashTrieMapSync<PowNullifier, Slot>,
         epoch_pow_reward: PowReward,
         pow_reward_pool: PowReward,
-        previous_epoch: Epoch,
+        current_epoch_nonce: ZkHash,
+        previous_epoch_nonce: ZkHash,
         blocks_slot: HashTrieMapSync<Hash, Slot>,
     }
 
@@ -150,7 +154,8 @@ pub mod test_utils {
                 pow_nullifiers: HashTrieMapSync::new_sync(),
                 epoch_pow_reward: 0,
                 pow_reward_pool: 0,
-                previous_epoch: Epoch::from(0u32),
+                current_epoch_nonce: ZkHash::default(),
+                previous_epoch_nonce: ZkHash::default(),
                 blocks_slot: HashTrieMapSync::new_sync(),
             }
         }
@@ -196,9 +201,15 @@ pub mod test_utils {
         }
 
         #[must_use]
-        pub fn with_epochs(mut self, previous: Epoch, current: Epoch) -> Self {
-            self.previous_epoch = previous;
-            self.epoch = current;
+        pub const fn with_epoch(mut self, epoch: Epoch) -> Self {
+            self.epoch = epoch;
+            self
+        }
+
+        #[must_use]
+        pub const fn with_epoch_nonces(mut self, previous: ZkHash, current: ZkHash) -> Self {
+            self.previous_epoch_nonce = previous;
+            self.current_epoch_nonce = current;
             self
         }
 
@@ -301,8 +312,12 @@ pub mod test_utils {
             self.pow_reward_pool
         }
 
-        fn get_previous_epoch(&self) -> Epoch {
-            self.previous_epoch
+        fn get_current_epoch_nonce(&self) -> ZkHash {
+            self.current_epoch_nonce
+        }
+
+        fn get_previous_epoch_nonce(&self) -> ZkHash {
+            self.previous_epoch_nonce
         }
 
         fn get_blocks_slot(&self) -> HashTrieMapSync<Hash, Slot> {

--- a/ledger/src/cryptarchia/mod.rs
+++ b/ledger/src/cryptarchia/mod.rs
@@ -212,6 +212,12 @@ pub struct LedgerState {
     // randomness contribution
     #[serde(with = "lb_groth16::serde::serde_fr")]
     pub nonce: Fr,
+    // Nonce of the epoch preceding `epoch_state`'s, retained so a `PoW` reward
+    // claim mined just before an epoch boundary stays verifiable for the reward
+    // window after the boundary. The current epoch drops out of `epoch_state` on
+    // transition, so it must be carried here explicitly.
+    #[serde(with = "lb_groth16::serde::serde_fr")]
+    pub previous_epoch_nonce: Fr,
     pub slot: Slot,
     // rolling snapshot of the state for the next epoch, used for epoch transitions
     pub next_epoch_state: EpochState,
@@ -347,6 +353,8 @@ impl LedgerState {
                 slot,
                 next_epoch_state,
                 epoch_state,
+                // The epoch we just left becomes the previous epoch.
+                previous_epoch_nonce: self.epoch_state.nonce,
                 block_density,
                 storage_gas_consumed_in_epoch: 0.into(),
                 storage_gas_ema: new_ema,
@@ -430,6 +438,10 @@ impl LedgerState {
                 slot,
                 next_epoch_state,
                 epoch_state,
+                // Every skipped epoch had no block, so the nonce stayed frozen
+                // at `self.nonce` throughout — that is the previous epoch's nonce
+                // (and matches the value used for `epoch_state` above).
+                previous_epoch_nonce: self.nonce,
                 block_density,
                 storage_gas_consumed_in_epoch: 0.into(),
                 storage_gas_ema: new_ema,
@@ -740,6 +752,9 @@ impl LedgerState {
         Self {
             utxos: utxos.clone(),
             nonce,
+            // No epoch precedes genesis; seed with the genesis nonce so an
+            // epoch-0 claim still matches (previous == current is harmless).
+            previous_epoch_nonce: nonce,
             slot,
             next_epoch_state: EpochState {
                 epoch: 1.into(),
@@ -1129,6 +1144,7 @@ pub mod tests {
         LedgerState {
             utxos,
             nonce: Fr::ZERO,
+            previous_epoch_nonce: Fr::ZERO,
             slot,
             next_epoch_state,
             epoch_state,
@@ -1499,6 +1515,32 @@ pub mod tests {
         );
         // Below the reference load, so admission loosens — up to the clamp.
         assert!(state.epoch_state.blend_pow_difficulty > epoch_1_difficulty);
+    }
+
+    #[test]
+    fn previous_epoch_nonce_is_retained_across_an_epoch_transition() {
+        // A PoW claim mined just before an epoch boundary must stay verifiable
+        // for the reward window after it, which needs the nonce of the epoch we
+        // just left — otherwise dropped when `epoch_state` rolls forward.
+        let config = config();
+        assert_eq!(config.epoch_length(), 100);
+        let sdp = SdpLedger::new(0.into());
+        let mut pow = PowState::new();
+
+        // Genesis (epoch 0). Stamp a distinct nonce on the current epoch so it
+        // is recognisable after the boundary; genesis seeds the previous-epoch
+        // nonce with the current one.
+        let mut state = genesis_state(&[utxo()]);
+        assert_eq!(state.previous_epoch_nonce, state.nonce);
+        let epoch_0_nonce = Fr::from(0xABCDu64);
+        state.epoch_state.nonce = epoch_0_nonce;
+
+        // Cross into epoch 1.
+        let state = apply_block(state, &mut pow, 100, 0, &sdp, &config);
+        assert_eq!(state.epoch_state.epoch, 1);
+
+        // The epoch just left is now retained as the previous-epoch nonce.
+        assert_eq!(state.previous_epoch_nonce, epoch_0_nonce);
     }
 
     #[test]

--- a/ledger/src/cryptarchia/test/tsi_simulation.rs
+++ b/ledger/src/cryptarchia/test/tsi_simulation.rs
@@ -225,6 +225,7 @@ fn genesis_ledger(config: &Config, leader_utxo: Utxo) -> Ledger<HeaderId> {
     let cryptarchia_ledger = LedgerState {
         utxos,
         nonce: Fr::ZERO,
+        previous_epoch_nonce: Fr::ZERO,
         slot: 0.into(),
         next_epoch_state: EpochState {
             epoch: 1.into(),

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -2068,14 +2068,11 @@ mod tests {
     }
 
     mod pow {
-        use lb_core::{
-            crypto::{ZkDigest as _, ZkHasher},
-            mantle::ops::{
-                NoOpProof,
-                pow::{ClaimPowRewardError, ClaimPowRewardOp, PowTarget},
-            },
+        use lb_core::mantle::ops::{
+            NoOpProof,
+            pow::{ClaimPowRewardError, ClaimPowRewardOp, PowTarget},
         };
-        use lb_groth16::fr_from_mod_bytes;
+        use lb_groth16::{AdditiveGroup as _, fr_from_mod_bytes};
 
         use super::*;
         use crate::mantle::pow::ClaimPoWConstants;
@@ -2109,9 +2106,9 @@ mod tests {
 
         fn claim_op() -> ClaimPowRewardOp {
             ClaimPowRewardOp {
-                // The nonce `validate_current_epoch_nonce` accepts for epoch
-                // 0, the current epoch of a fresh test ledger.
-                epoch_nonce: ZkHasher::digest(&[fr_from_mod_bytes(&0u32.to_le_bytes())]),
+                // The current epoch's randomness nonce, which for a fresh test
+                // ledger built from genesis is the genesis nonce (`Fr::ZERO`).
+                epoch_nonce: Fr::ZERO,
                 block_hash: [1u8; 32],
                 public_key: ZkPublicKey::new(Fr::from(42u64)),
             }

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -2072,7 +2072,6 @@ mod tests {
             NoOpProof,
             pow::{ClaimPowRewardError, ClaimPowRewardOp, PowTarget},
         };
-        use lb_groth16::{AdditiveGroup as _, fr_from_mod_bytes};
 
         use super::*;
         use crate::mantle::pow::ClaimPoWConstants;

--- a/ledger/src/mantle/helpers.rs
+++ b/ledger/src/mantle/helpers.rs
@@ -1,5 +1,5 @@
 use lb_core::{
-    crypto::Hash,
+    crypto::{Hash, ZkHash},
     mantle::{
         channel::Channels,
         ledger::{Declarations, Utxos},
@@ -146,8 +146,12 @@ impl OperationVerificationHelper for MantleOperationVerificationHelper<'_> {
         self.ledger_state.pow.reward_pool()
     }
 
-    fn get_previous_epoch(&self) -> Epoch {
-        Epoch::from(self.get_epoch().into_inner().saturating_sub(1))
+    fn get_current_epoch_nonce(&self) -> ZkHash {
+        self.cryptarchia_ledger.epoch_state.nonce
+    }
+
+    fn get_previous_epoch_nonce(&self) -> ZkHash {
+        self.cryptarchia_ledger.previous_epoch_nonce
     }
 
     fn get_blocks_slot(&self) -> HashTrieMapSync<Hash, Slot> {


### PR DESCRIPTION
## 1. What does this PR implement?

Pow core implementation left the placeholder of `ZkHash(epoch)` instead of actually tracking the previous epoch nonce.
This fixes it.

## 2. Does the code have enough context to be clearly understood?

Yes, its a simple (yet necessary) change

## 3. Who are the specification authors and who is accountable for this PR?

@danielSanchezQ @madxor 

## 4. Is the specification accurate and complete?

Yes

## 5. Does the implementation introduce changes in the specification?

No

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
