### PR TITLE
[Review: Tx Typestate] 1/6 — Signed-operation lifecycle

### DIFF
--- a/c-bindings/src/api/storage.rs
+++ b/c-bindings/src/api/storage.rs
@@ -1,7 +1,7 @@
 use std::ffi::{CString, c_char};
 
 use lb_core::mantle::transactions::states::Unverified;
-use lb_node::{RocksBackend, RuntimeServiceId, SignedMantleTx};
+use lb_node::{MantleTransaction, RocksBackend, RuntimeServiceId};
 
 use crate::{
     LogosBlockchainNode, OperationStatus,
@@ -36,7 +36,7 @@ pub(crate) fn get_block_sync(
 
     let block = runtime_handle
         .block_on(lb_api_service::http::mantle::get_block::<
-            SignedMantleTx<Unverified>,
+            MantleTransaction<Unverified>,
             RocksBackend,
             RuntimeServiceId,
         >(
@@ -141,7 +141,7 @@ pub(crate) fn get_transaction_sync(
 
     let tx = runtime_handle
         .block_on(lb_api_service::http::mantle::get_transaction::<
-            SignedMantleTx<Unverified>,
+            MantleTransaction<Unverified>,
             RocksBackend,
             RuntimeServiceId,
         >(overwatch_handle, tx_hash))
@@ -244,7 +244,7 @@ pub(crate) fn get_blocks_sync(
 
     let blocks = runtime_handle
         .block_on(lb_api_service::http::mantle::get_immutable_blocks::<
-            SignedMantleTx<Unverified>,
+            MantleTransaction<Unverified>,
             RocksBackend,
             RuntimeServiceId,
         >(overwatch_handle, from_slot, to_slot))

--- a/c-bindings/src/api/subscriptions.rs
+++ b/c-bindings/src/api/subscriptions.rs
@@ -14,7 +14,7 @@ use lb_core::{
     },
 };
 use lb_node::{
-    ApiStorageAdapter, RocksBackend, RuntimeServiceId, SignedMantleTx, StorageService,
+    ApiStorageAdapter, MantleTransaction, RocksBackend, RuntimeServiceId, StorageService,
     api::serializers::blocks::ApiProcessedBlockEventOwned, generic_services::CryptarchiaService,
 };
 use serde::Serialize;
@@ -33,15 +33,15 @@ use crate::{
 pub struct TxWithId {
     id: TxHash,
     #[serde(flatten)]
-    tx: SignedMantleTx<Unverified>,
+    tx: MantleTransaction<Unverified>,
 }
 
 impl Hashable for TxWithId {
     //noinspection RsTypeCheck: The type is correct, but the linter is confused by
     // the closure.
     const HASHER: hashable::Hasher<Self> =
-        |tx| <SignedMantleTx<Unverified> as Hashable>::HASHER(&tx.tx);
-    type Hash = <SignedMantleTx<Unverified> as Hashable>::Hash;
+        |tx| <MantleTransaction<Unverified> as Hashable>::HASHER(&tx.tx);
+    type Hash = <MantleTransaction<Unverified> as Hashable>::Hash;
 
     fn as_signing(&self) -> Vec<u8> {
         self.tx.as_signing()
@@ -86,7 +86,7 @@ pub fn subscribe_to_new_blocks_sync(
                 runtime_handler.spawn(async move {
                     while let Ok(event) = block_stream.recv().await {
                         let relay = storage_relay.clone();
-                        let res: Result<Option<CoreBlock<SignedMantleTx<Unverified>>>, _> =
+                        let res: Result<Option<CoreBlock<MantleTransaction<Unverified>>>, _> =
                             ApiStorageAdapter::<RuntimeServiceId>::get_block(relay, event.block_id)
                                 .await;
                         if let Ok(Some(block)) = res {
@@ -185,7 +185,7 @@ pub fn subscribe_to_processed_blocks_sync(
     let overwatch = node.get_overwatch_handle();
     runtime_handler.block_on(async move {
         let stream = match lb_api_service::http::mantle::get_new_blocks_stream::<
-            SignedMantleTx<Preverified>,
+            MantleTransaction<Preverified>,
             RocksBackend,
             CryptarchiaService<RuntimeServiceId>,
             RuntimeServiceId,

--- a/c-bindings/src/api/wallet.rs
+++ b/c-bindings/src/api/wallet.rs
@@ -8,7 +8,7 @@ use lb_api_service::http::mempool;
 use lb_core::{
     header::HeaderId as CoreHeaderId,
     mantle::{
-        Note, NoteId as CoreNoteId, Op, OpProof, RawMantleTx, SignedMantleTx,
+        MantleTransaction, Note, NoteId as CoreNoteId, Op, OpProof, RawMantleTx,
         gas::GasCost,
         ledger::{Inputs, Outputs},
         ops::{
@@ -682,7 +682,7 @@ impl TransferFundsArguments {
 ///
 /// # Returns
 ///
-/// A `Result` containing a [`SignedMantleTx`] on success, or an
+/// A `Result` containing a [`MantleTransaction`] on success, or an
 /// [`OperationStatus`] error on failure.
 pub(crate) fn transfer_funds_sync(
     node: &LogosBlockchainNode,
@@ -691,7 +691,7 @@ pub(crate) fn transfer_funds_sync(
     funding_public_keys: Vec<ZkPublicKey>,
     recipient_public_key: ZkPublicKey,
     amount: u64,
-) -> StatusResult<SignedMantleTx<Preverified>> {
+) -> StatusResult<MantleTransaction<Preverified>> {
     let runtime_handle = node.get_runtime_handle();
     runtime_handle.block_on(async {
         let handle = node.get_overwatch_handle();
@@ -935,8 +935,8 @@ impl ChannelDepositWithNotesArguments {
 ///
 /// # Returns
 ///
-/// A [`Result`] containing the submitted [`SignedMantleTx`] on success, or an
-/// [`OperationStatus`] error on failure.
+/// A [`Result`] containing the submitted [`MantleTransaction`] on success, or
+/// an [`OperationStatus`] error on failure.
 pub(crate) fn channel_deposit_with_notes_sync(
     node: &LogosBlockchainNode,
     tip: lb_core::header::HeaderId,
@@ -944,7 +944,7 @@ pub(crate) fn channel_deposit_with_notes_sync(
     change_public_key: ZkPublicKey,
     funding_public_keys: Vec<ZkPublicKey>,
     max_tx_fee: GasCost,
-) -> StatusResult<SignedMantleTx<Preverified>> {
+) -> StatusResult<MantleTransaction<Preverified>> {
     let runtime_handle = node.get_runtime_handle();
     runtime_handle.block_on(async {
         let handle = node.get_overwatch_handle();
@@ -1239,8 +1239,8 @@ impl ChannelDepositArguments {
 ///
 /// # Returns
 ///
-/// A [`Result`] containing the submitted [`SignedMantleTx`] on success, or an
-/// [`OperationStatus`] error on failure.
+/// A [`Result`] containing the submitted [`MantleTransaction`] on success, or
+/// an [`OperationStatus`] error on failure.
 pub(crate) fn channel_deposit_sync(
     node: &LogosBlockchainNode,
     tip: lb_core::header::HeaderId,
@@ -1248,7 +1248,7 @@ pub(crate) fn channel_deposit_sync(
     funding_public_key: ZkPublicKey,
     amount: Value,
     metadata: Metadata,
-) -> StatusResult<SignedMantleTx<Preverified>> {
+) -> StatusResult<MantleTransaction<Preverified>> {
     let runtime_handle = node.get_runtime_handle();
     runtime_handle.block_on(async {
         let handle = node.get_overwatch_handle();
@@ -1341,7 +1341,7 @@ pub(crate) fn channel_deposit_sync(
                     format!("Failed to sign deposit tx: {error}"),
                 )
             })?;
-        let signed_tx = SignedMantleTx::new(
+        let signed_tx = MantleTransaction::new(
             tx,
             [OpProof::ZkSig(user_sig.clone()), OpProof::ZkSig(user_sig)].into(),
         )
@@ -1668,7 +1668,7 @@ pub unsafe extern "C" fn submit_signed_transaction(
                 ));
             }
         };
-        let signed_tx: SignedMantleTx<Unverified> = match serde_json::from_str(signed_tx_json) {
+        let signed_tx: MantleTransaction<Unverified> = match serde_json::from_str(signed_tx_json) {
             Ok(signed_tx) => signed_tx,
             Err(error) => {
                 return FfiSubmitTransactionResult::err(OperationStatus::error(

--- a/core/benches/mantle_tx_components.rs
+++ b/core/benches/mantle_tx_components.rs
@@ -18,7 +18,7 @@ use lb_poseidon2::Digest;
 use logos_blockchain_core::{
     crypto::{Hasher, ZkHasher},
     mantle::{
-        SignedMantleTx,
+        MantleTransaction,
         ops::{
             Op, OpProof,
             channel::{
@@ -67,13 +67,13 @@ fn make_inscription_tx(payload_size: usize) -> RawMantleTx {
     )
 }
 
-// Helper fn to create a `SignedMantleTx`.
-fn make_signed_tx(payload_size: usize) -> SignedMantleTx<Unverified> {
+// Helper fn to create a `MantleTransaction`.
+fn make_signed_tx(payload_size: usize) -> MantleTransaction<Unverified> {
     let signing_key = Ed25519Key::from_bytes(&[1; 32]);
     let tx = make_inscription_tx(payload_size);
     let tx_hash = tx.hash();
     let op_sig = signing_key.sign_payload(&tx_hash.as_signing_bytes());
-    SignedMantleTx::new(tx, [OpProof::Ed25519Sig(op_sig)].into())
+    MantleTransaction::new(tx, [OpProof::Ed25519Sig(op_sig)].into())
 }
 
 // `Blake2b` wrapper function using the defined `Hasher`.
@@ -157,7 +157,7 @@ fn bench_sign_c_mantle_tx_new_verify_ops_proofs_single_proof(bencher: Bencher, s
             (tx, op_sig)
         })
         .bench_values(|(tx, op_sig): (RawMantleTx, Ed25519Signature)| {
-            black_box(SignedMantleTx::new(tx, [OpProof::Ed25519Sig(op_sig)].into()).preverify())
+            black_box(MantleTransaction::new(tx, [OpProof::Ed25519Sig(op_sig)].into()).preverify())
         });
 }
 
@@ -176,20 +176,20 @@ fn bench_sign_d_fully_empty(bencher: Bencher, size: usize) {
         })
         .bench_values(|(tx, tx_hash): (RawMantleTx, TxHash)| {
             let op_sig = signing_key.sign_payload(&tx_hash.as_signing_bytes());
-            black_box(SignedMantleTx::new(tx, [OpProof::Ed25519Sig(op_sig)].into()).preverify())
+            black_box(MantleTransaction::new(tx, [OpProof::Ed25519Sig(op_sig)].into()).preverify())
         });
 }
 
-// Encode a `SignedMantleTx` to bytes.
+// Encode a `MantleTransaction` to bytes.
 #[divan::bench(args = SIZES)]
-fn bench_encode_signed_mantle_tx(bencher: Bencher, size: usize) {
+fn bench_encode_mantle_transaction(bencher: Bencher, size: usize) {
     let signed_tx = make_signed_tx(size);
     bencher.bench_local(|| black_box(encode_signed_mantle_tx(&signed_tx)));
 }
 
-// Decode a `SignedMantleTx` from bytes.
+// Decode a `MantleTransaction` from bytes.
 #[divan::bench(args = SIZES)]
-fn bench_decode_signed_mantle_tx(bencher: Bencher, size: usize) {
+fn bench_decode_mantle_transaction(bencher: Bencher, size: usize) {
     let signed_tx = make_signed_tx(size);
     let encoded = encode_signed_mantle_tx(&signed_tx);
     bencher.bench_local(|| {

--- a/core/src/block/genesis.rs
+++ b/core/src/block/genesis.rs
@@ -17,7 +17,7 @@ use crate::{
             transfer::TransferOp,
         },
         transactions::{
-            GenesisTx, MAX_OPS_PER_TX, Ops, OpsProofs, VerificationError, genesis_tx,
+            GenesisTx, MAX_OPS_PER_TX, OpProofs, Ops, VerificationError, genesis_tx,
             mantle_tx::RawMantleTx,
         },
     },
@@ -1248,7 +1248,7 @@ impl GenesisBlockBuilder<WithAll> {
                 count: n,
             }));
         };
-        let mut ops_proofs = OpsProofs::from([
+        let mut ops_proofs = OpProofs::from([
             OpProof::ZkSig(ZkSignature::new(CompressedGroth16Proof::from_bytes(
                 &[0u8; 128],
             ))),
@@ -1368,7 +1368,7 @@ mod tests {
         ];
         ops.extend(extra_ops);
 
-        let ops_proofs = OpsProofs::try_from_iter(ops.iter().map(|op| match op {
+        let ops_proofs = OpProofs::try_from_iter(ops.iter().map(|op| match op {
             Op::ChannelInscribe(_) => OpProof::Ed25519Sig(Ed25519Signature::zero()),
             Op::Transfer(_) => OpProof::ZkSig(ZkSignature::new(
                 CompressedGroth16Proof::from_bytes(&[0u8; 128]),

--- a/core/src/block/genesis.rs
+++ b/core/src/block/genesis.rs
@@ -10,7 +10,7 @@ use crate::{
     block::{Block, BlockTransactions, UncleHeaders},
     header::Header,
     mantle::{
-        Note, Op, OpProof, SignedMantleTx,
+        MantleTransaction, Note, Op, OpProof,
         ledger::{BoundedOutputs, Inputs, Outputs},
         ops::{
             ZkAndEd25519Proof, channel::inscribe::InscriptionOp, sdp::SDPDeclareOp,
@@ -27,7 +27,7 @@ use crate::{
 /// [`GenesisBlockBuilder`].
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-    /// The op proofs supplied to [`SignedMantleTx`] failed verification.
+    /// The op proofs supplied to [`MantleTransaction`] failed verification.
     #[error("Transaction verification failed: {0}")]
     Verification(#[from] VerificationError),
     /// The constructed transaction does not satisfy genesis transaction
@@ -1263,7 +1263,7 @@ impl GenesisBlockBuilder<WithAll> {
                 .try_push(OpProof::ZkAndEd25519Sigs(proof))
                 .expect("genesis transaction proofs are bounded");
         }
-        let signed_tx = SignedMantleTx::new_trusted(RawMantleTx(capped_ops), ops_proofs);
+        let signed_tx = MantleTransaction::new_trusted(RawMantleTx(capped_ops), ops_proofs);
         Ok(GenesisBlock::genesis(GenesisTx::from_tx(signed_tx)?))
     }
 }
@@ -1358,7 +1358,7 @@ mod tests {
 
     // ── helpers for the with_genesis_tx path ──────────────────────────────────
 
-    fn make_signed_genesis_tx(extra_ops: Vec<Op>) -> SignedMantleTx<Preverified> {
+    fn make_signed_genesis_tx(extra_ops: Vec<Op>) -> MantleTransaction<Preverified> {
         let mut ops = vec![
             Op::Transfer(TransferOp::new(
                 Inputs::empty(),
@@ -1384,7 +1384,7 @@ mod tests {
         }))
         .expect("genesis transaction proofs are bounded");
 
-        SignedMantleTx::new_trusted(RawMantleTx(Ops::new_unchecked(ops)), ops_proofs)
+        MantleTransaction::new_trusted(RawMantleTx(Ops::new_unchecked(ops)), ops_proofs)
     }
 
     fn make_genesis_tx(extra_ops: Vec<Op>) -> GenesisTx {

--- a/core/src/mantle/ledger.rs
+++ b/core/src/mantle/ledger.rs
@@ -49,6 +49,7 @@ pub mod verification_mode {
 
 pub trait ProvableOperation {
     type Proof;
+    const CODE: u8; // TODO: Compile time check that this is unique across all operations?
 }
 
 pub trait PreverifiableOperation<Mode: verification_mode::VerificationMode>:

--- a/core/src/mantle/ledger.rs
+++ b/core/src/mantle/ledger.rs
@@ -16,6 +16,7 @@ use crate::{
     events::TxEvent,
     mantle::{
         channel::Channels,
+        ledger::verification_mode::VerificationMode,
         ops::{OpId, channel::ChannelId},
     },
     sdp::{Declaration, DeclarationId, locked_notes::LockedNotes},
@@ -40,38 +41,32 @@ pub type BoundedOutputs = UpperBoundedVec<Note, MAX_TRANSACTION_OUTPUTS>;
 pub mod verification_mode {
     pub trait VerificationMode {}
 
+    #[derive(Clone, Debug, PartialEq, Eq)]
     pub struct GenesisMode;
     impl VerificationMode for GenesisMode {}
 
+    #[derive(Clone, Debug, PartialEq, Eq)]
     pub struct StandardMode;
     impl VerificationMode for StandardMode {}
 }
 
 pub trait ProvableOperation {
     type Proof;
-    const CODE: u8; // TODO: Compile time check that this is unique across all operations?
+    const CODE: u8;
 }
 
-pub trait PreverifiableOperation<Mode: verification_mode::VerificationMode>:
-    ProvableOperation
-{
+pub trait PreverifiableOperation<Mode: VerificationMode> {
     type Context<'a>;
     type Error;
 
-    fn preverify(
-        &self,
-        proof: &Self::Proof,
-        context: &Self::Context<'_>,
-    ) -> Result<(), Self::Error>;
+    fn preverify(&self, context: &Self::Context<'_>) -> Result<(), Self::Error>;
 }
 
-pub trait VerifiableOperation<Mode: verification_mode::VerificationMode>:
-    ProvableOperation
-{
+pub trait VerifiableOperation<Mode: VerificationMode> {
     type Context<'a>;
     type Error;
 
-    fn verify(&self, proof: &Self::Proof, context: &Self::Context<'_>) -> Result<(), Self::Error>;
+    fn verify(&self, context: &Self::Context<'_>) -> Result<(), Self::Error>;
 }
 
 pub trait ExecutableOperation {
@@ -82,21 +77,6 @@ pub trait ExecutableOperation {
         &self,
         context: Self::Context<'a>,
     ) -> Result<(Self::Context<'a>, Vec<TxEvent>), Self::Error>;
-}
-
-pub trait Operation<Mode: verification_mode::VerificationMode>:
-    ProvableOperation + PreverifiableOperation<Mode> + VerifiableOperation<Mode> + ExecutableOperation
-{
-}
-
-impl<
-    T: ProvableOperation
-        + PreverifiableOperation<Mode>
-        + VerifiableOperation<Mode>
-        + ExecutableOperation,
-    Mode: verification_mode::VerificationMode,
-> Operation<Mode> for T
-{
 }
 
 pub type Utxos = UtxoTree<NoteId, Utxo, ZkHasher>;

--- a/core/src/mantle/mod.rs
+++ b/core/src/mantle/mod.rs
@@ -13,7 +13,7 @@ pub use gas::{GasProfile, TxGasCalculator};
 pub use ledger::{Note, NoteId, Utxo, Value};
 pub use ops::{Op, OpProof};
 pub use transactions::{
-    CryptarchiaParameter, GenesisTime, SignedMantleTx, hash::TxHash, mantle_tx::RawMantleTx,
+    CryptarchiaParameter, GenesisTime, MantleTransaction, hash::TxHash, mantle_tx::RawMantleTx,
 };
 
 pub use crate::mantle::transactions::VerificationError;

--- a/core/src/mantle/ops/channel/channel_transfer.rs
+++ b/core/src/mantle/ops/channel/channel_transfer.rs
@@ -12,7 +12,7 @@ use crate::{
             Utxos, VerifiableOperation, verification_mode, verification_mode::VerificationMode,
         },
         ops::{
-            OpId, SignedOp,
+            OpId, SignedOperation,
             channel::{ChannelId, verification::verify_channel_multi_sig},
         },
         transactions::{OperationVerificationHelper, hash::TxHashView, states::VerificationState},
@@ -180,7 +180,7 @@ impl ExecutableOperation for ChannelTransferOp {
 }
 
 impl<State: VerificationState, Mode: VerificationMode> SignedOperationExecutionGas
-    for SignedOp<ChannelTransferOp, State, Mode>
+    for SignedOperation<ChannelTransferOp, State, Mode>
 {
     fn gas_multiplier(&self) -> Value {
         let signature_count = self.proof().signatures().len();

--- a/core/src/mantle/ops/channel/channel_transfer.rs
+++ b/core/src/mantle/ops/channel/channel_transfer.rs
@@ -9,13 +9,18 @@ use crate::{
         gas::{Gas, MainnetGasProfile, OperationGas, SignedOperationExecutionGas},
         ledger::{
             ExecutableOperation, Inputs, Outputs, PreverifiableOperation, ProvableOperation, Utxo,
-            Utxos, VerifiableOperation, verification_mode, verification_mode::VerificationMode,
+            Utxos, VerifiableOperation,
+            verification_mode::{StandardMode, VerificationMode},
         },
         ops::{
             OpId, SignedOperation,
             channel::{ChannelId, verification::verify_channel_multi_sig},
         },
-        transactions::{OperationVerificationHelper, hash::TxHashView, states::VerificationState},
+        transactions::{
+            OperationVerificationHelper,
+            hash::TxHashView,
+            states::{Preverified, Unverified, VerificationState, Verified},
+        },
     },
     proofs::channel_multi_sig_proof::ChannelMultiSigProof,
     sdp::locked_notes::LockedNotes,
@@ -67,32 +72,37 @@ impl OperationGas<MainnetGasProfile> for ChannelTransferOp {
     const GAS_COST: Gas = Gas::new(56);
 }
 
-impl PreverifiableOperation<verification_mode::StandardMode> for ChannelTransferOp {
+impl PreverifiableOperation<StandardMode>
+    for SignedOperation<ChannelTransferOp, Unverified, StandardMode>
+{
     type Context<'a> = ();
     type Error = Error;
 
-    fn preverify(
-        &self,
-        _proof: &Self::Proof,
-        _context: &Self::Context<'_>,
-    ) -> Result<(), Self::Error> {
+    fn preverify(&self, _context: &Self::Context<'_>) -> Result<(), Self::Error> {
+        let operation = self.operation();
+
         // Ensure the inputs is non-empty
-        self.inputs.preverify()?;
+        operation.inputs.preverify()?;
 
         // Check that the outputs are valid
-        self.outputs.validate()?;
+        operation.outputs.validate()?;
 
         Ok(())
     }
 }
 
-impl VerifiableOperation<verification_mode::StandardMode> for ChannelTransferOp {
+impl VerifiableOperation<StandardMode>
+    for SignedOperation<ChannelTransferOp, Preverified, StandardMode>
+{
     type Context<'a> = ChannelTransferValidationContext<'a>;
     type Error = Error;
 
-    fn verify(&self, proof: &Self::Proof, context: &Self::Context<'_>) -> Result<(), Self::Error> {
+    fn verify(&self, context: &Self::Context<'_>) -> Result<(), Self::Error> {
+        let operation = self.operation();
+        let proof = self.proof();
+
         verify_channel_multi_sig(
-            &self.channel_id,
+            &operation.channel_id,
             proof,
             context.tx_hash_view.as_bytes(),
             context.helper,
@@ -105,22 +115,22 @@ impl VerifiableOperation<verification_mode::StandardMode> for ChannelTransferOp 
             context
                 .channels
                 .channels
-                .get(&self.channel_id)
+                .get(&operation.channel_id)
                 .ok_or(Error::ChannelNotFound {
-                    channel_id: self.channel_id,
+                    channel_id: operation.channel_id,
                 })?;
 
         // Check that the inputs are valid and belong to the channel
-        self.inputs.validate_in_channel(
+        operation.inputs.validate_in_channel(
             context.locked_notes,
             context.channels,
-            &self.channel_id,
+            &operation.channel_id,
             context.utxos,
         )?;
 
         // Check the balance is preserved
-        let input_amount = self.inputs.amount(context.utxos)?;
-        let output_amount = self.outputs.amount()?;
+        let input_amount = operation.inputs.amount(context.utxos)?;
+        let output_amount = operation.outputs.amount()?;
         if input_amount != output_amount {
             return Err(Error::UnbalancedTransfer);
         }
@@ -129,7 +139,7 @@ impl VerifiableOperation<verification_mode::StandardMode> for ChannelTransferOp 
         let signatures = proof.signatures();
         if signatures.len() != channel.transfer_threshold as usize {
             return Err(Error::ThresholdUnmet {
-                channel_id: self.channel_id,
+                channel_id: operation.channel_id,
                 threshold: channel.transfer_threshold,
                 actual: signatures.len(),
             });
@@ -152,7 +162,9 @@ impl VerifiableOperation<verification_mode::StandardMode> for ChannelTransferOp 
     }
 }
 
-impl ExecutableOperation for ChannelTransferOp {
+impl<Mode: VerificationMode> ExecutableOperation
+    for SignedOperation<ChannelTransferOp, Verified, Mode>
+{
     type Context<'a> = ChannelTransferExecutionContext;
     type Error = Error;
 
@@ -160,20 +172,22 @@ impl ExecutableOperation for ChannelTransferOp {
         &self,
         mut context: Self::Context<'a>,
     ) -> Result<(Self::Context<'a>, Vec<TxEvent>), Self::Error> {
+        let operation = self.operation();
+
         // Remove the inputs from the ledger and from the channel.
-        context.utxos = self.inputs.execute(context.utxos)?;
-        for note_id in self.inputs.iter() {
+        context.utxos = operation.inputs.execute(context.utxos)?;
+        for note_id in operation.inputs.iter() {
             context.channels = context
                 .channels
-                .unregister_channel_note(note_id, &self.channel_id)?;
+                .unregister_channel_note(note_id, &operation.channel_id)?;
         }
 
         // Add the outputs to the ledger and register them as channel notes.
-        context.utxos = self.outputs.execute(context.utxos, self);
-        for utxo in self.utxos() {
+        context.utxos = operation.outputs.execute(context.utxos, operation);
+        for utxo in operation.utxos() {
             context.channels = context
                 .channels
-                .register_channel_note(&utxo.id(), &self.channel_id)?;
+                .register_channel_note(&utxo.id(), &operation.channel_id)?;
         }
 
         Ok((context, Vec::new()))
@@ -205,9 +219,10 @@ mod test {
             outputs: Outputs::new([Note::new(100, ZkPublicKey::zero())]),
         };
         let proof = ChannelMultiSigProof::try_new([].into()).unwrap();
+        let signed_operation = SignedOperation::new(channel_transfer, proof);
 
         assert_eq!(
-            channel_transfer.preverify(&proof, &()),
+            signed_operation.preverify(&()),
             Err(Error::Inputs(InputsError::EmptyInputs))
         );
     }
@@ -222,9 +237,10 @@ mod test {
             outputs: Outputs::empty(),
         };
         let proof = ChannelMultiSigProof::try_new([].into()).unwrap();
+        let signed_operation = SignedOperation::new(channel_transfer, proof);
 
         assert_eq!(
-            channel_transfer.preverify(&proof, &()),
+            signed_operation.preverify(&()),
             Err(Error::Inputs(InputsError::EmptyInputs))
         );
     }

--- a/core/src/mantle/ops/channel/channel_transfer.rs
+++ b/core/src/mantle/ops/channel/channel_transfer.rs
@@ -60,6 +60,7 @@ impl ProvableOperation for ChannelTransferOp {
     // `SignedOperationExecutionGas::gas_multiplier` below reads this proof's
     // signature count. If this changes, update that too.
     type Proof = ChannelMultiSigProof;
+    const CODE: u8 = 0x14;
 }
 
 impl OperationGas<MainnetGasProfile> for ChannelTransferOp {

--- a/core/src/mantle/ops/channel/config.rs
+++ b/core/src/mantle/ops/channel/config.rs
@@ -15,7 +15,7 @@ use crate::{
             ExecutableOperation, PreverifiableOperation, ProvableOperation, VerifiableOperation,
             verification_mode, verification_mode::VerificationMode,
         },
-        ops::SignedOp,
+        ops::SignedOperation,
         transactions::{hash::TxHashView, states::VerificationState},
     },
     proofs::channel_multi_sig_proof::ChannelMultiSigProof,
@@ -163,7 +163,7 @@ impl ExecutableOperation for ChannelConfigOp {
 }
 
 impl<State: VerificationState, Mode: VerificationMode> SignedOperationExecutionGas
-    for SignedOp<ChannelConfigOp, State, Mode>
+    for SignedOperation<ChannelConfigOp, State, Mode>
 {
     fn gas_multiplier(&self) -> Value {
         let signature_count = self.proof().signatures().len();

--- a/core/src/mantle/ops/channel/config.rs
+++ b/core/src/mantle/ops/channel/config.rs
@@ -13,10 +13,13 @@ use crate::{
         gas::{Gas, MainnetGasProfile, OperationGas, SignedOperationExecutionGas},
         ledger::{
             ExecutableOperation, PreverifiableOperation, ProvableOperation, VerifiableOperation,
-            verification_mode, verification_mode::VerificationMode,
+            verification_mode::{StandardMode, VerificationMode},
         },
         ops::SignedOperation,
-        transactions::{hash::TxHashView, states::VerificationState},
+        transactions::{
+            hash::TxHashView,
+            states::{Preverified, Unverified, VerificationState, Verified},
+        },
     },
     proofs::channel_multi_sig_proof::ChannelMultiSigProof,
 };
@@ -64,17 +67,19 @@ impl OperationGas<MainnetGasProfile> for ChannelConfigOp {
     const GAS_COST: Gas = Gas::new(56);
 }
 
-impl PreverifiableOperation<verification_mode::StandardMode> for ChannelConfigOp {
+impl PreverifiableOperation<StandardMode>
+    for SignedOperation<ChannelConfigOp, Unverified, StandardMode>
+{
     type Context<'a> = ();
     type Error = Error;
 
-    fn preverify(
-        &self,
-        _proof: &Self::Proof,
-        _context: &Self::Context<'_>,
-    ) -> Result<(), Self::Error> {
+    fn preverify(&self, _context: &Self::Context<'_>) -> Result<(), Self::Error> {
+        let operation = self.operation();
+
         // Check config is well-formed
-        if self.configuration_threshold == 0 || self.transfer_threshold == 0 || self.keys.is_empty()
+        if operation.configuration_threshold == 0
+            || operation.transfer_threshold == 0
+            || operation.keys.is_empty()
         {
             return Err(Error::InvalidChannelConfig);
         }
@@ -83,20 +88,25 @@ impl PreverifiableOperation<verification_mode::StandardMode> for ChannelConfigOp
     }
 }
 
-impl VerifiableOperation<verification_mode::StandardMode> for ChannelConfigOp {
+impl VerifiableOperation<StandardMode>
+    for SignedOperation<ChannelConfigOp, Preverified, StandardMode>
+{
     type Context<'a> = ChannelConfigValidationContext<'a>;
     type Error = Error;
 
-    fn verify(&self, proof: &Self::Proof, context: &Self::Context<'_>) -> Result<(), Self::Error> {
+    fn verify(&self, context: &Self::Context<'_>) -> Result<(), Self::Error> {
+        let operation = self.operation();
+        let proof = self.proof();
+
         // Check that the indexes are unique and there is the same number of proof and
         // index. This is enforced by the proof structure that enforces it.
 
-        if let Some(channel) = context.channels.channels.get(&self.channel).cloned() {
+        if let Some(channel) = context.channels.channels.get(&operation.channel).cloned() {
             // Check there is enough signatures
             let signatures = proof.signatures();
             if signatures.len() != channel.configuration_threshold as usize {
                 return Err(Error::ThresholdUnmet {
-                    channel_id: self.channel,
+                    channel_id: operation.channel,
                     threshold: channel.configuration_threshold,
                     actual: proof.signatures().len(),
                 });
@@ -108,7 +118,7 @@ impl VerifiableOperation<verification_mode::StandardMode> for ChannelConfigOp {
                     .accredited_keys
                     .get(signature.channel_key_index as usize)
                     .ok_or_else(|| Error::InvalidSignatureIndex {
-                        channel_id: self.channel,
+                        channel_id: operation.channel,
                         sequencers: channel.accredited_keys.len(),
                         index: signature.channel_key_index,
                     })?
@@ -124,7 +134,9 @@ impl VerifiableOperation<verification_mode::StandardMode> for ChannelConfigOp {
     }
 }
 
-impl ExecutableOperation for ChannelConfigOp {
+impl<Mode: VerificationMode> ExecutableOperation
+    for SignedOperation<ChannelConfigOp, Verified, Mode>
+{
     type Context<'a> = ChannelConfigExecutionContext;
     type Error = Error;
 
@@ -132,30 +144,32 @@ impl ExecutableOperation for ChannelConfigOp {
         &self,
         mut context: Self::Context<'a>,
     ) -> Result<(Self::Context<'a>, Vec<TxEvent>), Self::Error> {
+        let operation = self.operation();
+
         // if the channel doesn't exist, create it otherwise just update the config
-        if let Some(channel) = context.channels.channels.get_mut(&self.channel) {
-            channel.accredited_keys = self.keys.clone().into();
-            channel.configuration_threshold = self.configuration_threshold;
+        if let Some(channel) = context.channels.channels.get_mut(&operation.channel) {
+            channel.accredited_keys = operation.keys.clone().into();
+            channel.configuration_threshold = operation.configuration_threshold;
             channel.tip_sequencer = 0;
             channel.tip_sequencer_starting_slot = context.block_slot;
-            channel.posting_timeframe = self.posting_timeframe.clone();
-            channel.posting_timeout = self.posting_timeout.clone();
-            channel.transfer_threshold = self.transfer_threshold;
+            channel.posting_timeframe = operation.posting_timeframe.clone();
+            channel.posting_timeout = operation.posting_timeout.clone();
+            channel.transfer_threshold = operation.transfer_threshold;
             channel.tip_slot = context.block_slot;
-            channel.tip_message = self.id();
+            channel.tip_message = operation.id();
         } else {
             context.channels.channels = context.channels.channels.insert(
-                self.channel,
+                operation.channel,
                 ChannelState {
-                    accredited_keys: self.keys.clone().into(),
-                    configuration_threshold: self.configuration_threshold,
-                    tip_message: self.id(),
+                    accredited_keys: operation.keys.clone().into(),
+                    configuration_threshold: operation.configuration_threshold,
+                    tip_message: operation.id(),
                     tip_slot: context.block_slot,
                     tip_sequencer: 0,
                     tip_sequencer_starting_slot: context.block_slot,
-                    posting_timeframe: self.posting_timeframe.clone(),
-                    transfer_threshold: self.transfer_threshold,
-                    posting_timeout: self.posting_timeout.clone(),
+                    posting_timeframe: operation.posting_timeframe.clone(),
+                    transfer_threshold: operation.transfer_threshold,
+                    posting_timeout: operation.posting_timeout.clone(),
                 },
             );
         }

--- a/core/src/mantle/ops/channel/config.rs
+++ b/core/src/mantle/ops/channel/config.rs
@@ -57,6 +57,7 @@ impl ProvableOperation for ChannelConfigOp {
     // `SignedOperationExecutionGas::gas_multiplier` below reads this proof's
     // signature count. If this changes, update that too.
     type Proof = ChannelMultiSigProof;
+    const CODE: u8 = 0x10;
 }
 
 impl OperationGas<MainnetGasProfile> for ChannelConfigOp {

--- a/core/src/mantle/ops/channel/deposit.rs
+++ b/core/src/mantle/ops/channel/deposit.rs
@@ -72,6 +72,7 @@ pub struct DepositExecutionContext {
 
 impl ProvableOperation for DepositOp {
     type Proof = ZkSignature;
+    const CODE: u8 = 0x12;
 }
 
 impl OperationGas<MainnetGasProfile> for DepositOp {

--- a/core/src/mantle/ops/channel/deposit.rs
+++ b/core/src/mantle/ops/channel/deposit.rs
@@ -14,7 +14,7 @@ use crate::{
             ProvableOperation, Utxos, VerifiableOperation, verification_mode,
             verification_mode::VerificationMode,
         },
-        ops::{OpId, SignedOp, channel::ChannelId},
+        ops::{OpId, SignedOperation, channel::ChannelId},
         transactions::{
             hash::{TxHash, TxHashView},
             states::VerificationState,
@@ -172,7 +172,7 @@ impl ExecutableOperation for DepositOp {
 }
 
 impl<State: VerificationState, Mode: VerificationMode> SignedOperationExecutionGas
-    for SignedOp<DepositOp, State, Mode>
+    for SignedOperation<DepositOp, State, Mode>
 {
     fn gas_multiplier(&self) -> Value {
         1

--- a/core/src/mantle/ops/channel/deposit.rs
+++ b/core/src/mantle/ops/channel/deposit.rs
@@ -11,13 +11,13 @@ use crate::{
         gas::{Gas, MainnetGasProfile, OperationGas, SignedOperationExecutionGas},
         ledger::{
             ExecutableOperation, Inputs, InputsError, Outputs, PreverifiableOperation,
-            ProvableOperation, Utxos, VerifiableOperation, verification_mode,
-            verification_mode::VerificationMode,
+            ProvableOperation, Utxos, VerifiableOperation,
+            verification_mode::{StandardMode, VerificationMode},
         },
         ops::{OpId, SignedOperation, channel::ChannelId},
         transactions::{
             hash::{TxHash, TxHashView},
-            states::VerificationState,
+            states::{Preverified, Unverified, VerificationState, Verified},
         },
     },
     sdp::locked_notes::LockedNotes,
@@ -79,44 +79,46 @@ impl OperationGas<MainnetGasProfile> for DepositOp {
     const GAS_COST: Gas = Gas::new(590);
 }
 
-impl PreverifiableOperation<verification_mode::StandardMode> for DepositOp {
+impl PreverifiableOperation<StandardMode> for SignedOperation<DepositOp, Unverified, StandardMode> {
     type Context<'a> = ();
     type Error = Error;
 
-    fn preverify(
-        &self,
-        _proof: &Self::Proof,
-        _context: &Self::Context<'_>,
-    ) -> Result<(), Self::Error> {
+    fn preverify(&self, _context: &Self::Context<'_>) -> Result<(), Self::Error> {
         // Ensure the inputs is non-empty
-        self.inputs.preverify()?;
+        self.operation().inputs.preverify()?;
 
         Ok(())
     }
 }
 
-impl VerifiableOperation<verification_mode::StandardMode> for DepositOp {
+impl VerifiableOperation<StandardMode> for SignedOperation<DepositOp, Preverified, StandardMode> {
     type Context<'a> = DepositValidationContext<'a>;
     type Error = Error;
 
-    fn verify(&self, proof: &Self::Proof, context: &Self::Context<'_>) -> Result<(), Self::Error> {
-        // Check that the channel exist
-        if !context.channels.channels.contains_key(&self.channel_id) {
+    fn verify(&self, context: &Self::Context<'_>) -> Result<(), Self::Error> {
+        let operation = self.operation();
+
+        // Check that the channel exists
+        if !context
+            .channels
+            .channels
+            .contains_key(&operation.channel_id)
+        {
             return Err(Error::ChannelNotFound {
-                channel_id: self.channel_id,
+                channel_id: operation.channel_id,
             });
         }
 
         // Check that inputs are spendable and not already channel notes
-        self.inputs.validate_not_in_channel(
+        operation.inputs.validate_not_in_channel(
             context.locked_notes,
             context.channels,
             context.utxos,
         )?;
 
         // Check the signature
-        let public_keys = self.inputs.get_pk(context.utxos)?;
-        if !ZkPublicKey::verify_multi(&public_keys, context.tx_hash_view.as_fr(), proof) {
+        let public_keys = operation.inputs.get_pk(context.utxos)?;
+        if !ZkPublicKey::verify_multi(&public_keys, context.tx_hash_view.as_fr(), self.proof()) {
             return Err(Error::InvalidSignature);
         }
 
@@ -124,7 +126,7 @@ impl VerifiableOperation<verification_mode::StandardMode> for DepositOp {
     }
 }
 
-impl ExecutableOperation for DepositOp {
+impl<Mode: VerificationMode> ExecutableOperation for SignedOperation<DepositOp, Verified, Mode> {
     type Context<'a> = DepositExecutionContext;
     type Error = Error;
 
@@ -132,21 +134,23 @@ impl ExecutableOperation for DepositOp {
         &self,
         mut context: Self::Context<'a>,
     ) -> Result<(Self::Context<'a>, Vec<TxEvent>), Self::Error> {
+        let operation = self.operation();
+
         // Get the amount deposited for the event payload
-        let amount_deposited = self.inputs.amount(&context.utxos)?;
-        let outputs = self.outputs(&context.utxos)?;
+        let amount_deposited = operation.inputs.amount(&context.utxos)?;
+        let outputs = operation.outputs(&context.utxos)?;
 
         // Remove the inputs from the ledger.
-        context.utxos = self.inputs.execute(context.utxos)?;
+        context.utxos = operation.inputs.execute(context.utxos)?;
 
         // Add the re-created notes to the ledger and register them as channel
         // notes.
-        context.utxos = outputs.execute(context.utxos, self);
+        context.utxos = outputs.execute(context.utxos, operation);
         let mut notes = DepositRecreatedNotes::default();
-        for utxo in outputs.utxos(self) {
+        for utxo in outputs.utxos(operation) {
             context.channels = context
                 .channels
-                .register_channel_note(&utxo.id(), &self.channel_id)?;
+                .register_channel_note(&utxo.id(), &operation.channel_id)?;
             notes
                 .try_push(DepositNote {
                     note_id: utxo.id(),
@@ -158,11 +162,11 @@ impl ExecutableOperation for DepositOp {
 
         let events = std::iter::once(TxEvent::new(
             context.tx_hash,
-            self.op_id(),
+            operation.op_id(),
             TxEventPayload::Deposit {
-                channel_id: self.channel_id,
+                channel_id: operation.channel_id,
                 amount: amount_deposited,
-                metadata: self.metadata.clone(),
+                metadata: operation.metadata.clone(),
                 notes,
             },
         ))
@@ -194,9 +198,10 @@ mod test {
             metadata: Metadata::empty(),
         };
         let proof = ZkSignature::new(CompressedGroth16Proof::from_bytes(&[0u8; 128]));
+        let signed_operation = SignedOperation::new(deposit, proof);
 
         assert_eq!(
-            deposit.preverify(&proof, &()),
+            signed_operation.preverify(&()),
             Err(Error::Inputs(InputsError::EmptyInputs))
         );
     }

--- a/core/src/mantle/ops/channel/inscribe.rs
+++ b/core/src/mantle/ops/channel/inscribe.rs
@@ -17,10 +17,13 @@ use crate::{
         gas::{Gas, MainnetGasProfile, OperationGas, SignedOperationExecutionGas},
         ledger::{
             ExecutableOperation, PreverifiableOperation, ProvableOperation, VerifiableOperation,
-            verification_mode, verification_mode::VerificationMode,
+            verification_mode::{StandardMode, VerificationMode},
         },
         ops::{SignedOperation, channel::config::Keys},
-        transactions::{hash::TxHashView, states::VerificationState},
+        transactions::{
+            hash::TxHashView,
+            states::{Preverified, Unverified, VerificationState, Verified},
+        },
     },
 };
 
@@ -95,55 +98,63 @@ impl OperationGas<MainnetGasProfile> for InscriptionOp {
     const GAS_COST: Gas = Gas::new(56);
 }
 
-impl PreverifiableOperation<verification_mode::StandardMode> for InscriptionOp {
+impl PreverifiableOperation<StandardMode>
+    for SignedOperation<InscriptionOp, Unverified, StandardMode>
+{
     type Context<'a> = InscriptionPreverificationContext<'a>;
     type Error = Error;
 
-    fn preverify(
-        &self,
-        proof: &Self::Proof,
-        context: &Self::Context<'_>,
-    ) -> Result<(), Self::Error> {
+    fn preverify(&self, context: &Self::Context<'_>) -> Result<(), Self::Error> {
         // Check the signature
-        self.signer
-            .verify(context.tx_hash_view.as_bytes(), proof)
+        self.operation()
+            .signer
+            .verify(context.tx_hash_view.as_bytes(), self.proof())
             .map_err(|_error| Error::InvalidSignature)?;
 
         Ok(())
     }
 }
 
-impl VerifiableOperation<verification_mode::StandardMode> for InscriptionOp {
+impl VerifiableOperation<StandardMode>
+    for SignedOperation<InscriptionOp, Preverified, StandardMode>
+{
     type Context<'a> = InscriptionValidationContext<'a>;
     type Error = Error;
 
-    fn verify(&self, _proof: &Self::Proof, context: &Self::Context<'_>) -> Result<(), Self::Error> {
+    fn verify(&self, context: &Self::Context<'_>) -> Result<(), Self::Error> {
+        let operation = self.operation();
+
         // Check if the channel exist otherwise the inscription is valid only if and
         // only if parent == ZERO
-        if let Some(channel) = context.channels.channels.get(&self.channel_id).cloned() {
+        if let Some(channel) = context
+            .channels
+            .channels
+            .get(&operation.channel_id)
+            .cloned()
+        {
             // Check the parent corresponds to the payload
-            if self.parent != channel.tip_message {
+            if operation.parent != channel.tip_message {
                 return Err(Error::InvalidParent {
-                    channel_id: self.channel_id,
-                    parent: self.parent.into(),
+                    channel_id: operation.channel_id,
+                    parent: operation.parent.into(),
                     actual: channel.tip_message.into(),
                 });
             }
 
             // Check that the signer is the authorized one
-            if self.signer
+            if operation.signer
                 != channel.accredited_keys[channel.round_robin(context.block_slot).0 as usize]
             {
                 return Err(Error::UnauthorizedSigner {
-                    channel_id: self.channel_id,
-                    signer: format!("{signer:?}", signer = self.signer),
+                    channel_id: operation.channel_id,
+                    signer: format!("{signer:?}", signer = operation.signer),
                 });
             }
-        } else if self.parent != MsgId::root() {
+        } else if operation.parent != MsgId::root() {
             // Checked that the parent is ZERO because channel doesn't exist
             return Err(Error::InvalidParent {
-                channel_id: self.channel_id,
-                parent: self.parent.into(),
+                channel_id: operation.channel_id,
+                parent: operation.parent.into(),
                 actual: MsgId::root().into(),
             });
         }
@@ -152,7 +163,9 @@ impl VerifiableOperation<verification_mode::StandardMode> for InscriptionOp {
     }
 }
 
-impl ExecutableOperation for InscriptionOp {
+impl<Mode: VerificationMode> ExecutableOperation
+    for SignedOperation<InscriptionOp, Verified, Mode>
+{
     type Context<'a> = InscriptionExecutionContext;
     type Error = Error;
 
@@ -160,14 +173,16 @@ impl ExecutableOperation for InscriptionOp {
         &self,
         mut context: Self::Context<'a>,
     ) -> Result<(Self::Context<'a>, Vec<TxEvent>), Self::Error> {
+        let operation = self.operation();
+
         // if the channel doesn't exist, create it
         let channel = context
             .channels
             .channels
-            .get(&self.channel_id)
+            .get(&operation.channel_id)
             .cloned()
             .unwrap_or_else(|| ChannelState {
-                accredited_keys: Keys::from(self.signer).into(),
+                accredited_keys: Keys::from(operation.signer).into(),
                 configuration_threshold: 1,
                 tip_message: MsgId::root(),
                 tip_slot: context.block_slot,
@@ -182,9 +197,9 @@ impl ExecutableOperation for InscriptionOp {
         // slot
         let (new_sequencer, new_starting_slot) = channel.round_robin(context.block_slot);
         context.channels.channels = context.channels.channels.insert(
-            self.channel_id,
+            operation.channel_id,
             ChannelState {
-                tip_message: self.id(),
+                tip_message: operation.id(),
                 accredited_keys: Arc::clone(&channel.accredited_keys),
                 tip_sequencer: new_sequencer,
                 tip_sequencer_starting_slot: new_starting_slot,

--- a/core/src/mantle/ops/channel/inscribe.rs
+++ b/core/src/mantle/ops/channel/inscribe.rs
@@ -88,6 +88,7 @@ pub struct InscriptionExecutionContext {
 
 impl ProvableOperation for InscriptionOp {
     type Proof = Ed25519Signature;
+    const CODE: u8 = 0x11;
 }
 
 impl OperationGas<MainnetGasProfile> for InscriptionOp {

--- a/core/src/mantle/ops/channel/inscribe.rs
+++ b/core/src/mantle/ops/channel/inscribe.rs
@@ -19,7 +19,7 @@ use crate::{
             ExecutableOperation, PreverifiableOperation, ProvableOperation, VerifiableOperation,
             verification_mode, verification_mode::VerificationMode,
         },
-        ops::{SignedOp, channel::config::Keys},
+        ops::{SignedOperation, channel::config::Keys},
         transactions::{hash::TxHashView, states::VerificationState},
     },
 };
@@ -196,7 +196,7 @@ impl ExecutableOperation for InscriptionOp {
 }
 
 impl<State: VerificationState, Mode: VerificationMode> SignedOperationExecutionGas
-    for SignedOp<InscriptionOp, State, Mode>
+    for SignedOperation<InscriptionOp, State, Mode>
 {
     fn gas_multiplier(&self) -> Value {
         1

--- a/core/src/mantle/ops/channel/verification.rs
+++ b/core/src/mantle/ops/channel/verification.rs
@@ -98,7 +98,7 @@ mod tests {
         channel::Channels,
         ops::channel::ChannelId,
         transactions::{
-            TxHash, signed_mantle_tx::test_utils::make_channel_state,
+            TxHash, mantle_transaction::test_utils::make_channel_state,
             verification_helper::test_utils::TestOperationVerificationHelper,
         },
     };

--- a/core/src/mantle/ops/channel/withdraw.rs
+++ b/core/src/mantle/ops/channel/withdraw.rs
@@ -9,13 +9,18 @@ use crate::{
         gas::{Gas, MainnetGasProfile, OperationGas, SignedOperationExecutionGas},
         ledger::{
             ExecutableOperation, Inputs, PreverifiableOperation, ProvableOperation, Utxos,
-            VerifiableOperation, verification_mode, verification_mode::VerificationMode,
+            VerifiableOperation,
+            verification_mode::{StandardMode, VerificationMode},
         },
         ops::{
             OpId, SignedOperation,
             channel::{ChannelId, verification::verify_channel_multi_sig},
         },
-        transactions::{OperationVerificationHelper, hash::TxHashView, states::VerificationState},
+        transactions::{
+            OperationVerificationHelper,
+            hash::TxHashView,
+            states::{Preverified, Unverified, VerificationState, Verified},
+        },
     },
     proofs::channel_multi_sig_proof::ChannelMultiSigProof,
     sdp::locked_notes::LockedNotes,
@@ -59,29 +64,32 @@ impl OperationGas<MainnetGasProfile> for ChannelWithdrawOp {
     const GAS_COST: Gas = Gas::new(56);
 }
 
-impl PreverifiableOperation<verification_mode::StandardMode> for ChannelWithdrawOp {
+impl PreverifiableOperation<StandardMode>
+    for SignedOperation<ChannelWithdrawOp, Unverified, StandardMode>
+{
     type Context<'a> = ();
     type Error = Error;
 
-    fn preverify(
-        &self,
-        _proof: &Self::Proof,
-        _context: &Self::Context<'_>,
-    ) -> Result<(), Self::Error> {
+    fn preverify(&self, _context: &Self::Context<'_>) -> Result<(), Self::Error> {
         // Ensure the inputs is non-empty
-        self.inputs.preverify()?;
+        self.operation().inputs.preverify()?;
 
         Ok(())
     }
 }
 
-impl VerifiableOperation<verification_mode::StandardMode> for ChannelWithdrawOp {
+impl VerifiableOperation<StandardMode>
+    for SignedOperation<ChannelWithdrawOp, Preverified, StandardMode>
+{
     type Context<'a> = WithdrawValidationContext<'a>;
     type Error = Error;
 
-    fn verify(&self, proof: &Self::Proof, context: &Self::Context<'_>) -> Result<(), Self::Error> {
+    fn verify(&self, context: &Self::Context<'_>) -> Result<(), Self::Error> {
+        let operation = self.operation();
+        let proof = self.proof();
+
         verify_channel_multi_sig(
-            &self.channel_id,
+            &operation.channel_id,
             proof,
             context.tx_hash_view.as_bytes(),
             context.helper,
@@ -94,16 +102,16 @@ impl VerifiableOperation<verification_mode::StandardMode> for ChannelWithdrawOp 
             context
                 .channels
                 .channels
-                .get(&self.channel_id)
+                .get(&operation.channel_id)
                 .ok_or(Error::ChannelNotFound {
-                    channel_id: self.channel_id,
+                    channel_id: operation.channel_id,
                 })?;
 
         // Check that the inputs are valid and belong to the channel
-        self.inputs.validate_in_channel(
+        operation.inputs.validate_in_channel(
             context.locked_notes,
             context.channels,
-            &self.channel_id,
+            &operation.channel_id,
             context.utxos,
         )?;
 
@@ -111,7 +119,7 @@ impl VerifiableOperation<verification_mode::StandardMode> for ChannelWithdrawOp 
         let signatures = proof.signatures();
         if signatures.len() != channel.transfer_threshold as usize {
             return Err(Error::ThresholdUnmet {
-                channel_id: self.channel_id,
+                channel_id: operation.channel_id,
                 threshold: channel.transfer_threshold,
                 actual: signatures.len(),
             });
@@ -134,7 +142,9 @@ impl VerifiableOperation<verification_mode::StandardMode> for ChannelWithdrawOp 
     }
 }
 
-impl ExecutableOperation for ChannelWithdrawOp {
+impl<Mode: VerificationMode> ExecutableOperation
+    for SignedOperation<ChannelWithdrawOp, Verified, Mode>
+{
     type Context<'a> = WithdrawExecutionContext;
     type Error = Error;
 
@@ -142,12 +152,14 @@ impl ExecutableOperation for ChannelWithdrawOp {
         &self,
         mut context: Self::Context<'a>,
     ) -> Result<(Self::Context<'a>, Vec<TxEvent>), Self::Error> {
+        let operation = self.operation();
+
         // Release the inputs from the channel. The notes keep their NoteId,
         // value and ZkPublicKey and stay in the ledger as regular notes.
-        for note_id in self.inputs.iter() {
+        for note_id in operation.inputs.iter() {
             context.channels = context
                 .channels
-                .unregister_channel_note(note_id, &self.channel_id)?;
+                .unregister_channel_note(note_id, &operation.channel_id)?;
         }
 
         Ok((context, Vec::new()))
@@ -176,9 +188,10 @@ mod test {
             inputs: Inputs::empty(),
         };
         let proof = ChannelMultiSigProof::try_new([].into()).unwrap();
+        let signed_operation = SignedOperation::new(withdraw, proof);
 
         assert_eq!(
-            withdraw.preverify(&proof, &()),
+            signed_operation.preverify(&()),
             Err(Error::Inputs(InputsError::EmptyInputs))
         );
     }

--- a/core/src/mantle/ops/channel/withdraw.rs
+++ b/core/src/mantle/ops/channel/withdraw.rs
@@ -12,7 +12,7 @@ use crate::{
             VerifiableOperation, verification_mode, verification_mode::VerificationMode,
         },
         ops::{
-            OpId, SignedOp,
+            OpId, SignedOperation,
             channel::{ChannelId, verification::verify_channel_multi_sig},
         },
         transactions::{OperationVerificationHelper, hash::TxHashView, states::VerificationState},
@@ -154,7 +154,7 @@ impl ExecutableOperation for ChannelWithdrawOp {
 }
 
 impl<State: VerificationState, Mode: VerificationMode> SignedOperationExecutionGas
-    for SignedOp<ChannelWithdrawOp, State, Mode>
+    for SignedOperation<ChannelWithdrawOp, State, Mode>
 {
     fn gas_multiplier(&self) -> Value {
         let signature_count = self.proof().signatures().len();

--- a/core/src/mantle/ops/channel/withdraw.rs
+++ b/core/src/mantle/ops/channel/withdraw.rs
@@ -52,6 +52,7 @@ impl ProvableOperation for ChannelWithdrawOp {
     // `SignedOperationExecutionGas::gas_multiplier` below reads this proof's
     // signature count. If this changes, update that too.
     type Proof = ChannelMultiSigProof;
+    const CODE: u8 = 0x13;
 }
 
 impl OperationGas<MainnetGasProfile> for ChannelWithdrawOp {

--- a/core/src/mantle/ops/codec.rs
+++ b/core/src/mantle/ops/codec.rs
@@ -12,7 +12,7 @@ use crate::{
     },
 };
 
-pub fn decode_ops_proofs<'a>(
+pub fn decode_op_proofs<'a>(
     input: &'a [u8],
     ops: &[Op],
 ) -> Result<(&'a [u8], OpProofs), DecodeError> {
@@ -87,7 +87,7 @@ fn encode_op_proof(proof: &OpProof, op: &Op) -> Vec<u8> {
     }
 }
 
-pub fn encode_ops_proofs(proofs: &[OpProof], ops: &[Op]) -> Vec<u8> {
+pub fn encode_op_proofs(proofs: &[OpProof], ops: &[Op]) -> Vec<u8> {
     let mut bytes = Vec::new();
     for (proof, op) in proofs.iter().zip(ops.iter()) {
         bytes.extend(encode_op_proof(proof, op));

--- a/core/src/mantle/ops/codec.rs
+++ b/core/src/mantle/ops/codec.rs
@@ -5,7 +5,7 @@ use crate::{
     mantle::{
         Op, OpProof,
         ops::{NoOpProof, ZkAndEd25519Proof},
-        transactions::OpsProofs,
+        transactions::OpProofs,
     },
     proofs::{
         channel_multi_sig_proof::ChannelMultiSigProof, leader_claim_proof::Groth16LeaderClaimProof,
@@ -15,7 +15,7 @@ use crate::{
 pub fn decode_ops_proofs<'a>(
     input: &'a [u8],
     ops: &[Op],
-) -> Result<(&'a [u8], OpsProofs), DecodeError> {
+) -> Result<(&'a [u8], OpProofs), DecodeError> {
     let mut remaining = input;
     let mut proofs = Vec::with_capacity(ops.len());
 
@@ -24,8 +24,8 @@ pub fn decode_ops_proofs<'a>(
         proofs.push(proof);
         remaining = new_remaining;
     }
-    let ops_proofs = OpsProofs::try_from(proofs).map_err(|_| {
-        DecodeError::length_out_of_bounds::<OpsProofs>(ops.len(), OpsProofs::MIN, OpsProofs::MAX)
+    let ops_proofs = OpProofs::try_from(proofs).map_err(|_| {
+        DecodeError::length_out_of_bounds::<OpProofs>(ops.len(), OpProofs::MIN, OpProofs::MAX)
     })?;
 
     Ok((remaining, ops_proofs))

--- a/core/src/mantle/ops/internal.rs
+++ b/core/src/mantle/ops/internal.rs
@@ -1,10 +1,10 @@
 use serde::{Deserialize, Serialize};
 
 use super::{
-    CHANNEL_CONFIG, CHANNEL_DEPOSIT, CHANNEL_TRANSFER, CHANNEL_WITHDRAW, CLAIM_POW_REWARD,
-    INSCRIBE, LEADER_CLAIM, Op, SDP_ACTIVE, SDP_DECLARE, SDP_WITHDRAW, TRANSFER,
+    Op,
     channel::{config::ChannelConfigOp, deposit::DepositOp, inscribe::InscriptionOp},
     leader_claim::LeaderClaimOp,
+    op_codes,
     sdp::{SDPActiveOp, SDPDeclareOp, SDPWithdrawOp},
     serde_::OpWire,
     transfer::TransferOp,
@@ -18,17 +18,17 @@ use crate::mantle::ops::{
 #[derive(Serialize)]
 #[serde(untagged)]
 pub enum OpSer<'a> {
-    ChannelInscribe(OpWire<INSCRIBE, &'a InscriptionOp>),
-    ChannelConfig(OpWire<CHANNEL_CONFIG, &'a ChannelConfigOp>),
-    ChannelDeposit(OpWire<CHANNEL_DEPOSIT, &'a DepositOp>),
-    ChannelWithdraw(OpWire<CHANNEL_WITHDRAW, &'a ChannelWithdrawOp>),
-    ChannelTransfer(OpWire<CHANNEL_TRANSFER, &'a ChannelTransferOp>),
-    SDPDeclare(OpWire<SDP_DECLARE, &'a SDPDeclareOp>),
-    SDPWithdraw(OpWire<SDP_WITHDRAW, &'a SDPWithdrawOp>),
-    SDPActive(OpWire<SDP_ACTIVE, &'a SDPActiveOp>),
-    LeaderClaim(OpWire<LEADER_CLAIM, &'a LeaderClaimOp>),
-    Transfer(OpWire<TRANSFER, &'a TransferOp>),
-    ClaimPowReward(OpWire<CLAIM_POW_REWARD, &'a ClaimPowRewardOp>),
+    ChannelInscribe(OpWire<{ op_codes::INSCRIBE }, &'a InscriptionOp>),
+    ChannelConfig(OpWire<{ op_codes::CHANNEL_CONFIG }, &'a ChannelConfigOp>),
+    ChannelDeposit(OpWire<{ op_codes::CHANNEL_DEPOSIT }, &'a DepositOp>),
+    ChannelWithdraw(OpWire<{ op_codes::CHANNEL_WITHDRAW }, &'a ChannelWithdrawOp>),
+    ChannelTransfer(OpWire<{ op_codes::CHANNEL_TRANSFER }, &'a ChannelTransferOp>),
+    SDPDeclare(OpWire<{ op_codes::SDP_DECLARE }, &'a SDPDeclareOp>),
+    SDPWithdraw(OpWire<{ op_codes::SDP_WITHDRAW }, &'a SDPWithdrawOp>),
+    SDPActive(OpWire<{ op_codes::SDP_ACTIVE }, &'a SDPActiveOp>),
+    LeaderClaim(OpWire<{ op_codes::LEADER_CLAIM }, &'a LeaderClaimOp>),
+    Transfer(OpWire<{ op_codes::TRANSFER }, &'a TransferOp>),
+    ClaimPowReward(OpWire<{ op_codes::CLAIM_POW_REWARD }, &'a ClaimPowRewardOp>),
 }
 
 impl<'a> From<&'a Op> for OpSer<'a> {
@@ -53,17 +53,17 @@ impl<'a> From<&'a Op> for OpSer<'a> {
 #[derive(Deserialize)]
 #[serde(untagged)]
 pub enum OpDe {
-    ChannelInscribe(OpWire<INSCRIBE, InscriptionOp>),
-    ChannelConfig(OpWire<CHANNEL_CONFIG, ChannelConfigOp>),
-    ChannelDeposit(OpWire<CHANNEL_DEPOSIT, DepositOp>),
-    ChannelWithdraw(OpWire<CHANNEL_WITHDRAW, ChannelWithdrawOp>),
-    ChannelTransfer(OpWire<CHANNEL_TRANSFER, ChannelTransferOp>),
-    SDPDeclare(OpWire<SDP_DECLARE, SDPDeclareOp>),
-    SDPWithdraw(OpWire<SDP_WITHDRAW, SDPWithdrawOp>),
-    SDPActive(OpWire<SDP_ACTIVE, SDPActiveOp>),
-    LeaderClaim(OpWire<LEADER_CLAIM, LeaderClaimOp>),
-    Transfer(OpWire<TRANSFER, TransferOp>),
-    ClaimPoWReward(OpWire<CLAIM_POW_REWARD, ClaimPowRewardOp>),
+    ChannelInscribe(OpWire<{ op_codes::INSCRIBE }, InscriptionOp>),
+    ChannelConfig(OpWire<{ op_codes::CHANNEL_CONFIG }, ChannelConfigOp>),
+    ChannelDeposit(OpWire<{ op_codes::CHANNEL_DEPOSIT }, DepositOp>),
+    ChannelWithdraw(OpWire<{ op_codes::CHANNEL_WITHDRAW }, ChannelWithdrawOp>),
+    ChannelTransfer(OpWire<{ op_codes::CHANNEL_TRANSFER }, ChannelTransferOp>),
+    SDPDeclare(OpWire<{ op_codes::SDP_DECLARE }, SDPDeclareOp>),
+    SDPWithdraw(OpWire<{ op_codes::SDP_WITHDRAW }, SDPWithdrawOp>),
+    SDPActive(OpWire<{ op_codes::SDP_ACTIVE }, SDPActiveOp>),
+    LeaderClaim(OpWire<{ op_codes::LEADER_CLAIM }, LeaderClaimOp>),
+    Transfer(OpWire<{ op_codes::TRANSFER }, TransferOp>),
+    ClaimPoWReward(OpWire<{ op_codes::CLAIM_POW_REWARD }, ClaimPowRewardOp>),
 }
 
 impl From<OpDe> for Op {

--- a/core/src/mantle/ops/internal.rs
+++ b/core/src/mantle/ops/internal.rs
@@ -4,31 +4,33 @@ use super::{
     Op,
     channel::{config::ChannelConfigOp, deposit::DepositOp, inscribe::InscriptionOp},
     leader_claim::LeaderClaimOp,
-    op_codes,
     sdp::{SDPActiveOp, SDPDeclareOp, SDPWithdrawOp},
     serde_::OpWire,
     transfer::TransferOp,
 };
-use crate::mantle::ops::{
-    channel::{channel_transfer::ChannelTransferOp, withdraw::ChannelWithdrawOp},
-    pow::ClaimPowRewardOp,
+use crate::mantle::{
+    ledger::ProvableOperation as _,
+    ops::{
+        channel::{channel_transfer::ChannelTransferOp, withdraw::ChannelWithdrawOp},
+        pow::ClaimPowRewardOp,
+    },
 };
 
 /// Core set of supported Mantle operations and their serialization behaviour.
 #[derive(Serialize)]
 #[serde(untagged)]
 pub enum OpSer<'a> {
-    ChannelInscribe(OpWire<{ op_codes::INSCRIBE }, &'a InscriptionOp>),
-    ChannelConfig(OpWire<{ op_codes::CHANNEL_CONFIG }, &'a ChannelConfigOp>),
-    ChannelDeposit(OpWire<{ op_codes::CHANNEL_DEPOSIT }, &'a DepositOp>),
-    ChannelWithdraw(OpWire<{ op_codes::CHANNEL_WITHDRAW }, &'a ChannelWithdrawOp>),
-    ChannelTransfer(OpWire<{ op_codes::CHANNEL_TRANSFER }, &'a ChannelTransferOp>),
-    SDPDeclare(OpWire<{ op_codes::SDP_DECLARE }, &'a SDPDeclareOp>),
-    SDPWithdraw(OpWire<{ op_codes::SDP_WITHDRAW }, &'a SDPWithdrawOp>),
-    SDPActive(OpWire<{ op_codes::SDP_ACTIVE }, &'a SDPActiveOp>),
-    LeaderClaim(OpWire<{ op_codes::LEADER_CLAIM }, &'a LeaderClaimOp>),
-    Transfer(OpWire<{ op_codes::TRANSFER }, &'a TransferOp>),
-    ClaimPowReward(OpWire<{ op_codes::CLAIM_POW_REWARD }, &'a ClaimPowRewardOp>),
+    ChannelInscribe(OpWire<{ InscriptionOp::CODE }, &'a InscriptionOp>),
+    ChannelConfig(OpWire<{ ChannelConfigOp::CODE }, &'a ChannelConfigOp>),
+    ChannelDeposit(OpWire<{ DepositOp::CODE }, &'a DepositOp>),
+    ChannelWithdraw(OpWire<{ ChannelWithdrawOp::CODE }, &'a ChannelWithdrawOp>),
+    ChannelTransfer(OpWire<{ ChannelTransferOp::CODE }, &'a ChannelTransferOp>),
+    SDPDeclare(OpWire<{ SDPDeclareOp::CODE }, &'a SDPDeclareOp>),
+    SDPWithdraw(OpWire<{ SDPWithdrawOp::CODE }, &'a SDPWithdrawOp>),
+    SDPActive(OpWire<{ SDPActiveOp::CODE }, &'a SDPActiveOp>),
+    LeaderClaim(OpWire<{ LeaderClaimOp::CODE }, &'a LeaderClaimOp>),
+    Transfer(OpWire<{ TransferOp::CODE }, &'a TransferOp>),
+    ClaimPowReward(OpWire<{ ClaimPowRewardOp::CODE }, &'a ClaimPowRewardOp>),
 }
 
 impl<'a> From<&'a Op> for OpSer<'a> {
@@ -53,17 +55,17 @@ impl<'a> From<&'a Op> for OpSer<'a> {
 #[derive(Deserialize)]
 #[serde(untagged)]
 pub enum OpDe {
-    ChannelInscribe(OpWire<{ op_codes::INSCRIBE }, InscriptionOp>),
-    ChannelConfig(OpWire<{ op_codes::CHANNEL_CONFIG }, ChannelConfigOp>),
-    ChannelDeposit(OpWire<{ op_codes::CHANNEL_DEPOSIT }, DepositOp>),
-    ChannelWithdraw(OpWire<{ op_codes::CHANNEL_WITHDRAW }, ChannelWithdrawOp>),
-    ChannelTransfer(OpWire<{ op_codes::CHANNEL_TRANSFER }, ChannelTransferOp>),
-    SDPDeclare(OpWire<{ op_codes::SDP_DECLARE }, SDPDeclareOp>),
-    SDPWithdraw(OpWire<{ op_codes::SDP_WITHDRAW }, SDPWithdrawOp>),
-    SDPActive(OpWire<{ op_codes::SDP_ACTIVE }, SDPActiveOp>),
-    LeaderClaim(OpWire<{ op_codes::LEADER_CLAIM }, LeaderClaimOp>),
-    Transfer(OpWire<{ op_codes::TRANSFER }, TransferOp>),
-    ClaimPoWReward(OpWire<{ op_codes::CLAIM_POW_REWARD }, ClaimPowRewardOp>),
+    ChannelInscribe(OpWire<{ InscriptionOp::CODE }, InscriptionOp>),
+    ChannelConfig(OpWire<{ ChannelConfigOp::CODE }, ChannelConfigOp>),
+    ChannelDeposit(OpWire<{ DepositOp::CODE }, DepositOp>),
+    ChannelWithdraw(OpWire<{ ChannelWithdrawOp::CODE }, ChannelWithdrawOp>),
+    ChannelTransfer(OpWire<{ ChannelTransferOp::CODE }, ChannelTransferOp>),
+    SDPDeclare(OpWire<{ SDPDeclareOp::CODE }, SDPDeclareOp>),
+    SDPWithdraw(OpWire<{ SDPWithdrawOp::CODE }, SDPWithdrawOp>),
+    SDPActive(OpWire<{ SDPActiveOp::CODE }, SDPActiveOp>),
+    LeaderClaim(OpWire<{ LeaderClaimOp::CODE }, LeaderClaimOp>),
+    Transfer(OpWire<{ TransferOp::CODE }, TransferOp>),
+    ClaimPoWReward(OpWire<{ ClaimPowRewardOp::CODE }, ClaimPowRewardOp>),
 }
 
 impl From<OpDe> for Op {

--- a/core/src/mantle/ops/internal.rs
+++ b/core/src/mantle/ops/internal.rs
@@ -20,6 +20,7 @@ use crate::mantle::{
 #[derive(Serialize)]
 #[serde(untagged)]
 pub enum OpSer<'a> {
+    Transfer(OpWire<{ TransferOp::CODE }, &'a TransferOp>),
     ChannelInscribe(OpWire<{ InscriptionOp::CODE }, &'a InscriptionOp>),
     ChannelConfig(OpWire<{ ChannelConfigOp::CODE }, &'a ChannelConfigOp>),
     ChannelDeposit(OpWire<{ DepositOp::CODE }, &'a DepositOp>),
@@ -29,13 +30,13 @@ pub enum OpSer<'a> {
     SDPWithdraw(OpWire<{ SDPWithdrawOp::CODE }, &'a SDPWithdrawOp>),
     SDPActive(OpWire<{ SDPActiveOp::CODE }, &'a SDPActiveOp>),
     LeaderClaim(OpWire<{ LeaderClaimOp::CODE }, &'a LeaderClaimOp>),
-    Transfer(OpWire<{ TransferOp::CODE }, &'a TransferOp>),
     ClaimPowReward(OpWire<{ ClaimPowRewardOp::CODE }, &'a ClaimPowRewardOp>),
 }
 
 impl<'a> From<&'a Op> for OpSer<'a> {
     fn from(value: &'a Op) -> Self {
         match value {
+            Op::Transfer(op) => Self::Transfer(OpWire::new(op)),
             Op::ChannelInscribe(op) => Self::ChannelInscribe(OpWire::new(op)),
             Op::ChannelConfig(op) => Self::ChannelConfig(OpWire::new(op)),
             Op::ChannelDeposit(op) => Self::ChannelDeposit(OpWire::new(op)),
@@ -45,7 +46,6 @@ impl<'a> From<&'a Op> for OpSer<'a> {
             Op::SDPWithdraw(op) => Self::SDPWithdraw(OpWire::new(op)),
             Op::SDPActive(op) => Self::SDPActive(OpWire::new(op)),
             Op::LeaderClaim(op) => Self::LeaderClaim(OpWire::new(op)),
-            Op::Transfer(op) => Self::Transfer(OpWire::new(op)),
             Op::ClaimPowReward(op) => Self::ClaimPowReward(OpWire::new(op)),
         }
     }
@@ -55,8 +55,9 @@ impl<'a> From<&'a Op> for OpSer<'a> {
 #[derive(Deserialize)]
 #[serde(untagged)]
 pub enum OpDe {
-    ChannelInscribe(OpWire<{ InscriptionOp::CODE }, InscriptionOp>),
+    Transfer(OpWire<{ TransferOp::CODE }, TransferOp>),
     ChannelConfig(OpWire<{ ChannelConfigOp::CODE }, ChannelConfigOp>),
+    ChannelInscribe(OpWire<{ InscriptionOp::CODE }, InscriptionOp>),
     ChannelDeposit(OpWire<{ DepositOp::CODE }, DepositOp>),
     ChannelWithdraw(OpWire<{ ChannelWithdrawOp::CODE }, ChannelWithdrawOp>),
     ChannelTransfer(OpWire<{ ChannelTransferOp::CODE }, ChannelTransferOp>),
@@ -64,15 +65,15 @@ pub enum OpDe {
     SDPWithdraw(OpWire<{ SDPWithdrawOp::CODE }, SDPWithdrawOp>),
     SDPActive(OpWire<{ SDPActiveOp::CODE }, SDPActiveOp>),
     LeaderClaim(OpWire<{ LeaderClaimOp::CODE }, LeaderClaimOp>),
-    Transfer(OpWire<{ TransferOp::CODE }, TransferOp>),
-    ClaimPoWReward(OpWire<{ ClaimPowRewardOp::CODE }, ClaimPowRewardOp>),
+    ClaimPowReward(OpWire<{ ClaimPowRewardOp::CODE }, ClaimPowRewardOp>),
 }
 
 impl From<OpDe> for Op {
     fn from(value: OpDe) -> Self {
         match value {
-            OpDe::ChannelInscribe(w) => Self::ChannelInscribe(w.into_op()),
+            OpDe::Transfer(w) => Self::Transfer(w.into_op()),
             OpDe::ChannelConfig(w) => Self::ChannelConfig(w.into_op()),
+            OpDe::ChannelInscribe(w) => Self::ChannelInscribe(w.into_op()),
             OpDe::ChannelDeposit(w) => Self::ChannelDeposit(w.into_op()),
             OpDe::ChannelWithdraw(w) => Self::ChannelWithdraw(w.into_op()),
             OpDe::ChannelTransfer(w) => Self::ChannelTransfer(w.into_op()),
@@ -80,8 +81,7 @@ impl From<OpDe> for Op {
             OpDe::SDPWithdraw(w) => Self::SDPWithdraw(w.into_op()),
             OpDe::SDPActive(w) => Self::SDPActive(w.into_op()),
             OpDe::LeaderClaim(w) => Self::LeaderClaim(w.into_op()),
-            OpDe::Transfer(w) => Self::Transfer(w.into_op()),
-            OpDe::ClaimPoWReward(w) => Self::ClaimPowReward(w.into_op()),
+            OpDe::ClaimPowReward(w) => Self::ClaimPowReward(w.into_op()),
         }
     }
 }

--- a/core/src/mantle/ops/leader_claim.rs
+++ b/core/src/mantle/ops/leader_claim.rs
@@ -15,12 +15,13 @@ use crate::{
         gas::{Gas, MainnetGasProfile, OperationGas, SignedOperationExecutionGas},
         ledger::{
             ExecutableOperation, PreverifiableOperation, ProvableOperation, Utxos,
-            VerifiableOperation, verification_mode, verification_mode::VerificationMode,
+            VerifiableOperation,
+            verification_mode::{StandardMode, VerificationMode},
         },
         ops::{OpId, SignedOperation},
         transactions::{
             hash::{TxHash, TxHashView},
-            states::VerificationState,
+            states::{Preverified, Unverified, VerificationState, Verified},
         },
     },
     proofs::leader_claim_proof::{
@@ -191,18 +192,18 @@ impl OperationGas<MainnetGasProfile> for LeaderClaimOp {
     const GAS_COST: Gas = Gas::new(580);
 }
 
-impl PreverifiableOperation<verification_mode::StandardMode> for LeaderClaimOp {
+impl PreverifiableOperation<StandardMode>
+    for SignedOperation<LeaderClaimOp, Unverified, StandardMode>
+{
     type Context<'a> = LeaderClaimPreverificationContext<'a>;
     type Error = LeaderClaimError;
 
-    fn preverify(
-        &self,
-        proof: &Self::Proof,
-        context: &Self::Context<'_>,
-    ) -> Result<(), Self::Error> {
-        let is_verified = proof.verify(&LeaderClaimPublic {
-            voucher_nullifier: self.voucher_nullifier.into(),
-            voucher_root: self.rewards_root.into(),
+    fn preverify(&self, context: &Self::Context<'_>) -> Result<(), Self::Error> {
+        let operation = self.operation();
+
+        let is_verified = self.proof().verify(&LeaderClaimPublic {
+            voucher_nullifier: operation.voucher_nullifier.into(),
+            voucher_root: operation.rewards_root.into(),
             mantle_tx_hash: *context.tx_hash_view.as_fr(),
         });
 
@@ -214,24 +215,28 @@ impl PreverifiableOperation<verification_mode::StandardMode> for LeaderClaimOp {
     }
 }
 
-impl VerifiableOperation<verification_mode::StandardMode> for LeaderClaimOp {
+impl VerifiableOperation<StandardMode>
+    for SignedOperation<LeaderClaimOp, Preverified, StandardMode>
+{
     type Context<'a> = LeaderClaimVerificationContext<'a>;
     type Error = LeaderClaimError;
 
-    fn verify(&self, proof: &Self::Proof, context: &Self::Context<'_>) -> Result<(), Self::Error> {
+    fn verify(&self, context: &Self::Context<'_>) -> Result<(), Self::Error> {
+        let operation = self.operation();
+
         // Check that the nullifier isn't in the set
-        if context.nullifiers.contains(&self.voucher_nullifier) {
+        if context.nullifiers.contains(&operation.voucher_nullifier) {
             return Err(LeaderClaimError::DuplicatedVoucherNullifier);
         }
 
         // Check that the voucher root is the same as in the ledger
-        if context.claimable_vouchers_root != &self.rewards_root {
+        if context.claimable_vouchers_root != &operation.rewards_root {
             return Err(LeaderClaimError::VouchersRootMismatch);
         }
 
         // Check the proof of claim
-        if !proof.verify(&LeaderClaimPublic {
-            voucher_nullifier: self.voucher_nullifier.into(),
+        if !self.proof().verify(&LeaderClaimPublic {
+            voucher_nullifier: operation.voucher_nullifier.into(),
             voucher_root: context.claimable_vouchers_root.0,
             mantle_tx_hash: *context.tx_hash_view.as_fr(),
         }) {
@@ -242,7 +247,9 @@ impl VerifiableOperation<verification_mode::StandardMode> for LeaderClaimOp {
     }
 }
 
-impl ExecutableOperation for LeaderClaimOp {
+impl<Mode: VerificationMode> ExecutableOperation
+    for SignedOperation<LeaderClaimOp, Verified, Mode>
+{
     type Context<'a> = LeaderClaimExecutionContext;
     type Error = LeaderClaimError;
 
@@ -250,11 +257,13 @@ impl ExecutableOperation for LeaderClaimOp {
         &self,
         mut context: Self::Context<'a>,
     ) -> Result<(Self::Context<'a>, Vec<TxEvent>), Self::Error> {
+        let operation = self.operation();
+
         // Add the nullifier to the nullifier set
-        context.nullifiers = context.nullifiers.insert(self.voucher_nullifier);
+        context.nullifiers = context.nullifiers.insert(operation.voucher_nullifier);
 
         // Distribute the reward
-        let utxo = self.utxo(context.reward_amount);
+        let utxo = operation.utxo(context.reward_amount);
         context.utxos = context.utxos.insert(utxo.id(), utxo).0;
 
         // Remove the distributed rewards from the pool
@@ -265,9 +274,9 @@ impl ExecutableOperation for LeaderClaimOp {
             context,
             vec![TxEvent::new(
                 tx_hash,
-                self.op_id(),
+                operation.op_id(),
                 TxEventPayload::LeaderRewardClaimed {
-                    voucher_nullifier: self.voucher_nullifier,
+                    voucher_nullifier: operation.voucher_nullifier,
                     utxo,
                 },
             )],
@@ -319,28 +328,74 @@ mod tests {
         };
         let nullifiers = rpds::HashTrieSetSync::new_sync();
         let tx_hash_view = TxHashView::from(tx_hash);
-        let context = LeaderClaimVerificationContext {
+        let preverify_context = LeaderClaimPreverificationContext {
+            tx_hash_view: &tx_hash_view,
+        };
+        let verify_context = LeaderClaimVerificationContext {
             nullifiers: &nullifiers,
             claimable_vouchers_root: &voucher_root,
             tx_hash_view: &tx_hash_view,
         };
 
-        assert_eq!(op.verify(&proof, &context), Ok(()));
+        let unverified_signed_operation = SignedOperation::new(op, proof);
+        let preverified_signed_operation = unverified_signed_operation
+            .into_preverified(&preverify_context)
+            .expect("preverify should accept a valid proof");
+        let _verified_signed_operation = preverified_signed_operation
+            .into_verified(&verify_context)
+            .expect("verify should accept a valid claim");
     }
 
     #[test]
     fn execute_emits_leader_reward_claimed_event() {
         let voucher_secret = VoucherSecret::from(Fr::from(7u64));
+        let voucher_cm = VoucherCm::from_secret(voucher_secret);
+        let (mmr, voucher_path) = MerkleMountainRange::<VoucherCm, ZkHasher>::new()
+            .push_with_paths(voucher_cm, &mut [])
+            .expect("MMR shouldn't be full");
+        let voucher_root = RewardsRoot::from(mmr.frontier_root());
         let reward_amount = 38;
-        let pk = ZkPublicKey::zero();
         let tx_hash = TxHash::from([11u8; 32]);
+        let proof = Groth16LeaderClaimProof::prove(
+            LeaderClaimPrivate::try_new(
+                LeaderClaimPublic::new(
+                    VoucherNullifier::from_secret(voucher_secret).into(),
+                    voucher_root.into(),
+                    tx_hash.to_fr(),
+                ),
+                &voucher_path,
+                voucher_secret,
+            )
+            .expect("voucher path should match the PoC circuit height"),
+        )
+        .expect("proof generation should succeed");
+
         let op = LeaderClaimOp {
-            rewards_root: RewardsRoot::default(),
+            rewards_root: voucher_root,
             voucher_nullifier: VoucherNullifier::from_secret(voucher_secret),
-            pk,
+            pk: ZkPublicKey::zero(),
+        };
+        let nullifiers = rpds::HashTrieSetSync::new_sync();
+        let tx_hash_view = TxHashView::from(tx_hash);
+        let preverify_context = LeaderClaimPreverificationContext {
+            tx_hash_view: &tx_hash_view,
+        };
+        let verify_context = LeaderClaimVerificationContext {
+            nullifiers: &nullifiers,
+            claimable_vouchers_root: &voucher_root,
+            tx_hash_view: &tx_hash_view,
         };
 
-        let (context, events) = op
+        let unverified_signed_operation = SignedOperation::new(op, proof);
+        let preverified_signed_operation = unverified_signed_operation
+            .into_preverified(&preverify_context)
+            .expect("preverify should accept a valid proof");
+        let verified_signed_operation = preverified_signed_operation
+            .into_verified(&verify_context)
+            .expect("verify should accept a valid claim");
+        let operation = verified_signed_operation.operation().clone();
+
+        let (context, events) = verified_signed_operation
             .execute(LeaderClaimExecutionContext {
                 nullifiers: rpds::HashTrieSetSync::new_sync(),
                 reward_amount,
@@ -350,11 +405,11 @@ mod tests {
             })
             .expect("leader claim execution should succeed");
 
-        assert!(context.nullifiers.contains(&op.voucher_nullifier));
+        assert!(context.nullifiers.contains(&operation.voucher_nullifier));
         assert_eq!(context.claimable_rewards, 62);
         assert_eq!(
-            context.utxos.get(&op.utxo(reward_amount).id()),
-            Some(op.utxo(reward_amount))
+            context.utxos.get(&operation.utxo(reward_amount).id()),
+            Some(operation.utxo(reward_amount))
         );
 
         let mut events = events.iter();
@@ -371,9 +426,9 @@ mod tests {
             panic!("expected LeaderRewardClaimed tx event");
         };
         assert_eq!(*event_tx_hash, tx_hash);
-        assert_eq!(*op_id, op.op_id());
-        assert_eq!(*voucher_nullifier, op.voucher_nullifier);
-        assert_eq!(*utxo, op.utxo(reward_amount));
+        assert_eq!(*op_id, operation.op_id());
+        assert_eq!(*voucher_nullifier, operation.voucher_nullifier);
+        assert_eq!(*utxo, operation.utxo(reward_amount));
         assert!(events.next().is_none());
     }
 
@@ -417,20 +472,16 @@ mod tests {
             voucher_nullifier: bogus_nf,
             pk: ZkPublicKey::zero(),
         };
-        let nullifiers = rpds::HashTrieSetSync::new_sync();
         let tx_hash_view = TxHashView::from(tx_hash);
-        let context = LeaderClaimVerificationContext {
-            nullifiers: &nullifiers,
-            claimable_vouchers_root: &voucher_root,
+        let preverify_context = LeaderClaimPreverificationContext {
             tx_hash_view: &tx_hash_view,
         };
 
         // The proof is verified against `op.voucher_nullifier`, which does not
-        // match the proven voucher -> rejected. A voucher cannot be claimed under
-        // a substituted nullifier.
-        assert_eq!(
-            op.verify(&proof, &context),
-            Err(LeaderClaimError::InvalidPoC)
-        );
+        // match the proven voucher -> rejected during preverify. A voucher
+        // cannot be claimed under a substituted nullifier.
+        let unverified_signed_operation = SignedOperation::new(op, proof);
+        let preverify_result = unverified_signed_operation.into_preverified(&preverify_context);
+        assert_eq!(preverify_result.err(), Some(LeaderClaimError::InvalidPoC));
     }
 }

--- a/core/src/mantle/ops/leader_claim.rs
+++ b/core/src/mantle/ops/leader_claim.rs
@@ -17,7 +17,7 @@ use crate::{
             ExecutableOperation, PreverifiableOperation, ProvableOperation, Utxos,
             VerifiableOperation, verification_mode, verification_mode::VerificationMode,
         },
-        ops::{OpId, SignedOp},
+        ops::{OpId, SignedOperation},
         transactions::{
             hash::{TxHash, TxHashView},
             states::VerificationState,
@@ -275,7 +275,7 @@ impl ExecutableOperation for LeaderClaimOp {
 }
 
 impl<State: VerificationState, Mode: VerificationMode> SignedOperationExecutionGas
-    for SignedOp<LeaderClaimOp, State, Mode>
+    for SignedOperation<LeaderClaimOp, State, Mode>
 {
     fn gas_multiplier(&self) -> Value {
         1

--- a/core/src/mantle/ops/leader_claim.rs
+++ b/core/src/mantle/ops/leader_claim.rs
@@ -184,6 +184,7 @@ pub struct LeaderClaimExecutionContext {
 
 impl ProvableOperation for LeaderClaimOp {
     type Proof = Groth16LeaderClaimProof;
+    const CODE: u8 = 0x30;
 }
 
 impl OperationGas<MainnetGasProfile> for LeaderClaimOp {

--- a/core/src/mantle/ops/mod.rs
+++ b/core/src/mantle/ops/mod.rs
@@ -72,11 +72,11 @@ mod mantle_test_vectors {
     use lb_codec::BinaryEncode as _;
     use lb_cryptarchia_engine::Epoch;
     use lb_key_management_system_keys::keys::{Ed25519Key, ZkPublicKey};
-    use lb_poseidon2::Fr;
+    use lb_poseidon2::{Fr, ZkHash};
 
     use super::*;
     use crate::{
-        crypto::{Digest as _, Hasher},
+        crypto::{Digest as _, Hash, Hasher},
         mantle::{
             Note, RawMantleTx,
             channel::{SlotTimeframe, SlotTimeout},
@@ -91,6 +91,7 @@ mod mantle_test_vectors {
                     withdraw::ChannelWithdrawOp,
                 },
                 leader_claim::LeaderClaimOp,
+                pow::ClaimPowRewardOp,
                 transfer::TransferOp,
             },
             traits::Hashable as _,
@@ -190,6 +191,12 @@ mod mantle_test_vectors {
                 rewards_root: Fr::from(32u64).into(),
                 voucher_nullifier: Fr::from(33u64).into(),
                 pk: zk_pk(34),
+            }),
+            // ClaimPowReward (0x40)
+            Op::ClaimPowReward(ClaimPowRewardOp {
+                epoch_nonce: ZkHash::from(Fr::from(35u64)),
+                block_hash: Hash::from([36u8; 32]),
+                public_key: zk_pk(37),
             }),
         ]
     }

--- a/core/src/mantle/ops/mod.rs
+++ b/core/src/mantle/ops/mod.rs
@@ -23,20 +23,6 @@ pub use crate::mantle::ops::{
 pub(crate) static OPERATION_ID_V1: LazyLock<Vec<u8>> =
     LazyLock::new(|| b"OPERATION_ID_V1".to_vec());
 
-pub(crate) mod op_codes {
-    pub const TRANSFER: u8 = 0x00;
-    pub const CHANNEL_CONFIG: u8 = 0x10;
-    pub const INSCRIBE: u8 = 0x11;
-    pub const CHANNEL_DEPOSIT: u8 = 0x12;
-    pub const CHANNEL_WITHDRAW: u8 = 0x13;
-    pub const CHANNEL_TRANSFER: u8 = 0x14;
-    pub const SDP_DECLARE: u8 = 0x20;
-    pub const SDP_WITHDRAW: u8 = 0x21;
-    pub const SDP_ACTIVE: u8 = 0x22;
-    pub const LEADER_CLAIM: u8 = 0x30;
-    pub const CLAIM_POW_REWARD: u8 = 0x40;
-}
-
 /// Mantle reference test-vector generators.
 ///
 /// This module does not assert library behaviour: it emits reference test

--- a/core/src/mantle/ops/mod.rs
+++ b/core/src/mantle/ops/mod.rs
@@ -7,6 +7,7 @@ pub mod op_proof;
 pub mod pow;
 pub mod sdp;
 mod serde_;
+pub mod signed_op;
 pub mod signed_operation;
 pub mod transfer;
 
@@ -15,6 +16,7 @@ use std::sync::LazyLock;
 pub use crate::mantle::ops::{
     op::{Op, OpId},
     op_proof::{NoOpProof, OpProof, ZkAndEd25519Proof},
+    signed_op::SignedOp,
     signed_operation::SignedOperation,
 };
 

--- a/core/src/mantle/ops/mod.rs
+++ b/core/src/mantle/ops/mod.rs
@@ -1,312 +1,37 @@
 pub mod channel;
-pub mod leader_claim;
-pub mod sdp;
-pub mod transfer;
-
-pub(crate) mod internal;
-
 pub(crate) mod codec;
+pub(crate) mod internal;
+pub mod leader_claim;
+pub mod op;
+pub mod op_proof;
 pub mod pow;
+pub mod sdp;
 mod serde_;
 pub mod signed_operation;
+pub mod transfer;
 
 use std::sync::LazyLock;
 
-use channel::{
-    channel_transfer::ChannelTransferOp, config::ChannelConfigOp, deposit::DepositOp,
-    inscribe::InscriptionOp, withdraw::ChannelWithdrawOp,
-};
-use lb_codec::{BinaryDecode, BinaryEncode, DecodeError};
-use lb_key_management_system_keys::keys::{Ed25519Signature, ZkSignature};
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
-pub use signed_operation::SignedOperation;
-
-use super::{
-    gas::{Gas, GasProfile},
-    ops::{
-        leader_claim::LeaderClaimOp,
-        sdp::{SDPActiveOp, SDPDeclareOp, SDPWithdrawOp},
-    },
-};
-use crate::{
-    crypto::{Digest as _, Hash, Hasher},
-    mantle::{
-        gas::OperationGas,
-        ops::{
-            internal::{OpDe, OpSer},
-            pow::ClaimPowRewardOp,
-            transfer::TransferOp,
-        },
-    },
-    proofs::{
-        channel_multi_sig_proof::ChannelMultiSigProof, leader_claim_proof::Groth16LeaderClaimProof,
-    },
+pub use crate::mantle::ops::{
+    op::{Op, OpId},
+    op_proof::{NoOpProof, OpProof, ZkAndEd25519Proof},
+    signed_operation::SignedOperation,
 };
 
-static OPERATION_ID_V1: LazyLock<Vec<u8>> = LazyLock::new(|| b"OPERATION_ID_V1".to_vec());
+pub(crate) static OPERATION_ID_V1: LazyLock<Vec<u8>> =
+    LazyLock::new(|| b"OPERATION_ID_V1".to_vec());
 
-pub trait OpId {
-    fn op_id(&self) -> Hash {
-        let mut encoded_bytes = OPERATION_ID_V1.clone();
-        encoded_bytes.extend(self.op_bytes());
-        Hasher::digest(&encoded_bytes).into()
-    }
-
-    fn op_bytes(&self) -> Vec<u8>;
-}
-
-const TRANSFER: u8 = 0x00;
-const CHANNEL_CONFIG: u8 = 0x10;
-const INSCRIBE: u8 = 0x11;
-const CHANNEL_DEPOSIT: u8 = 0x12;
-const CHANNEL_WITHDRAW: u8 = 0x13;
-const CHANNEL_TRANSFER: u8 = 0x14;
-const SDP_DECLARE: u8 = 0x20;
-const SDP_WITHDRAW: u8 = 0x21;
-const SDP_ACTIVE: u8 = 0x22;
-const LEADER_CLAIM: u8 = 0x30;
-const CLAIM_POW_REWARD: u8 = 0x40;
-
-/// Core set of supported Mantle operations.
-///
-/// This type serves as the public-facing representation of [`OpSer`] and
-/// [`OpDe`], delegating default serialization and deserialization to them.
-///
-/// Serialization and deserialization share a single [`serde_::OpWire`] wire
-/// shape, which carries an `opcode` tag used to identify the correct variant.
-/// Due to limitations in [`bincode`] and [`serde`]'s `#[serde(untagged)]`
-/// enums, binary deserialization is routed through [`decode_op`] instead.
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub enum Op {
-    ChannelInscribe(InscriptionOp),
-    ChannelConfig(ChannelConfigOp),
-    ChannelDeposit(DepositOp),
-    ChannelWithdraw(ChannelWithdrawOp),
-    ChannelTransfer(ChannelTransferOp),
-    SDPDeclare(SDPDeclareOp),
-    SDPWithdraw(SDPWithdrawOp),
-    SDPActive(SDPActiveOp),
-    LeaderClaim(LeaderClaimOp),
-    Transfer(TransferOp),
-    ClaimPowReward(ClaimPowRewardOp),
-}
-
-/// Delegates serialization through the [`OpInternal`] representation.
-impl Serialize for Op {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        if serializer.is_human_readable() {
-            let op_ser = OpSer::from(self);
-            op_ser.serialize(serializer)
-        } else {
-            let bytes = self.encode();
-            serializer.serialize_bytes(&bytes)
-        }
-    }
-}
-
-/// Delegates deserialization through the [`OpDe`] representation.
-///
-/// If the deserializer is non-human-readable it falls back into custom
-/// decoding via [`decode_op`]. Otherwise, it deserializes via [`OpDe`]'s
-/// default behaviour.
-impl<'de> Deserialize<'de> for Op {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        if deserializer.is_human_readable() {
-            OpDe::deserialize(deserializer).map(Self::from)
-        } else {
-            let bytes = <Vec<u8>>::deserialize(deserializer)?;
-            Self::decode(&bytes, &())
-                .map(|(_, op)| op)
-                .map_err(serde::de::Error::custom)
-        }
-    }
-}
-
-// Op = Opcode OpPayload
-impl BinaryEncode for Op {
-    fn encoded_length(&self) -> usize {
-        let payload = match self {
-            Self::ChannelInscribe(op) => op.encoded_length(),
-            Self::ChannelConfig(op) => op.encoded_length(),
-            Self::ChannelDeposit(op) => op.encoded_length(),
-            Self::ChannelWithdraw(op) => op.encoded_length(),
-            Self::ChannelTransfer(op) => op.encoded_length(),
-            Self::SDPDeclare(op) => op.encoded_length(),
-            Self::SDPWithdraw(op) => op.encoded_length(),
-            Self::SDPActive(op) => op.encoded_length(),
-            Self::LeaderClaim(op) => op.encoded_length(),
-            Self::Transfer(op) => op.encoded_length(),
-            Self::ClaimPowReward(op) => op.encoded_length(),
-        };
-        self.code().encoded_length().checked_add(payload).unwrap()
-    }
-
-    fn encode_into(&self, out: &mut Vec<u8>) {
-        self.code().encode_into(out);
-        match self {
-            Self::ChannelInscribe(op) => op.encode_into(out),
-            Self::ChannelConfig(op) => op.encode_into(out),
-            Self::ChannelDeposit(op) => op.encode_into(out),
-            Self::ChannelWithdraw(op) => op.encode_into(out),
-            Self::ChannelTransfer(op) => op.encode_into(out),
-            Self::SDPDeclare(op) => op.encode_into(out),
-            Self::SDPWithdraw(op) => op.encode_into(out),
-            Self::SDPActive(op) => op.encode_into(out),
-            Self::LeaderClaim(op) => op.encode_into(out),
-            Self::Transfer(op) => op.encode_into(out),
-            Self::ClaimPowReward(op) => op.encode_into(out),
-        }
-    }
-}
-
-impl BinaryDecode for Op {
-    type Context = ();
-
-    fn decode<'input>(
-        input: &'input [u8],
-        (): &Self::Context,
-    ) -> Result<(&'input [u8], Self), DecodeError> {
-        let (input, opcode) = u8::decode(input, &())?;
-
-        match opcode {
-            INSCRIBE => InscriptionOp::decode(input, &())
-                .map(|(rest, op)| (rest, Self::ChannelInscribe(op))),
-            CHANNEL_CONFIG => ChannelConfigOp::decode(input, &())
-                .map(|(rest, op)| (rest, Self::ChannelConfig(op))),
-            CHANNEL_DEPOSIT => {
-                DepositOp::decode(input, &()).map(|(rest, op)| (rest, Self::ChannelDeposit(op)))
-            }
-            CHANNEL_WITHDRAW => ChannelWithdrawOp::decode(input, &())
-                .map(|(rest, op)| (rest, Self::ChannelWithdraw(op))),
-            CHANNEL_TRANSFER => ChannelTransferOp::decode(input, &())
-                .map(|(rest, op)| (rest, Self::ChannelTransfer(op))),
-            SDP_DECLARE => {
-                SDPDeclareOp::decode(input, &()).map(|(rest, op)| (rest, Self::SDPDeclare(op)))
-            }
-            SDP_WITHDRAW => {
-                SDPWithdrawOp::decode(input, &()).map(|(rest, op)| (rest, Self::SDPWithdraw(op)))
-            }
-            SDP_ACTIVE => {
-                SDPActiveOp::decode(input, &()).map(|(rest, op)| (rest, Self::SDPActive(op)))
-            }
-            LEADER_CLAIM => {
-                LeaderClaimOp::decode(input, &()).map(|(rest, op)| (rest, Self::LeaderClaim(op)))
-            }
-            TRANSFER => TransferOp::decode(input, &()).map(|(rest, op)| (rest, Self::Transfer(op))),
-            CLAIM_POW_REWARD => ClaimPowRewardOp::decode(input, &())
-                .map(|(rest, op)| (rest, Self::ClaimPowReward(op))),
-            other => Err(DecodeError::unknown_discriminant::<Self>(u64::from(other))),
-        }
-    }
-}
-
-const fn gas_constant_of<Profile, Op>(_op: &Op) -> Gas
-where
-    Profile: GasProfile,
-    Op: OperationGas<Profile>,
-{
-    Op::GAS_COST
-}
-
-// We just check that the enum discriminant tag is encoded correctly, so a
-// single fixture is fine here.
-// TODO: Remove once the `BinaryCodec` macro supports enums.
-
-impl Op {
-    #[must_use]
-    pub const fn as_str(&self) -> &'static str {
-        match self {
-            Self::ChannelInscribe(_) => "ChannelInscribe",
-            Self::ChannelConfig(_) => "ChannelConfig",
-            Self::ChannelDeposit(_) => "ChannelDeposit",
-            Self::ChannelWithdraw(_) => "ChannelWithdraw",
-            Self::ChannelTransfer(_) => "ChannelTransfer",
-            Self::SDPDeclare(_) => "SDPDeclare",
-            Self::SDPWithdraw(_) => "SDPWithdraw",
-            Self::SDPActive(_) => "SDPActive",
-            Self::LeaderClaim(_) => "LeaderClaim",
-            Self::Transfer(_) => "Transfer",
-            Self::ClaimPowReward(_) => "ClaimPowReward",
-        }
-    }
-
-    #[must_use]
-    pub const fn execution_gas<Profile: GasProfile>(&self) -> Gas {
-        match self {
-            Self::ChannelInscribe(op) => gas_constant_of(op),
-            Self::ChannelConfig(op) => gas_constant_of(op),
-            Self::ChannelDeposit(op) => gas_constant_of(op),
-            Self::ChannelWithdraw(op) => gas_constant_of(op),
-            Self::ChannelTransfer(op) => gas_constant_of(op),
-            Self::SDPDeclare(op) => gas_constant_of(op),
-            Self::SDPWithdraw(op) => gas_constant_of(op),
-            Self::SDPActive(op) => gas_constant_of(op),
-            Self::LeaderClaim(op) => gas_constant_of(op),
-            Self::Transfer(op) => gas_constant_of(op),
-            Self::ClaimPowReward(op) => gas_constant_of(op),
-        }
-    }
-
-    const fn code(&self) -> u8 {
-        match self {
-            Self::ChannelInscribe(_) => INSCRIBE,
-            Self::ChannelConfig(_) => CHANNEL_CONFIG,
-            Self::ChannelDeposit(_) => CHANNEL_DEPOSIT,
-            Self::ChannelWithdraw(_) => CHANNEL_WITHDRAW,
-            Self::ChannelTransfer(_) => CHANNEL_TRANSFER,
-            Self::SDPDeclare(_) => SDP_DECLARE,
-            Self::SDPWithdraw(_) => SDP_WITHDRAW,
-            Self::SDPActive(_) => SDP_ACTIVE,
-            Self::LeaderClaim(_) => LEADER_CLAIM,
-            Self::Transfer(_) => TRANSFER,
-            Self::ClaimPowReward(_) => CLAIM_POW_REWARD,
-        }
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct ZkAndEd25519Proof {
-    pub zk_sig: ZkSignature,
-    pub ed25519_sig: Ed25519Signature,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct NoOpProof;
-
-impl BinaryEncode for NoOpProof {
-    fn encoded_length(&self) -> usize {
-        0
-    }
-
-    fn encode_into(&self, _out: &mut Vec<u8>) {}
-}
-
-impl BinaryDecode for NoOpProof {
-    type Context = ();
-
-    fn decode<'input>(
-        input: &'input [u8],
-        _context: &Self::Context,
-    ) -> Result<(&'input [u8], Self), DecodeError> {
-        Ok((input, Self))
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub enum OpProof {
-    Ed25519Sig(Ed25519Signature),
-    ZkSig(ZkSignature),
-    ZkAndEd25519Sigs(ZkAndEd25519Proof),
-    PoC(Groth16LeaderClaimProof),
-    ChannelMultiSigProof(ChannelMultiSigProof),
-    None(NoOpProof),
-}
+pub(crate) const TRANSFER: u8 = 0x00;
+pub(crate) const CHANNEL_CONFIG: u8 = 0x10;
+pub(crate) const INSCRIBE: u8 = 0x11;
+pub(crate) const CHANNEL_DEPOSIT: u8 = 0x12;
+pub(crate) const CHANNEL_WITHDRAW: u8 = 0x13;
+pub(crate) const CHANNEL_TRANSFER: u8 = 0x14;
+pub(crate) const SDP_DECLARE: u8 = 0x20;
+pub(crate) const SDP_WITHDRAW: u8 = 0x21;
+pub(crate) const SDP_ACTIVE: u8 = 0x22;
+pub(crate) const LEADER_CLAIM: u8 = 0x30;
+pub(crate) const CLAIM_POW_REWARD: u8 = 0x40;
 
 /// Mantle reference test-vector generators.
 ///
@@ -340,17 +65,30 @@ mod mantle_test_vectors {
         quota::{PROOF_OF_QUOTA_SIZE, VerifiedProofOfQuota},
         selection::{PROOF_OF_SELECTION_SIZE, VerifiedProofOfSelection},
     };
+    use lb_codec::BinaryEncode as _;
     use lb_cryptarchia_engine::Epoch;
     use lb_key_management_system_keys::keys::{Ed25519Key, ZkPublicKey};
     use lb_poseidon2::Fr;
 
     use super::*;
     use crate::{
+        crypto::{Digest as _, Hasher},
         mantle::{
             Note, RawMantleTx,
             channel::{SlotTimeframe, SlotTimeout},
             ledger::{Inputs, NoteId, Outputs},
-            ops::channel::{ChannelId, MsgId, config::Keys, deposit::Metadata},
+            ops::{
+                channel::{
+                    ChannelId, MsgId,
+                    channel_transfer::ChannelTransferOp,
+                    config::{ChannelConfigOp, Keys},
+                    deposit::{DepositOp, Metadata},
+                    inscribe::InscriptionOp,
+                    withdraw::ChannelWithdrawOp,
+                },
+                leader_claim::LeaderClaimOp,
+                transfer::TransferOp,
+            },
             traits::Hashable as _,
             transactions::Ops,
         },

--- a/core/src/mantle/ops/mod.rs
+++ b/core/src/mantle/ops/mod.rs
@@ -8,7 +8,7 @@ pub(crate) mod internal;
 pub(crate) mod codec;
 pub mod pow;
 mod serde_;
-pub mod signed_op;
+pub mod signed_operation;
 
 use std::sync::LazyLock;
 
@@ -19,7 +19,7 @@ use channel::{
 use lb_codec::{BinaryDecode, BinaryEncode, DecodeError};
 use lb_key_management_system_keys::keys::{Ed25519Signature, ZkSignature};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-pub use signed_op::SignedOp;
+pub use signed_operation::SignedOperation;
 
 use super::{
     gas::{Gas, GasProfile},

--- a/core/src/mantle/ops/mod.rs
+++ b/core/src/mantle/ops/mod.rs
@@ -21,17 +21,19 @@ pub use crate::mantle::ops::{
 pub(crate) static OPERATION_ID_V1: LazyLock<Vec<u8>> =
     LazyLock::new(|| b"OPERATION_ID_V1".to_vec());
 
-pub(crate) const TRANSFER: u8 = 0x00;
-pub(crate) const CHANNEL_CONFIG: u8 = 0x10;
-pub(crate) const INSCRIBE: u8 = 0x11;
-pub(crate) const CHANNEL_DEPOSIT: u8 = 0x12;
-pub(crate) const CHANNEL_WITHDRAW: u8 = 0x13;
-pub(crate) const CHANNEL_TRANSFER: u8 = 0x14;
-pub(crate) const SDP_DECLARE: u8 = 0x20;
-pub(crate) const SDP_WITHDRAW: u8 = 0x21;
-pub(crate) const SDP_ACTIVE: u8 = 0x22;
-pub(crate) const LEADER_CLAIM: u8 = 0x30;
-pub(crate) const CLAIM_POW_REWARD: u8 = 0x40;
+pub(crate) mod op_codes {
+    pub const TRANSFER: u8 = 0x00;
+    pub const CHANNEL_CONFIG: u8 = 0x10;
+    pub const INSCRIBE: u8 = 0x11;
+    pub const CHANNEL_DEPOSIT: u8 = 0x12;
+    pub const CHANNEL_WITHDRAW: u8 = 0x13;
+    pub const CHANNEL_TRANSFER: u8 = 0x14;
+    pub const SDP_DECLARE: u8 = 0x20;
+    pub const SDP_WITHDRAW: u8 = 0x21;
+    pub const SDP_ACTIVE: u8 = 0x22;
+    pub const LEADER_CLAIM: u8 = 0x30;
+    pub const CLAIM_POW_REWARD: u8 = 0x40;
+}
 
 /// Mantle reference test-vector generators.
 ///

--- a/core/src/mantle/ops/op.rs
+++ b/core/src/mantle/ops/op.rs
@@ -1,0 +1,237 @@
+use lb_codec::{BinaryDecode, BinaryEncode, DecodeError};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+use crate::{
+    crypto::{Digest as _, Hash, Hasher},
+    mantle::{
+        GasProfile,
+        gas::{Gas, OperationGas},
+        ops::{
+            CHANNEL_CONFIG, CHANNEL_DEPOSIT, CHANNEL_TRANSFER, CHANNEL_WITHDRAW, CLAIM_POW_REWARD,
+            INSCRIBE, LEADER_CLAIM, OPERATION_ID_V1, SDP_ACTIVE, SDP_DECLARE, SDP_WITHDRAW,
+            TRANSFER,
+            channel::{
+                channel_transfer::ChannelTransferOp, config::ChannelConfigOp, deposit::DepositOp,
+                inscribe::InscriptionOp, withdraw::ChannelWithdrawOp,
+            },
+            internal::{OpDe, OpSer},
+            leader_claim::LeaderClaimOp,
+            pow::ClaimPowRewardOp,
+            sdp::{SDPActiveOp, SDPDeclareOp, SDPWithdrawOp},
+            transfer::TransferOp,
+        },
+    },
+};
+
+pub trait OpId {
+    fn op_id(&self) -> Hash {
+        let mut encoded_bytes = OPERATION_ID_V1.clone();
+        encoded_bytes.extend(self.op_bytes());
+        Hasher::digest(&encoded_bytes).into()
+    }
+
+    fn op_bytes(&self) -> Vec<u8>;
+}
+
+/// Core set of supported Mantle operations.
+///
+/// This type serves as the public-facing representation of [`OpSer`] and
+/// [`OpDe`], delegating default serialization and deserialization to them.
+///
+/// Serialization and deserialization share a single [`serde_::OpWire`] wire
+/// shape, which carries an `opcode` tag used to identify the correct variant.
+/// Due to limitations in [`bincode`] and [`serde`]'s `#[serde(untagged)]`
+/// enums, binary deserialization is routed through [`decode_op`] instead.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum Op {
+    ChannelInscribe(InscriptionOp),
+    ChannelConfig(ChannelConfigOp),
+    ChannelDeposit(DepositOp),
+    ChannelWithdraw(ChannelWithdrawOp),
+    ChannelTransfer(ChannelTransferOp),
+    SDPDeclare(SDPDeclareOp),
+    SDPWithdraw(SDPWithdrawOp),
+    SDPActive(SDPActiveOp),
+    LeaderClaim(LeaderClaimOp),
+    Transfer(TransferOp),
+    ClaimPowReward(ClaimPowRewardOp),
+}
+
+/// Delegates serialization through the [`OpInternal`] representation.
+impl Serialize for Op {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        if serializer.is_human_readable() {
+            let op_ser = OpSer::from(self);
+            op_ser.serialize(serializer)
+        } else {
+            let bytes = self.encode();
+            serializer.serialize_bytes(&bytes)
+        }
+    }
+}
+
+/// Delegates deserialization through the [`OpDe`] representation.
+///
+/// If the deserializer is non-human-readable it falls back into custom
+/// decoding via [`decode_op`]. Otherwise, it deserializes via [`OpDe`]'s
+/// default behaviour.
+impl<'de> Deserialize<'de> for Op {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        if deserializer.is_human_readable() {
+            OpDe::deserialize(deserializer).map(Self::from)
+        } else {
+            let bytes = <Vec<u8>>::deserialize(deserializer)?;
+            Self::decode(&bytes, &())
+                .map(|(_, op)| op)
+                .map_err(serde::de::Error::custom)
+        }
+    }
+}
+
+// Op = Opcode OpPayload
+impl BinaryEncode for Op {
+    fn encoded_length(&self) -> usize {
+        let payload = match self {
+            Self::ChannelInscribe(op) => op.encoded_length(),
+            Self::ChannelConfig(op) => op.encoded_length(),
+            Self::ChannelDeposit(op) => op.encoded_length(),
+            Self::ChannelWithdraw(op) => op.encoded_length(),
+            Self::ChannelTransfer(op) => op.encoded_length(),
+            Self::SDPDeclare(op) => op.encoded_length(),
+            Self::SDPWithdraw(op) => op.encoded_length(),
+            Self::SDPActive(op) => op.encoded_length(),
+            Self::LeaderClaim(op) => op.encoded_length(),
+            Self::Transfer(op) => op.encoded_length(),
+            Self::ClaimPowReward(op) => op.encoded_length(),
+        };
+        self.code().encoded_length().checked_add(payload).unwrap()
+    }
+
+    fn encode_into(&self, out: &mut Vec<u8>) {
+        self.code().encode_into(out);
+        match self {
+            Self::ChannelInscribe(op) => op.encode_into(out),
+            Self::ChannelConfig(op) => op.encode_into(out),
+            Self::ChannelDeposit(op) => op.encode_into(out),
+            Self::ChannelWithdraw(op) => op.encode_into(out),
+            Self::ChannelTransfer(op) => op.encode_into(out),
+            Self::SDPDeclare(op) => op.encode_into(out),
+            Self::SDPWithdraw(op) => op.encode_into(out),
+            Self::SDPActive(op) => op.encode_into(out),
+            Self::LeaderClaim(op) => op.encode_into(out),
+            Self::Transfer(op) => op.encode_into(out),
+            Self::ClaimPowReward(op) => op.encode_into(out),
+        }
+    }
+}
+
+impl BinaryDecode for Op {
+    type Context = ();
+
+    fn decode<'input>(
+        input: &'input [u8],
+        (): &Self::Context,
+    ) -> Result<(&'input [u8], Self), DecodeError> {
+        let (input, opcode) = u8::decode(input, &())?;
+
+        match opcode {
+            INSCRIBE => InscriptionOp::decode(input, &())
+                .map(|(rest, op)| (rest, Self::ChannelInscribe(op))),
+            CHANNEL_CONFIG => ChannelConfigOp::decode(input, &())
+                .map(|(rest, op)| (rest, Self::ChannelConfig(op))),
+            CHANNEL_DEPOSIT => {
+                DepositOp::decode(input, &()).map(|(rest, op)| (rest, Self::ChannelDeposit(op)))
+            }
+            CHANNEL_WITHDRAW => ChannelWithdrawOp::decode(input, &())
+                .map(|(rest, op)| (rest, Self::ChannelWithdraw(op))),
+            CHANNEL_TRANSFER => ChannelTransferOp::decode(input, &())
+                .map(|(rest, op)| (rest, Self::ChannelTransfer(op))),
+            SDP_DECLARE => {
+                SDPDeclareOp::decode(input, &()).map(|(rest, op)| (rest, Self::SDPDeclare(op)))
+            }
+            SDP_WITHDRAW => {
+                SDPWithdrawOp::decode(input, &()).map(|(rest, op)| (rest, Self::SDPWithdraw(op)))
+            }
+            SDP_ACTIVE => {
+                SDPActiveOp::decode(input, &()).map(|(rest, op)| (rest, Self::SDPActive(op)))
+            }
+            LEADER_CLAIM => {
+                LeaderClaimOp::decode(input, &()).map(|(rest, op)| (rest, Self::LeaderClaim(op)))
+            }
+            TRANSFER => TransferOp::decode(input, &()).map(|(rest, op)| (rest, Self::Transfer(op))),
+            CLAIM_POW_REWARD => ClaimPowRewardOp::decode(input, &())
+                .map(|(rest, op)| (rest, Self::ClaimPowReward(op))),
+            other => Err(DecodeError::unknown_discriminant::<Self>(u64::from(other))),
+        }
+    }
+}
+
+const fn gas_cost_of<Profile, Op>(_op: &Op) -> Gas
+where
+    Profile: GasProfile,
+    Op: OperationGas<Profile>,
+{
+    Op::GAS_COST
+}
+
+// We just check that the enum discriminant tag is encoded correctly, so a
+// single fixture is fine here.
+// TODO: Remove once the `BinaryCodec` macro supports enums.
+
+impl Op {
+    #[must_use]
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            Self::ChannelInscribe(_) => "ChannelInscribe",
+            Self::ChannelConfig(_) => "ChannelConfig",
+            Self::ChannelDeposit(_) => "ChannelDeposit",
+            Self::ChannelWithdraw(_) => "ChannelWithdraw",
+            Self::ChannelTransfer(_) => "ChannelTransfer",
+            Self::SDPDeclare(_) => "SDPDeclare",
+            Self::SDPWithdraw(_) => "SDPWithdraw",
+            Self::SDPActive(_) => "SDPActive",
+            Self::LeaderClaim(_) => "LeaderClaim",
+            Self::Transfer(_) => "Transfer",
+            Self::ClaimPowReward(_) => "ClaimPowReward",
+        }
+    }
+
+    #[must_use]
+    pub const fn execution_gas<Profile: GasProfile>(&self) -> Gas {
+        match self {
+            Self::ChannelInscribe(op) => gas_cost_of(op),
+            Self::ChannelConfig(op) => gas_cost_of(op),
+            Self::ChannelDeposit(op) => gas_cost_of(op),
+            Self::ChannelWithdraw(op) => gas_cost_of(op),
+            Self::ChannelTransfer(op) => gas_cost_of(op),
+            Self::SDPDeclare(op) => gas_cost_of(op),
+            Self::SDPWithdraw(op) => gas_cost_of(op),
+            Self::SDPActive(op) => gas_cost_of(op),
+            Self::LeaderClaim(op) => gas_cost_of(op),
+            Self::Transfer(op) => gas_cost_of(op),
+            Self::ClaimPowReward(op) => gas_cost_of(op),
+        }
+    }
+
+    const fn code(&self) -> u8 {
+        match self {
+            Self::ChannelInscribe(_) => INSCRIBE,
+            Self::ChannelConfig(_) => CHANNEL_CONFIG,
+            Self::ChannelDeposit(_) => CHANNEL_DEPOSIT,
+            Self::ChannelWithdraw(_) => CHANNEL_WITHDRAW,
+            Self::ChannelTransfer(_) => CHANNEL_TRANSFER,
+            Self::SDPDeclare(_) => SDP_DECLARE,
+            Self::SDPWithdraw(_) => SDP_WITHDRAW,
+            Self::SDPActive(_) => SDP_ACTIVE,
+            Self::LeaderClaim(_) => LEADER_CLAIM,
+            Self::Transfer(_) => TRANSFER,
+            Self::ClaimPowReward(_) => CLAIM_POW_REWARD,
+        }
+    }
+}

--- a/core/src/mantle/ops/op.rs
+++ b/core/src/mantle/ops/op.rs
@@ -7,15 +7,14 @@ use crate::{
         GasProfile,
         gas::{Gas, OperationGas},
         ops::{
-            CHANNEL_CONFIG, CHANNEL_DEPOSIT, CHANNEL_TRANSFER, CHANNEL_WITHDRAW, CLAIM_POW_REWARD,
-            INSCRIBE, LEADER_CLAIM, OPERATION_ID_V1, SDP_ACTIVE, SDP_DECLARE, SDP_WITHDRAW,
-            TRANSFER,
+            OPERATION_ID_V1,
             channel::{
                 channel_transfer::ChannelTransferOp, config::ChannelConfigOp, deposit::DepositOp,
                 inscribe::InscriptionOp, withdraw::ChannelWithdrawOp,
             },
             internal::{OpDe, OpSer},
             leader_claim::LeaderClaimOp,
+            op_codes,
             pow::ClaimPowRewardOp,
             sdp::{SDPActiveOp, SDPDeclareOp, SDPWithdrawOp},
             transfer::TransferOp,
@@ -141,31 +140,33 @@ impl BinaryDecode for Op {
         let (input, opcode) = u8::decode(input, &())?;
 
         match opcode {
-            INSCRIBE => InscriptionOp::decode(input, &())
+            op_codes::INSCRIBE => InscriptionOp::decode(input, &())
                 .map(|(rest, op)| (rest, Self::ChannelInscribe(op))),
-            CHANNEL_CONFIG => ChannelConfigOp::decode(input, &())
+            op_codes::CHANNEL_CONFIG => ChannelConfigOp::decode(input, &())
                 .map(|(rest, op)| (rest, Self::ChannelConfig(op))),
-            CHANNEL_DEPOSIT => {
+            op_codes::CHANNEL_DEPOSIT => {
                 DepositOp::decode(input, &()).map(|(rest, op)| (rest, Self::ChannelDeposit(op)))
             }
-            CHANNEL_WITHDRAW => ChannelWithdrawOp::decode(input, &())
+            op_codes::CHANNEL_WITHDRAW => ChannelWithdrawOp::decode(input, &())
                 .map(|(rest, op)| (rest, Self::ChannelWithdraw(op))),
-            CHANNEL_TRANSFER => ChannelTransferOp::decode(input, &())
+            op_codes::CHANNEL_TRANSFER => ChannelTransferOp::decode(input, &())
                 .map(|(rest, op)| (rest, Self::ChannelTransfer(op))),
-            SDP_DECLARE => {
+            op_codes::SDP_DECLARE => {
                 SDPDeclareOp::decode(input, &()).map(|(rest, op)| (rest, Self::SDPDeclare(op)))
             }
-            SDP_WITHDRAW => {
+            op_codes::SDP_WITHDRAW => {
                 SDPWithdrawOp::decode(input, &()).map(|(rest, op)| (rest, Self::SDPWithdraw(op)))
             }
-            SDP_ACTIVE => {
+            op_codes::SDP_ACTIVE => {
                 SDPActiveOp::decode(input, &()).map(|(rest, op)| (rest, Self::SDPActive(op)))
             }
-            LEADER_CLAIM => {
+            op_codes::LEADER_CLAIM => {
                 LeaderClaimOp::decode(input, &()).map(|(rest, op)| (rest, Self::LeaderClaim(op)))
             }
-            TRANSFER => TransferOp::decode(input, &()).map(|(rest, op)| (rest, Self::Transfer(op))),
-            CLAIM_POW_REWARD => ClaimPowRewardOp::decode(input, &())
+            op_codes::TRANSFER => {
+                TransferOp::decode(input, &()).map(|(rest, op)| (rest, Self::Transfer(op)))
+            }
+            op_codes::CLAIM_POW_REWARD => ClaimPowRewardOp::decode(input, &())
                 .map(|(rest, op)| (rest, Self::ClaimPowReward(op))),
             other => Err(DecodeError::unknown_discriminant::<Self>(u64::from(other))),
         }
@@ -221,17 +222,17 @@ impl Op {
 
     const fn code(&self) -> u8 {
         match self {
-            Self::ChannelInscribe(_) => INSCRIBE,
-            Self::ChannelConfig(_) => CHANNEL_CONFIG,
-            Self::ChannelDeposit(_) => CHANNEL_DEPOSIT,
-            Self::ChannelWithdraw(_) => CHANNEL_WITHDRAW,
-            Self::ChannelTransfer(_) => CHANNEL_TRANSFER,
-            Self::SDPDeclare(_) => SDP_DECLARE,
-            Self::SDPWithdraw(_) => SDP_WITHDRAW,
-            Self::SDPActive(_) => SDP_ACTIVE,
-            Self::LeaderClaim(_) => LEADER_CLAIM,
-            Self::Transfer(_) => TRANSFER,
-            Self::ClaimPowReward(_) => CLAIM_POW_REWARD,
+            Self::ChannelInscribe(_) => op_codes::INSCRIBE,
+            Self::ChannelConfig(_) => op_codes::CHANNEL_CONFIG,
+            Self::ChannelDeposit(_) => op_codes::CHANNEL_DEPOSIT,
+            Self::ChannelWithdraw(_) => op_codes::CHANNEL_WITHDRAW,
+            Self::ChannelTransfer(_) => op_codes::CHANNEL_TRANSFER,
+            Self::SDPDeclare(_) => op_codes::SDP_DECLARE,
+            Self::SDPWithdraw(_) => op_codes::SDP_WITHDRAW,
+            Self::SDPActive(_) => op_codes::SDP_ACTIVE,
+            Self::LeaderClaim(_) => op_codes::LEADER_CLAIM,
+            Self::Transfer(_) => op_codes::TRANSFER,
+            Self::ClaimPowReward(_) => op_codes::CLAIM_POW_REWARD,
         }
     }
 }

--- a/core/src/mantle/ops/op.rs
+++ b/core/src/mantle/ops/op.rs
@@ -6,6 +6,7 @@ use crate::{
     mantle::{
         GasProfile,
         gas::{Gas, OperationGas},
+        ledger::ProvableOperation as _,
         ops::{
             OPERATION_ID_V1,
             channel::{
@@ -14,7 +15,6 @@ use crate::{
             },
             internal::{OpDe, OpSer},
             leader_claim::LeaderClaimOp,
-            op_codes,
             pow::ClaimPowRewardOp,
             sdp::{SDPActiveOp, SDPDeclareOp, SDPWithdrawOp},
             transfer::TransferOp,
@@ -140,33 +140,33 @@ impl BinaryDecode for Op {
         let (input, opcode) = u8::decode(input, &())?;
 
         match opcode {
-            op_codes::INSCRIBE => InscriptionOp::decode(input, &())
+            InscriptionOp::CODE => InscriptionOp::decode(input, &())
                 .map(|(rest, op)| (rest, Self::ChannelInscribe(op))),
-            op_codes::CHANNEL_CONFIG => ChannelConfigOp::decode(input, &())
+            ChannelConfigOp::CODE => ChannelConfigOp::decode(input, &())
                 .map(|(rest, op)| (rest, Self::ChannelConfig(op))),
-            op_codes::CHANNEL_DEPOSIT => {
+            DepositOp::CODE => {
                 DepositOp::decode(input, &()).map(|(rest, op)| (rest, Self::ChannelDeposit(op)))
             }
-            op_codes::CHANNEL_WITHDRAW => ChannelWithdrawOp::decode(input, &())
+            ChannelWithdrawOp::CODE => ChannelWithdrawOp::decode(input, &())
                 .map(|(rest, op)| (rest, Self::ChannelWithdraw(op))),
-            op_codes::CHANNEL_TRANSFER => ChannelTransferOp::decode(input, &())
+            ChannelTransferOp::CODE => ChannelTransferOp::decode(input, &())
                 .map(|(rest, op)| (rest, Self::ChannelTransfer(op))),
-            op_codes::SDP_DECLARE => {
+            SDPDeclareOp::CODE => {
                 SDPDeclareOp::decode(input, &()).map(|(rest, op)| (rest, Self::SDPDeclare(op)))
             }
-            op_codes::SDP_WITHDRAW => {
+            SDPWithdrawOp::CODE => {
                 SDPWithdrawOp::decode(input, &()).map(|(rest, op)| (rest, Self::SDPWithdraw(op)))
             }
-            op_codes::SDP_ACTIVE => {
+            SDPActiveOp::CODE => {
                 SDPActiveOp::decode(input, &()).map(|(rest, op)| (rest, Self::SDPActive(op)))
             }
-            op_codes::LEADER_CLAIM => {
+            LeaderClaimOp::CODE => {
                 LeaderClaimOp::decode(input, &()).map(|(rest, op)| (rest, Self::LeaderClaim(op)))
             }
-            op_codes::TRANSFER => {
+            TransferOp::CODE => {
                 TransferOp::decode(input, &()).map(|(rest, op)| (rest, Self::Transfer(op)))
             }
-            op_codes::CLAIM_POW_REWARD => ClaimPowRewardOp::decode(input, &())
+            ClaimPowRewardOp::CODE => ClaimPowRewardOp::decode(input, &())
                 .map(|(rest, op)| (rest, Self::ClaimPowReward(op))),
             other => Err(DecodeError::unknown_discriminant::<Self>(u64::from(other))),
         }
@@ -222,17 +222,17 @@ impl Op {
 
     const fn code(&self) -> u8 {
         match self {
-            Self::ChannelInscribe(_) => op_codes::INSCRIBE,
-            Self::ChannelConfig(_) => op_codes::CHANNEL_CONFIG,
-            Self::ChannelDeposit(_) => op_codes::CHANNEL_DEPOSIT,
-            Self::ChannelWithdraw(_) => op_codes::CHANNEL_WITHDRAW,
-            Self::ChannelTransfer(_) => op_codes::CHANNEL_TRANSFER,
-            Self::SDPDeclare(_) => op_codes::SDP_DECLARE,
-            Self::SDPWithdraw(_) => op_codes::SDP_WITHDRAW,
-            Self::SDPActive(_) => op_codes::SDP_ACTIVE,
-            Self::LeaderClaim(_) => op_codes::LEADER_CLAIM,
-            Self::Transfer(_) => op_codes::TRANSFER,
-            Self::ClaimPowReward(_) => op_codes::CLAIM_POW_REWARD,
+            Self::ChannelInscribe(_) => InscriptionOp::CODE,
+            Self::ChannelConfig(_) => ChannelConfigOp::CODE,
+            Self::ChannelDeposit(_) => DepositOp::CODE,
+            Self::ChannelWithdraw(_) => ChannelWithdrawOp::CODE,
+            Self::ChannelTransfer(_) => ChannelTransferOp::CODE,
+            Self::SDPDeclare(_) => SDPDeclareOp::CODE,
+            Self::SDPWithdraw(_) => SDPWithdrawOp::CODE,
+            Self::SDPActive(_) => SDPActiveOp::CODE,
+            Self::LeaderClaim(_) => LeaderClaimOp::CODE,
+            Self::Transfer(_) => TransferOp::CODE,
+            Self::ClaimPowReward(_) => ClaimPowRewardOp::CODE,
         }
     }
 }

--- a/core/src/mantle/ops/op.rs
+++ b/core/src/mantle/ops/op.rs
@@ -173,10 +173,10 @@ impl BinaryDecode for Op {
     }
 }
 
-const fn gas_cost_of<Profile, Op>(_op: &Op) -> Gas
+const fn gas_cost_of<Op, Profile>(_op: &Op) -> Gas
 where
-    Profile: GasProfile,
     Op: OperationGas<Profile>,
+    Profile: GasProfile,
 {
     Op::GAS_COST
 }
@@ -204,7 +204,7 @@ impl Op {
     }
 
     #[must_use]
-    pub const fn execution_gas<Profile: GasProfile>(&self) -> Gas {
+    pub const fn gas_cost<Profile: GasProfile>(&self) -> Gas {
         match self {
             Self::ChannelInscribe(op) => gas_cost_of(op),
             Self::ChannelConfig(op) => gas_cost_of(op),

--- a/core/src/mantle/ops/op_proof.rs
+++ b/core/src/mantle/ops/op_proof.rs
@@ -1,0 +1,45 @@
+use lb_codec::{BinaryDecode, BinaryEncode, DecodeError};
+use lb_key_management_system_keys::keys::{Ed25519Signature, ZkSignature};
+use serde::{Deserialize, Serialize};
+
+use crate::proofs::{
+    channel_multi_sig_proof::ChannelMultiSigProof, leader_claim_proof::Groth16LeaderClaimProof,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NoOpProof;
+
+impl BinaryEncode for NoOpProof {
+    fn encoded_length(&self) -> usize {
+        0
+    }
+
+    fn encode_into(&self, _out: &mut Vec<u8>) {}
+}
+
+impl BinaryDecode for NoOpProof {
+    type Context = ();
+
+    fn decode<'input>(
+        input: &'input [u8],
+        _context: &Self::Context,
+    ) -> Result<(&'input [u8], Self), DecodeError> {
+        Ok((input, Self))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ZkAndEd25519Proof {
+    pub zk_sig: ZkSignature,
+    pub ed25519_sig: Ed25519Signature,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum OpProof {
+    Ed25519Sig(Ed25519Signature),
+    ZkSig(ZkSignature),
+    ZkAndEd25519Sigs(ZkAndEd25519Proof),
+    PoC(Groth16LeaderClaimProof),
+    ChannelMultiSigProof(ChannelMultiSigProof),
+    None(NoOpProof),
+}

--- a/core/src/mantle/ops/pow.rs
+++ b/core/src/mantle/ops/pow.rs
@@ -12,12 +12,14 @@ use crate::{
     events::{TxEvent, TxEventPayload},
     mantle::{
         Note, TxHash, Utxo, Value,
-        gas::{Gas, MainnetGasProfile, OperationGas},
+        gas::{Gas, MainnetGasProfile, OperationGas, SignedOperationExecutionGas},
         ledger::{
             ExecutableOperation, PreverifiableOperation, ProvableOperation, Utxos,
-            VerifiableOperation, verification_mode,
+            VerifiableOperation,
+            verification_mode::{StandardMode, VerificationMode},
         },
-        ops::{NoOpProof, OpId},
+        ops::{NoOpProof, OpId, SignedOperation},
+        transactions::states::{Preverified, Unverified, VerificationState, Verified},
     },
 };
 
@@ -272,35 +274,37 @@ impl OperationGas<MainnetGasProfile> for ClaimPowRewardOp {
     const GAS_COST: Gas = Gas::new(1);
 }
 
-impl PreverifiableOperation<verification_mode::StandardMode> for ClaimPowRewardOp {
+impl PreverifiableOperation<StandardMode>
+    for SignedOperation<ClaimPowRewardOp, Unverified, StandardMode>
+{
     type Context<'a> = ();
     type Error = ClaimPowRewardError;
 
-    fn preverify(
-        &self,
-        _proof: &Self::Proof,
-        _context: &Self::Context<'_>,
-    ) -> Result<(), Self::Error> {
+    fn preverify(&self, _context: &Self::Context<'_>) -> Result<(), Self::Error> {
         Ok(())
     }
 }
 
-impl VerifiableOperation<verification_mode::StandardMode> for ClaimPowRewardOp {
+impl VerifiableOperation<StandardMode>
+    for SignedOperation<ClaimPowRewardOp, Preverified, StandardMode>
+{
     type Context<'a> = ClaimPoWRewardVerificationContext<'a>;
     type Error = ClaimPowRewardError;
 
-    fn verify(&self, _proof: &Self::Proof, context: &Self::Context<'_>) -> Result<(), Self::Error> {
+    fn verify(&self, context: &Self::Context<'_>) -> Result<(), Self::Error> {
+        let operation = self.operation();
+
         context.are_pow_reward_enabled()?;
-        context.accept_claim::<{ SLOT_WINDOW }>(self.block_hash)?;
-        context.validate_current_epoch_nonce(self.epoch_nonce)?;
-        let puzzle_ticket = self.get_puzzle_ticket();
+        context.accept_claim::<{ SLOT_WINDOW }>(operation.block_hash)?;
+        context.validate_current_epoch_nonce(operation.epoch_nonce)?;
+        let puzzle_ticket = operation.get_puzzle_ticket();
         context.validate_difficulty_reward(puzzle_ticket)?;
         context.validate_double_claiming(puzzle_ticket)?;
         Ok(())
     }
 }
 
-impl ExecutableOperation for ClaimPowRewardOp {
+impl ExecutableOperation for SignedOperation<ClaimPowRewardOp, Verified, StandardMode> {
     type Context<'a> = ClaimPoWRewardExecutionContext;
     type Error = ClaimPowRewardError;
 
@@ -308,16 +312,18 @@ impl ExecutableOperation for ClaimPowRewardOp {
         &self,
         mut context: Self::Context<'a>,
     ) -> Result<(Self::Context<'a>, Vec<TxEvent>), Self::Error> {
+        let operation = self.operation();
+
         let slot = context
             .block_slots
-            .get(&self.block_hash)
+            .get(&operation.block_hash)
             .expect("Existence should be check in verification");
         // add the nullifier to the set
-        let nullifier = self.get_puzzle_ticket();
+        let nullifier = operation.get_puzzle_ticket();
         context.nullifiers.insert_mut(nullifier, *slot);
         // create output note
-        let note = Note::new(context.epoch_reward, self.public_key);
-        let op_id = self.op_id();
+        let note = Note::new(context.epoch_reward, operation.public_key);
+        let op_id = operation.op_id();
         let utxo = Utxo {
             op_id,
             output_index: 0,
@@ -339,6 +345,14 @@ impl ExecutableOperation for ClaimPowRewardOp {
                 },
             )],
         ))
+    }
+}
+
+impl<State: VerificationState, Mode: VerificationMode> SignedOperationExecutionGas
+    for SignedOperation<ClaimPowRewardOp, State, Mode>
+{
+    fn gas_multiplier(&self) -> Value {
+        1
     }
 }
 
@@ -524,7 +538,11 @@ mod tests {
     fn validate_accepts_claim_with_current_epoch_nonce() {
         let nullifiers = HashTrieMapSync::new_sync();
         let ctx = accepting_context(&nullifiers);
-        assert_eq!(claim_op(CURRENT_EPOCH).verify(&NoOpProof, &ctx), Ok(()));
+        let op = claim_op(CURRENT_EPOCH);
+        let signed_operation = SignedOperation::new(op, NoOpProof)
+            .into_preverified(&())
+            .unwrap();
+        assert_eq!(signed_operation.verify(&ctx), Ok(()));
     }
 
     #[test]
@@ -533,7 +551,11 @@ mod tests {
         // stays claimable, so the previous epoch's nonce is also accepted.
         let nullifiers = HashTrieMapSync::new_sync();
         let ctx = accepting_context(&nullifiers);
-        assert_eq!(claim_op(PREVIOUS_EPOCH).verify(&NoOpProof, &ctx), Ok(()));
+        let op = claim_op(PREVIOUS_EPOCH);
+        let signed_operation = SignedOperation::new(op, NoOpProof)
+            .into_preverified(&())
+            .unwrap();
+        assert_eq!(signed_operation.verify(&ctx), Ok(()));
     }
 
     #[test]
@@ -541,10 +563,13 @@ mod tests {
         let nullifiers = HashTrieMapSync::new_sync();
         let ctx = accepting_context(&nullifiers);
         let op = claim_op(PREVIOUS_EPOCH - 1);
+        let signed_operation = SignedOperation::new(op, NoOpProof)
+            .into_preverified(&())
+            .unwrap();
         assert_eq!(
-            op.verify(&NoOpProof, &ctx),
+            signed_operation.verify(&ctx),
             Err(ClaimPowRewardError::MismatchEpochNonce {
-                claim: op.epoch_nonce,
+                claim: signed_operation.operation().epoch_nonce,
                 accepted: (PREVIOUS_EPOCH.into(), CURRENT_EPOCH.into()),
             })
         );
@@ -557,8 +582,12 @@ mod tests {
         // The hardest possible target: only a ticket of exactly zero would
         // pass, and this op's ticket is not zero.
         ctx.reward_difficulty = Fr::ZERO;
+        let op = claim_op(CURRENT_EPOCH);
+        let signed_operation = SignedOperation::new(op, NoOpProof)
+            .into_preverified(&())
+            .unwrap();
         assert_eq!(
-            claim_op(CURRENT_EPOCH).verify(&NoOpProof, &ctx),
+            signed_operation.verify(&ctx),
             Err(ClaimPowRewardError::InvalidPoWRewardTicket)
         );
     }
@@ -572,8 +601,11 @@ mod tests {
         let op = claim_op(CURRENT_EPOCH);
         let mut ctx = accepting_context(&nullifiers);
         ctx.reward_difficulty = op.get_puzzle_ticket().into();
+        let signed_operation = SignedOperation::new(op, NoOpProof)
+            .into_preverified(&())
+            .unwrap();
         assert_eq!(
-            op.verify(&NoOpProof, &ctx),
+            signed_operation.verify(&ctx),
             Err(ClaimPowRewardError::InvalidPoWRewardTicket)
         );
     }
@@ -584,8 +616,11 @@ mod tests {
         let nullifiers =
             HashTrieMapSync::new_sync().insert(op.get_puzzle_ticket(), Slot::from(45u64));
         let ctx = accepting_context(&nullifiers);
+        let signed_operation = SignedOperation::new(op, NoOpProof)
+            .into_preverified(&())
+            .unwrap();
         assert_eq!(
-            op.verify(&NoOpProof, &ctx),
+            signed_operation.verify(&ctx),
             Err(ClaimPowRewardError::DoubleClaimed)
         );
     }
@@ -593,10 +628,16 @@ mod tests {
     #[test]
     fn execute_issues_reward_utxo_and_registers_nullifier() {
         let op = claim_op(CURRENT_EPOCH);
+        let signed_operation = SignedOperation::new(op, NoOpProof)
+            .into_preverified(&())
+            .unwrap()
+            .into_verified(&accepting_context(&HashTrieMapSync::new_sync()))
+            .unwrap();
+        let operation = signed_operation.operation().clone();
         let epoch_reward = 10;
         let tx_hash = TxHash::from([11u8; 32]);
 
-        let (ctx, events) = op
+        let (ctx, events) = signed_operation
             .execute(ClaimPoWRewardExecutionContext {
                 reward_pool: 1_000,
                 epoch_reward,
@@ -610,7 +651,7 @@ mod tests {
         // The spent solution is recorded against the anchor block's slot,
         // and the pool pays out sigma_e.
         assert_eq!(
-            ctx.nullifiers.get(&op.get_puzzle_ticket()),
+            ctx.nullifiers.get(&operation.get_puzzle_ticket()),
             Some(&Slot::from(45u64))
         );
         assert_eq!(ctx.reward_pool, 990);
@@ -619,9 +660,9 @@ mod tests {
         // (§5.3 execution step 3). Regression: the persistent-tree insert
         // result used to be discarded, so the note never reached the set.
         let expected_utxo = Utxo {
-            op_id: op.op_id(),
+            op_id: operation.op_id(),
             output_index: 0,
-            note: Note::new(epoch_reward, op.public_key),
+            note: Note::new(epoch_reward, operation.public_key),
         };
         assert_eq!(ctx.utxos.get(&expected_utxo.id()), Some(expected_utxo));
 
@@ -639,8 +680,8 @@ mod tests {
             panic!("expected PoWRewardClaimed tx event");
         };
         assert_eq!(*event_tx_hash, tx_hash);
-        assert_eq!(*op_id, op.op_id());
-        assert_eq!(*pow_nullifier, op.get_puzzle_ticket());
+        assert_eq!(*op_id, operation.op_id());
+        assert_eq!(*pow_nullifier, operation.get_puzzle_ticket());
         assert_eq!(*utxo, expected_utxo);
         assert!(events.next().is_none());
     }
@@ -654,7 +695,12 @@ mod tests {
         // and aborts loudly rather than minting a reward note the pool
         // cannot back.
         let op = claim_op(CURRENT_EPOCH);
-        drop(op.execute(ClaimPoWRewardExecutionContext {
+        let signed_operation = SignedOperation::new(op, NoOpProof)
+            .into_preverified(&())
+            .unwrap()
+            .into_verified(&accepting_context(&HashTrieMapSync::new_sync()))
+            .unwrap();
+        drop(signed_operation.execute(ClaimPoWRewardExecutionContext {
             reward_pool: 5,
             epoch_reward: 10,
             nullifiers: HashTrieMapSync::new_sync(),

--- a/core/src/mantle/ops/pow.rs
+++ b/core/src/mantle/ops/pow.rs
@@ -265,6 +265,7 @@ impl ClaimPoWRewardExecutionContext {
 
 impl ProvableOperation for ClaimPowRewardOp {
     type Proof = NoOpProof;
+    const CODE: u8 = 0x40;
 }
 
 impl OperationGas<MainnetGasProfile> for ClaimPowRewardOp {

--- a/core/src/mantle/ops/sdp/active.rs
+++ b/core/src/mantle/ops/sdp/active.rs
@@ -11,10 +11,14 @@ use crate::{
         gas::{Gas, MainnetGasProfile, OperationGas, SignedOperationExecutionGas},
         ledger::{
             Declarations, ExecutableOperation, PreverifiableOperation, ProvableOperation,
-            VerifiableOperation, verification_mode, verification_mode::VerificationMode,
+            VerifiableOperation,
+            verification_mode::{StandardMode, VerificationMode},
         },
         ops::SignedOperation,
-        transactions::{hash::TxHashView, states::VerificationState},
+        transactions::{
+            hash::TxHashView,
+            states::{Preverified, Unverified, VerificationState, Verified},
+        },
     },
 };
 
@@ -40,27 +44,27 @@ impl OperationGas<MainnetGasProfile> for SDPActiveOp {
     const GAS_COST: Gas = Gas::new(590);
 }
 
-impl PreverifiableOperation<verification_mode::StandardMode> for SDPActiveOp {
+impl PreverifiableOperation<StandardMode>
+    for SignedOperation<SDPActiveOp, Unverified, StandardMode>
+{
     type Context<'a> = ();
     type Error = SdpError;
 
-    fn preverify(
-        &self,
-        _proof: &Self::Proof,
-        _context: &Self::Context<'_>,
-    ) -> Result<(), Self::Error> {
+    fn preverify(&self, _context: &Self::Context<'_>) -> Result<(), Self::Error> {
         Ok(())
     }
 }
 
-impl VerifiableOperation<verification_mode::StandardMode> for SDPActiveOp {
+impl VerifiableOperation<StandardMode> for SignedOperation<SDPActiveOp, Preverified, StandardMode> {
     type Context<'a> = SDPActiveValidationContext<'a>;
     type Error = SdpError;
 
-    fn verify(&self, proof: &Self::Proof, context: &Self::Context<'_>) -> Result<(), Self::Error> {
+    fn verify(&self, context: &Self::Context<'_>) -> Result<(), Self::Error> {
+        let operation = self.operation();
+
         // Check the declaration exists
-        let Some(declaration) = context.declarations.get(&self.declaration_id) else {
-            return Err(SdpError::DeclarationNotFound(self.declaration_id));
+        let Some(declaration) = context.declarations.get(&operation.declaration_id) else {
+            return Err(SdpError::DeclarationNotFound(operation.declaration_id));
         };
 
         // Check the declaration hasn't been withdrawn
@@ -69,21 +73,25 @@ impl VerifiableOperation<verification_mode::StandardMode> for SDPActiveOp {
             && withdraw_at <= context.epoch
         {
             return Err(SdpError::DeclarationWithdrawn {
-                declaration_id: self.declaration_id,
+                declaration_id: operation.declaration_id,
                 withdraw_at,
             });
         }
 
         // Check the nonce is increasing
-        if self.nonce <= declaration.nonce {
+        if operation.nonce <= declaration.nonce {
             return Err(SdpError::InvalidNonce {
-                message_nonce: self.nonce,
+                message_nonce: operation.nonce,
                 declaration_nonce: declaration.nonce,
             });
         }
 
         // Check the signature over the `zk_id`
-        if !ZkPublicKey::verify_multi(&[declaration.zk_id], context.tx_hash_view.as_fr(), proof) {
+        if !ZkPublicKey::verify_multi(
+            &[declaration.zk_id],
+            context.tx_hash_view.as_fr(),
+            self.proof(),
+        ) {
             return Err(SdpError::InvalidZkSignature);
         }
 
@@ -91,7 +99,7 @@ impl VerifiableOperation<verification_mode::StandardMode> for SDPActiveOp {
     }
 }
 
-impl ExecutableOperation for SDPActiveOp {
+impl<Mode: VerificationMode> ExecutableOperation for SignedOperation<SDPActiveOp, Verified, Mode> {
     type Context<'a> = SDPActiveExecutionContext;
     type Error = SdpError;
 
@@ -100,13 +108,15 @@ impl ExecutableOperation for SDPActiveOp {
         &self,
         mut context: Self::Context<'a>,
     ) -> Result<(Self::Context<'a>, Vec<TxEvent>), Self::Error> {
+        let operation = self.operation();
+
         let declaration = context
             .declarations
-            .get_mut(&self.declaration_id)
+            .get_mut(&operation.declaration_id)
             .expect("The operation should have been validated");
 
         declaration.active = context.epoch;
-        declaration.nonce = self.nonce;
+        declaration.nonce = operation.nonce;
         info!(
             target: LOG_TARGET,
             provider_id = ?declaration.provider_id,

--- a/core/src/mantle/ops/sdp/active.rs
+++ b/core/src/mantle/ops/sdp/active.rs
@@ -33,6 +33,7 @@ pub struct SDPActiveExecutionContext {
 
 impl ProvableOperation for SDPActiveOp {
     type Proof = ZkSignature;
+    const CODE: u8 = 0x22;
 }
 
 impl OperationGas<MainnetGasProfile> for SDPActiveOp {

--- a/core/src/mantle/ops/sdp/active.rs
+++ b/core/src/mantle/ops/sdp/active.rs
@@ -13,7 +13,7 @@ use crate::{
             Declarations, ExecutableOperation, PreverifiableOperation, ProvableOperation,
             VerifiableOperation, verification_mode, verification_mode::VerificationMode,
         },
-        ops::SignedOp,
+        ops::SignedOperation,
         transactions::{hash::TxHashView, states::VerificationState},
     },
 };
@@ -119,7 +119,7 @@ impl ExecutableOperation for SDPActiveOp {
 }
 
 impl<State: VerificationState, Mode: VerificationMode> SignedOperationExecutionGas
-    for SignedOp<SDPActiveOp, State, Mode>
+    for SignedOperation<SDPActiveOp, State, Mode>
 {
     fn gas_multiplier(&self) -> Value {
         1

--- a/core/src/mantle/ops/sdp/declare.rs
+++ b/core/src/mantle/ops/sdp/declare.rs
@@ -10,10 +10,14 @@ use crate::{
         gas::{Gas, MainnetGasProfile, OperationGas, SignedOperationExecutionGas},
         ledger::{
             Declarations, ExecutableOperation, PreverifiableOperation, ProvableOperation, Utxos,
-            VerifiableOperation, verification_mode, verification_mode::VerificationMode,
+            VerifiableOperation,
+            verification_mode::{GenesisMode, StandardMode, VerificationMode},
         },
         ops::{SignedOperation, ZkAndEd25519Proof},
-        transactions::{hash::TxHashView, states::VerificationState},
+        transactions::{
+            hash::TxHashView,
+            states::{Preverified, Unverified, VerificationState, Verified},
+        },
     },
     sdp::{Declaration, MinStake, locked_notes::LockedNotes},
 };
@@ -164,41 +168,44 @@ impl OperationGas<MainnetGasProfile> for SDPDeclareOp {
     const GAS_COST: Gas = Gas::new(646);
 }
 
-impl PreverifiableOperation<verification_mode::StandardMode> for SDPDeclareOp {
+impl PreverifiableOperation<StandardMode>
+    for SignedOperation<SDPDeclareOp, Unverified, StandardMode>
+{
     type Context<'a> = SDPDeclarePreverificationContext<'a>;
     type Error = SdpError;
 
-    fn preverify(
-        &self,
-        proof: &Self::Proof,
-        context: &Self::Context<'_>,
-    ) -> Result<(), Self::Error> {
-        self.preverify(context.tx_hash_view, &proof.ed25519_sig)
+    fn preverify(&self, context: &Self::Context<'_>) -> Result<(), Self::Error> {
+        self.operation()
+            .preverify(context.tx_hash_view, &self.proof().ed25519_sig)
     }
 }
 
-impl VerifiableOperation<verification_mode::StandardMode> for SDPDeclareOp {
+impl VerifiableOperation<StandardMode>
+    for SignedOperation<SDPDeclareOp, Preverified, StandardMode>
+{
     type Context<'a> = SDPDeclareVerificationContext<'a>;
     type Error = SdpError;
 
-    fn verify(&self, proof: &Self::Proof, context: &Self::Context<'_>) -> Result<(), Self::Error> {
+    fn verify(&self, context: &Self::Context<'_>) -> Result<(), Self::Error> {
+        let operation = self.operation();
+
         // Check that the note exist
-        let Some((utxo, _)) = context.utxo_tree.utxos().get(&self.locked_note_id) else {
-            return Err(SdpError::InexistingNote(self.locked_note_id));
+        let Some((utxo, _)) = context.utxo_tree.utxos().get(&operation.locked_note_id) else {
+            return Err(SdpError::InexistingNote(operation.locked_note_id));
         };
 
         // Ensure locked note exists and ownership over the locked note and `zk_id`
         let note = utxo.note;
         if !ZkPublicKey::verify_multi(
-            &[note.pk, self.zk_id],
+            &[note.pk, operation.zk_id],
             context.tx_hash_view.as_fr(),
-            &proof.zk_sig,
+            &self.proof().zk_sig,
         ) {
             return Err(SdpError::InvalidZkSignature);
         }
 
         SDPDeclareValidationExt::validate(
-            self,
+            operation,
             note,
             context.channels,
             context.declarations,
@@ -208,32 +215,33 @@ impl VerifiableOperation<verification_mode::StandardMode> for SDPDeclareOp {
     }
 }
 
-impl PreverifiableOperation<verification_mode::GenesisMode> for SDPDeclareOp {
+impl PreverifiableOperation<GenesisMode>
+    for SignedOperation<SDPDeclareOp, Unverified, GenesisMode>
+{
     type Context<'a> = SDPDeclarePreverificationContext<'a>;
     type Error = SdpError;
 
-    fn preverify(
-        &self,
-        proof: &Self::Proof,
-        context: &Self::Context<'_>,
-    ) -> Result<(), Self::Error> {
-        self.preverify(context.tx_hash_view, &proof.ed25519_sig)
+    fn preverify(&self, context: &Self::Context<'_>) -> Result<(), Self::Error> {
+        self.operation()
+            .preverify(context.tx_hash_view, &self.proof().ed25519_sig)
     }
 }
 
-impl VerifiableOperation<verification_mode::GenesisMode> for SDPDeclareOp {
+impl VerifiableOperation<GenesisMode> for SignedOperation<SDPDeclareOp, Preverified, GenesisMode> {
     type Context<'a> = SDPDeclareGenesisValidationContext<'a>;
     type Error = SdpError;
 
-    fn verify(&self, _proof: &Self::Proof, context: &Self::Context<'_>) -> Result<(), Self::Error> {
+    fn verify(&self, context: &Self::Context<'_>) -> Result<(), Self::Error> {
+        let operation = self.operation();
+
         // Check that the note exist
-        let Some((utxo, _)) = context.utxo_tree.utxos().get(&self.locked_note_id) else {
-            return Err(SdpError::InexistingNote(self.locked_note_id));
+        let Some((utxo, _)) = context.utxo_tree.utxos().get(&operation.locked_note_id) else {
+            return Err(SdpError::InexistingNote(operation.locked_note_id));
         };
         let note = utxo.note;
 
         SDPDeclareValidationExt::validate(
-            self,
+            operation,
             note,
             context.channels,
             context.declarations,
@@ -243,7 +251,7 @@ impl VerifiableOperation<verification_mode::GenesisMode> for SDPDeclareOp {
     }
 }
 
-impl ExecutableOperation for SDPDeclareOp {
+impl<Mode: VerificationMode> ExecutableOperation for SignedOperation<SDPDeclareOp, Verified, Mode> {
     type Context<'a> = SDPDeclareExecutionContext;
     type Error = SdpError;
 
@@ -251,7 +259,7 @@ impl ExecutableOperation for SDPDeclareOp {
         &self,
         context: Self::Context<'a>,
     ) -> Result<(Self::Context<'a>, Vec<TxEvent>), Self::Error> {
-        SDPDeclareValidationExt::execute(self, context)
+        SDPDeclareValidationExt::execute(self.operation(), context)
     }
 }
 

--- a/core/src/mantle/ops/sdp/declare.rs
+++ b/core/src/mantle/ops/sdp/declare.rs
@@ -12,7 +12,7 @@ use crate::{
             Declarations, ExecutableOperation, PreverifiableOperation, ProvableOperation, Utxos,
             VerifiableOperation, verification_mode, verification_mode::VerificationMode,
         },
-        ops::{SignedOp, ZkAndEd25519Proof},
+        ops::{SignedOperation, ZkAndEd25519Proof},
         transactions::{hash::TxHashView, states::VerificationState},
     },
     sdp::{Declaration, MinStake, locked_notes::LockedNotes},
@@ -255,7 +255,7 @@ impl ExecutableOperation for SDPDeclareOp {
 }
 
 impl<State: VerificationState, Mode: VerificationMode> SignedOperationExecutionGas
-    for SignedOp<SDPDeclareOp, State, Mode>
+    for SignedOperation<SDPDeclareOp, State, Mode>
 {
     fn gas_multiplier(&self) -> Value {
         1

--- a/core/src/mantle/ops/sdp/declare.rs
+++ b/core/src/mantle/ops/sdp/declare.rs
@@ -157,6 +157,7 @@ pub struct SDPDeclareExecutionContext {
 
 impl ProvableOperation for SDPDeclareOp {
     type Proof = ZkAndEd25519Proof;
+    const CODE: u8 = 0x20;
 }
 
 impl OperationGas<MainnetGasProfile> for SDPDeclareOp {

--- a/core/src/mantle/ops/sdp/withdraw.rs
+++ b/core/src/mantle/ops/sdp/withdraw.rs
@@ -11,10 +11,14 @@ use crate::{
         gas::{Gas, MainnetGasProfile, OperationGas, SignedOperationExecutionGas},
         ledger::{
             Declarations, ExecutableOperation, PreverifiableOperation, ProvableOperation,
-            VerifiableOperation, verification_mode, verification_mode::VerificationMode,
+            VerifiableOperation,
+            verification_mode::{StandardMode, VerificationMode},
         },
         ops::SignedOperation,
-        transactions::{hash::TxHashView, states::VerificationState},
+        transactions::{
+            hash::TxHashView,
+            states::{Preverified, Unverified, VerificationState, Verified},
+        },
     },
     sdp::{self, locked_notes::LockedNotes},
 };
@@ -43,33 +47,35 @@ impl OperationGas<MainnetGasProfile> for SDPWithdrawOp {
     const GAS_COST: Gas = Gas::new(590);
 }
 
-impl PreverifiableOperation<verification_mode::StandardMode> for SDPWithdrawOp {
+impl PreverifiableOperation<StandardMode>
+    for SignedOperation<SDPWithdrawOp, Unverified, StandardMode>
+{
     type Context<'a> = ();
     type Error = SdpError;
 
-    fn preverify(
-        &self,
-        _proof: &Self::Proof,
-        _context: &Self::Context<'_>,
-    ) -> Result<(), Self::Error> {
+    fn preverify(&self, _context: &Self::Context<'_>) -> Result<(), Self::Error> {
         Ok(())
     }
 }
 
-impl VerifiableOperation<verification_mode::StandardMode> for SDPWithdrawOp {
+impl VerifiableOperation<StandardMode>
+    for SignedOperation<SDPWithdrawOp, Preverified, StandardMode>
+{
     type Context<'a> = SDPWithdrawValidationContext<'a>;
     type Error = SdpError;
 
-    fn verify(&self, proof: &Self::Proof, context: &Self::Context<'_>) -> Result<(), Self::Error> {
+    fn verify(&self, context: &Self::Context<'_>) -> Result<(), Self::Error> {
+        let operation = self.operation();
+
         // Check that the declaration exists
-        let Some(declaration) = context.declarations.get(&self.declaration_id) else {
-            return Err(SdpError::DeclarationNotFound(self.declaration_id));
+        let Some(declaration) = context.declarations.get(&operation.declaration_id) else {
+            return Err(SdpError::DeclarationNotFound(operation.declaration_id));
         };
 
         // Check that the declaration hasn't been already scheduled to be withdrawn.
         if let Some(withdraw_at) = declaration.withdraw_at {
             return Err(SdpError::DeclarationWithdrawn {
-                declaration_id: self.declaration_id,
+                declaration_id: operation.declaration_id,
                 withdraw_at,
             });
         }
@@ -77,19 +83,19 @@ impl VerifiableOperation<verification_mode::StandardMode> for SDPWithdrawOp {
         // Check that the locked note is locked for this service
         if !context
             .locked_notes
-            .is_locked_for_service(&self.locked_note_id, &declaration.service_type)
+            .is_locked_for_service(&operation.locked_note_id, &declaration.service_type)
         {
             return Err(SdpError::NoteNotLockedForService {
-                note_id: self.locked_note_id,
+                note_id: operation.locked_note_id,
                 service_type: declaration.service_type,
             });
         }
 
         // Check that the locked note exist (it corresponds to the declaration locked
         // note)
-        if declaration.locked_note_id != self.locked_note_id {
+        if declaration.locked_note_id != operation.locked_note_id {
             return Err(SdpError::InvalidLockedNote {
-                note_id: self.locked_note_id,
+                note_id: operation.locked_note_id,
                 expected: declaration.locked_note_id,
             });
         }
@@ -98,20 +104,20 @@ impl VerifiableOperation<verification_mode::StandardMode> for SDPWithdrawOp {
         // Operation.
         let note = context
             .locked_notes
-            .get(&self.locked_note_id)
+            .get(&operation.locked_note_id)
             .expect("The Operation has been checked above");
         if !ZkPublicKey::verify_multi(
             &[note.pk, declaration.zk_id],
             context.tx_hash_view.as_fr(),
-            proof,
+            self.proof(),
         ) {
             return Err(SdpError::InvalidZkSignature);
         }
 
         // Check that the nonce is greater than the previous one
-        if self.nonce <= declaration.nonce {
+        if operation.nonce <= declaration.nonce {
             return Err(SdpError::InvalidNonce {
-                message_nonce: self.nonce,
+                message_nonce: operation.nonce,
                 declaration_nonce: declaration.nonce,
             });
         }
@@ -120,7 +126,9 @@ impl VerifiableOperation<verification_mode::StandardMode> for SDPWithdrawOp {
     }
 }
 
-impl ExecutableOperation for SDPWithdrawOp {
+impl<Mode: VerificationMode> ExecutableOperation
+    for SignedOperation<SDPWithdrawOp, Verified, Mode>
+{
     type Context<'a> = SDPWithdrawExecutionContext;
     type Error = SdpError;
 
@@ -128,9 +136,11 @@ impl ExecutableOperation for SDPWithdrawOp {
         &self,
         mut context: Self::Context<'a>,
     ) -> Result<(Self::Context<'a>, Vec<TxEvent>), Self::Error> {
+        let operation = self.operation();
+
         let declaration = context
             .declarations
-            .get_mut(&self.declaration_id)
+            .get_mut(&operation.declaration_id)
             .expect("The operation should have been validated");
 
         // Delay the withdrawal by `SNAPSHOT_FINALIZATION_DELAY` epochs
@@ -140,7 +150,7 @@ impl ExecutableOperation for SDPWithdrawOp {
         // epochs ago.
         // The note will be unlocked once the withdrawn epoch set here is reached.
         declaration.withdraw_at = Some(context.epoch.strict_add(sdp::SNAPSHOT_FINALIZATION_DELAY));
-        declaration.nonce = self.nonce;
+        declaration.nonce = operation.nonce;
 
         debug!(
             target: LOG_TARGET,

--- a/core/src/mantle/ops/sdp/withdraw.rs
+++ b/core/src/mantle/ops/sdp/withdraw.rs
@@ -36,6 +36,7 @@ pub struct SDPWithdrawExecutionContext {
 
 impl ProvableOperation for SDPWithdrawOp {
     type Proof = ZkSignature;
+    const CODE: u8 = 0x21;
 }
 
 impl OperationGas<MainnetGasProfile> for SDPWithdrawOp {

--- a/core/src/mantle/ops/sdp/withdraw.rs
+++ b/core/src/mantle/ops/sdp/withdraw.rs
@@ -13,7 +13,7 @@ use crate::{
             Declarations, ExecutableOperation, PreverifiableOperation, ProvableOperation,
             VerifiableOperation, verification_mode, verification_mode::VerificationMode,
         },
-        ops::SignedOp,
+        ops::SignedOperation,
         transactions::{hash::TxHashView, states::VerificationState},
     },
     sdp::{self, locked_notes::LockedNotes},
@@ -154,7 +154,7 @@ impl ExecutableOperation for SDPWithdrawOp {
 }
 
 impl<State: VerificationState, Mode: VerificationMode> SignedOperationExecutionGas
-    for SignedOp<SDPWithdrawOp, State, Mode>
+    for SignedOperation<SDPWithdrawOp, State, Mode>
 {
     fn gas_multiplier(&self) -> Value {
         1

--- a/core/src/mantle/ops/serde_.rs
+++ b/core/src/mantle/ops/serde_.rs
@@ -25,6 +25,8 @@ impl<'de, const CODE: u8> Deserialize<'de> for ConstU8<CODE> {
 }
 
 /// Shared `{ opcode, payload }` wire shape used in both directions.
+// TODO: If `Inner` is always a ProvableOperation, then we can leverage `: ProvableOperation` toOp
+//  satisfy the `CODE`.
 #[derive(Serialize, Deserialize)]
 pub struct OpWire<const CODE: u8, Inner> {
     opcode: ConstU8<CODE>,

--- a/core/src/mantle/ops/serde_.rs
+++ b/core/src/mantle/ops/serde_.rs
@@ -25,8 +25,6 @@ impl<'de, const CODE: u8> Deserialize<'de> for ConstU8<CODE> {
 }
 
 /// Shared `{ opcode, payload }` wire shape used in both directions.
-// TODO: If `Inner` is always a ProvableOperation, then we can leverage `: ProvableOperation` toOp
-//  satisfy the `CODE`.
 #[derive(Serialize, Deserialize)]
 pub struct OpWire<const CODE: u8, Inner> {
     opcode: ConstU8<CODE>,

--- a/core/src/mantle/ops/signed_op.rs
+++ b/core/src/mantle/ops/signed_op.rs
@@ -1,0 +1,28 @@
+use crate::mantle::{
+    ledger::verification_mode::VerificationMode,
+    ops::{
+        SignedOperation,
+        channel::{
+            channel_transfer::ChannelTransferOp, config::ChannelConfigOp, deposit::DepositOp,
+            inscribe::InscriptionOp, withdraw::ChannelWithdrawOp,
+        },
+        leader_claim::LeaderClaimOp,
+        sdp::{SDPActiveOp, SDPDeclareOp, SDPWithdrawOp},
+        transfer::TransferOp,
+    },
+    transactions::states::VerificationState,
+};
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum SignedOp<State: VerificationState, Mode: VerificationMode> {
+    ChannelInscribe(SignedOperation<InscriptionOp, State, Mode>),
+    ChannelConfig(SignedOperation<ChannelConfigOp, State, Mode>),
+    ChannelDeposit(SignedOperation<DepositOp, State, Mode>),
+    ChannelWithdraw(SignedOperation<ChannelWithdrawOp, State, Mode>),
+    ChannelTransfer(SignedOperation<ChannelTransferOp, State, Mode>),
+    SDPDeclare(SignedOperation<SDPDeclareOp, State, Mode>),
+    SDPWithdraw(SignedOperation<SDPWithdrawOp, State, Mode>),
+    SDPActive(SignedOperation<SDPActiveOp, State, Mode>),
+    LeaderClaim(SignedOperation<LeaderClaimOp, State, Mode>),
+    Transfer(SignedOperation<TransferOp, State, Mode>),
+}

--- a/core/src/mantle/ops/signed_operation.rs
+++ b/core/src/mantle/ops/signed_operation.rs
@@ -13,24 +13,24 @@ use crate::{
     },
 };
 
-pub struct SignedOp<T: ProvableOperation, State: VerificationState, Mode: VerificationMode> {
+pub struct SignedOperation<T: ProvableOperation, State: VerificationState, Mode: VerificationMode> {
     operation: T,
     proof: T::Proof,
     _marker: PhantomData<(State, Mode)>,
 }
 
 impl<T: ProvableOperation, State: VerificationState, Mode: VerificationMode>
-    SignedOp<T, State, Mode>
+    SignedOperation<T, State, Mode>
 {
     #[must_use]
-    fn into_state<NewState: VerificationState>(self) -> SignedOp<T, NewState, Mode> {
+    fn into_state<NewState: VerificationState>(self) -> SignedOperation<T, NewState, Mode> {
         let Self {
             operation,
             proof,
             _marker,
         } = self;
 
-        SignedOp::<T, NewState, Mode> {
+        SignedOperation::<T, NewState, Mode> {
             operation,
             proof,
             _marker: PhantomData,
@@ -48,7 +48,7 @@ impl<T: ProvableOperation, State: VerificationState, Mode: VerificationMode>
     }
 }
 
-impl<T: ProvableOperation, Mode: VerificationMode> SignedOp<T, Unverified, Mode> {
+impl<T: ProvableOperation, Mode: VerificationMode> SignedOperation<T, Unverified, Mode> {
     #[must_use]
     pub const fn new(operation: T, proof: T::Proof) -> Self {
         Self {
@@ -59,21 +59,21 @@ impl<T: ProvableOperation, Mode: VerificationMode> SignedOp<T, Unverified, Mode>
     }
 }
 
-impl<T: PreverifiableOperation<Mode>, Mode: VerificationMode> SignedOp<T, Unverified, Mode> {
+impl<T: PreverifiableOperation<Mode>, Mode: VerificationMode> SignedOperation<T, Unverified, Mode> {
     pub fn preverify(
         self,
         context: &T::Context<'_>,
-    ) -> Result<SignedOp<T, Preverified, Mode>, T::Error> {
+    ) -> Result<SignedOperation<T, Preverified, Mode>, T::Error> {
         self.operation.preverify(&self.proof, context)?;
         Ok(self.into_state())
     }
 }
 
-impl<T: VerifiableOperation<Mode>, Mode: VerificationMode> SignedOp<T, Preverified, Mode> {
+impl<T: VerifiableOperation<Mode>, Mode: VerificationMode> SignedOperation<T, Preverified, Mode> {
     pub fn verify(
         self,
         context: &T::Context<'_>,
-    ) -> Result<SignedOp<T, Verified, Mode>, (Self, T::Error)> {
+    ) -> Result<SignedOperation<T, Verified, Mode>, (Self, T::Error)> {
         let verify_result = self.operation.verify(&self.proof, context);
         match verify_result {
             Ok(()) => Ok(self.into_state()),
@@ -82,7 +82,7 @@ impl<T: VerifiableOperation<Mode>, Mode: VerificationMode> SignedOp<T, Preverifi
     }
 }
 
-impl<T: Operation<Mode>, Mode: VerificationMode> SignedOp<T, Verified, Mode> {
+impl<T: Operation<Mode>, Mode: VerificationMode> SignedOperation<T, Verified, Mode> {
     pub fn execute<'a>(
         &self,
         context: <T as ExecutableOperation>::Context<'a>,
@@ -94,7 +94,7 @@ impl<T: Operation<Mode>, Mode: VerificationMode> SignedOp<T, Verified, Mode> {
     }
 }
 
-impl<Profile, T, State, Mode> OperationGas<Profile> for SignedOp<T, State, Mode>
+impl<Profile, T, State, Mode> OperationGas<Profile> for SignedOperation<T, State, Mode>
 where
     Profile: GasProfile,
     T: OperationGas<Profile> + ProvableOperation,

--- a/core/src/mantle/ops/signed_operation.rs
+++ b/core/src/mantle/ops/signed_operation.rs
@@ -13,6 +13,7 @@ use crate::{
     },
 };
 
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct SignedOperation<T: ProvableOperation, State: VerificationState, Mode: VerificationMode> {
     operation: T,
     proof: T::Proof,

--- a/core/src/mantle/ops/signed_operation.rs
+++ b/core/src/mantle/ops/signed_operation.rs
@@ -6,8 +6,8 @@ use crate::{
         GasProfile,
         gas::{Gas, OperationGas},
         ledger::{
-            ExecutableOperation, Operation, PreverifiableOperation, ProvableOperation,
-            VerifiableOperation, verification_mode::VerificationMode,
+            ExecutableOperation, PreverifiableOperation, ProvableOperation, VerifiableOperation,
+            verification_mode::VerificationMode,
         },
         transactions::states::{Preverified, Unverified, VerificationState, Verified},
     },
@@ -47,6 +47,21 @@ impl<T: ProvableOperation, State: VerificationState, Mode: VerificationMode>
     pub const fn proof(&self) -> &T::Proof {
         &self.proof
     }
+
+    /// Converts a `SignedOperation<T, State, Mode>` into a
+    /// `SignedOperation<T, NewState, Mode>` without performing any
+    /// verification.
+    ///
+    /// This function is intended for
+    /// [`GenesisTx`](crate::mantle::transactions::genesis_tx::GenesisTx) and
+    /// testing purposes only.
+    #[must_use]
+    #[doc(hidden)]
+    pub fn into_state_trusted<NewState: VerificationState>(
+        self,
+    ) -> SignedOperation<T, NewState, Mode> {
+        self.into_state()
+    }
 }
 
 impl<T: ProvableOperation, Mode: VerificationMode> SignedOperation<T, Unverified, Mode> {
@@ -60,22 +75,34 @@ impl<T: ProvableOperation, Mode: VerificationMode> SignedOperation<T, Unverified
     }
 }
 
-impl<T: PreverifiableOperation<Mode>, Mode: VerificationMode> SignedOperation<T, Unverified, Mode> {
-    pub fn preverify(
+impl<T: ProvableOperation, Mode: VerificationMode> SignedOperation<T, Unverified, Mode>
+where
+    Self: PreverifiableOperation<Mode>,
+{
+    pub fn into_preverified(
         self,
-        context: &T::Context<'_>,
-    ) -> Result<SignedOperation<T, Preverified, Mode>, T::Error> {
-        self.operation.preverify(&self.proof, context)?;
+        context: &<Self as PreverifiableOperation<Mode>>::Context<'_>,
+    ) -> Result<SignedOperation<T, Preverified, Mode>, <Self as PreverifiableOperation<Mode>>::Error>
+    {
+        self.preverify(context)?;
         Ok(self.into_state())
     }
 }
 
-impl<T: VerifiableOperation<Mode>, Mode: VerificationMode> SignedOperation<T, Preverified, Mode> {
-    pub fn verify(
+pub type VerifyError<T, Mode> = (
+    SignedOperation<T, Preverified, Mode>,
+    <SignedOperation<T, Preverified, Mode> as VerifiableOperation<Mode>>::Error,
+);
+
+impl<T: ProvableOperation, Mode: VerificationMode> SignedOperation<T, Preverified, Mode>
+where
+    Self: VerifiableOperation<Mode>,
+{
+    pub fn into_verified(
         self,
-        context: &T::Context<'_>,
-    ) -> Result<SignedOperation<T, Verified, Mode>, (Self, T::Error)> {
-        let verify_result = self.operation.verify(&self.proof, context);
+        context: &<Self as VerifiableOperation<Mode>>::Context<'_>,
+    ) -> Result<SignedOperation<T, Verified, Mode>, VerifyError<T, Mode>> {
+        let verify_result = self.verify(context);
         match verify_result {
             Ok(()) => Ok(self.into_state()),
             Err(error) => Err((self, error)),
@@ -83,15 +110,24 @@ impl<T: VerifiableOperation<Mode>, Mode: VerificationMode> SignedOperation<T, Pr
     }
 }
 
-impl<T: Operation<Mode>, Mode: VerificationMode> SignedOperation<T, Verified, Mode> {
-    pub fn execute<'a>(
-        &self,
-        context: <T as ExecutableOperation>::Context<'a>,
-    ) -> Result<
-        (<T as ExecutableOperation>::Context<'a>, Vec<TxEvent>),
-        <T as ExecutableOperation>::Error,
-    > {
-        self.operation.execute(context)
+pub type ExecuteOk<'context, T, Mode> = (
+    <SignedOperation<T, Verified, Mode> as ExecutableOperation>::Context<'context>,
+    Vec<TxEvent>,
+);
+pub type ExecuteError<T, Mode> = (
+    SignedOperation<T, Verified, Mode>,
+    <SignedOperation<T, Verified, Mode> as ExecutableOperation>::Error,
+);
+
+impl<T: ProvableOperation, Mode: VerificationMode> SignedOperation<T, Verified, Mode>
+where
+    Self: ExecutableOperation,
+{
+    pub fn execute(
+        self,
+        context: <Self as ExecutableOperation>::Context<'_>,
+    ) -> Result<ExecuteOk<'_, T, Mode>, ExecuteError<T, Mode>> {
+        <Self as ExecutableOperation>::execute(&self, context).map_err(|error| (self, error))
     }
 }
 

--- a/core/src/mantle/ops/transfer.rs
+++ b/core/src/mantle/ops/transfer.rs
@@ -11,11 +11,14 @@ use crate::{
         gas::{Gas, MainnetGasProfile, OperationGas, SignedOperationExecutionGas},
         ledger::{
             self, ExecutableOperation, Inputs, Outputs, PreverifiableOperation, ProvableOperation,
-            Utxo, Utxos, VerifiableOperation, verification_mode,
-            verification_mode::VerificationMode,
+            Utxo, Utxos, VerifiableOperation,
+            verification_mode::{StandardMode, VerificationMode},
         },
         ops::{OpId, SignedOperation},
-        transactions::{hash::TxHashView, states::VerificationState},
+        transactions::{
+            hash::TxHashView,
+            states::{Preverified, Unverified, VerificationState, Verified},
+        },
     },
     sdp::locked_notes::LockedNotes,
 };
@@ -94,40 +97,42 @@ impl OperationGas<MainnetGasProfile> for TransferOp {
     const GAS_COST: Gas = Gas::new(590);
 }
 
-impl PreverifiableOperation<verification_mode::StandardMode> for TransferOp {
+impl PreverifiableOperation<StandardMode>
+    for SignedOperation<TransferOp, Unverified, StandardMode>
+{
     type Context<'a> = ();
     type Error = TransferError;
 
-    fn preverify(
-        &self,
-        _proof: &Self::Proof,
-        _context: &Self::Context<'_>,
-    ) -> Result<(), Self::Error> {
+    fn preverify(&self, _context: &Self::Context<'_>) -> Result<(), Self::Error> {
+        let operation = self.operation();
+
         // Ensure the inputs is non-empty
-        self.inputs.preverify()?;
+        operation.inputs.preverify()?;
 
         // Validate Outputs
-        self.outputs.validate()?;
+        operation.outputs.validate()?;
 
         Ok(())
     }
 }
 
-impl VerifiableOperation<verification_mode::StandardMode> for TransferOp {
+impl VerifiableOperation<StandardMode> for SignedOperation<TransferOp, Preverified, StandardMode> {
     type Context<'a> = TransferValidationContext<'a>;
     type Error = TransferError;
 
-    fn verify(&self, proof: &Self::Proof, context: &Self::Context<'_>) -> Result<(), Self::Error> {
+    fn verify(&self, context: &Self::Context<'_>) -> Result<(), Self::Error> {
+        let operation = self.operation();
+
         // Validate Inputs
-        self.inputs.validate_not_in_channel(
+        operation.inputs.validate_not_in_channel(
             context.locked_notes,
             context.channels,
             context.utxos,
         )?;
 
         // Check the transfer Proof
-        let pks = self.inputs.get_pk(context.utxos)?;
-        if !ZkPublicKey::verify_multi(&pks, context.tx_hash_view.as_fr(), proof) {
+        let pks = operation.inputs.get_pk(context.utxos)?;
+        if !ZkPublicKey::verify_multi(&pks, context.tx_hash_view.as_fr(), self.proof()) {
             return Err(TransferError::InvalidProof);
         }
 
@@ -135,7 +140,7 @@ impl VerifiableOperation<verification_mode::StandardMode> for TransferOp {
     }
 }
 
-impl ExecutableOperation for TransferOp {
+impl<Mode: VerificationMode> ExecutableOperation for SignedOperation<TransferOp, Verified, Mode> {
     type Context<'a> = Utxos;
     type Error = TransferError;
 
@@ -143,10 +148,13 @@ impl ExecutableOperation for TransferOp {
         &self,
         mut utxos: Self::Context<'a>,
     ) -> Result<(Self::Context<'a>, Vec<TxEvent>), Self::Error> {
+        let operation = self.operation();
+
         // Remove inputs from the ledger
-        utxos = self.inputs.execute(utxos)?;
+        utxos = operation.inputs.execute(utxos)?;
+
         // Add outputs from the ledger
-        utxos = self.outputs.execute(utxos, self);
+        utxos = operation.outputs.execute(utxos, self.operation());
         Ok((utxos, Vec::new()))
     }
 }
@@ -176,9 +184,10 @@ mod test {
             outputs: Outputs::new([Note::new(100, pk)]),
         };
         let proof = ZkSignature::new(CompressedGroth16Proof::from_bytes(&[0u8; 128]));
+        let signed_operation = SignedOperation::new(transfer, proof);
 
         assert_eq!(
-            transfer.preverify(&proof, &()),
+            signed_operation.preverify(&()),
             Err(TransferError::Inputs(ledger::InputsError::EmptyInputs))
         );
     }

--- a/core/src/mantle/ops/transfer.rs
+++ b/core/src/mantle/ops/transfer.rs
@@ -87,6 +87,7 @@ pub struct TransferValidationContext<'a> {
 
 impl ProvableOperation for TransferOp {
     type Proof = ZkSignature;
+    const CODE: u8 = 0x00;
 }
 
 impl OperationGas<MainnetGasProfile> for TransferOp {

--- a/core/src/mantle/ops/transfer.rs
+++ b/core/src/mantle/ops/transfer.rs
@@ -14,7 +14,7 @@ use crate::{
             Utxo, Utxos, VerifiableOperation, verification_mode,
             verification_mode::VerificationMode,
         },
-        ops::{OpId, SignedOp},
+        ops::{OpId, SignedOperation},
         transactions::{hash::TxHashView, states::VerificationState},
     },
     sdp::locked_notes::LockedNotes,
@@ -151,7 +151,7 @@ impl ExecutableOperation for TransferOp {
 }
 
 impl<State: VerificationState, Mode: VerificationMode> SignedOperationExecutionGas
-    for SignedOp<TransferOp, State, Mode>
+    for SignedOperation<TransferOp, State, Mode>
 {
     fn gas_multiplier(&self) -> Value {
         1

--- a/core/src/mantle/traits/mod.rs
+++ b/core/src/mantle/traits/mod.rs
@@ -2,6 +2,7 @@ pub mod genesis;
 pub mod hashable;
 pub mod mantle_tx;
 pub mod preverified_tx;
+pub mod signed_mantle_tx;
 pub mod storage;
 
 pub use genesis::GenesisTx;

--- a/core/src/mantle/traits/preverified_tx.rs
+++ b/core/src/mantle/traits/preverified_tx.rs
@@ -1,6 +1,6 @@
-use crate::mantle::{traits::mantle_tx::MantleTxWithProofs, transactions::VerifiedOps};
+use crate::mantle::{traits::mantle_tx::MantleTxWithProofs, transactions::VerifiedOperations};
 
 pub trait PreverifiedMantleTx: MantleTxWithProofs {
     /// Returns the cursor to the verified operations in this transaction.
-    fn verified_ops(&self) -> VerifiedOps<'_>;
+    fn verified_ops(&self) -> VerifiedOperations<'_>;
 }

--- a/core/src/mantle/traits/signed_mantle_tx.rs
+++ b/core/src/mantle/traits/signed_mantle_tx.rs
@@ -1,0 +1,8 @@
+use crate::mantle::{
+    ledger::verification_mode::VerificationMode,
+    transactions::{SignedOps, states::VerificationState},
+};
+
+pub trait SignedMantleTx<State: VerificationState, Mode: VerificationMode> {
+    fn signed_ops(&self) -> &SignedOps<State, Mode>;
+}

--- a/core/src/mantle/transactions/codec.rs
+++ b/core/src/mantle/transactions/codec.rs
@@ -5,7 +5,7 @@ use lb_key_management_system_keys::keys::ED25519_SIGNATURE_SIZE;
 use crate::{
     mantle::{
         MantleTransaction, Op,
-        ops::codec::{decode_ops_proofs, encode_ops_proofs},
+        ops::codec::{decode_op_proofs, encode_op_proofs},
         transactions::{
             mantle_tx::{MantleTx as _, MantleTxGasContext, RawMantleTx},
             states::{Unverified, VerificationState},
@@ -19,7 +19,7 @@ pub fn decode_signed_mantle_tx(
 ) -> Result<(&[u8], MantleTransaction<Unverified>), DecodeError> {
     // MantleTransaction = MantleTx OpProofs
     let (input, mantle_tx) = RawMantleTx::decode(input)?;
-    let (input, ops_proofs) = decode_ops_proofs(input, mantle_tx.ops())?;
+    let (input, ops_proofs) = decode_op_proofs(input, mantle_tx.ops())?;
 
     let signed_tx = MantleTransaction::new(mantle_tx, ops_proofs);
 
@@ -30,7 +30,7 @@ pub fn decode_signed_mantle_tx(
 pub fn encode_signed_mantle_tx<State: VerificationState>(tx: &MantleTransaction<State>) -> Vec<u8> {
     let mut bytes = Vec::new();
     bytes.extend(tx.mantle_tx().encode());
-    bytes.extend(encode_ops_proofs(tx.ops_proofs(), tx.mantle_tx().ops()));
+    bytes.extend(encode_op_proofs(tx.ops_proofs(), tx.mantle_tx().ops()));
     bytes
 }
 

--- a/core/src/mantle/transactions/codec.rs
+++ b/core/src/mantle/transactions/codec.rs
@@ -17,7 +17,7 @@ use crate::{
 pub fn decode_signed_mantle_tx(
     input: &[u8],
 ) -> Result<(&[u8], MantleTransaction<Unverified>), DecodeError> {
-    // MantleTransaction = MantleTx OpsProofs
+    // MantleTransaction = MantleTx OpProofs
     let (input, mantle_tx) = RawMantleTx::decode(input)?;
     let (input, ops_proofs) = decode_ops_proofs(input, mantle_tx.ops())?;
 
@@ -133,7 +133,7 @@ mod tests {
                 transfer::TransferOp,
             },
             traits::Hashable as _,
-            transactions::{GasPrices, Ops, OpsProofs},
+            transactions::{GasPrices, OpProofs, Ops},
         },
         proofs::{
             channel_multi_sig_proof::{ChannelMultiSigProof, IndexedSignature},
@@ -175,7 +175,7 @@ mod tests {
     fn test_decode_signed_mantle_tx_empty() {
         let mantle_tx = RawMantleTx(Ops::new_unchecked(vec![]));
 
-        let signed_tx = MantleTransaction::new(mantle_tx, OpsProofs::empty());
+        let signed_tx = MantleTransaction::new(mantle_tx, OpProofs::empty());
 
         #[expect(
             clippy::string_add,
@@ -393,7 +393,7 @@ mod tests {
     fn test_encode_decode_roundtrip_signed_tx() {
         // Create a simple MantleTransaction
         let mantle_tx = RawMantleTx(Ops::new_unchecked(vec![]));
-        let original_tx = MantleTransaction::new(mantle_tx, OpsProofs::empty());
+        let original_tx = MantleTransaction::new(mantle_tx, OpProofs::empty());
 
         // Encode
         let encoded = encode_signed_mantle_tx(&original_tx);
@@ -417,7 +417,7 @@ mod tests {
         let predicted_size = minimum_signed_mantle_tx_size(&mantle_tx, &gas_context);
 
         // Create a signed tx and encode it to get actual size
-        let signed_tx = MantleTransaction::new(mantle_tx, OpsProofs::empty());
+        let signed_tx = MantleTransaction::new(mantle_tx, OpProofs::empty());
         let encoded = encode_signed_mantle_tx(&signed_tx);
         let actual_size = encoded.len();
 

--- a/core/src/mantle/transactions/codec.rs
+++ b/core/src/mantle/transactions/codec.rs
@@ -4,7 +4,7 @@ use lb_key_management_system_keys::keys::ED25519_SIGNATURE_SIZE;
 
 use crate::{
     mantle::{
-        Op, SignedMantleTx,
+        MantleTransaction, Op,
         ops::codec::{decode_ops_proofs, encode_ops_proofs},
         transactions::{
             mantle_tx::{MantleTx as _, MantleTxGasContext, RawMantleTx},
@@ -16,18 +16,18 @@ use crate::{
 
 pub fn decode_signed_mantle_tx(
     input: &[u8],
-) -> Result<(&[u8], SignedMantleTx<Unverified>), DecodeError> {
-    // SignedMantleTx = MantleTx OpsProofs
+) -> Result<(&[u8], MantleTransaction<Unverified>), DecodeError> {
+    // MantleTransaction = MantleTx OpsProofs
     let (input, mantle_tx) = RawMantleTx::decode(input)?;
     let (input, ops_proofs) = decode_ops_proofs(input, mantle_tx.ops())?;
 
-    let signed_tx = SignedMantleTx::new(mantle_tx, ops_proofs);
+    let signed_tx = MantleTransaction::new(mantle_tx, ops_proofs);
 
     Ok((input, signed_tx))
 }
 
 #[must_use]
-pub fn encode_signed_mantle_tx<State: VerificationState>(tx: &SignedMantleTx<State>) -> Vec<u8> {
+pub fn encode_signed_mantle_tx<State: VerificationState>(tx: &MantleTransaction<State>) -> Vec<u8> {
     let mut bytes = Vec::new();
     bytes.extend(tx.mantle_tx().encode());
     bytes.extend(encode_ops_proofs(tx.ops_proofs(), tx.mantle_tx().ops()));
@@ -175,7 +175,7 @@ mod tests {
     fn test_decode_signed_mantle_tx_empty() {
         let mantle_tx = RawMantleTx(Ops::new_unchecked(vec![]));
 
-        let signed_tx = SignedMantleTx::new(mantle_tx, OpsProofs::empty());
+        let signed_tx = MantleTransaction::new(mantle_tx, OpsProofs::empty());
 
         #[expect(
             clippy::string_add,
@@ -213,7 +213,7 @@ mod tests {
         let tx_hash = mantle_tx.hash();
         let inscribe_sig =
             OpProof::Ed25519Sig(signing_key.sign_payload(&tx_hash.as_signing_bytes()));
-        let signed_tx = SignedMantleTx::new(mantle_tx, [inscribe_sig].into());
+        let signed_tx = MantleTransaction::new(mantle_tx, [inscribe_sig].into());
 
         #[expect(
             clippy::string_add,
@@ -272,7 +272,7 @@ mod tests {
 
         // Encode and decode roundtrip test (no hardcoded test vector since signatures
         // are deterministic)
-        let signed_tx = SignedMantleTx::new(
+        let signed_tx = MantleTransaction::new(
             mantle_tx,
             [
                 OpProof::Ed25519Sig(sig),
@@ -316,7 +316,7 @@ mod tests {
                 let tx_hash = mantle_tx.hash();
                 let op_sig = signing_key.sign_payload(&tx_hash.as_signing_bytes());
                 let signed_tx =
-                    SignedMantleTx::new(mantle_tx, [OpProof::Ed25519Sig(op_sig)].into());
+                    MantleTransaction::new(mantle_tx, [OpProof::Ed25519Sig(op_sig)].into());
 
                 let encoded = encode_signed_mantle_tx(&signed_tx);
 
@@ -391,9 +391,9 @@ mod tests {
 
     #[test]
     fn test_encode_decode_roundtrip_signed_tx() {
-        // Create a simple SignedMantleTx
+        // Create a simple MantleTransaction
         let mantle_tx = RawMantleTx(Ops::new_unchecked(vec![]));
-        let original_tx = SignedMantleTx::new(mantle_tx, OpsProofs::empty());
+        let original_tx = MantleTransaction::new(mantle_tx, OpsProofs::empty());
 
         // Encode
         let encoded = encode_signed_mantle_tx(&original_tx);
@@ -417,7 +417,7 @@ mod tests {
         let predicted_size = minimum_signed_mantle_tx_size(&mantle_tx, &gas_context);
 
         // Create a signed tx and encode it to get actual size
-        let signed_tx = SignedMantleTx::new(mantle_tx, OpsProofs::empty());
+        let signed_tx = MantleTransaction::new(mantle_tx, OpsProofs::empty());
         let encoded = encode_signed_mantle_tx(&signed_tx);
         let actual_size = encoded.len();
 
@@ -444,7 +444,7 @@ mod tests {
         // Create a signed tx and encode it to get actual size
         let tx_hash = mantle_tx.hash();
         let op_sig = signing_key.sign_payload(&tx_hash.as_signing_bytes());
-        let signed_tx = SignedMantleTx::new(mantle_tx, [OpProof::Ed25519Sig(op_sig)].into());
+        let signed_tx = MantleTransaction::new(mantle_tx, [OpProof::Ed25519Sig(op_sig)].into());
         let encoded = encode_signed_mantle_tx(&signed_tx);
         let actual_size = encoded.len();
 
@@ -481,7 +481,7 @@ mod tests {
         // Create a signed tx and encode it to get the actual size.
         // New channel → empty proof (no signatures required for just-in-time create).
         let config_proof = ChannelMultiSigProof::try_new([].into()).unwrap();
-        let signed_tx = SignedMantleTx::new(
+        let signed_tx = MantleTransaction::new(
             mantle_tx,
             [OpProof::ChannelMultiSigProof(config_proof)].into(),
         );
@@ -533,7 +533,8 @@ mod tests {
             zk_sig: ZkKey::multi_sign(&[locked_note_sk, zk_sk], &tx_hash.to_fr()).unwrap(),
             ed25519_sig: Ed25519Signature::from_bytes(&[0u8; 64]),
         };
-        let signed_tx = SignedMantleTx::new(mantle_tx, [OpProof::ZkAndEd25519Sigs(proof)].into());
+        let signed_tx =
+            MantleTransaction::new(mantle_tx, [OpProof::ZkAndEd25519Sigs(proof)].into());
         let encoded = encode_signed_mantle_tx(&signed_tx);
         let actual_size = encoded.len();
 
@@ -560,7 +561,7 @@ mod tests {
         let predicted_size = minimum_signed_mantle_tx_size(&mantle_tx, &gas_context);
 
         // Create a signed tx and encode it to get actual size
-        let signed_tx = SignedMantleTx::new(
+        let signed_tx = MantleTransaction::new(
             mantle_tx,
             [OpProof::ZkSig(
                 ZkKey::multi_sign(&[ZkKey::zero()], &tx_hash.to_fr()).unwrap(),
@@ -599,7 +600,7 @@ mod tests {
         let predicted_size = minimum_signed_mantle_tx_size(&mantle_tx, &gas_context);
 
         let tx_hash = mantle_tx.hash();
-        let signed_tx = SignedMantleTx::new(
+        let signed_tx = MantleTransaction::new(
             mantle_tx,
             [OpProof::ZkSig(
                 ZkKey::multi_sign(&[ZkKey::zero()], &tx_hash.to_fr()).unwrap(),
@@ -663,7 +664,7 @@ mod tests {
         // Create a signed tx and encode it to get the actual size.
         // ChannelConfig creates the channel here, so its proof has no signatures.
         let config_proof = ChannelMultiSigProof::try_new([].into()).unwrap();
-        let signed_tx = SignedMantleTx::new(
+        let signed_tx = MantleTransaction::new(
             mantle_tx,
             [
                 OpProof::Ed25519Sig(op_sig),
@@ -703,7 +704,7 @@ mod tests {
         let predicted_size = minimum_signed_mantle_tx_size(&mantle_tx, &gas_context);
 
         // Create a signed tx and encode it to get actual size
-        let signed_tx = SignedMantleTx::new(
+        let signed_tx = MantleTransaction::new(
             mantle_tx,
             [OpProof::ZkSig(ZkKey::multi_sign(&[], &Fr::ZERO).unwrap())].into(),
         );
@@ -775,7 +776,7 @@ mod tests {
             zk_sig: ZkKey::multi_sign(&[locked_note_sk, zk_sk], &tx_hash.to_fr()).unwrap(),
             ed25519_sig: op_ed25519_sig,
         };
-        let signed_tx = SignedMantleTx::new(
+        let signed_tx = MantleTransaction::new(
             mantle_tx,
             [
                 OpProof::Ed25519Sig(op_ed25519_sig),
@@ -809,7 +810,7 @@ mod tests {
             Groth16LeaderClaimProof::new(CompressedGroth16Proof::from_bytes(&[0u8; 128]));
 
         // Construct directly to skip proof verification (dummy proof won't verify)
-        let signed_tx = SignedMantleTx::new(mantle_tx, [OpProof::PoC(poc_proof)].into());
+        let signed_tx = MantleTransaction::new(mantle_tx, [OpProof::PoC(poc_proof)].into());
 
         let encoded = encode_signed_mantle_tx(&signed_tx);
         assert_eq!(predicted_size, encoded.len());
@@ -852,7 +853,7 @@ mod tests {
         )
         .unwrap();
         let signed_tx =
-            SignedMantleTx::new(mantle_tx, [OpProof::ChannelMultiSigProof(proof)].into());
+            MantleTransaction::new(mantle_tx, [OpProof::ChannelMultiSigProof(proof)].into());
 
         let encoded = encode_signed_mantle_tx(&signed_tx);
         let (remaining, decoded_tx) = decode_signed_mantle_tx(&encoded).unwrap();

--- a/core/src/mantle/transactions/genesis_tx.rs
+++ b/core/src/mantle/transactions/genesis_tx.rs
@@ -406,7 +406,7 @@ mod tests {
                 ZkAndEd25519Proof,
                 channel::{Ed25519PublicKey, inscribe::Inscription},
             },
-            transactions::{Ops, OpsProofs},
+            transactions::{OpProofs, Ops},
         },
         sdp::{Locator, ProviderId, ServiceType},
     };
@@ -480,8 +480,8 @@ mod tests {
         let mut new_ops = vec![Op::Transfer(transfer_op)];
         new_ops.append(&mut ops);
         let mantle_tx = RawMantleTx(Ops::new_unchecked(new_ops));
-        let ops_proofs = OpsProofs::try_from(ops_proofs).unwrap();
-        let mut new_op_proofs = OpsProofs::from(OpProof::ZkSig(
+        let ops_proofs = OpProofs::try_from(ops_proofs).unwrap();
+        let mut new_op_proofs = OpProofs::from(OpProof::ZkSig(
             ZkKey::multi_sign(&[], &mantle_tx.hash().to_fr()).unwrap(),
         ));
         for proof in ops_proofs {

--- a/core/src/mantle/transactions/genesis_tx.rs
+++ b/core/src/mantle/transactions/genesis_tx.rs
@@ -9,7 +9,7 @@ use time::OffsetDateTime;
 use crate::{
     crypto::{Digest as _, Hasher},
     mantle::{
-        OpProof, SignedMantleTx,
+        MantleTransaction, OpProof,
         gas::{Gas, GasCost, GasOverflow, GasProfile, TxGasCalculator},
         ops::{
             Op,
@@ -29,7 +29,7 @@ use crate::{
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GenesisTx {
-    tx: SignedMantleTx<Preverified>,
+    tx: MantleTransaction<Preverified>,
     cryptarchia_parameter: CryptarchiaParameter,
 }
 
@@ -65,7 +65,7 @@ pub enum Error {
 }
 
 impl GenesisTx {
-    pub fn from_tx(signed_mantle_tx: SignedMantleTx<Preverified>) -> Result<Self, Error> {
+    pub fn from_tx(signed_mantle_tx: MantleTransaction<Preverified>) -> Result<Self, Error> {
         let mantle_tx = signed_mantle_tx.mantle_tx();
 
         // Genesis transactions must contain exactly one transfer as the first op,
@@ -241,7 +241,7 @@ impl<'de> Deserialize<'de> for GenesisTx {
     where
         D: serde::Deserializer<'de>,
     {
-        let tx = SignedMantleTx::deserialize(deserializer)?.into_trusted();
+        let tx = MantleTransaction::deserialize(deserializer)?.into_trusted();
         Self::from_tx(tx).map_err(serde::de::Error::custom)
     }
 }
@@ -475,7 +475,7 @@ mod tests {
     fn create_trusted_tx(
         mut ops: Vec<Op>,
         ops_proofs: Vec<OpProof>,
-    ) -> SignedMantleTx<Preverified> {
+    ) -> MantleTransaction<Preverified> {
         let transfer_op = TransferOp::new(Inputs::empty(), Outputs::new([create_test_note(1000)]));
         let mut new_ops = vec![Op::Transfer(transfer_op)];
         new_ops.append(&mut ops);
@@ -487,7 +487,7 @@ mod tests {
         for proof in ops_proofs {
             new_op_proofs.try_push(proof).unwrap();
         }
-        SignedMantleTx::new_trusted(mantle_tx, new_op_proofs)
+        MantleTransaction::new_trusted(mantle_tx, new_op_proofs)
     }
 
     #[test]

--- a/core/src/mantle/transactions/mantle_transaction.rs
+++ b/core/src/mantle/transactions/mantle_transaction.rs
@@ -42,21 +42,21 @@ use crate::{
 // TODO: Increase test coverage after type state refactor.
 //   The current tests behave just like the old code.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct SignedMantleTx<State: VerificationState> {
+pub struct MantleTransaction<State: VerificationState> {
     pub(crate) mantle_tx: RawMantleTx,
     // TODO: make this more efficient
     ops_proofs: OpsProofs,
     state: PhantomData<State>,
 }
 
-impl<State: VerificationState> SignedMantleTx<State> {
-    fn into_state<T: VerificationState>(self) -> SignedMantleTx<T> {
+impl<State: VerificationState> MantleTransaction<State> {
+    fn into_state<T: VerificationState>(self) -> MantleTransaction<T> {
         let Self {
             mantle_tx,
             ops_proofs,
             ..
         } = self;
-        SignedMantleTx::<T> {
+        MantleTransaction::<T> {
             mantle_tx,
             ops_proofs,
             state: PhantomData,
@@ -87,7 +87,7 @@ impl<State: VerificationState> SignedMantleTx<State> {
     }
 }
 
-impl SignedMantleTx<Unverified> {
+impl MantleTransaction<Unverified> {
     #[must_use]
     pub const fn new(mantle_tx: RawMantleTx, ops_proofs: OpsProofs) -> Self {
         Self {
@@ -175,7 +175,7 @@ impl SignedMantleTx<Unverified> {
         Ok(())
     }
 
-    fn into_preverified(self) -> SignedMantleTx<Preverified> {
+    fn into_preverified(self) -> MantleTransaction<Preverified> {
         self.into_state()
     }
 
@@ -189,27 +189,27 @@ impl SignedMantleTx<Unverified> {
     /// - Each operation has a corresponding proof of the correct type
     /// - [`InscriptionOp`](crate::mantle::ops::channel::inscribe::InscriptionOp)
     ///   and [`LeaderClaimOp`](crate::mantle::ops::leader_claim::LeaderClaimOp) have valid signatures/proofs.
-    pub fn preverify(self) -> Result<SignedMantleTx<Preverified>, VerificationError> {
+    pub fn preverify(self) -> Result<MantleTransaction<Preverified>, VerificationError> {
         self.ensure_one_proof_per_op()?;
         self.preverify_ops()?;
         Ok(self.into_preverified())
     }
 
-    /// Converts a `SignedMantleTx<Unverified>` into a
-    /// `SignedMantleTx<Preverified>` without performing any verification.
+    /// Converts a `MantleTransaction<Unverified>` into a
+    /// `MantleTransaction<Preverified>` without performing any verification.
     ///
     /// This function is intended for
     /// [`GenesisTx`](crate::mantle::transactions::genesis_tx::GenesisTx) and
     /// testing purposes only.
     #[must_use]
     #[doc(hidden)]
-    pub(crate) fn into_trusted(self) -> SignedMantleTx<Preverified> {
-        SignedMantleTx::new_trusted(self.mantle_tx, self.ops_proofs)
+    pub(crate) fn into_trusted(self) -> MantleTransaction<Preverified> {
+        MantleTransaction::new_trusted(self.mantle_tx, self.ops_proofs)
     }
 }
 
-impl SignedMantleTx<Preverified> {
-    /// Creates a new `SignedMantleTx<Preverified>` without performing any
+impl MantleTransaction<Preverified> {
+    /// Creates a new `MantleTransaction<Preverified>` without performing any
     /// verification.
     ///
     /// This function is intended for
@@ -353,7 +353,7 @@ impl SignedMantleTx<Preverified> {
                     .verify(proof, &context)
                     .map_err(VerificationError::ClaimPowRewardError)
             }
-            // SignedMantleTx<Preverified> invariant: Op/Proof pairs have been verified in
+            // MantleTransaction<Preverified> invariant: Op/Proof pairs have been verified in
             // preverify, so this branch should be unreachable.
             _ => {
                 unreachable!("All stateless verification should have been done in preverify.");
@@ -367,7 +367,7 @@ impl SignedMantleTx<Preverified> {
     }
 }
 
-impl<State: VerificationState> Hashable for SignedMantleTx<State> {
+impl<State: VerificationState> Hashable for MantleTransaction<State> {
     //noinspection RsTypeCheck: The type is correct, but the linter is confused by
     // the closure.
     const HASHER: hashable::Hasher<Self> = |tx| {
@@ -381,7 +381,7 @@ impl<State: VerificationState> Hashable for SignedMantleTx<State> {
     }
 }
 
-impl<State: VerificationState> MantleTxWithProofs for SignedMantleTx<State> {
+impl<State: VerificationState> MantleTxWithProofs for MantleTransaction<State> {
     fn mantle_tx(&self) -> &RawMantleTx {
         &self.mantle_tx
     }
@@ -391,7 +391,7 @@ impl<State: VerificationState> MantleTxWithProofs for SignedMantleTx<State> {
     }
 }
 
-impl<State: VerificationState> TxGasCalculator for SignedMantleTx<State> {
+impl<State: VerificationState> TxGasCalculator for MantleTransaction<State> {
     type Context = GasPrices;
 
     fn total_gas_cost<Profile: GasProfile>(
@@ -448,13 +448,13 @@ fn signed_op_execution_gas<Profile: GasProfile>(
     op.execution_gas::<Profile>().checked_mul(multiplier)
 }
 
-impl<State: VerificationState> StorageSize for SignedMantleTx<State> {
+impl<State: VerificationState> StorageSize for MantleTransaction<State> {
     fn storage_size(&self) -> usize {
         self.gas_storage_size() as usize
     }
 }
 
-impl PreverifiedMantleTx for SignedMantleTx<Preverified> {
+impl PreverifiedMantleTx for MantleTransaction<Preverified> {
     fn verified_ops(&self) -> VerifiedOps<'_> {
         self.verified_ops()
     }
@@ -462,13 +462,15 @@ impl PreverifiedMantleTx for SignedMantleTx<Preverified> {
 
 #[derive(Serialize)]
 #[serde(rename = "SignedMantleTx")]
-struct SignedMantleTxSerde<'a> {
+struct MantleTransactionSerde<'a> {
     mantle_tx: &'a RawMantleTx,
     ops_proofs: &'a [OpProof],
 }
 
-impl<'a, State: VerificationState> From<&'a SignedMantleTx<State>> for SignedMantleTxSerde<'a> {
-    fn from(signed_mantle_tx: &'a SignedMantleTx<State>) -> Self {
+impl<'a, State: VerificationState> From<&'a MantleTransaction<State>>
+    for MantleTransactionSerde<'a>
+{
+    fn from(signed_mantle_tx: &'a MantleTransaction<State>) -> Self {
         Self {
             mantle_tx: &signed_mantle_tx.mantle_tx,
             ops_proofs: &signed_mantle_tx.ops_proofs,
@@ -476,13 +478,13 @@ impl<'a, State: VerificationState> From<&'a SignedMantleTx<State>> for SignedMan
     }
 }
 
-impl<State: VerificationState> Serialize for SignedMantleTx<State> {
+impl<State: VerificationState> Serialize for MantleTransaction<State> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
         if serializer.is_human_readable() {
-            SignedMantleTxSerde::from(self).serialize(serializer)
+            MantleTransactionSerde::from(self).serialize(serializer)
         } else {
             encode_signed_mantle_tx(self).serialize(serializer)
         }
@@ -491,24 +493,24 @@ impl<State: VerificationState> Serialize for SignedMantleTx<State> {
 
 #[derive(Deserialize)]
 #[serde(rename = "SignedMantleTx")]
-struct OwnedSignedMantleTxSerde {
+struct OwnedMantleTransactionSerde {
     mantle_tx: RawMantleTx,
     ops_proofs: OpsProofs,
 }
 
-impl From<OwnedSignedMantleTxSerde> for SignedMantleTx<Unverified> {
-    fn from(helper: OwnedSignedMantleTxSerde) -> Self {
+impl From<OwnedMantleTransactionSerde> for MantleTransaction<Unverified> {
+    fn from(helper: OwnedMantleTransactionSerde) -> Self {
         Self::new(helper.mantle_tx, helper.ops_proofs)
     }
 }
 
-impl<'de> Deserialize<'de> for SignedMantleTx<Unverified> {
+impl<'de> Deserialize<'de> for MantleTransaction<Unverified> {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {
         if deserializer.is_human_readable() {
-            OwnedSignedMantleTxSerde::deserialize(deserializer).map(Self::from)
+            OwnedMantleTransactionSerde::deserialize(deserializer).map(Self::from)
         } else {
             let bytes: Vec<u8> = Deserialize::deserialize(deserializer)?;
             let (remaining, tx) =
@@ -527,12 +529,12 @@ impl<'de> Deserialize<'de> for SignedMantleTx<Unverified> {
 // TODO: This `impl` might be removed in favor of explicit preverification at
 // specific boundaries.   E.g.: HTTP service uses `Unverify` and only runs
 // `preverify` when crossing the boundary.
-impl<'de> Deserialize<'de> for SignedMantleTx<Preverified> {
+impl<'de> Deserialize<'de> for MantleTransaction<Preverified> {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {
-        let unverified_tx = SignedMantleTx::<Unverified>::deserialize(deserializer)?;
+        let unverified_tx = MantleTransaction::<Unverified>::deserialize(deserializer)?;
         unverified_tx.preverify().map_err(serde::de::Error::custom)
     }
 }
@@ -546,7 +548,7 @@ pub mod test_utils {
     use lb_key_management_system_keys::keys::Ed25519Key;
 
     use crate::mantle::{
-        NoteId, Op, OpProof, RawMantleTx, SignedMantleTx,
+        MantleTransaction, NoteId, Op, OpProof, RawMantleTx,
         channel::{ChannelState, SlotTimeframe, SlotTimeout},
         ledger::Inputs,
         ops::channel::{
@@ -603,7 +605,7 @@ pub mod test_utils {
         channel_id: ChannelId,
         signing_keys: &[&Ed25519Key],
         inputs: Option<Inputs>,
-    ) -> SignedMantleTx<Preverified> {
+    ) -> MantleTransaction<Preverified> {
         let inputs = inputs.unwrap_or_else(|| Inputs::new([NoteId(Fr::from(0u64))]));
         let mantle_tx = create_test_mantle_tx(vec![Op::ChannelWithdraw(ChannelWithdrawOp {
             channel_id,
@@ -613,7 +615,7 @@ pub mod test_utils {
         let tx_hash = mantle_tx.hash();
         let proof = create_channel_multi_sig_proof(&tx_hash, signing_keys);
 
-        let tx = SignedMantleTx::new(mantle_tx, [OpProof::ChannelMultiSigProof(proof)].into())
+        let tx = MantleTransaction::new(mantle_tx, [OpProof::ChannelMultiSigProof(proof)].into())
             .preverify()
             .unwrap();
         assert_eq!(
@@ -647,7 +649,7 @@ mod tests {
         },
         transactions::{
             MantleTxGasContext,
-            signed_mantle_tx::test_utils::{create_test_inscribe_op, create_test_mantle_tx},
+            mantle_transaction::test_utils::{create_test_inscribe_op, create_test_mantle_tx},
         },
     };
 
@@ -740,7 +742,7 @@ mod tests {
         let deposit_proof = ZkKey::multi_sign(&[], &tx_hash.to_fr()).unwrap();
         let withdraw_proof = create_channel_multi_sig_proof(&tx_hash, &withdraw_signers);
 
-        let signed_tx = SignedMantleTx::new(
+        let signed_tx = MantleTransaction::new(
             mantle_tx,
             [
                 OpProof::ChannelMultiSigProof(config_proof),
@@ -776,7 +778,7 @@ mod tests {
         let signature = signing_key.sign_payload(&tx_hash.as_signing_bytes());
 
         let result =
-            SignedMantleTx::new(mantle_tx, [OpProof::Ed25519Sig(signature)].into()).preverify();
+            MantleTransaction::new(mantle_tx, [OpProof::Ed25519Sig(signature)].into()).preverify();
 
         assert!(result.is_ok());
     }
@@ -786,7 +788,7 @@ mod tests {
         let signing_key = Ed25519Key::from_bytes(&[1; 32]);
         let inscribe_op = create_test_inscribe_op(&signing_key);
         let mantle_tx = create_test_mantle_tx(vec![Op::ChannelInscribe(inscribe_op)]);
-        let result = SignedMantleTx::new(mantle_tx, OpsProofs::empty()).preverify();
+        let result = MantleTransaction::new(mantle_tx, OpsProofs::empty()).preverify();
 
         assert!(matches!(
             result,
@@ -809,7 +811,7 @@ mod tests {
         let signature = wrong_signing_key.sign_payload(&tx_hash.as_signing_bytes());
 
         let result =
-            SignedMantleTx::new(mantle_tx, [OpProof::Ed25519Sig(signature)].into()).preverify();
+            MantleTransaction::new(mantle_tx, [OpProof::Ed25519Sig(signature)].into()).preverify();
 
         assert!(matches!(
             result,
@@ -828,7 +830,7 @@ mod tests {
         // Use wrong proof type
         let tx_hash = mantle_tx.hash();
         let zk_sig = OpProof::ZkSig(ZkKey::multi_sign(&[], &tx_hash.to_fr()).unwrap());
-        let result = SignedMantleTx::new(mantle_tx, [zk_sig].into()).preverify();
+        let result = MantleTransaction::new(mantle_tx, [zk_sig].into()).preverify();
 
         assert!(matches!(
             result,
@@ -856,7 +858,7 @@ mod tests {
         let sig1 = signing_key1.sign_payload(&tx_hash.as_signing_bytes());
         let sig2 = signing_key2.sign_payload(&tx_hash.as_signing_bytes());
 
-        let result = SignedMantleTx::new(
+        let result = MantleTransaction::new(
             mantle_tx,
             [OpProof::Ed25519Sig(sig1), OpProof::Ed25519Sig(sig2)].into(),
         )
@@ -883,7 +885,7 @@ mod tests {
         let sig1 = signing_key1.sign_payload(&tx_hash.as_signing_bytes());
         let sig2 = wrong_key.sign_payload(&tx_hash.as_signing_bytes()); // Wrong signature
 
-        let result = SignedMantleTx::new(
+        let result = MantleTransaction::new(
             mantle_tx,
             [OpProof::Ed25519Sig(sig1), OpProof::Ed25519Sig(sig2)].into(),
         )
@@ -914,7 +916,7 @@ mod tests {
         let transfer_sig = ZkKey::multi_sign(&[input_sk], &mantle_tx.hash().to_fr())
             .expect("Signing should succeed");
         let result =
-            SignedMantleTx::new(mantle_tx, [OpProof::ZkSig(transfer_sig)].into()).preverify();
+            MantleTransaction::new(mantle_tx, [OpProof::ZkSig(transfer_sig)].into()).preverify();
 
         assert_eq!(
             result,
@@ -933,13 +935,14 @@ mod tests {
         let tx_hash = mantle_tx.hash();
         let signature = signing_key.sign_payload(&tx_hash.as_signing_bytes());
 
-        let signed_tx = SignedMantleTx::new(mantle_tx, [OpProof::Ed25519Sig(signature)].into())
+        let signed_tx = MantleTransaction::new(mantle_tx, [OpProof::Ed25519Sig(signature)].into())
             .preverify()
             .unwrap();
 
         // Serialize and deserialize
         let serialized = serde_json::to_string(&signed_tx).unwrap();
-        let deserialized: Result<SignedMantleTx<Unverified>, _> = serde_json::from_str(&serialized);
+        let deserialized: Result<MantleTransaction<Unverified>, _> =
+            serde_json::from_str(&serialized);
         let deserialized_signed_tx = deserialized.unwrap().preverify().unwrap();
 
         assert_eq!(deserialized_signed_tx, signed_tx);
@@ -951,18 +954,18 @@ mod tests {
         let inscribe_op = create_test_inscribe_op(&signing_key);
         let mantle_tx = create_test_mantle_tx(vec![Op::ChannelInscribe(inscribe_op)]);
 
-        let helper = SignedMantleTx::new(mantle_tx, OpsProofs::empty());
+        let helper = MantleTransaction::new(mantle_tx, OpsProofs::empty());
 
         let serialized = serde_json::to_string(&helper).unwrap();
 
-        // Deserialization into `SignedMantleTx<Unverified>` should succeed, even with
-        // missing proof.
-        serde_json::from_str::<SignedMantleTx<Unverified>>(&serialized)
+        // Deserialization into `MantleTransaction<Unverified>` should succeed, even
+        // with missing proof.
+        serde_json::from_str::<MantleTransaction<Unverified>>(&serialized)
             .expect("Unverified deserialization should succeed");
 
-        // Deserialization into `SignedMantleTx<Preverified>` should fail due to missing
-        // proof.
-        let deserialized: Result<SignedMantleTx<Preverified>, _> =
+        // Deserialization into `MantleTransaction<Preverified>` should fail due to
+        // missing proof.
+        let deserialized: Result<MantleTransaction<Preverified>, _> =
             serde_json::from_str(&serialized);
 
         let err_msg = deserialized
@@ -984,18 +987,19 @@ mod tests {
         let tx_hash = mantle_tx.hash();
         let wrong_signature = wrong_key.sign_payload(&tx_hash.as_signing_bytes());
 
-        let helper = SignedMantleTx::new(mantle_tx, [OpProof::Ed25519Sig(wrong_signature)].into());
+        let helper =
+            MantleTransaction::new(mantle_tx, [OpProof::Ed25519Sig(wrong_signature)].into());
 
         let serialized = serde_json::to_string(&helper).unwrap();
 
-        // Deserialization into `SignedMantleTx<Unverified>` should succeed, even with
-        // invalid signature.
-        serde_json::from_str::<SignedMantleTx<Unverified>>(&serialized)
+        // Deserialization into `MantleTransaction<Unverified>` should succeed, even
+        // with invalid signature.
+        serde_json::from_str::<MantleTransaction<Unverified>>(&serialized)
             .expect("Unverified deserialization should succeed");
 
-        // Deserialization into `SignedMantleTx<Preverified>` should fail due to invalid
-        // signature.
-        let deserialized: Result<SignedMantleTx<Preverified>, _> =
+        // Deserialization into `MantleTransaction<Preverified>` should fail due to
+        // invalid signature.
+        let deserialized: Result<MantleTransaction<Preverified>, _> =
             serde_json::from_str(&serialized);
 
         let err_msg = deserialized
@@ -1013,7 +1017,7 @@ mod tests {
         let signature = signing_key.sign_payload(&tx_hash.as_signing_bytes());
 
         // Test too few proofs
-        let result = SignedMantleTx::new(mantle_tx.clone(), OpsProofs::empty()).preverify();
+        let result = MantleTransaction::new(mantle_tx.clone(), OpsProofs::empty()).preverify();
         assert!(matches!(
             result,
             Err(VerificationError::ProofCountMismatch {
@@ -1023,7 +1027,7 @@ mod tests {
         ));
 
         // Test too many proofs
-        let result = SignedMantleTx::new(
+        let result = MantleTransaction::new(
             mantle_tx,
             [
                 OpProof::Ed25519Sig(signature),

--- a/core/src/mantle/transactions/mantle_transaction.rs
+++ b/core/src/mantle/transactions/mantle_transaction.rs
@@ -30,7 +30,7 @@ use crate::{
             mantle_tx::OpWithProof,
         },
         transactions::{
-            GasPrices, OpProofs, OperationVerificationHelper, VerifiedOps,
+            GasPrices, OpProofs, OperationVerificationHelper, VerifiedOperations,
             codec::{decode_signed_mantle_tx, encode_signed_mantle_tx},
             hash::{TxHash, TxHashView},
             mantle_tx::MantleTx as _,
@@ -362,7 +362,7 @@ impl MantleTransaction<Preverified> {
     }
 
     #[must_use]
-    pub fn verified_ops(&self) -> VerifiedOps<'_> {
+    pub fn verified_ops(&self) -> VerifiedOperations<'_> {
         self.into()
     }
 }
@@ -455,7 +455,7 @@ impl<State: VerificationState> StorageSize for MantleTransaction<State> {
 }
 
 impl PreverifiedMantleTx for MantleTransaction<Preverified> {
-    fn verified_ops(&self) -> VerifiedOps<'_> {
+    fn verified_ops(&self) -> VerifiedOperations<'_> {
         self.verified_ops()
     }
 }

--- a/core/src/mantle/transactions/mantle_transaction.rs
+++ b/core/src/mantle/transactions/mantle_transaction.rs
@@ -30,7 +30,7 @@ use crate::{
             mantle_tx::OpWithProof,
         },
         transactions::{
-            GasPrices, OperationVerificationHelper, OpsProofs, VerifiedOps,
+            GasPrices, OpProofs, OperationVerificationHelper, VerifiedOps,
             codec::{decode_signed_mantle_tx, encode_signed_mantle_tx},
             hash::{TxHash, TxHashView},
             mantle_tx::MantleTx as _,
@@ -45,7 +45,7 @@ use crate::{
 pub struct MantleTransaction<State: VerificationState> {
     pub(crate) mantle_tx: RawMantleTx,
     // TODO: make this more efficient
-    ops_proofs: OpsProofs,
+    ops_proofs: OpProofs,
     state: PhantomData<State>,
 }
 
@@ -77,19 +77,19 @@ impl<State: VerificationState> MantleTransaction<State> {
     }
 
     #[must_use]
-    pub const fn ops_proofs(&self) -> &OpsProofs {
+    pub const fn ops_proofs(&self) -> &OpProofs {
         &self.ops_proofs
     }
 
     #[must_use]
-    pub fn into_parts(self) -> (RawMantleTx, OpsProofs) {
+    pub fn into_parts(self) -> (RawMantleTx, OpProofs) {
         (self.mantle_tx, self.ops_proofs)
     }
 }
 
 impl MantleTransaction<Unverified> {
     #[must_use]
-    pub const fn new(mantle_tx: RawMantleTx, ops_proofs: OpsProofs) -> Self {
+    pub const fn new(mantle_tx: RawMantleTx, ops_proofs: OpProofs) -> Self {
         Self {
             mantle_tx,
             ops_proofs,
@@ -217,7 +217,7 @@ impl MantleTransaction<Preverified> {
     /// testing purposes only.
     #[must_use]
     #[doc(hidden)]
-    pub const fn new_trusted(mantle_tx: RawMantleTx, ops_proofs: OpsProofs) -> Self {
+    pub const fn new_trusted(mantle_tx: RawMantleTx, ops_proofs: OpProofs) -> Self {
         Self {
             mantle_tx,
             ops_proofs,
@@ -495,7 +495,7 @@ impl<State: VerificationState> Serialize for MantleTransaction<State> {
 #[serde(rename = "SignedMantleTx")]
 struct OwnedMantleTransactionSerde {
     mantle_tx: RawMantleTx,
-    ops_proofs: OpsProofs,
+    ops_proofs: OpProofs,
 }
 
 impl From<OwnedMantleTransactionSerde> for MantleTransaction<Unverified> {
@@ -788,7 +788,7 @@ mod tests {
         let signing_key = Ed25519Key::from_bytes(&[1; 32]);
         let inscribe_op = create_test_inscribe_op(&signing_key);
         let mantle_tx = create_test_mantle_tx(vec![Op::ChannelInscribe(inscribe_op)]);
-        let result = MantleTransaction::new(mantle_tx, OpsProofs::empty()).preverify();
+        let result = MantleTransaction::new(mantle_tx, OpProofs::empty()).preverify();
 
         assert!(matches!(
             result,
@@ -954,7 +954,7 @@ mod tests {
         let inscribe_op = create_test_inscribe_op(&signing_key);
         let mantle_tx = create_test_mantle_tx(vec![Op::ChannelInscribe(inscribe_op)]);
 
-        let helper = MantleTransaction::new(mantle_tx, OpsProofs::empty());
+        let helper = MantleTransaction::new(mantle_tx, OpProofs::empty());
 
         let serialized = serde_json::to_string(&helper).unwrap();
 
@@ -1017,7 +1017,7 @@ mod tests {
         let signature = signing_key.sign_payload(&tx_hash.as_signing_bytes());
 
         // Test too few proofs
-        let result = MantleTransaction::new(mantle_tx.clone(), OpsProofs::empty()).preverify();
+        let result = MantleTransaction::new(mantle_tx.clone(), OpProofs::empty()).preverify();
         assert!(matches!(
             result,
             Err(VerificationError::ProofCountMismatch {

--- a/core/src/mantle/transactions/mantle_transaction.rs
+++ b/core/src/mantle/transactions/mantle_transaction.rs
@@ -440,12 +440,12 @@ fn signed_op_execution_gas<Profile: GasProfile>(
             Op::ChannelConfig(_) | Op::ChannelWithdraw(_) | Op::ChannelTransfer(_),
             OpProof::ChannelMultiSigProof(proof),
         ) => proof.signatures().len(),
-        _ => return Ok(op.execution_gas::<Profile>()),
+        _ => return Ok(op.gas_cost::<Profile>()),
     };
     let multiplier = Value::try_from(signature_count)
         .expect("channel multi-signature proofs are bounded to u16::MAX signatures");
 
-    op.execution_gas::<Profile>().checked_mul(multiplier)
+    op.gas_cost::<Profile>().checked_mul(multiplier)
 }
 
 impl<State: VerificationState> StorageSize for MantleTransaction<State> {

--- a/core/src/mantle/transactions/mantle_tx.rs
+++ b/core/src/mantle/transactions/mantle_tx.rs
@@ -8,7 +8,7 @@ use crate::{
     block::MAX_BLOCK_TRANSACTIONS_SIZE,
     crypto::{Digest as _, Hasher},
     mantle::{
-        GasProfile, Op, SignedMantleTx, TxHash, Value,
+        GasProfile, MantleTransaction, Op, TxHash, Value,
         channel::Channels,
         gas::{Gas, GasCost, GasOverflow},
         ops::{
@@ -140,8 +140,8 @@ fn contextual_op_execution_gas<Profile: GasProfile>(
         .checked_mul(Value::from(multiplier))
 }
 
-impl<State: VerificationState> From<SignedMantleTx<State>> for RawMantleTx {
-    fn from(signed_tx: SignedMantleTx<State>) -> Self {
+impl<State: VerificationState> From<MantleTransaction<State>> for RawMantleTx {
+    fn from(signed_tx: MantleTransaction<State>) -> Self {
         signed_tx.mantle_tx
     }
 }

--- a/core/src/mantle/transactions/mantle_tx.rs
+++ b/core/src/mantle/transactions/mantle_tx.rs
@@ -133,10 +133,10 @@ fn contextual_op_execution_gas<Profile: GasProfile>(
         Op::ChannelTransfer(operation) => context
             .transfer_threshold(&operation.channel_id)
             .unwrap_or(0),
-        _ => return Ok(op.execution_gas::<Profile>()),
+        _ => return Ok(op.gas_cost::<Profile>()),
     };
 
-    op.execution_gas::<Profile>()
+    op.gas_cost::<Profile>()
         .checked_mul(Value::from(multiplier))
 }
 

--- a/core/src/mantle/transactions/mod.rs
+++ b/core/src/mantle/transactions/mod.rs
@@ -4,9 +4,9 @@ pub mod errors;
 pub mod gas;
 pub mod genesis_tx;
 pub mod hash;
+pub mod mantle_transaction;
 pub mod mantle_tx;
 pub mod raw_signed_mantle_tx;
-pub mod signed_mantle_tx;
 pub mod states;
 pub mod verification_helper;
 pub mod verified_ops;
@@ -17,8 +17,8 @@ pub use gas::{GENESIS_EXECUTION_GAS_PRICE, GENESIS_STORAGE_GAS_PRICE, GasPrices}
 pub use genesis_tx::{CryptarchiaParameter, GenesisTime, GenesisTx};
 pub use hash::TxHash;
 use lb_utils::bounded::UpperBoundedVec;
+pub use mantle_transaction::MantleTransaction;
 pub use mantle_tx::{MantleTxContext, MantleTxGasContext, RawMantleTx};
-pub use signed_mantle_tx::SignedMantleTx;
 pub use verification_helper::OperationVerificationHelper;
 pub use verified_ops::VerifiedOps;
 

--- a/core/src/mantle/transactions/mod.rs
+++ b/core/src/mantle/transactions/mod.rs
@@ -5,6 +5,7 @@ pub mod gas;
 pub mod genesis_tx;
 pub mod hash;
 pub mod mantle_tx;
+pub mod raw_signed_mantle_tx;
 pub mod signed_mantle_tx;
 pub mod states;
 pub mod verification_helper;

--- a/core/src/mantle/transactions/mod.rs
+++ b/core/src/mantle/transactions/mod.rs
@@ -37,4 +37,4 @@ use crate::mantle::{Op, OpProof, ops::SignedOp};
 pub const MAX_OPS_PER_TX: usize = u8::MAX as usize;
 pub type Ops = UpperBoundedVec<Op, MAX_OPS_PER_TX>;
 pub type SignedOps<State, Mode> = UpperBoundedVec<SignedOp<State, Mode>, MAX_OPS_PER_TX>;
-pub type OpsProofs = UpperBoundedVec<OpProof, MAX_OPS_PER_TX>;
+pub type OpProofs = UpperBoundedVec<OpProof, MAX_OPS_PER_TX>;

--- a/core/src/mantle/transactions/mod.rs
+++ b/core/src/mantle/transactions/mod.rs
@@ -21,7 +21,7 @@ pub use signed_mantle_tx::SignedMantleTx;
 pub use verification_helper::OperationVerificationHelper;
 pub use verified_ops::VerifiedOps;
 
-use crate::mantle::{Op, OpProof};
+use crate::mantle::{Op, OpProof, ops::SignedOp};
 
 // ==============================================================================
 // Memory Safety Limits
@@ -35,4 +35,5 @@ use crate::mantle::{Op, OpProof};
 // allow 4MiB.
 pub const MAX_OPS_PER_TX: usize = u8::MAX as usize;
 pub type Ops = UpperBoundedVec<Op, MAX_OPS_PER_TX>;
+pub type SignedOps<State, Mode> = UpperBoundedVec<SignedOp<State, Mode>, MAX_OPS_PER_TX>;
 pub type OpsProofs = UpperBoundedVec<OpProof, MAX_OPS_PER_TX>;

--- a/core/src/mantle/transactions/mod.rs
+++ b/core/src/mantle/transactions/mod.rs
@@ -20,7 +20,7 @@ use lb_utils::bounded::UpperBoundedVec;
 pub use mantle_transaction::MantleTransaction;
 pub use mantle_tx::{MantleTxContext, MantleTxGasContext, RawMantleTx};
 pub use verification_helper::OperationVerificationHelper;
-pub use verified_ops::VerifiedOps;
+pub use verified_ops::VerifiedOperations;
 
 use crate::mantle::{Op, OpProof, ops::SignedOp};
 

--- a/core/src/mantle/transactions/raw_signed_mantle_tx.rs
+++ b/core/src/mantle/transactions/raw_signed_mantle_tx.rs
@@ -1,0 +1,34 @@
+use crate::mantle::{
+    ledger::verification_mode::VerificationMode,
+    traits::signed_mantle_tx::SignedMantleTx,
+    transactions::{SignedOps, states::VerificationState},
+};
+
+pub struct RawSignedMantleTx<State: VerificationState, Mode: VerificationMode>(
+    SignedOps<State, Mode>,
+);
+
+impl<State: VerificationState, Mode: VerificationMode> RawSignedMantleTx<State, Mode> {
+    #[must_use]
+    pub const fn new(signed_ops: SignedOps<State, Mode>) -> Self {
+        Self(signed_ops)
+    }
+
+    #[must_use]
+    pub const fn inner(&self) -> &SignedOps<State, Mode> {
+        &self.0
+    }
+
+    #[must_use]
+    pub fn into_inner(self) -> SignedOps<State, Mode> {
+        self.0
+    }
+}
+
+impl<State: VerificationState, Mode: VerificationMode> SignedMantleTx<State, Mode>
+    for RawSignedMantleTx<State, Mode>
+{
+    fn signed_ops(&self) -> &SignedOps<State, Mode> {
+        self.inner()
+    }
+}

--- a/core/src/mantle/transactions/verified_ops.rs
+++ b/core/src/mantle/transactions/verified_ops.rs
@@ -7,14 +7,14 @@ use crate::mantle::{
     },
 };
 
-pub struct VerifiedOps<'tx> {
+pub struct VerifiedOperations<'tx> {
     ops: &'tx [Op],
     proofs: &'tx [OpProof],
     tx_hash_view: TxHashView,
     index: usize,
 }
 
-impl<'tx> VerifiedOps<'tx> {
+impl<'tx> VerifiedOperations<'tx> {
     #[must_use]
     pub fn new(transaction: &'tx MantleTransaction<Preverified>) -> Self {
         let ops = transaction.mantle_tx.ops();
@@ -71,9 +71,9 @@ impl<'tx> VerifiedOps<'tx> {
     }
 }
 
-impl<'tx> From<&'tx MantleTransaction<Preverified>> for VerifiedOps<'tx> {
+impl<'tx> From<&'tx MantleTransaction<Preverified>> for VerifiedOperations<'tx> {
     fn from(transaction: &'tx MantleTransaction<Preverified>) -> Self {
-        VerifiedOps::new(transaction)
+        VerifiedOperations::new(transaction)
     }
 }
 

--- a/core/src/mantle/transactions/verified_ops.rs
+++ b/core/src/mantle/transactions/verified_ops.rs
@@ -1,5 +1,5 @@
 use crate::mantle::{
-    Op, OpProof, SignedMantleTx, VerificationError,
+    MantleTransaction, Op, OpProof, VerificationError,
     traits::Hashable as _,
     transactions::{
         OperationVerificationHelper, hash::TxHashView, mantle_tx::MantleTx as _,
@@ -16,7 +16,7 @@ pub struct VerifiedOps<'tx> {
 
 impl<'tx> VerifiedOps<'tx> {
     #[must_use]
-    pub fn new(transaction: &'tx SignedMantleTx<Preverified>) -> Self {
+    pub fn new(transaction: &'tx MantleTransaction<Preverified>) -> Self {
         let ops = transaction.mantle_tx.ops();
         let proofs = transaction.ops_proofs();
         let tx_hash = transaction.hash();
@@ -49,11 +49,10 @@ impl<'tx> VerifiedOps<'tx> {
     ) -> Option<Result<&'tx Op, VerificationError>> {
         let index = self.index;
         let op = self.ops.get(index)?;
-        let proof = self
-            .proofs
-            .get(index)
-            .expect("SignedMantleTx<Preverified> invariant: ops and proofs have the same length");
-        if let Err(error) = SignedMantleTx::<Preverified>::verify_stateful_op(
+        let proof = self.proofs.get(index).expect(
+            "MantleTransaction<Preverified> invariant: ops and proofs have the same length",
+        );
+        if let Err(error) = MantleTransaction::<Preverified>::verify_stateful_op(
             index,
             op,
             proof,
@@ -72,8 +71,8 @@ impl<'tx> VerifiedOps<'tx> {
     }
 }
 
-impl<'tx> From<&'tx SignedMantleTx<Preverified>> for VerifiedOps<'tx> {
-    fn from(transaction: &'tx SignedMantleTx<Preverified>) -> Self {
+impl<'tx> From<&'tx MantleTransaction<Preverified>> for VerifiedOps<'tx> {
+    fn from(transaction: &'tx MantleTransaction<Preverified>) -> Self {
         VerifiedOps::new(transaction)
     }
 }
@@ -89,7 +88,7 @@ mod tests {
         ledger::Inputs,
         ops::channel::{ChannelId, config::Keys},
         transactions::{
-            signed_mantle_tx::test_utils::{create_withdraw_tx, make_channel_state},
+            mantle_transaction::test_utils::{create_withdraw_tx, make_channel_state},
             verification_helper::test_utils::TestOperationVerificationHelper,
         },
     };

--- a/deployment/l2-sequencer-archival-demo/archiver/src/block.rs
+++ b/deployment/l2-sequencer-archival-demo/archiver/src/block.rs
@@ -5,7 +5,7 @@ use lb_common_http_client::CommonHttpClient;
 use lb_core::{
     header::HeaderId,
     mantle::{
-        Op, SignedMantleTx,
+        MantleTransaction, Op,
         ops::channel::{ChannelId, inscribe::InscriptionOp},
         traits::Hashable as _,
         transactions::{hash::TxHash, states::Unverified},
@@ -84,7 +84,7 @@ impl BlockStream {
 }
 
 fn extract_l2_blocks(
-    block_txs: impl Iterator<Item = SignedMantleTx<Unverified>>,
+    block_txs: impl Iterator<Item = MantleTransaction<Unverified>>,
     decoded_channel_id: &ChannelId,
     token_name: &str,
 ) -> Vec<(BlockData, TxHash)> {

--- a/deployment/l2-sequencer-archival-demo/sequencer/src/sequencer.rs
+++ b/deployment/l2-sequencer-archival-demo/sequencer/src/sequencer.rs
@@ -4,7 +4,7 @@ use lb_common_http_client::{ChainServiceInfo, CommonHttpClient};
 use lb_core::{
     header::HeaderId,
     mantle::{
-        SignedMantleTx,
+        MantleTransaction,
         ops::{
             Op, OpProof,
             channel::{
@@ -161,7 +161,11 @@ impl Sequencer {
     }
 
     /// Create and sign a transaction for inscribing data
-    fn create_inscribe_tx(&self, data: Inscription, parent: MsgId) -> SignedMantleTx<Unverified> {
+    fn create_inscribe_tx(
+        &self,
+        data: Inscription,
+        parent: MsgId,
+    ) -> MantleTransaction<Unverified> {
         let verifying_key_bytes = self.signing_key.public_key().to_bytes();
         let verifying_key =
             Ed25519PublicKey::from_bytes(&verifying_key_bytes).expect("valid ed25519 public key");
@@ -184,11 +188,11 @@ impl Sequencer {
             lb_key_management_system_service::keys::Ed25519Signature::from_bytes(&signature_bytes);
 
         // TODO: Should preverify?
-        SignedMantleTx::new(inscribe_tx, [OpProof::Ed25519Sig(signature)].into())
+        MantleTransaction::new(inscribe_tx, [OpProof::Ed25519Sig(signature)].into())
     }
 
     /// Post a transaction to the node and wait for inclusion
-    async fn post_and_wait(&self, tx: &SignedMantleTx<Unverified>) -> Result<()> {
+    async fn post_and_wait(&self, tx: &MantleTransaction<Unverified>) -> Result<()> {
         // Post the transaction
         self.http_client
             .post_transaction(self.node_url.clone(), tx.clone())
@@ -273,7 +277,7 @@ impl Sequencer {
     }
 
     fn get_expected_inscription<State: VerificationState>(
-        tx: &SignedMantleTx<State>,
+        tx: &MantleTransaction<State>,
     ) -> &InscriptionOp {
         let expected_op = tx
             .mantle_tx()
@@ -312,7 +316,7 @@ impl Sequencer {
     }
 
     /// Wait for a transaction to be included in a block.
-    async fn wait_for_inclusion(&self, tx: &SignedMantleTx<Unverified>) -> Result<()> {
+    async fn wait_for_inclusion(&self, tx: &MantleTransaction<Unverified>) -> Result<()> {
         let expected_inscription = Self::get_expected_inscription(tx);
 
         let timeout_duration = Duration::from_mins(5);

--- a/deployment/tui-zone/src/run_commands/run_config.rs
+++ b/deployment/tui-zone/src/run_commands/run_config.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use lb_codec::BinaryEncode as _;
 use lb_core::{
     mantle::{
-        Op, OpProof, SignedMantleTx,
+        MantleTransaction, Op, OpProof,
         ops::channel::{
             ChannelId, ChannelKeyIndex,
             config::{ChannelConfigOp, Keys},
@@ -238,7 +238,7 @@ pub(crate) fn run_config_combine(args: ConfigCombineArgs) -> RunResult<()> {
         )
         .into());
     }
-    let signed_tx = SignedMantleTx::new(tx, [OpProof::ChannelMultiSigProof(proof)].into());
+    let signed_tx = MantleTransaction::new(tx, [OpProof::ChannelMultiSigProof(proof)].into());
     let signed = SignedConfigFile {
         version: ZONE_FILE_TRANSFER_VERSION,
         kind: ZONE_SIGNED_CONFIG.to_owned(),

--- a/deployment/tui-zone/src/run_commands/run_deposit.rs
+++ b/deployment/tui-zone/src/run_commands/run_deposit.rs
@@ -1,5 +1,5 @@
 use lb_core::mantle::{
-    Op, OpProof, SignedMantleTx, ops::channel::inscribe::Inscription, traits::Hashable as _,
+    MantleTransaction, Op, OpProof, ops::channel::inscribe::Inscription, traits::Hashable as _,
 };
 use lb_key_management_system_service::keys::ZkKey;
 
@@ -42,7 +42,7 @@ pub(crate) async fn run_deposit(args: DepositArgs) -> RunResult<()> {
         inscription,
     )?;
     let user_sig = ZkKey::multi_sign(&[wallet_key], &tx.hash().to_fr())?;
-    let signed_tx = SignedMantleTx::new(
+    let signed_tx = MantleTransaction::new(
         tx,
         [
             OpProof::ZkSig(user_sig.clone()),

--- a/deployment/tui-zone/src/run_commands/run_withdraw.rs
+++ b/deployment/tui-zone/src/run_commands/run_withdraw.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use lb_core::{
     mantle::{
-        Op, OpProof, SignedMantleTx,
+        MantleTransaction, Op, OpProof,
         ops::channel::{ChannelId, ChannelKeyIndex},
         traits::Hashable as _,
         transactions::{codec::encode_signed_mantle_tx, mantle_tx::MantleTx as _},
@@ -206,7 +206,7 @@ pub(crate) fn run_withdraw_combine(args: WithdrawCombineArgs) -> RunResult<()> {
         })
         .collect::<RunResult<Vec<_>>>()?
         .try_into()?;
-    let signed_tx = SignedMantleTx::new(tx, op_proofs);
+    let signed_tx = MantleTransaction::new(tx, op_proofs);
     let signed = SignedWithdrawFile {
         version: ZONE_FILE_TRANSFER_VERSION,
         kind: ZONE_SIGNED_TRANSACTION.to_owned(),

--- a/deployment/tui-zone/src/run_commands/unit_tests.rs
+++ b/deployment/tui-zone/src/run_commands/unit_tests.rs
@@ -16,7 +16,7 @@ mod tests {
             withdraw::ChannelWithdrawOp,
         },
         traits::Hashable as _,
-        transactions::{Ops, OpsProofs, codec::encode_signed_mantle_tx},
+        transactions::{OpProofs, Ops, codec::encode_signed_mantle_tx},
     };
     use lb_groth16::{Fr, fr_to_bytes};
     use lb_key_management_system_service::keys::{ED25519_SECRET_KEY_SIZE, Ed25519Key, ZkKey};
@@ -122,7 +122,7 @@ mod tests {
         ensure_tx_hash(&hex::encode(tx.hash().as_ref()), tx.hash()).unwrap();
         assert!(ensure_tx_hash(&hex::encode([1u8; 32]), tx.hash()).is_err());
 
-        let signed_tx = MantleTransaction::new(tx, OpsProofs::empty());
+        let signed_tx = MantleTransaction::new(tx, OpProofs::empty());
         let signed_encoded = hex::encode(encode_signed_mantle_tx(&signed_tx));
         assert_eq!(
             decode_signed_mantle_tx_hex(&signed_encoded).unwrap(),

--- a/deployment/tui-zone/src/run_commands/unit_tests.rs
+++ b/deployment/tui-zone/src/run_commands/unit_tests.rs
@@ -8,7 +8,7 @@ mod tests {
 
     use lb_codec::BinaryEncode as _;
     use lb_core::mantle::{
-        Note, NoteId, Op, RawMantleTx, SignedMantleTx, Utxo, Value,
+        MantleTransaction, Note, NoteId, Op, RawMantleTx, Utxo, Value,
         ledger::Inputs,
         ops::channel::{
             ChannelId, MsgId,
@@ -122,7 +122,7 @@ mod tests {
         ensure_tx_hash(&hex::encode(tx.hash().as_ref()), tx.hash()).unwrap();
         assert!(ensure_tx_hash(&hex::encode([1u8; 32]), tx.hash()).is_err());
 
-        let signed_tx = SignedMantleTx::new(tx, OpsProofs::empty());
+        let signed_tx = MantleTransaction::new(tx, OpsProofs::empty());
         let signed_encoded = hex::encode(encode_signed_mantle_tx(&signed_tx));
         assert_eq!(
             decode_signed_mantle_tx_hex(&signed_encoded).unwrap(),

--- a/deployment/tui-zone/src/run_commands/utils.rs
+++ b/deployment/tui-zone/src/run_commands/utils.rs
@@ -7,7 +7,7 @@ use std::{
 use chrono::{DateTime, Utc};
 use lb_codec::BinaryDecodeExt as _;
 use lb_core::mantle::{
-    Note, SignedMantleTx, Utxo, Value,
+    MantleTransaction, Note, Utxo, Value,
     channel::ChannelState,
     ledger::{Inputs, Outputs},
     ops::{
@@ -238,7 +238,7 @@ pub fn decode_mantle_tx_hex(value: &str) -> RunResult<RawMantleTx> {
 }
 
 /// Decode a hex-encoded signed mantle transaction and reject trailing bytes.
-pub fn decode_signed_mantle_tx_hex(value: &str) -> RunResult<SignedMantleTx<Unverified>> {
+pub fn decode_signed_mantle_tx_hex(value: &str) -> RunResult<MantleTransaction<Unverified>> {
     let bytes = decode_hex(value)?;
     let (remaining, tx) = decode_signed_mantle_tx(&bytes).map_err(|error| format!("{error:?}"))?;
     if !remaining.is_empty() {

--- a/ledger/src/cryptarchia/mod.rs
+++ b/ledger/src/cryptarchia/mod.rs
@@ -832,9 +832,9 @@ pub mod tests {
     use lb_core::{
         crypto::{Digest as _, Hasher},
         mantle::{
-            Note, Op,
+            MantleTransaction, Note, Op,
             OpProof::ZkSig,
-            RawMantleTx, SignedMantleTx, TxGasCalculator as _,
+            RawMantleTx, TxGasCalculator as _,
             gas::MainnetGasProfile,
             ledger::{Inputs, Outputs},
             ops::{leader_claim::VoucherCm, sdp::SDPDeclareOp},
@@ -983,7 +983,7 @@ pub mod tests {
             slot,
             &proof,
             &UncleSlots::default(),
-            std::iter::empty::<&SignedMantleTx<Preverified>>(),
+            std::iter::empty::<&MantleTransaction<Preverified>>(),
         )?;
         ledger.commit_update(id, state);
         Ok(id)
@@ -1883,7 +1883,7 @@ pub mod tests {
     fn create_tx_with_transfer(
         inputs: &[(&ZkKey, &Utxo)],
         outputs: Vec<Note>,
-    ) -> (SignedMantleTx<Unverified>, TransferOp, ZkSignature) {
+    ) -> (MantleTransaction<Unverified>, TransferOp, ZkSignature) {
         let sks = inputs
             .iter()
             .map(|(sk, _)| (*sk).clone())
@@ -1895,7 +1895,7 @@ pub mod tests {
         );
         let mantle_tx = RawMantleTx([Op::Transfer(transfer_op.clone())].into());
         let transfer_sig = ZkKey::multi_sign(&sks, &mantle_tx.hash().to_fr()).unwrap();
-        let tx = SignedMantleTx::new(mantle_tx, [ZkSig(transfer_sig.clone())].into());
+        let tx = MantleTransaction::new(mantle_tx, [ZkSig(transfer_sig.clone())].into());
         (tx, transfer_op, transfer_sig)
     }
 

--- a/ledger/src/cryptarchia/test/tsi_simulation.rs
+++ b/ledger/src/cryptarchia/test/tsi_simulation.rs
@@ -26,7 +26,7 @@ use std::{num::NonZero, sync::Arc};
 use lb_core::{
     crypto::{Digest as _, Hasher},
     mantle::{
-        Note, SignedMantleTx, Utxo, Value,
+        MantleTransaction, Note, Utxo, Value,
         gas::MainnetGasProfile,
         transactions::{
             GENESIS_EXECUTION_GAS_PRICE, GENESIS_STORAGE_GAS_PRICE, states::Preverified,
@@ -384,7 +384,7 @@ fn apply_block_to_ledger(
             slot,
             &proof,
             uncle_slots,
-            std::iter::empty::<&SignedMantleTx<Preverified>>(),
+            std::iter::empty::<&MantleTransaction<Preverified>>(),
         )
         .expect("ledger update");
     ledger.commit_update(id, state);

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -768,9 +768,9 @@ impl LedgerState {
     ///
     /// Verification is interleaved with execution: each operation is verified
     /// against the current ledger state (via
-    /// [`SignedMantleTx::verified_ops`]) immediately before it is executed, so
-    /// an operation may depend on state produced by earlier operations in
-    /// the same transaction.
+    /// [`MantleTransaction::verified_ops`]) immediately before it is executed,
+    /// so an operation may depend on state produced by earlier operations
+    /// in the same transaction.
     ///
     /// # Returns
     ///
@@ -824,7 +824,7 @@ mod tests {
     use lb_core::{
         events::DepositNote,
         mantle::{
-            Note, OpProof, RawMantleTx, SignedMantleTx, TxGasCalculator as _,
+            MantleTransaction, Note, OpProof, RawMantleTx, TxGasCalculator as _,
             gas::MainnetGasProfile,
             ledger::{Inputs, Outputs, Utxos, VerifiableOperation as _},
             ops::{
@@ -878,7 +878,7 @@ mod tests {
         inputs: Vec<NoteId>,
         outputs: Vec<Note>,
         sks: &[ZkKey],
-    ) -> SignedMantleTx<Unverified> {
+    ) -> MantleTransaction<Unverified> {
         let transfer_op = TransferOp::new(
             Inputs::try_new(inputs).expect("Invalid inputs size"),
             Outputs::try_new(outputs).expect("Invalid outputs size"),
@@ -888,7 +888,7 @@ mod tests {
             ZkKey::multi_sign(sks, &mantle_tx.hash().to_fr()).unwrap(),
         )]
         .into();
-        SignedMantleTx::new(mantle_tx, ops_proofs)
+        MantleTransaction::new(mantle_tx, ops_proofs)
     }
 
     pub fn create_test_ledger() -> (Ledger<HeaderId>, HeaderId, Utxo) {
@@ -950,14 +950,14 @@ mod tests {
         MultiSequencer(ChannelMultiSigProof),
     }
 
-    fn create_signed_tx(op: Op, signing_key: &Key) -> SignedMantleTx<Preverified> {
+    fn create_signed_tx(op: Op, signing_key: &Key) -> MantleTransaction<Preverified> {
         create_multi_signed_tx(vec![op], vec![signing_key])
     }
 
     fn create_multi_signed_tx(
         ops: Vec<Op>,
         signing_keys: Vec<&Key>,
-    ) -> SignedMantleTx<Preverified> {
+    ) -> MantleTransaction<Preverified> {
         let mantle_tx = RawMantleTx(Ops::new_unchecked(ops.clone()));
 
         let tx_hash = mantle_tx.hash();
@@ -977,7 +977,7 @@ mod tests {
             .collect::<Vec<_>>();
         let ops_proofs = OpsProofs::try_from(ops_proofs).expect("operation proofs are bounded");
 
-        SignedMantleTx::new(mantle_tx, ops_proofs)
+        MantleTransaction::new(mantle_tx, ops_proofs)
             .preverify()
             .expect("Test transaction should have valid signatures")
     }
@@ -2190,9 +2190,9 @@ mod tests {
             assert!(difficulty_at(&test_ledger, block_1) > genesis_difficulty);
         }
 
-        fn claim_tx() -> SignedMantleTx<Preverified> {
+        fn claim_tx() -> MantleTransaction<Preverified> {
             let mantle_tx = RawMantleTx([Op::ClaimPowReward(claim_op())].into());
-            SignedMantleTx::new(mantle_tx, [OpProof::None(NoOpProof)].into())
+            MantleTransaction::new(mantle_tx, [OpProof::None(NoOpProof)].into())
                 .preverify()
                 .expect("claim op with OpProof::None should pass preverification")
         }

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -842,7 +842,7 @@ mod tests {
             },
             traits::Hashable as _,
             transactions::{
-                Ops, OpsProofs,
+                OpProofs, Ops,
                 hash::TxHashView,
                 mantle_tx::MantleTx as _,
                 states::{Preverified, Unverified},
@@ -975,7 +975,7 @@ mod tests {
                 Key::MultiSequencer(proof) => OpProof::ChannelMultiSigProof(proof.clone()),
             })
             .collect::<Vec<_>>();
-        let ops_proofs = OpsProofs::try_from(ops_proofs).expect("operation proofs are bounded");
+        let ops_proofs = OpProofs::try_from(ops_proofs).expect("operation proofs are bounded");
 
         MantleTransaction::new(mantle_tx, ops_proofs)
             .preverify()

--- a/nodes/api-common/src/bodies/wallet.rs
+++ b/nodes/api-common/src/bodies/wallet.rs
@@ -95,7 +95,8 @@ pub mod transfer_funds {
     use lb_core::{
         header::HeaderId,
         mantle::{
-            SignedMantleTx, Value, traits::Hashable as _, transactions::states::VerificationState,
+            MantleTransaction, Value, traits::Hashable as _,
+            transactions::states::VerificationState,
         },
     };
     use lb_key_management_system_keys::keys::ZkPublicKey;
@@ -119,8 +120,8 @@ pub mod transfer_funds {
         pub hash: lb_core::mantle::transactions::TxHash,
     }
 
-    impl<State: VerificationState> From<SignedMantleTx<State>> for WalletTransferFundsResponseBody {
-        fn from(value: SignedMantleTx<State>) -> Self {
+    impl<State: VerificationState> From<MantleTransaction<State>> for WalletTransferFundsResponseBody {
+        fn from(value: MantleTransaction<State>) -> Self {
             Self {
                 hash: value.mantle_tx().hash(),
             }

--- a/nodes/node/binary/src/api/backend.rs
+++ b/nodes/node/binary/src/api/backend.rs
@@ -20,7 +20,7 @@ use lb_chain_leader_service::api::ChainLeaderServiceData;
 use lb_chain_service::CryptarchiaConsensus;
 use lb_core::{
     header::HeaderId,
-    mantle::{SignedMantleTx, traits::Hashable, transactions::states::Preverified},
+    mantle::{MantleTransaction, traits::Hashable, transactions::states::Preverified},
 };
 pub use lb_http_api_common::settings::AxumBackendSettings;
 use lb_http_api_common::{metrics::http_metrics_middleware, paths};
@@ -113,8 +113,8 @@ where
         lb_api_service::http::storage::StorageAdapter<RuntimeServiceId> + Send + Sync + 'static,
     MempoolStorageAdapter: lb_tx_service::storage::MempoolStorageAdapter<
             RuntimeServiceId,
-            Item = SignedMantleTx<Preverified>,
-            Key = <SignedMantleTx<Preverified> as Hashable>::Hash,
+            Item = MantleTransaction<Preverified>,
+            Key = <MantleTransaction<Preverified> as Hashable>::Hash,
         > + Send
         + Sync
         + Clone
@@ -151,14 +151,14 @@ where
         + AsServiceId<
             TxMempoolService<
                 lb_tx_service::network::adapters::libp2p::Libp2pAdapter<
-                    SignedMantleTx<Preverified>,
-                    <SignedMantleTx<Preverified> as Hashable>::Hash,
+                    MantleTransaction<Preverified>,
+                    <MantleTransaction<Preverified> as Hashable>::Hash,
                     RuntimeServiceId,
                 >,
                 Mempool<
                     HeaderId,
-                    SignedMantleTx<Preverified>,
-                    <SignedMantleTx<Preverified> as Hashable>::Hash,
+                    MantleTransaction<Preverified>,
+                    <MantleTransaction<Preverified> as Hashable>::Hash,
                     MempoolStorageAdapter,
                     RuntimeServiceId,
                 >,

--- a/nodes/node/binary/src/api/handlers.rs
+++ b/nodes/node/binary/src/api/handlers.rs
@@ -26,7 +26,7 @@ use lb_core::{
     events::Events,
     header::HeaderId,
     mantle::{
-        Op, OpProof, SignedMantleTx, TxHash,
+        MantleTransaction, Op, OpProof, TxHash,
         channel::ChannelState,
         ops::channel::ChannelId,
         traits::Hashable,
@@ -218,8 +218,8 @@ async fn fetch_blocks_stream_chunk<StorageBackend, RuntimeServiceId>(
 where
     StorageBackend: lb_storage_service::backends::StorageBackend + Send + Sync + 'static,
     StorageBackend::Block: Serialize,
-    <StorageBackend as StorageChainApi>::Block:
-        TryFrom<Block<SignedMantleTx<Unverified>>> + TryInto<Block<SignedMantleTx<Unverified>>>,
+    <StorageBackend as StorageChainApi>::Block: TryFrom<Block<MantleTransaction<Unverified>>>
+        + TryInto<Block<MantleTransaction<Unverified>>>,
     <StorageBackend as StorageChainApi>::Tx: From<Bytes> + AsRef<[u8]>,
     <StorageBackend as StorageChainApi>::Events: TryFrom<Events> + TryInto<Events>,
     RuntimeServiceId: Debug
@@ -276,8 +276,8 @@ fn build_blocks_stream<StorageBackend, RuntimeServiceId>(
 where
     StorageBackend: lb_storage_service::backends::StorageBackend + Send + Sync + 'static,
     StorageBackend::Block: Serialize,
-    <StorageBackend as StorageChainApi>::Block:
-        TryFrom<Block<SignedMantleTx<Unverified>>> + TryInto<Block<SignedMantleTx<Unverified>>>,
+    <StorageBackend as StorageChainApi>::Block: TryFrom<Block<MantleTransaction<Unverified>>>
+        + TryInto<Block<MantleTransaction<Unverified>>>,
     <StorageBackend as StorageChainApi>::Tx: From<Bytes> + AsRef<[u8]>,
     <StorageBackend as StorageChainApi>::Events: TryFrom<Events> + TryInto<Events>,
     RuntimeServiceId: Debug
@@ -381,8 +381,8 @@ pub async fn mantle_metrics<StorageAdapter, RuntimeServiceId>(
 where
     StorageAdapter: lb_tx_service::storage::MempoolStorageAdapter<
             RuntimeServiceId,
-            Item = SignedMantleTx<Preverified>,
-            Key = <SignedMantleTx<Preverified> as Hashable>::Hash,
+            Item = MantleTransaction<Preverified>,
+            Key = <MantleTransaction<Preverified> as Hashable>::Hash,
         > + Send
         + Sync
         + Clone
@@ -398,14 +398,14 @@ where
         + AsServiceId<
             TxMempoolService<
                 MempoolNetworkAdapter<
-                    SignedMantleTx<Preverified>,
-                    <SignedMantleTx<Preverified> as Hashable>::Hash,
+                    MantleTransaction<Preverified>,
+                    <MantleTransaction<Preverified> as Hashable>::Hash,
                     RuntimeServiceId,
                 >,
                 Mempool<
                     HeaderId,
-                    SignedMantleTx<Preverified>,
-                    <SignedMantleTx<Preverified> as Hashable>::Hash,
+                    MantleTransaction<Preverified>,
+                    <MantleTransaction<Preverified> as Hashable>::Hash,
                     StorageAdapter,
                     RuntimeServiceId,
                 >,
@@ -430,13 +430,13 @@ where
 )]
 pub async fn mantle_status<StorageAdapter, RuntimeServiceId>(
     State(handle): State<OverwatchHandle<RuntimeServiceId>>,
-    Json(items): Json<Vec<<SignedMantleTx<Preverified> as Hashable>::Hash>>,
+    Json(items): Json<Vec<<MantleTransaction<Preverified> as Hashable>::Hash>>,
 ) -> Response
 where
     StorageAdapter: lb_tx_service::storage::MempoolStorageAdapter<
             RuntimeServiceId,
-            Item = SignedMantleTx<Preverified>,
-            Key = <SignedMantleTx<Preverified> as Hashable>::Hash,
+            Item = MantleTransaction<Preverified>,
+            Key = <MantleTransaction<Preverified> as Hashable>::Hash,
         > + Send
         + Sync
         + Clone
@@ -452,14 +452,14 @@ where
         + AsServiceId<
             TxMempoolService<
                 MempoolNetworkAdapter<
-                    SignedMantleTx<Preverified>,
-                    <SignedMantleTx<Preverified> as Hashable>::Hash,
+                    MantleTransaction<Preverified>,
+                    <MantleTransaction<Preverified> as Hashable>::Hash,
                     RuntimeServiceId,
                 >,
                 Mempool<
                     HeaderId,
-                    SignedMantleTx<Preverified>,
-                    <SignedMantleTx<Preverified> as Hashable>::Hash,
+                    MantleTransaction<Preverified>,
+                    <MantleTransaction<Preverified> as Hashable>::Hash,
                     StorageAdapter,
                     RuntimeServiceId,
                 >,
@@ -705,7 +705,7 @@ where
 {
     make_request_and_return_response!(blend::blend_pending_transactions::<
         BlendService,
-        SignedMantleTx<Preverified>,
+        MantleTransaction<Preverified>,
         TxHash,
         RuntimeServiceId,
     >(&handle, Hashable::hash))
@@ -721,7 +721,7 @@ where
 )]
 pub async fn blend_tx<BlendService, RuntimeServiceId>(
     State(handle): State<OverwatchHandle<RuntimeServiceId>>,
-    Json(tx): Json<SignedMantleTx<Preverified>>,
+    Json(tx): Json<MantleTransaction<Preverified>>,
 ) -> Response
 where
     BlendService: ServiceData<
@@ -731,7 +731,7 @@ where
 {
     make_request_and_return_response!(blend::blend_transaction::<
         BlendService,
-        SignedMantleTx<Preverified>,
+        MantleTransaction<Preverified>,
         TxHash,
         RuntimeServiceId,
     >(&handle, tx, Hashable::hash))
@@ -747,13 +747,13 @@ where
 )]
 pub async fn add_tx<StorageAdapter, RuntimeServiceId>(
     State(handle): State<OverwatchHandle<RuntimeServiceId>>,
-    Json(tx): Json<SignedMantleTx<Preverified>>,
+    Json(tx): Json<MantleTransaction<Preverified>>,
 ) -> Response
 where
     StorageAdapter: lb_tx_service::storage::MempoolStorageAdapter<
             RuntimeServiceId,
-            Item = SignedMantleTx<Preverified>,
-            Key = <SignedMantleTx<Preverified> as Hashable>::Hash,
+            Item = MantleTransaction<Preverified>,
+            Key = <MantleTransaction<Preverified> as Hashable>::Hash,
         > + Send
         + Sync
         + Clone
@@ -769,14 +769,14 @@ where
         + AsServiceId<
             TxMempoolService<
                 MempoolNetworkAdapter<
-                    SignedMantleTx<Preverified>,
-                    <SignedMantleTx<Preverified> as Hashable>::Hash,
+                    MantleTransaction<Preverified>,
+                    <MantleTransaction<Preverified> as Hashable>::Hash,
                     RuntimeServiceId,
                 >,
                 Mempool<
                     HeaderId,
-                    SignedMantleTx<Preverified>,
-                    <SignedMantleTx<Preverified> as Hashable>::Hash,
+                    MantleTransaction<Preverified>,
+                    <MantleTransaction<Preverified> as Hashable>::Hash,
                     StorageAdapter,
                     RuntimeServiceId,
                 >,
@@ -788,13 +788,13 @@ where
     make_request_and_return_response!(mempool::add_tx::<
         Libp2pNetworkBackend,
         MempoolNetworkAdapter<
-            SignedMantleTx<Preverified>,
-            <SignedMantleTx<Preverified> as Hashable>::Hash,
+            MantleTransaction<Preverified>,
+            <MantleTransaction<Preverified> as Hashable>::Hash,
             RuntimeServiceId,
         >,
         StorageAdapter,
-        SignedMantleTx<Preverified>,
-        <SignedMantleTx<Preverified> as Hashable>::Hash,
+        MantleTransaction<Preverified>,
+        <MantleTransaction<Preverified> as Hashable>::Hash,
         RuntimeServiceId,
     >(&handle, tx, Hashable::hash))
 }
@@ -813,8 +813,8 @@ pub async fn mempool_view<StorageAdapter, RuntimeServiceId>(
 where
     StorageAdapter: lb_tx_service::storage::MempoolStorageAdapter<
             RuntimeServiceId,
-            Item = SignedMantleTx<Preverified>,
-            Key = <SignedMantleTx<Preverified> as Hashable>::Hash,
+            Item = MantleTransaction<Preverified>,
+            Key = <MantleTransaction<Preverified> as Hashable>::Hash,
         > + Send
         + Sync
         + Clone
@@ -831,14 +831,14 @@ where
         + AsServiceId<
             TxMempoolService<
                 MempoolNetworkAdapter<
-                    SignedMantleTx<Preverified>,
-                    <SignedMantleTx<Preverified> as Hashable>::Hash,
+                    MantleTransaction<Preverified>,
+                    <MantleTransaction<Preverified> as Hashable>::Hash,
                     RuntimeServiceId,
                 >,
                 Mempool<
                     HeaderId,
-                    SignedMantleTx<Preverified>,
-                    <SignedMantleTx<Preverified> as Hashable>::Hash,
+                    MantleTransaction<Preverified>,
+                    <MantleTransaction<Preverified> as Hashable>::Hash,
                     StorageAdapter,
                     RuntimeServiceId,
                 >,
@@ -858,8 +858,8 @@ async fn current_tip_mempool_view<StorageAdapter, RuntimeServiceId>(
 where
     StorageAdapter: lb_tx_service::storage::MempoolStorageAdapter<
             RuntimeServiceId,
-            Item = SignedMantleTx<Preverified>,
-            Key = <SignedMantleTx<Preverified> as Hashable>::Hash,
+            Item = MantleTransaction<Preverified>,
+            Key = <MantleTransaction<Preverified> as Hashable>::Hash,
         > + Send
         + Sync
         + Clone
@@ -876,14 +876,14 @@ where
         + AsServiceId<
             TxMempoolService<
                 MempoolNetworkAdapter<
-                    SignedMantleTx<Preverified>,
-                    <SignedMantleTx<Preverified> as Hashable>::Hash,
+                    MantleTransaction<Preverified>,
+                    <MantleTransaction<Preverified> as Hashable>::Hash,
                     RuntimeServiceId,
                 >,
                 Mempool<
                     HeaderId,
-                    SignedMantleTx<Preverified>,
-                    <SignedMantleTx<Preverified> as Hashable>::Hash,
+                    MantleTransaction<Preverified>,
+                    <MantleTransaction<Preverified> as Hashable>::Hash,
                     StorageAdapter,
                     RuntimeServiceId,
                 >,
@@ -905,8 +905,8 @@ async fn mempool_view_at<StorageAdapter, RuntimeServiceId>(
 where
     StorageAdapter: lb_tx_service::storage::MempoolStorageAdapter<
             RuntimeServiceId,
-            Item = SignedMantleTx<Preverified>,
-            Key = <SignedMantleTx<Preverified> as Hashable>::Hash,
+            Item = MantleTransaction<Preverified>,
+            Key = <MantleTransaction<Preverified> as Hashable>::Hash,
         > + Send
         + Sync
         + Clone
@@ -922,14 +922,14 @@ where
         + AsServiceId<
             TxMempoolService<
                 MempoolNetworkAdapter<
-                    SignedMantleTx<Preverified>,
-                    <SignedMantleTx<Preverified> as Hashable>::Hash,
+                    MantleTransaction<Preverified>,
+                    <MantleTransaction<Preverified> as Hashable>::Hash,
                     RuntimeServiceId,
                 >,
                 Mempool<
                     HeaderId,
-                    SignedMantleTx<Preverified>,
-                    <SignedMantleTx<Preverified> as Hashable>::Hash,
+                    MantleTransaction<Preverified>,
+                    <MantleTransaction<Preverified> as Hashable>::Hash,
                     StorageAdapter,
                     RuntimeServiceId,
                 >,
@@ -941,14 +941,14 @@ where
     let relay = handle
         .relay::<TxMempoolService<
             MempoolNetworkAdapter<
-                SignedMantleTx<Preverified>,
-                <SignedMantleTx<Preverified> as Hashable>::Hash,
+                MantleTransaction<Preverified>,
+                <MantleTransaction<Preverified> as Hashable>::Hash,
                 RuntimeServiceId,
             >,
             Mempool<
                 HeaderId,
-                SignedMantleTx<Preverified>,
-                <SignedMantleTx<Preverified> as Hashable>::Hash,
+                MantleTransaction<Preverified>,
+                <MantleTransaction<Preverified> as Hashable>::Hash,
                 StorageAdapter,
                 RuntimeServiceId,
             >,
@@ -969,7 +969,7 @@ where
     let txs = receiver.await?;
 
     Ok(
-        tokio_stream::StreamExt::map(txs, |tx: SignedMantleTx<Preverified>| tx.hash())
+        tokio_stream::StreamExt::map(txs, |tx: MantleTransaction<Preverified>| tx.hash())
             .collect()
             .await,
     )
@@ -1019,8 +1019,8 @@ where
     WalletService: WalletServiceData,
     StorageAdapter: lb_tx_service::storage::MempoolStorageAdapter<
             RuntimeServiceId,
-            Item = SignedMantleTx<Preverified>,
-            Key = <SignedMantleTx<Preverified> as Hashable>::Hash,
+            Item = MantleTransaction<Preverified>,
+            Key = <MantleTransaction<Preverified> as Hashable>::Hash,
         > + Send
         + Sync
         + Clone
@@ -1037,14 +1037,14 @@ where
         + AsServiceId<
             TxMempoolService<
                 MempoolNetworkAdapter<
-                    SignedMantleTx<Preverified>,
-                    <SignedMantleTx<Preverified> as Hashable>::Hash,
+                    MantleTransaction<Preverified>,
+                    <MantleTransaction<Preverified> as Hashable>::Hash,
                     RuntimeServiceId,
                 >,
                 Mempool<
                     HeaderId,
-                    SignedMantleTx<Preverified>,
-                    <SignedMantleTx<Preverified> as Hashable>::Hash,
+                    MantleTransaction<Preverified>,
+                    <MantleTransaction<Preverified> as Hashable>::Hash,
                     StorageAdapter,
                     RuntimeServiceId,
                 >,
@@ -1083,13 +1083,13 @@ where
         mempool::add_tx::<
             Libp2pNetworkBackend,
             MempoolNetworkAdapter<
-                SignedMantleTx<Preverified>,
-                <SignedMantleTx<Preverified> as Hashable>::Hash,
+                MantleTransaction<Preverified>,
+                <MantleTransaction<Preverified> as Hashable>::Hash,
                 RuntimeServiceId,
             >,
             StorageAdapter,
-            SignedMantleTx<Preverified>,
-            <SignedMantleTx<Preverified> as Hashable>::Hash,
+            MantleTransaction<Preverified>,
+            <MantleTransaction<Preverified> as Hashable>::Hash,
             RuntimeServiceId,
         >(&handle, signed_tx, Hashable::hash)
         .await?;
@@ -1362,8 +1362,8 @@ pub async fn immutable_blocks<StorageBackend, RuntimeServiceId>(
 where
     StorageBackend: lb_storage_service::backends::StorageBackend + Send + Sync + 'static, /* TODO: StorageChainApi */
     StorageBackend::Block: Serialize,
-    <StorageBackend as StorageChainApi>::Block:
-        TryFrom<Block<SignedMantleTx<Unverified>>> + TryInto<Block<SignedMantleTx<Unverified>>>,
+    <StorageBackend as StorageChainApi>::Block: TryFrom<Block<MantleTransaction<Unverified>>>
+        + TryInto<Block<MantleTransaction<Unverified>>>,
     <StorageBackend as StorageChainApi>::Tx: From<Bytes> + AsRef<[u8]>,
     <StorageBackend as StorageChainApi>::Events: TryFrom<Events> + TryInto<Events>,
     RuntimeServiceId: Debug
@@ -1405,7 +1405,7 @@ where
         Ok(relay) => relay,
         Err(error) => return error.into_response(),
     };
-    let block = HttpStorageAdapter::get_block::<SignedMantleTx<Unverified>>(relay, id).await;
+    let block = HttpStorageAdapter::get_block::<MantleTransaction<Unverified>>(relay, id).await;
     match block {
         Ok(Some(block)) => {
             let api_block = ApiBlock::from(&block);
@@ -1514,11 +1514,11 @@ pub async fn blocks_stream<StorageBackend, ConsensusService, RuntimeServiceId>(
 where
     StorageBackend: lb_storage_service::backends::StorageBackend + Send + Sync + 'static,
     StorageBackend::Block: Serialize,
-    <StorageBackend as StorageChainApi>::Block:
-        TryFrom<Block<SignedMantleTx<Preverified>>> + TryInto<Block<SignedMantleTx<Preverified>>>,
+    <StorageBackend as StorageChainApi>::Block: TryFrom<Block<MantleTransaction<Preverified>>>
+        + TryInto<Block<MantleTransaction<Preverified>>>,
     <StorageBackend as StorageChainApi>::Tx: From<Bytes> + AsRef<[u8]>,
     <StorageBackend as StorageChainApi>::Events: TryFrom<Events> + TryInto<Events>,
-    ConsensusService: ServiceData<Message = ConsensusMsg<SignedMantleTx<Preverified>>> + 'static,
+    ConsensusService: ServiceData<Message = ConsensusMsg<MantleTransaction<Preverified>>> + 'static,
     RuntimeServiceId: Debug
         + Sync
         + Display
@@ -1554,8 +1554,8 @@ pub async fn blocks_range_stream<StorageBackend, RuntimeServiceId>(
 where
     StorageBackend: lb_storage_service::backends::StorageBackend + Send + Sync + 'static,
     StorageBackend::Block: Serialize,
-    <StorageBackend as StorageChainApi>::Block:
-        TryFrom<Block<SignedMantleTx<Unverified>>> + TryInto<Block<SignedMantleTx<Unverified>>>,
+    <StorageBackend as StorageChainApi>::Block: TryFrom<Block<MantleTransaction<Unverified>>>
+        + TryInto<Block<MantleTransaction<Unverified>>>,
     <StorageBackend as StorageChainApi>::Tx: From<Bytes> + AsRef<[u8]>,
     <StorageBackend as StorageChainApi>::Events: TryFrom<Events> + TryInto<Events>,
     RuntimeServiceId: Debug
@@ -1647,7 +1647,7 @@ where
         Err(error) => return error.into_response(),
     };
     let Ok(transactions) =
-        HttpStorageAdapter::get_transactions::<SignedMantleTx<Unverified>>(relay, id).await
+        HttpStorageAdapter::get_transactions::<MantleTransaction<Unverified>>(relay, id).await
     else {
         return ApiError::InternalServerError.into_response();
     };
@@ -1781,8 +1781,8 @@ pub mod wallet {
         WalletService: WalletServiceData + 'static,
         StorageAdapter: lb_tx_service::storage::MempoolStorageAdapter<
                 RuntimeServiceId,
-                Item = SignedMantleTx<Preverified>,
-                Key = <SignedMantleTx<Preverified> as Hashable>::Hash,
+                Item = MantleTransaction<Preverified>,
+                Key = <MantleTransaction<Preverified> as Hashable>::Hash,
             > + Send
             + Sync
             + Clone
@@ -1799,14 +1799,14 @@ pub mod wallet {
             + AsServiceId<
                 TxMempoolService<
                     MempoolNetworkAdapter<
-                        SignedMantleTx<Preverified>,
-                        <SignedMantleTx<Preverified> as Hashable>::Hash,
+                        MantleTransaction<Preverified>,
+                        <MantleTransaction<Preverified> as Hashable>::Hash,
                         RuntimeServiceId,
                     >,
                     Mempool<
                         HeaderId,
-                        SignedMantleTx<Preverified>,
-                        <SignedMantleTx<Preverified> as Hashable>::Hash,
+                        MantleTransaction<Preverified>,
+                        <MantleTransaction<Preverified> as Hashable>::Hash,
                         StorageAdapter,
                         RuntimeServiceId,
                     >,
@@ -1842,13 +1842,13 @@ pub mod wallet {
                 if let Err(e) = mempool::add_tx::<
                     Libp2pNetworkBackend,
                     MempoolNetworkAdapter<
-                        SignedMantleTx<Preverified>,
-                        <SignedMantleTx<Preverified> as Hashable>::Hash,
+                        MantleTransaction<Preverified>,
+                        <MantleTransaction<Preverified> as Hashable>::Hash,
                         RuntimeServiceId,
                     >,
                     StorageAdapter,
-                    SignedMantleTx<Preverified>,
-                    <SignedMantleTx<Preverified> as Hashable>::Hash,
+                    MantleTransaction<Preverified>,
+                    <MantleTransaction<Preverified> as Hashable>::Hash,
                     RuntimeServiceId,
                 >(&handle, transaction.clone(), Hashable::hash)
                 .await
@@ -1878,8 +1878,8 @@ pub mod wallet {
         WalletService: WalletServiceData,
         StorageAdapter: lb_tx_service::storage::MempoolStorageAdapter<
                 RuntimeServiceId,
-                Item = SignedMantleTx<Preverified>,
-                Key = <SignedMantleTx<Preverified> as Hashable>::Hash,
+                Item = MantleTransaction<Preverified>,
+                Key = <MantleTransaction<Preverified> as Hashable>::Hash,
             > + Send
             + Sync
             + Clone
@@ -1896,14 +1896,14 @@ pub mod wallet {
             + AsServiceId<
                 TxMempoolService<
                     MempoolNetworkAdapter<
-                        SignedMantleTx<Preverified>,
-                        <SignedMantleTx<Preverified> as Hashable>::Hash,
+                        MantleTransaction<Preverified>,
+                        <MantleTransaction<Preverified> as Hashable>::Hash,
                         RuntimeServiceId,
                     >,
                     Mempool<
                         HeaderId,
-                        SignedMantleTx<Preverified>,
-                        <SignedMantleTx<Preverified> as Hashable>::Hash,
+                        MantleTransaction<Preverified>,
+                        <MantleTransaction<Preverified> as Hashable>::Hash,
                         StorageAdapter,
                         RuntimeServiceId,
                     >,
@@ -1938,8 +1938,8 @@ pub mod wallet {
         WalletService: WalletServiceData,
         StorageAdapter: lb_tx_service::storage::MempoolStorageAdapter<
                 RuntimeServiceId,
-                Item = SignedMantleTx<Preverified>,
-                Key = <SignedMantleTx<Preverified> as Hashable>::Hash,
+                Item = MantleTransaction<Preverified>,
+                Key = <MantleTransaction<Preverified> as Hashable>::Hash,
             > + Send
             + Sync
             + Clone
@@ -1956,14 +1956,14 @@ pub mod wallet {
             + AsServiceId<
                 TxMempoolService<
                     MempoolNetworkAdapter<
-                        SignedMantleTx<Preverified>,
-                        <SignedMantleTx<Preverified> as Hashable>::Hash,
+                        MantleTransaction<Preverified>,
+                        <MantleTransaction<Preverified> as Hashable>::Hash,
                         RuntimeServiceId,
                     >,
                     Mempool<
                         HeaderId,
-                        SignedMantleTx<Preverified>,
-                        <SignedMantleTx<Preverified> as Hashable>::Hash,
+                        MantleTransaction<Preverified>,
+                        <MantleTransaction<Preverified> as Hashable>::Hash,
                         StorageAdapter,
                         RuntimeServiceId,
                     >,
@@ -1998,8 +1998,8 @@ pub mod wallet {
         WalletService: WalletServiceData,
         StorageAdapter: lb_tx_service::storage::MempoolStorageAdapter<
                 RuntimeServiceId,
-                Item = SignedMantleTx<Preverified>,
-                Key = <SignedMantleTx<Preverified> as Hashable>::Hash,
+                Item = MantleTransaction<Preverified>,
+                Key = <MantleTransaction<Preverified> as Hashable>::Hash,
             > + Send
             + Sync
             + Clone
@@ -2016,14 +2016,14 @@ pub mod wallet {
             + AsServiceId<
                 TxMempoolService<
                     MempoolNetworkAdapter<
-                        SignedMantleTx<Preverified>,
-                        <SignedMantleTx<Preverified> as Hashable>::Hash,
+                        MantleTransaction<Preverified>,
+                        <MantleTransaction<Preverified> as Hashable>::Hash,
                         RuntimeServiceId,
                     >,
                     Mempool<
                         HeaderId,
-                        SignedMantleTx<Preverified>,
-                        <SignedMantleTx<Preverified> as Hashable>::Hash,
+                        MantleTransaction<Preverified>,
+                        <MantleTransaction<Preverified> as Hashable>::Hash,
                         StorageAdapter,
                         RuntimeServiceId,
                     >,

--- a/nodes/node/binary/src/api/serializers/blocks.rs
+++ b/nodes/node/binary/src/api/serializers/blocks.rs
@@ -3,7 +3,7 @@ use lb_chain_service::Slot;
 use lb_core::{
     block::{Block, SignedHeader},
     header::{ContentId, Header, HeaderId},
-    mantle::{SignedMantleTx, transactions::states::VerificationState},
+    mantle::{MantleTransaction, transactions::states::VerificationState},
     proofs::leader_proof::Groth16LeaderProof,
 };
 use lb_key_management_system_service::keys::Ed25519Signature;
@@ -21,7 +21,7 @@ pub struct ApiBlock<'block> {
 
 impl<'block> ApiBlock<'block> {
     pub fn serialize<State: VerificationState, Serializer>(
-        block: &'block Block<SignedMantleTx<State>>,
+        block: &'block Block<MantleTransaction<State>>,
         serializer: Serializer,
     ) -> Result<Serializer::Ok, Serializer::Error>
     where
@@ -31,10 +31,10 @@ impl<'block> ApiBlock<'block> {
     }
 }
 
-impl<'block, State: VerificationState> From<&'block Block<SignedMantleTx<State>>>
+impl<'block, State: VerificationState> From<&'block Block<MantleTransaction<State>>>
     for ApiBlock<'block>
 {
-    fn from(value: &'block Block<SignedMantleTx<State>>) -> Self {
+    fn from(value: &'block Block<MantleTransaction<State>>) -> Self {
         let transactions = value
             .transactions()
             .iter()
@@ -69,11 +69,11 @@ impl<'block> From<&'block SignedHeader> for ApiSignedHeader<'block> {
 #[serde(transparent)]
 pub struct ApiBlockOwned<State: VerificationState> {
     #[serde(with = "ApiBlock")]
-    block: Block<SignedMantleTx<State>>,
+    block: Block<MantleTransaction<State>>,
 }
 
-impl<State: VerificationState> From<Block<SignedMantleTx<State>>> for ApiBlockOwned<State> {
-    fn from(value: Block<SignedMantleTx<State>>) -> Self {
+impl<State: VerificationState> From<Block<MantleTransaction<State>>> for ApiBlockOwned<State> {
+    fn from(value: Block<MantleTransaction<State>>) -> Self {
         Self { block: value }
     }
 }
@@ -104,7 +104,7 @@ pub struct ApiHeaderSerializer {
 pub struct ApiProcessedBlockEvent<'block, State: VerificationState> {
     /// The processed block.
     #[serde(with = "ApiBlock")]
-    pub block: &'block Block<SignedMantleTx<State>>,
+    pub block: &'block Block<MantleTransaction<State>>,
     /// The current canonical tip after processing this block.
     pub tip: &'block HeaderId,
     pub tip_slot: &'block Slot,
@@ -115,7 +115,7 @@ pub struct ApiProcessedBlockEvent<'block, State: VerificationState> {
 
 impl<'block, State: VerificationState> ApiProcessedBlockEvent<'block, State> {
     pub fn serialize<Serializer>(
-        value: &'block BlockWithChainState<SignedMantleTx<State>>,
+        value: &'block BlockWithChainState<MantleTransaction<State>>,
         serializer: Serializer,
     ) -> Result<Serializer::Ok, Serializer::Error>
     where
@@ -125,10 +125,10 @@ impl<'block, State: VerificationState> ApiProcessedBlockEvent<'block, State> {
     }
 }
 
-impl<'block, State: VerificationState> From<&'block BlockWithChainState<SignedMantleTx<State>>>
+impl<'block, State: VerificationState> From<&'block BlockWithChainState<MantleTransaction<State>>>
     for ApiProcessedBlockEvent<'block, State>
 {
-    fn from(value: &'block BlockWithChainState<SignedMantleTx<State>>) -> Self {
+    fn from(value: &'block BlockWithChainState<MantleTransaction<State>>) -> Self {
         Self {
             block: &value.block,
             tip: &value.tip,
@@ -143,20 +143,20 @@ impl<'block, State: VerificationState> From<&'block BlockWithChainState<SignedMa
 #[serde(transparent)]
 pub struct ApiProcessedBlockEventOwned<State: VerificationState> {
     #[serde(with = "ApiProcessedBlockEvent")]
-    block_with_chain_state: BlockWithChainState<SignedMantleTx<State>>,
+    block_with_chain_state: BlockWithChainState<MantleTransaction<State>>,
 }
 
 impl<State: VerificationState> ApiProcessedBlockEventOwned<State> {
     #[must_use]
-    pub const fn block(&self) -> &Block<SignedMantleTx<State>> {
+    pub const fn block(&self) -> &Block<MantleTransaction<State>> {
         &self.block_with_chain_state.block
     }
 }
 
-impl<State: VerificationState> From<BlockWithChainState<SignedMantleTx<State>>>
+impl<State: VerificationState> From<BlockWithChainState<MantleTransaction<State>>>
     for ApiProcessedBlockEventOwned<State>
 {
-    fn from(value: BlockWithChainState<SignedMantleTx<State>>) -> Self {
+    fn from(value: BlockWithChainState<MantleTransaction<State>>) -> Self {
         Self {
             block_with_chain_state: value,
         }

--- a/nodes/node/binary/src/api/serializers/transactions.rs
+++ b/nodes/node/binary/src/api/serializers/transactions.rs
@@ -1,5 +1,5 @@
 use lb_core::mantle::{
-    SignedMantleTx, TxHash,
+    MantleTransaction, TxHash,
     traits::Hashable,
     transactions::{Ops, OpsProofs, mantle_tx::MantleTx, states::VerificationState},
 };
@@ -29,8 +29,10 @@ pub struct ApiSignedTransaction<'tx> {
     ops_proofs: &'tx OpsProofs,
 }
 
-impl<'tx, State: VerificationState> From<&'tx SignedMantleTx<State>> for ApiSignedTransaction<'tx> {
-    fn from(value: &'tx SignedMantleTx<State>) -> Self {
+impl<'tx, State: VerificationState> From<&'tx MantleTransaction<State>>
+    for ApiSignedTransaction<'tx>
+{
+    fn from(value: &'tx MantleTransaction<State>) -> Self {
         Self {
             mantle_tx: value.mantle_tx().into(),
             ops_proofs: value.ops_proofs(),

--- a/nodes/node/binary/src/api/serializers/transactions.rs
+++ b/nodes/node/binary/src/api/serializers/transactions.rs
@@ -1,7 +1,7 @@
 use lb_core::mantle::{
     MantleTransaction, TxHash,
     traits::Hashable,
-    transactions::{Ops, OpsProofs, mantle_tx::MantleTx, states::VerificationState},
+    transactions::{OpProofs, Ops, mantle_tx::MantleTx, states::VerificationState},
 };
 use serde::Serialize;
 
@@ -26,7 +26,7 @@ where
 #[derive(Serialize)]
 pub struct ApiSignedTransaction<'tx> {
     mantle_tx: ApiTransactionSerializer<'tx>,
-    ops_proofs: &'tx OpsProofs,
+    ops_proofs: &'tx OpProofs,
 }
 
 impl<'tx, State: VerificationState> From<&'tx MantleTransaction<State>>

--- a/nodes/node/binary/src/config/mempool/mod.rs
+++ b/nodes/node/binary/src/config/mempool/mod.rs
@@ -1,5 +1,5 @@
 use lb_core::mantle::{
-    SignedMantleTx,
+    MantleTransaction,
     traits::Hashable as _,
     transactions::{hash::TxHash, states::Preverified},
 };
@@ -24,11 +24,11 @@ impl ServiceConfig {
         recovery_data: RecoveryData,
     ) -> TxMempoolSettings<
         MempoolSettings,
-        Libp2pNetworkAdapterSettings<TxHash, SignedMantleTx<Preverified>>,
+        Libp2pNetworkAdapterSettings<TxHash, MantleTransaction<Preverified>>,
     > {
         TxMempoolSettings {
             network_adapter: Libp2pNetworkAdapterSettings {
-                id: SignedMantleTx::<Preverified>::hash,
+                id: MantleTransaction::<Preverified>::hash,
                 topic: self.deployment.pubsub_topic,
             },
             pool: MempoolSettings {

--- a/nodes/node/binary/src/generic_services/mod.rs
+++ b/nodes/node/binary/src/generic_services/mod.rs
@@ -4,7 +4,7 @@ use lb_chain_service::CryptarchiaConsensus;
 use lb_core::{
     header::HeaderId,
     mantle::{
-        SignedMantleTx,
+        MantleTransaction,
         traits::Hashable,
         transactions::{hash::TxHash, states::Preverified},
     },
@@ -22,19 +22,19 @@ pub mod sdp;
 
 pub type MempoolNetworkAdapter<RuntimeServiceId> =
     lb_tx_service::network::adapters::libp2p::Libp2pAdapter<
-        SignedMantleTx<Preverified>,
-        <SignedMantleTx<Preverified> as Hashable>::Hash,
+        MantleTransaction<Preverified>,
+        <MantleTransaction<Preverified> as Hashable>::Hash,
         RuntimeServiceId,
     >;
 
 pub type MempoolRocksStorageAdapter = RocksStorageAdapter<
-    SignedMantleTx<Preverified>,
-    <SignedMantleTx<Preverified> as Hashable>::Hash,
+    MantleTransaction<Preverified>,
+    <MantleTransaction<Preverified> as Hashable>::Hash,
 >;
 
 pub type MempoolPool<RuntimeServiceId> = Mempool<
     HeaderId,
-    SignedMantleTx<Preverified>,
+    MantleTransaction<Preverified>,
     TxHash,
     MempoolRocksStorageAdapter,
     RuntimeServiceId,
@@ -51,24 +51,24 @@ pub type TimeService<RuntimeServiceId> =
     lb_time_service::TimeService<NtpTimeBackend, RuntimeServiceId>;
 
 pub type MempoolAdapter<RuntimeServiceId> = lb_tx_service::network::adapters::libp2p::Libp2pAdapter<
-    SignedMantleTx<Preverified>,
-    <SignedMantleTx<Preverified> as Hashable>::Hash,
+    MantleTransaction<Preverified>,
+    <MantleTransaction<Preverified> as Hashable>::Hash,
     RuntimeServiceId,
 >;
 
 pub type MempoolBackend<RuntimeServiceId> = Mempool<
     HeaderId,
-    SignedMantleTx<Preverified>,
-    <SignedMantleTx<Preverified> as Hashable>::Hash,
+    MantleTransaction<Preverified>,
+    <MantleTransaction<Preverified> as Hashable>::Hash,
     RocksStorageAdapter<
-        SignedMantleTx<Preverified>,
-        <SignedMantleTx<Preverified> as Hashable>::Hash,
+        MantleTransaction<Preverified>,
+        <MantleTransaction<Preverified> as Hashable>::Hash,
     >,
     RuntimeServiceId,
 >;
 
 pub type CryptarchiaService<RuntimeServiceId> = CryptarchiaConsensus<
-    SignedMantleTx<Preverified>,
+    MantleTransaction<Preverified>,
     RocksBackend,
     NtpTimeBackend,
     RuntimeServiceId,
@@ -76,7 +76,7 @@ pub type CryptarchiaService<RuntimeServiceId> = CryptarchiaConsensus<
 
 pub type ChainNetworkService<RuntimeServiceId> = lb_chain_network_service::ChainNetwork<
     CryptarchiaService<RuntimeServiceId>,
-    LibP2pAdapter<SignedMantleTx<Preverified>, RuntimeServiceId>,
+    LibP2pAdapter<MantleTransaction<Preverified>, RuntimeServiceId>,
     MempoolBackend<RuntimeServiceId>,
     MempoolAdapter<RuntimeServiceId>,
     NtpTimeBackend,
@@ -89,7 +89,7 @@ pub type KeyManagementService<RuntimeServiceId> =
 pub type WalletService<Cryptarchia, RuntimeServiceId> = lb_wallet_service::WalletService<
     KeyManagementService<RuntimeServiceId>,
     Cryptarchia,
-    SignedMantleTx<Preverified>,
+    MantleTransaction<Preverified>,
     RocksBackend,
     RuntimeServiceId,
 >;
@@ -108,17 +108,17 @@ pub type CryptarchiaLeaderService<Cryptarchia, ChainNetwork, Wallet, RuntimeServ
 
 pub type SdpMempoolAdapter<RuntimeServiceId> = sdp::mempool::SdpMempoolAdapter<
     lb_tx_service::network::adapters::libp2p::Libp2pAdapter<
-        SignedMantleTx<Preverified>,
+        MantleTransaction<Preverified>,
         TxHash,
         RuntimeServiceId,
     >,
     Mempool<
         HeaderId,
-        SignedMantleTx<Preverified>,
+        MantleTransaction<Preverified>,
         TxHash,
         RocksStorageAdapter<
-            SignedMantleTx<Preverified>,
-            <SignedMantleTx<Preverified> as Hashable>::Hash,
+            MantleTransaction<Preverified>,
+            <MantleTransaction<Preverified> as Hashable>::Hash,
         >,
         RuntimeServiceId,
     >,

--- a/nodes/node/binary/src/generic_services/sdp/mempool.rs
+++ b/nodes/node/binary/src/generic_services/sdp/mempool.rs
@@ -6,7 +6,7 @@ use std::{
 use lb_core::{
     header::HeaderId,
     mantle::{
-        SignedMantleTx,
+        MantleTransaction,
         traits::Hashable as _,
         transactions::{hash::TxHash, states::Preverified},
     },
@@ -40,7 +40,7 @@ where
 impl<MempoolNetAdapter, Mempool, RuntimeServiceId> SdpMempoolAdapterTrait
     for SdpMempoolAdapter<MempoolNetAdapter, Mempool, RuntimeServiceId>
 where
-    Mempool: RecoverableMempool<BlockId = HeaderId, Key = TxHash, Item = SignedMantleTx<Preverified>>
+    Mempool: RecoverableMempool<BlockId = HeaderId, Key = TxHash, Item = MantleTransaction<Preverified>>
         + Send
         + Sync,
     Mempool::RecoveryState: Serialize + for<'de> Deserialize<'de>,
@@ -65,7 +65,7 @@ where
 {
     type MempoolService =
         TxMempoolService<MempoolNetAdapter, Mempool, Mempool::Storage, RuntimeServiceId>;
-    type Tx = SignedMantleTx<Preverified>;
+    type Tx = MantleTransaction<Preverified>;
 
     fn new(mempool_relay: OutboundRelay<<Self::MempoolService as ServiceData>::Message>) -> Self {
         Self {

--- a/nodes/node/binary/src/generic_services/sdp/wallet.rs
+++ b/nodes/node/binary/src/generic_services/sdp/wallet.rs
@@ -1,6 +1,6 @@
 use lb_core::{
     mantle::{
-        Op, SignedMantleTx,
+        MantleTransaction, Op,
         transactions::{MantleTxBuilder, states::Preverified},
     },
     sdp::{ActiveMessage, DeclarationMessage, WithdrawMessage},
@@ -41,7 +41,7 @@ where
         mut tx_builder: MantleTxBuilder,
         declaration: DeclarationMessage,
         config: &SdpWalletConfig,
-    ) -> Result<SignedMantleTx<Preverified>, SdpWalletError> {
+    ) -> Result<MantleTransaction<Preverified>, SdpWalletError> {
         tx_builder = tx_builder.push_op(Op::SDPDeclare(declaration))?;
 
         let TipResponse {
@@ -82,7 +82,7 @@ where
         mut tx_builder: MantleTxBuilder,
         withdraw: WithdrawMessage,
         config: &SdpWalletConfig,
-    ) -> Result<SignedMantleTx<Preverified>, SdpWalletError> {
+    ) -> Result<MantleTransaction<Preverified>, SdpWalletError> {
         tx_builder = tx_builder.push_op(Op::SDPWithdraw(withdraw))?;
 
         let TipResponse {
@@ -123,7 +123,7 @@ where
         mut tx_builder: MantleTxBuilder,
         active: ActiveMessage,
         config: &SdpWalletConfig,
-    ) -> Result<SignedMantleTx<Preverified>, SdpWalletError> {
+    ) -> Result<MantleTransaction<Preverified>, SdpWalletError> {
         tx_builder = tx_builder.push_op(Op::SDPActive(active))?;
 
         let TipResponse {

--- a/nodes/node/binary/src/lib.rs
+++ b/nodes/node/binary/src/lib.rs
@@ -15,7 +15,7 @@ use lb_core::mantle::transactions::states::Preverified;
 pub use lb_core::{
     codec,
     header::HeaderId,
-    mantle::{SignedMantleTx, traits::Hashable, transactions::hash::TxHash},
+    mantle::{MantleTransaction, traits::Hashable, transactions::hash::TxHash},
 };
 pub use lb_network_service::backends::libp2p::Libp2p as NetworkBackend;
 pub use lb_storage_service::backends::{
@@ -96,7 +96,7 @@ pub type ApiService = lb_api_service::ApiService<
     AxumBackend<
         NtpTimeBackend,
         ApiStorageAdapter<RuntimeServiceId>,
-        RocksStorageAdapter<SignedMantleTx<Preverified>, TxHash>,
+        RocksStorageAdapter<MantleTransaction<Preverified>, TxHash>,
         SdpMempoolAdapter<RuntimeServiceId>,
         SdpWalletAdapter<RuntimeServiceId>,
         SdpRecoveryBackend<RuntimeServiceId>,

--- a/nodes/node/http-client/src/lib.rs
+++ b/nodes/node/http-client/src/lib.rs
@@ -8,7 +8,7 @@ use lb_core::{
     block::MAX_BLOCK_TRANSACTIONS_SIZE,
     header::{ContentId, HeaderId},
     mantle::{
-        SignedMantleTx, channel::ChannelState, ops::channel::ChannelId,
+        MantleTransaction, channel::ChannelState, ops::channel::ChannelId,
         transactions::states::Unverified,
     },
     proofs::leader_proof::Groth16LeaderProof,
@@ -67,7 +67,7 @@ pub struct ApiHeader {
 pub struct ApiBlock {
     pub header: ApiHeader,
     pub uncle_headers: Vec<ApiSignedHeader>,
-    pub transactions: Vec<SignedMantleTx<Unverified>>,
+    pub transactions: Vec<MantleTransaction<Unverified>>,
 }
 
 /// Client-side signed header representation matching the server's

--- a/services/api/src/http/consensus/cryptarchia.rs
+++ b/services/api/src/http/consensus/cryptarchia.rs
@@ -4,7 +4,7 @@ use futures::{StreamExt as _, TryStreamExt as _};
 use lb_chain_service::{ChainServiceInfo, CryptarchiaConsensus, Query};
 use lb_core::{
     header::HeaderId,
-    mantle::{SignedMantleTx, transactions::states::Preverified},
+    mantle::{MantleTransaction, transactions::states::Preverified},
 };
 use lb_ledger::LedgerState;
 use lb_storage_service::backends::rocksdb::RocksBackend;
@@ -15,7 +15,7 @@ use tokio::sync::oneshot;
 use crate::http::DynError;
 
 pub type Cryptarchia<RuntimeServiceId> = CryptarchiaConsensus<
-    SignedMantleTx<Preverified>,
+    MantleTransaction<Preverified>,
     RocksBackend,
     NtpTimeBackend,
     RuntimeServiceId,

--- a/services/api/src/http/mantle.rs
+++ b/services/api/src/http/mantle.rs
@@ -13,7 +13,7 @@ use lb_core::{
     events::Events,
     header::HeaderId,
     mantle::{
-        SignedMantleTx,
+        MantleTransaction,
         channel::ChannelState,
         ops::channel::ChannelId,
         traits::Hashable,
@@ -63,14 +63,14 @@ pub struct BlockWithChainState<Tx> {
 
 pub type MempoolService<StorageAdapter, RuntimeServiceId> = TxMempoolService<
     MempoolNetworkAdapter<
-        SignedMantleTx<Preverified>,
-        <SignedMantleTx<Preverified> as Hashable>::Hash,
+        MantleTransaction<Preverified>,
+        <MantleTransaction<Preverified> as Hashable>::Hash,
         RuntimeServiceId,
     >,
     Mempool<
         HeaderId,
-        SignedMantleTx<Preverified>,
-        <SignedMantleTx<Preverified> as Hashable>::Hash,
+        MantleTransaction<Preverified>,
+        <MantleTransaction<Preverified> as Hashable>::Hash,
         StorageAdapter,
         RuntimeServiceId,
     >,
@@ -113,8 +113,8 @@ pub async fn mantle_mempool_metrics<StorageAdapter, RuntimeServiceId>(
 where
     StorageAdapter: lb_tx_service::storage::MempoolStorageAdapter<
             RuntimeServiceId,
-            Key = <SignedMantleTx<Preverified> as Hashable>::Hash,
-            Item = SignedMantleTx<Preverified>,
+            Key = <MantleTransaction<Preverified> as Hashable>::Hash,
+            Item = MantleTransaction<Preverified>,
         > + Clone
         + 'static,
     StorageAdapter::Error: Debug,
@@ -143,13 +143,13 @@ where
 
 pub async fn mantle_mempool_status<StorageAdapter, RuntimeServiceId>(
     handle: &overwatch::overwatch::handle::OverwatchHandle<RuntimeServiceId>,
-    items: Vec<<SignedMantleTx<Preverified> as Hashable>::Hash>,
+    items: Vec<<MantleTransaction<Preverified> as Hashable>::Hash>,
 ) -> Result<Vec<Status>, super::DynError>
 where
     StorageAdapter: lb_tx_service::storage::MempoolStorageAdapter<
             RuntimeServiceId,
-            Key = <SignedMantleTx<Preverified> as Hashable>::Hash,
-            Item = SignedMantleTx<Preverified>,
+            Key = <MantleTransaction<Preverified> as Hashable>::Hash,
+            Item = MantleTransaction<Preverified>,
         > + Clone
         + 'static,
     StorageAdapter::Error: Debug,

--- a/services/blend/src/message.rs
+++ b/services/blend/src/message.rs
@@ -55,7 +55,7 @@ pub enum ServiceMessage<NodeId> {
     /// Request the transactions still waiting for a `PoW` solution to back
     /// their layer proofs, oldest first.
     // TODO: Change this to be tx IDs once we have strong types at the API level and we don't blend
-    // `Vec<u8>`s but actual `SignedMantleTx`s.
+    // `Vec<u8>`s but actual `MantleTransaction`s.
     GetPendingTransactions {
         reply: oneshot::Sender<Vec<Vec<u8>>>,
     },

--- a/services/chain/chain-leader/src/lib.rs
+++ b/services/chain/chain-leader/src/lib.rs
@@ -22,7 +22,7 @@ use lb_core::{
     },
     header::HeaderId,
     mantle::{
-        SignedMantleTx,
+        MantleTransaction,
         gas::MainnetGasProfile,
         traits::{Hashable, MantleTxWithProofs, StorageSize},
         transactions::{hash::TxHash, states::Preverified},
@@ -258,7 +258,7 @@ where
         > + lb_blend_service::ServiceComponents<NodeId: Send + Sync>
         + Send
         + 'static,
-    Mempool: MemPool<Item = SignedMantleTx<Preverified>>
+    Mempool: MemPool<Item = MantleTransaction<Preverified>>
         + RecoverableMempool<BlockId = HeaderId, Key = TxHash>
         + Send
         + Sync
@@ -537,7 +537,7 @@ where
         > + lb_blend_service::ServiceComponents<NodeId: Send + Sync>
         + Send
         + 'static,
-    Mempool: MemPool<Item = SignedMantleTx<Preverified>>
+    Mempool: MemPool<Item = MantleTransaction<Preverified>>
         + RecoverableMempool<BlockId = HeaderId, Key = TxHash>
         + Send
         + Sync

--- a/services/chain/chain-service/src/sync/block_provider.rs
+++ b/services/chain/chain-service/src/sync/block_provider.rs
@@ -591,7 +591,7 @@ mod tests {
         crypto::ZkHasher,
         events::Events,
         mantle::{
-            Note, RawMantleTx, SignedMantleTx, ledger::Utxo, ops::leader_claim::VoucherCm,
+            MantleTransaction, Note, RawMantleTx, ledger::Utxo, ops::leader_claim::VoucherCm,
             transactions::states::Unverified,
         },
         proofs::leader_proof::{LeaderPrivate, LeaderPublic},
@@ -764,7 +764,7 @@ mod tests {
         storage_relay: StorageRelay<RocksBackend>,
         cryptarchia: lb_cryptarchia_engine::Cryptarchia<HeaderId>,
         proof: lb_core::proofs::leader_proof::Groth16LeaderProof,
-        provider: BlockProvider<RocksBackend, SignedMantleTx<Unverified>>,
+        provider: BlockProvider<RocksBackend, MantleTransaction<Unverified>>,
     }
 
     impl TestEnv {
@@ -828,7 +828,12 @@ mod tests {
             &self,
             count: usize,
             slot_offset: u64,
-        ) -> Vec<(Block<SignedMantleTx<Unverified>>, HeaderId, HeaderId, Slot)> {
+        ) -> Vec<(
+            Block<MantleTransaction<Unverified>>,
+            HeaderId,
+            HeaderId,
+            Slot,
+        )> {
             let mut blocks = Vec::new();
             let mut prev_header = HeaderId::from([0u8; 32]);
 
@@ -901,7 +906,7 @@ mod tests {
             &self,
             prev_header: HeaderId,
             slot: Slot,
-        ) -> Option<Block<SignedMantleTx<Unverified>>> {
+        ) -> Option<Block<MantleTransaction<Unverified>>> {
             let dummy_signing_key = Ed25519Key::from_bytes(&[1u8; 32]);
             Block::create(
                 prev_header,
@@ -916,7 +921,7 @@ mod tests {
 
         async fn add_block(
             &mut self,
-            block: &Block<SignedMantleTx<Unverified>>,
+            block: &Block<MantleTransaction<Unverified>>,
             header_id: HeaderId,
             prev_header: HeaderId,
             slot: Slot,
@@ -930,7 +935,7 @@ mod tests {
 
         async fn store_block_only(
             &self,
-            block: &Block<SignedMantleTx<Unverified>>,
+            block: &Block<MantleTransaction<Unverified>>,
             header_id: HeaderId,
         ) {
             let parent_id = block.header().parent();
@@ -957,7 +962,7 @@ mod tests {
 
         async fn store_block_in_storage(
             &self,
-            block: &Block<SignedMantleTx<Unverified>>,
+            block: &Block<MantleTransaction<Unverified>>,
             header_id: HeaderId,
             slot: Slot,
         ) {
@@ -995,7 +1000,7 @@ mod tests {
             if let Some(ProviderResponse::Available(mut stream)) = rx.recv().await {
                 while let Some(res) = &stream.next().await {
                     if let Ok(bytes) = &res {
-                        let block: Block<SignedMantleTx<Unverified>> =
+                        let block: Block<MantleTransaction<Unverified>> =
                             Block::from_bytes(bytes).unwrap();
                         blocks.push(block.header().id());
                     } else {

--- a/services/chain/chain-service/src/tests/mod.rs
+++ b/services/chain/chain-service/src/tests/mod.rs
@@ -9,7 +9,7 @@ use futures::StreamExt as _;
 use lb_core::{
     block::{Block, BlockTransactions, UncleHeaders},
     mantle::{
-        Note, SignedMantleTx, Utxo,
+        MantleTransaction, Note, Utxo,
         ops::leader_claim::{VoucherCm, VoucherSecret},
         transactions::states::Preverified,
     },
@@ -264,7 +264,7 @@ async fn recovery_blocks_fall_back_to_lib_when_tip_missing_from_storage() {
     let _storage_svc = spawn_storage_service(storage_rx);
     let (time_tx, _time_rx) = mpsc::channel(10);
     let relays = CryptarchiaConsensusRelays::<
-        SignedMantleTx<Preverified>,
+        MantleTransaction<Preverified>,
         RocksBackend,
         TestRuntimeServiceId,
     >::new(
@@ -300,7 +300,7 @@ async fn process_block_does_not_mutate_state_when_storage_send_fails() {
     drop(storage_rx);
     let (time_tx, _time_rx) = mpsc::channel(10);
     let relays = CryptarchiaConsensusRelays::<
-        SignedMantleTx<Preverified>,
+        MantleTransaction<Preverified>,
         RocksBackend,
         TestRuntimeServiceId,
     >::new(
@@ -336,7 +336,7 @@ async fn process_block_does_not_mutate_state_when_storage_send_fails() {
     assert!(lib_rx.try_recv().is_err());
 }
 
-fn test_chain_with_next_block() -> (Cryptarchia, Block<SignedMantleTx<Preverified>>) {
+fn test_chain_with_next_block() -> (Cryptarchia, Block<MantleTransaction<Preverified>>) {
     let k = 3.try_into().unwrap();
     let config = ledger_config(k);
     let genesis_id = [0; 32].into();
@@ -428,7 +428,7 @@ pub fn try_build_block(
     key: &ZkKey,
     start_slot: Slot,
     uncle_headers: UncleHeaders,
-) -> Option<(Block<SignedMantleTx<Preverified>>, Ed25519Key)> {
+) -> Option<(Block<MantleTransaction<Preverified>>, Ed25519Key)> {
     let start_slot: u64 = start_slot.into();
     for slot in start_slot..=(start_slot + 1000) {
         let epoch_state = cryptarchia.epoch_state_for_slot(slot.into()).unwrap();
@@ -516,7 +516,7 @@ pub struct TestRuntimeServiceId;
 
 impl
     AsServiceId<
-        CryptarchiaConsensus<SignedMantleTx<Preverified>, RocksBackend, SystemTimeBackend, Self>,
+        CryptarchiaConsensus<MantleTransaction<Preverified>, RocksBackend, SystemTimeBackend, Self>,
     > for TestRuntimeServiceId
 {
     const SERVICE_ID: Self = Self;

--- a/services/chain/chain-service/src/uncle.rs
+++ b/services/chain/chain-service/src/uncle.rs
@@ -174,7 +174,7 @@ mod tests {
     use lb_core::{
         block::BlockTransactions,
         header::{ContentId, Header},
-        mantle::{SignedMantleTx, Utxo, transactions::states::Preverified},
+        mantle::{MantleTransaction, Utxo, transactions::states::Preverified},
         proofs::leader_proof::Groth16LeaderProof,
     };
     use lb_cryptarchia_engine::{Slot, UncleSlots};
@@ -398,8 +398,8 @@ mod tests {
     #[expect(clippy::type_complexity, reason = "a test helper")]
     fn chain_with_fork() -> (
         Cryptarchia,
-        Block<SignedMantleTx<Preverified>>,
-        Block<SignedMantleTx<Preverified>>,
+        Block<MantleTransaction<Preverified>>,
+        Block<MantleTransaction<Preverified>>,
         Ed25519Key,
         ZkKey,
         Utxo,
@@ -445,7 +445,7 @@ mod tests {
         (cryptarchia, b1, u1, u1_key, zk_key, utxo)
     }
 
-    fn signed_header(block: &Block<SignedMantleTx<Preverified>>) -> SignedHeader {
+    fn signed_header(block: &Block<MantleTransaction<Preverified>>) -> SignedHeader {
         SignedHeader::new(block.header().clone(), *block.signature())
     }
 
@@ -457,7 +457,7 @@ mod tests {
         uncle_headers: UncleHeaders,
         proof: &Groth16LeaderProof,
         key: &Ed25519Key,
-    ) -> Block<SignedMantleTx<Preverified>> {
+    ) -> Block<MantleTransaction<Preverified>> {
         Block::create(
             parent,
             slot,

--- a/services/sdp/src/lib.rs
+++ b/services/sdp/src/lib.rs
@@ -14,7 +14,7 @@ use lb_chain_service::{
 use lb_core::{
     header::HeaderId,
     mantle::{
-        NoteId, SignedMantleTx,
+        MantleTransaction, NoteId,
         transactions::{MantleTxBuilder, states::Preverified},
     },
     sdp::{ActiveMessage, ActivityMetadata, DeclarationId, DeclarationMessage, WithdrawMessage},
@@ -119,9 +119,10 @@ impl<MempoolAdapter, WalletAdapter, ChainService, StateStorage, RuntimeServiceId
     ServiceCore<RuntimeServiceId>
     for SdpService<MempoolAdapter, WalletAdapter, ChainService, StateStorage, RuntimeServiceId>
 where
-    MempoolAdapter: SdpMempoolAdapter<Tx = SignedMantleTx<Preverified>> + Send + Sync + 'static,
+    MempoolAdapter: SdpMempoolAdapter<Tx = MantleTransaction<Preverified>> + Send + Sync + 'static,
     WalletAdapter: SdpWalletAdapter + Send + Sync + 'static,
-    ChainService: CryptarchiaServiceData<Tx = SignedMantleTx<Preverified>> + Send + Sync + 'static,
+    ChainService:
+        CryptarchiaServiceData<Tx = MantleTransaction<Preverified>> + Send + Sync + 'static,
     StateStorage: SdpStateStorage<RuntimeServiceId> + Send + Sync,
     RuntimeServiceId: Debug
         + AsServiceId<Self>
@@ -246,9 +247,10 @@ where
 impl<MempoolAdapter, WalletAdapter, ChainService, StateStorage, RuntimeServiceId>
     SdpService<MempoolAdapter, WalletAdapter, ChainService, StateStorage, RuntimeServiceId>
 where
-    MempoolAdapter: SdpMempoolAdapter<Tx = SignedMantleTx<Preverified>> + Send + Sync + 'static,
+    MempoolAdapter: SdpMempoolAdapter<Tx = MantleTransaction<Preverified>> + Send + Sync + 'static,
     WalletAdapter: SdpWalletAdapter + Send + Sync + 'static,
-    ChainService: CryptarchiaServiceData<Tx = SignedMantleTx<Preverified>> + Send + Sync + 'static,
+    ChainService:
+        CryptarchiaServiceData<Tx = MantleTransaction<Preverified>> + Send + Sync + 'static,
     StateStorage: SdpStateStorage<RuntimeServiceId> + Send + Sync,
     RuntimeServiceId: Debug
         + AsServiceId<Self>

--- a/services/sdp/src/wallet.rs
+++ b/services/sdp/src/wallet.rs
@@ -1,6 +1,6 @@
 use lb_core::{
     mantle::{
-        SignedMantleTx,
+        MantleTransaction,
         gas::{GasCost, GasOverflow},
         transactions::{MantleTxBuilder, TxBuilderError, states::Preverified},
     },
@@ -45,19 +45,19 @@ pub trait SdpWalletAdapter {
         tx_builder: MantleTxBuilder,
         declaration: DeclarationMessage,
         config: &SdpWalletConfig,
-    ) -> Result<SignedMantleTx<Preverified>, SdpWalletError>;
+    ) -> Result<MantleTransaction<Preverified>, SdpWalletError>;
 
     async fn active_tx(
         &self,
         tx_builder: MantleTxBuilder,
         active_message: ActiveMessage,
         config: &SdpWalletConfig,
-    ) -> Result<SignedMantleTx<Preverified>, SdpWalletError>;
+    ) -> Result<MantleTransaction<Preverified>, SdpWalletError>;
 
     async fn withdraw_tx(
         &self,
         tx_builder: MantleTxBuilder,
         withdraw: WithdrawMessage,
         config: &SdpWalletConfig,
-    ) -> Result<SignedMantleTx<Preverified>, SdpWalletError>;
+    ) -> Result<MantleTransaction<Preverified>, SdpWalletError>;
 }

--- a/services/wallet/src/api.rs
+++ b/services/wallet/src/api.rs
@@ -1,7 +1,7 @@
 use lb_core::{
     header::HeaderId,
     mantle::{
-        Note, SignedMantleTx, Value,
+        MantleTransaction, Note, Value,
         gas::GasCost,
         ops::leader_claim::{RewardsRoot, VoucherCm},
         transactions::{
@@ -169,7 +169,7 @@ where
         reward_amount: Value,
         funding_pk: ZkPublicKey,
         max_tx_fee: GasCost,
-    ) -> Result<TipResponse<SignedMantleTx<Preverified>>, WalletApiError> {
+    ) -> Result<TipResponse<MantleTransaction<Preverified>>, WalletApiError> {
         let (resp_tx, rx) = oneshot::channel();
 
         self.relay
@@ -204,7 +204,7 @@ where
         funding_pks: Vec<ZkPublicKey>,
         recipient_pk: ZkPublicKey,
         amount: Value,
-    ) -> Result<TipResponse<SignedMantleTx<Preverified>>, WalletApiError> {
+    ) -> Result<TipResponse<MantleTransaction<Preverified>>, WalletApiError> {
         let mantle_tx_builder =
             MantleTxBuilder::new().add_ledger_output(Note::new(amount, recipient_pk))?;
         let funded_tx_builder = self
@@ -217,7 +217,7 @@ where
         &self,
         tip: Option<HeaderId>,
         tx_builder: MantleTxBuilder,
-    ) -> Result<TipResponse<SignedMantleTx<Preverified>>, WalletApiError> {
+    ) -> Result<TipResponse<MantleTransaction<Preverified>>, WalletApiError> {
         let (resp_tx, rx) = oneshot::channel();
 
         self.relay

--- a/services/wallet/src/lib.rs
+++ b/services/wallet/src/lib.rs
@@ -29,7 +29,7 @@ use lb_core::{
         },
         traits::{Hashable as _, MantleTxWithProofs},
         transactions::{
-            MantleTxBuilder, MantleTxContext, OpsProofs, TxBuilderError, mantle_tx::MantleTx as _,
+            MantleTxBuilder, MantleTxContext, OpProofs, TxBuilderError, mantle_tx::MantleTx as _,
             states::Preverified,
         },
     },
@@ -929,7 +929,7 @@ where
         let mantle_tx = tx_builder.clone().build()?;
         let tx_hash = mantle_tx.hash();
 
-        let mut ops_proofs = OpsProofs::empty();
+        let mut ops_proofs = OpProofs::empty();
         for (i, op) in mantle_tx.ops().iter().enumerate() {
             let proof = match op {
                 Op::ChannelInscribe(inscribe_op) => {

--- a/services/wallet/src/lib.rs
+++ b/services/wallet/src/lib.rs
@@ -16,7 +16,7 @@ use lb_core::{
     events::Events,
     header::HeaderId,
     mantle::{
-        NoteId, Op, OpProof, SignedMantleTx, TxHash, Utxo, Value, VerificationError,
+        MantleTransaction, NoteId, Op, OpProof, TxHash, Utxo, Value, VerificationError,
         gas::{GasCost, GasOverflow, MainnetGasProfile},
         ledger::Inputs,
         ops::{
@@ -169,12 +169,12 @@ pub enum WalletMsg {
         reward_amount: Value,
         funding_pk: ZkPublicKey,
         max_tx_fee: GasCost,
-        resp_tx: Sender<Result<TipResponse<SignedMantleTx<Preverified>>, WalletServiceError>>,
+        resp_tx: Sender<Result<TipResponse<MantleTransaction<Preverified>>, WalletServiceError>>,
     },
     SignTx {
         tip: Option<HeaderId>,
         tx_builder: MantleTxBuilder,
-        resp_tx: Sender<Result<TipResponse<SignedMantleTx<Preverified>>, WalletServiceError>>,
+        resp_tx: Sender<Result<TipResponse<MantleTransaction<Preverified>>, WalletServiceError>>,
     },
     SignTxWithEd25519 {
         tx_hash: TxHash,
@@ -219,7 +219,7 @@ pub struct UtxoWithKeyId {
 }
 
 struct LeaderClaimTx {
-    signed_tx: SignedMantleTx<Preverified>,
+    signed_tx: MantleTransaction<Preverified>,
     voucher_nullifier: VoucherNullifier,
     funded_notes: Vec<NoteId>,
 }
@@ -922,7 +922,7 @@ where
         tip_leader: LedgerState,
         kms: &KmsServiceApi<Kms, RuntimeServiceId>,
         wallet: &Wallet,
-    ) -> Result<SignedMantleTx<Preverified>, WalletServiceError> {
+    ) -> Result<MantleTransaction<Preverified>, WalletServiceError> {
         // TODO: Maybe Unverified?
         // Extract input public keys before building the transaction
         let mut channel_multi_sig_proofs = tx_builder.channel_multi_sig_proofs().clone();
@@ -969,7 +969,7 @@ where
             ops_proofs.try_push(proof)?;
         }
 
-        let signed_mantle_tx = SignedMantleTx::new(mantle_tx, ops_proofs)
+        let signed_mantle_tx = MantleTransaction::new(mantle_tx, ops_proofs)
             .preverify()
             .expect("Preverification should not fail.");
 
@@ -1267,7 +1267,7 @@ where
         ledger: LedgerState,
         state: &mut ServiceState<'_>,
         kms: &KmsServiceApi<Kms, RuntimeServiceId>,
-    ) -> Result<(SignedMantleTx<Preverified>, Vec<NoteId>), WalletServiceError> {
+    ) -> Result<(MantleTransaction<Preverified>, Vec<NoteId>), WalletServiceError> {
         let context = ledger.tx_context();
         let tx_builder = MantleTxBuilder::new().push_op(Op::LeaderClaim(LeaderClaimOp {
             rewards_root: request.rewards_root,
@@ -1304,7 +1304,7 @@ where
         ledger: LedgerState,
         state: &ServiceState<'_>,
         kms: &KmsServiceApi<Kms, RuntimeServiceId>,
-    ) -> Result<SignedMantleTx<Preverified>, WalletServiceError> {
+    ) -> Result<MantleTransaction<Preverified>, WalletServiceError> {
         let context = ledger.tx_context();
         let net_balance = funded_tx_builder.net_balance();
         let gas_cost = funded_tx_builder.minimum_gas_cost::<MainnetGasProfile>(&context)?;

--- a/tests/src/common/fee_spec.rs
+++ b/tests/src/common/fee_spec.rs
@@ -19,7 +19,7 @@ use std::collections::{HashMap, HashSet};
 
 use lb_common_http_client::ApiBlock;
 use lb_core::mantle::{
-    Note, Op, SignedMantleTx, Utxo,
+    MantleTransaction, Note, Op, Utxo,
     gas::{MainnetGasProfile, TxGasCalculator as _},
     traits::Hashable as _,
     transactions::{
@@ -142,7 +142,7 @@ pub fn self_transfer_paying_fee_at(
     account: &WalletAccount,
     prices: &GasPrices,
     tip: i128,
-) -> SignedMantleTx<Preverified> {
+) -> MantleTransaction<Preverified> {
     const MAX_FEE_CONVERGENCE_ATTEMPTS: usize = 32;
 
     let utxo = genesis_utxos
@@ -220,7 +220,7 @@ pub fn self_transfer_paying_fee_at(
     let proofs = transfer_proofs_for_funded_wallet_tx(&mantle_tx, &account.secret_key)
         .expect("transfer proofs should build");
 
-    SignedMantleTx::new(mantle_tx, proofs)
+    MantleTransaction::new(mantle_tx, proofs)
         .preverify()
         .expect("signed transaction should be valid")
 }
@@ -232,7 +232,7 @@ pub fn self_transfer_paying_fee_at(
 ///
 /// Returns both sizes when they differ.
 pub fn check_size_prediction<State: VerificationState>(
-    tx: &SignedMantleTx<State>,
+    tx: &MantleTransaction<State>,
     prices: &GasPrices,
 ) -> Result<(), String> {
     let gas_context = MantleTxGasContext::new(HashMap::new(), HashMap::new(), prices.clone());
@@ -256,7 +256,7 @@ pub fn check_size_prediction<State: VerificationState>(
 /// genesis notes.
 pub fn net_balance_against<State: VerificationState>(
     genesis_utxos: &[Utxo],
-    tx: &SignedMantleTx<State>,
+    tx: &MantleTransaction<State>,
 ) -> Result<u64, String> {
     let mut input_sum = 0u64;
     let mut output_sum = 0u64;
@@ -290,7 +290,7 @@ pub fn net_balance_against<State: VerificationState>(
 /// calculated.
 pub fn fee_surplus_at<State: VerificationState>(
     genesis_utxos: &[Utxo],
-    tx: &SignedMantleTx<State>,
+    tx: &MantleTransaction<State>,
     prices: &GasPrices,
 ) -> Result<i128, String> {
     let paid = net_balance_against(genesis_utxos, tx)?;

--- a/tests/src/common/wallet/funding_from_chain.rs
+++ b/tests/src/common/wallet/funding_from_chain.rs
@@ -7,7 +7,7 @@ use lb_core::mantle::{
     ops::channel::{ChannelId, ChannelKeyIndex},
     traits::Hashable as _,
     transactions::{
-        GasPrices, MantleTxBuilder, MantleTxContext, MantleTxGasContext, OpsProofs,
+        GasPrices, MantleTxBuilder, MantleTxContext, MantleTxGasContext, OpProofs,
         states::Unverified,
     },
 };
@@ -86,7 +86,7 @@ pub async fn funded_signed_tx(
         transfer_proofs_for_funded_wallet_tx(&mantle_tx, &funding_account.secret_key)
             .expect("transfer proofs should build"),
     );
-    let signed_tx = MantleTransaction::new(mantle_tx, OpsProofs::try_from(proofs).unwrap());
+    let signed_tx = MantleTransaction::new(mantle_tx, OpProofs::try_from(proofs).unwrap());
 
     (signed_tx, fee)
 }

--- a/tests/src/common/wallet/funding_from_chain.rs
+++ b/tests/src/common/wallet/funding_from_chain.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use lb_common_http_client::Error as HttpClientError;
 use lb_core::mantle::{
-    Op, OpProof, SignedMantleTx, TxHash, Utxo,
+    MantleTransaction, Op, OpProof, TxHash, Utxo,
     gas::MainnetGasProfile,
     ops::channel::{ChannelId, ChannelKeyIndex},
     traits::Hashable as _,
@@ -53,7 +53,7 @@ pub async fn funded_signed_tx(
     transfer_thresholds: HashMap<ChannelId, ChannelKeyIndex>,
     op: Op,
     op_proof: impl FnOnce(TxHash) -> OpProof,
-) -> (SignedMantleTx<Unverified>, u64) {
+) -> (MantleTransaction<Unverified>, u64) {
     let funding_source =
         current_wallet_funding_source(node, genesis_utxos, funding_account.clone())
             .await
@@ -86,7 +86,7 @@ pub async fn funded_signed_tx(
         transfer_proofs_for_funded_wallet_tx(&mantle_tx, &funding_account.secret_key)
             .expect("transfer proofs should build"),
     );
-    let signed_tx = SignedMantleTx::new(mantle_tx, OpsProofs::try_from(proofs).unwrap());
+    let signed_tx = MantleTransaction::new(mantle_tx, OpsProofs::try_from(proofs).unwrap());
 
     (signed_tx, fee)
 }

--- a/tests/src/common/wallet/scanner/accounting.rs
+++ b/tests/src/common/wallet/scanner/accounting.rs
@@ -2,7 +2,7 @@ use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, hash_map::Entry};
 
 use lb_common_http_client::ApiBlock;
 use lb_core::mantle::{
-    NoteId, SignedMantleTx, TxHash, Utxo,
+    MantleTransaction, NoteId, TxHash, Utxo,
     ops::Op,
     traits::Hashable as _,
     transactions::{mantle_tx::MantleTx as _, states::Unverified},
@@ -106,7 +106,7 @@ impl ScannerAccounting {
     /// Record transaction hashes from a block without changing wallet UTXOs.
     pub fn observe_block_transactions(&mut self, block: &ApiBlock) {
         self.observed_transaction_hashes
-            .extend(block.transactions.iter().map(SignedMantleTx::hash));
+            .extend(block.transactions.iter().map(MantleTransaction::hash));
     }
 
     #[must_use]
@@ -146,7 +146,7 @@ impl ScannerAccounting {
         self.tracked_wallets.len()
     }
 
-    fn apply_transaction(&mut self, tx: &SignedMantleTx<Unverified>) {
+    fn apply_transaction(&mut self, tx: &MantleTransaction<Unverified>) {
         for op in tx.mantle_tx().ops() {
             match op {
                 Op::Transfer(transfer) => {
@@ -224,7 +224,7 @@ mod tests {
     use lb_core::{
         header::{ContentId, HeaderId},
         mantle::{
-            Note, RawMantleTx, SignedMantleTx, Utxo,
+            MantleTransaction, Note, RawMantleTx, Utxo,
             ledger::{Inputs, Outputs},
             ops::{
                 Op,
@@ -256,7 +256,7 @@ mod tests {
         Utxo::new([output_index as u8; 32], output_index, Note::new(value, pk))
     }
 
-    fn block(seed: u8, txs: Vec<SignedMantleTx<Unverified>>) -> ApiBlock {
+    fn block(seed: u8, txs: Vec<MantleTransaction<Unverified>>) -> ApiBlock {
         ApiBlock {
             header: ApiHeader {
                 id: HeaderId::from([seed; 32]),
@@ -272,8 +272,8 @@ mod tests {
 
     /// A transaction creating `outputs`. A channel withdraw no longer creates
     /// notes, so a transfer is what the accounting observes owned outputs from.
-    fn transfer_tx(outputs: [Note; 2]) -> SignedMantleTx<Unverified> {
-        SignedMantleTx::new(
+    fn transfer_tx(outputs: [Note; 2]) -> MantleTransaction<Unverified> {
+        MantleTransaction::new(
             RawMantleTx(
                 [Op::Transfer(TransferOp::new(
                     Inputs::empty(),
@@ -350,7 +350,7 @@ mod tests {
     #[test]
     fn accounting_removes_spent_utxos() {
         let owned = utxo(10, 0, pk(1));
-        let spend = SignedMantleTx::new(
+        let spend = MantleTransaction::new(
             RawMantleTx(
                 [Op::ChannelDeposit(DepositOp {
                     channel_id: ChannelId::from([0; 32]),
@@ -384,11 +384,11 @@ mod tests {
     fn sdp_declare_hides_and_withdraw_restores_locked_utxo() {
         let locked = utxo(10, 0, pk(1));
         let declaration = sdp_declaration(locked.id());
-        let declare_tx = SignedMantleTx::new(
+        let declare_tx = MantleTransaction::new(
             RawMantleTx([Op::SDPDeclare(declaration.clone())].into()),
             OpsProofs::empty(),
         );
-        let withdraw_tx = SignedMantleTx::new(
+        let withdraw_tx = MantleTransaction::new(
             RawMantleTx(
                 [Op::SDPWithdraw(WithdrawMessage {
                     declaration_id: declaration.id(),

--- a/tests/src/common/wallet/scanner/accounting.rs
+++ b/tests/src/common/wallet/scanner/accounting.rs
@@ -232,7 +232,7 @@ mod tests {
                 transfer::TransferOp,
             },
             traits::Hashable as _,
-            transactions::{OpsProofs, states::Unverified},
+            transactions::{OpProofs, states::Unverified},
         },
         proofs::leader_proof::Groth16LeaderProof,
         sdp::{DeclarationMessage, Locator, ProviderId, ServiceType, WithdrawMessage},
@@ -281,7 +281,7 @@ mod tests {
                 ))]
                 .into(),
             ),
-            OpsProofs::empty(),
+            OpProofs::empty(),
         )
     }
 
@@ -359,7 +359,7 @@ mod tests {
                 })]
                 .into(),
             ),
-            OpsProofs::empty(),
+            OpProofs::empty(),
         );
         let mut accounting =
             ScannerAccounting::new(vec![TrackedWalletKeys::new("alice", [pk(1)])], &[owned])
@@ -386,7 +386,7 @@ mod tests {
         let declaration = sdp_declaration(locked.id());
         let declare_tx = MantleTransaction::new(
             RawMantleTx([Op::SDPDeclare(declaration.clone())].into()),
-            OpsProofs::empty(),
+            OpProofs::empty(),
         );
         let withdraw_tx = MantleTransaction::new(
             RawMantleTx(
@@ -397,7 +397,7 @@ mod tests {
                 })]
                 .into(),
             ),
-            OpsProofs::empty(),
+            OpProofs::empty(),
         );
         let mut accounting =
             ScannerAccounting::new(vec![TrackedWalletKeys::new("alice", [pk(1)])], &[locked])

--- a/tests/src/common/wallet/transaction/prepared.rs
+++ b/tests/src/common/wallet/transaction/prepared.rs
@@ -2,7 +2,7 @@
 
 use lb_core::mantle::{
     TxHash,
-    transactions::{MantleTxBuilder, MantleTxContext, OpsProofs},
+    transactions::{MantleTxBuilder, MantleTxContext, OpProofs},
 };
 
 use super::{
@@ -15,7 +15,7 @@ pub struct PreparedWalletTransaction {
     funded_builder: MantleTxBuilder,
     context: MantleTxContext,
     tx_hash: TxHash,
-    transfer_proofs: OpsProofs,
+    transfer_proofs: OpProofs,
     reserved_inputs: WalletReservedInputs,
 }
 
@@ -25,7 +25,7 @@ impl PreparedWalletTransaction {
         funded_builder: MantleTxBuilder,
         context: MantleTxContext,
         tx_hash: TxHash,
-        transfer_proofs: OpsProofs,
+        transfer_proofs: OpProofs,
         reserved_inputs: WalletReservedInputs,
     ) -> Self {
         Self {
@@ -44,7 +44,7 @@ impl PreparedWalletTransaction {
 
     pub fn sign_with_leading_proofs(
         self,
-        leading_op_proofs: OpsProofs,
+        leading_op_proofs: OpProofs,
     ) -> Result<SignedWalletTransaction, WalletTransactionError> {
         let Self {
             funded_builder,

--- a/tests/src/common/wallet/transaction/signed.rs
+++ b/tests/src/common/wallet/transaction/signed.rs
@@ -1,14 +1,14 @@
 //! Signed wallet transaction plus reservation and fee accounting metadata.
 
 use lb_core::mantle::{
-    SignedMantleTx,
+    MantleTransaction,
     transactions::{hash::TxHash, states::Preverified},
 };
 
 use crate::common::wallet::WalletReservedInputs;
 
 pub struct SignedWalletTransaction {
-    signed_tx: SignedMantleTx<Preverified>,
+    signed_tx: MantleTransaction<Preverified>,
     tx_hash: TxHash,
     reserved_inputs: WalletReservedInputs,
     paid_fee: u64,
@@ -18,7 +18,7 @@ pub struct SignedWalletTransaction {
 impl SignedWalletTransaction {
     #[must_use]
     pub(super) const fn new(
-        signed_tx: SignedMantleTx<Preverified>,
+        signed_tx: MantleTransaction<Preverified>,
         tx_hash: TxHash,
         reserved_inputs: WalletReservedInputs,
         paid_fee: u64,
@@ -34,7 +34,7 @@ impl SignedWalletTransaction {
     }
 
     #[must_use]
-    pub const fn signed_tx(&self) -> &SignedMantleTx<Preverified> {
+    pub const fn signed_tx(&self) -> &MantleTransaction<Preverified> {
         &self.signed_tx
     }
 

--- a/tests/src/common/wallet/transaction/signing.rs
+++ b/tests/src/common/wallet/transaction/signing.rs
@@ -3,7 +3,7 @@
 use std::collections::HashMap;
 
 use lb_core::mantle::{
-    NoteId, Op, OpProof, RawMantleTx, SignedMantleTx, TxGasCalculator as _, TxHash,
+    MantleTransaction, NoteId, Op, OpProof, RawMantleTx, TxGasCalculator as _, TxHash,
     gas::MainnetGasProfile,
     traits::Hashable as _,
     transactions::{MantleTxBuilder, MantleTxContext, OpsProofs, mantle_tx::MantleTx as _},
@@ -29,7 +29,7 @@ pub(super) fn sign_prepared_wallet_transaction(
     op_proofs.extend(transfer_proofs);
     let op_proofs = OpsProofs::try_from(op_proofs)?;
 
-    let signed_tx = SignedMantleTx::new(mantle_tx, op_proofs).preverify()?;
+    let signed_tx = MantleTransaction::new(mantle_tx, op_proofs).preverify()?;
     let mandatory_fee_at_preparation = signed_tx
         .total_gas_cost::<MainnetGasProfile>(&gas_prices)?
         .into_inner();

--- a/tests/src/common/wallet/transaction/signing.rs
+++ b/tests/src/common/wallet/transaction/signing.rs
@@ -6,7 +6,7 @@ use lb_core::mantle::{
     MantleTransaction, NoteId, Op, OpProof, RawMantleTx, TxGasCalculator as _, TxHash,
     gas::MainnetGasProfile,
     traits::Hashable as _,
-    transactions::{MantleTxBuilder, MantleTxContext, OpsProofs, mantle_tx::MantleTx as _},
+    transactions::{MantleTxBuilder, MantleTxContext, OpProofs, mantle_tx::MantleTx as _},
 };
 use lb_key_management_system_service::keys::ZkKey;
 
@@ -19,15 +19,15 @@ pub(super) fn sign_prepared_wallet_transaction(
     funded_builder: MantleTxBuilder,
     context: &MantleTxContext,
     tx_hash: TxHash,
-    transfer_proofs: OpsProofs,
+    transfer_proofs: OpProofs,
     reserved_inputs: WalletReservedInputs,
-    leading_op_proofs: OpsProofs,
+    leading_op_proofs: OpProofs,
 ) -> Result<SignedWalletTransaction, WalletTransactionError> {
     let gas_prices = context.gas_context.get_gas_prices();
     let mantle_tx = funded_builder.build()?;
     let mut op_proofs = leading_op_proofs.into_inner();
     op_proofs.extend(transfer_proofs);
-    let op_proofs = OpsProofs::try_from(op_proofs)?;
+    let op_proofs = OpProofs::try_from(op_proofs)?;
 
     let signed_tx = MantleTransaction::new(mantle_tx, op_proofs).preverify()?;
     let mandatory_fee_at_preparation = signed_tx
@@ -67,7 +67,7 @@ pub(super) fn sign_prepared_wallet_transaction(
 pub fn transfer_proofs_for_funded_wallet_tx(
     tx: &RawMantleTx,
     signing_key: &ZkKey,
-) -> Result<OpsProofs, WalletTransactionError> {
+) -> Result<OpProofs, WalletTransactionError> {
     let tx_hash = tx.hash();
     let proofs = tx
         .ops()
@@ -88,14 +88,14 @@ pub fn transfer_proofs_for_funded_wallet_tx(
             )?))
         })
         .collect::<Result<Vec<_>, _>>()?;
-    Ok(OpsProofs::try_from(proofs).expect("transaction proofs are bounded"))
+    Ok(OpProofs::try_from(proofs).expect("transaction proofs are bounded"))
 }
 
 pub(super) fn build_transfer_proofs(
     ops: &[Op],
     tx_hash: &TxHash,
     transfer_signers: &WalletTransferSigners,
-) -> Result<OpsProofs, WalletTransactionError> {
+) -> Result<OpProofs, WalletTransactionError> {
     let proofs = ops
         .iter()
         .filter_map(|op| match op {
@@ -120,5 +120,5 @@ pub(super) fn build_transfer_proofs(
             )?))
         })
         .collect::<Result<Vec<_>, _>>()?;
-    Ok(OpsProofs::try_from(proofs).expect("transaction proofs are bounded"))
+    Ok(OpProofs::try_from(proofs).expect("transaction proofs are bounded"))
 }

--- a/tests/src/cucumber/steps/fees/actions.rs
+++ b/tests/src/cucumber/steps/fees/actions.rs
@@ -9,7 +9,7 @@ use lb_common_http_client::ApiBlock;
 use lb_core::{
     header::HeaderId,
     mantle::{
-        SignedMantleTx,
+        MantleTransaction,
         gas::{GasCost, MainnetGasProfile, TxGasCalculator as _},
         traits::Hashable as _,
         transactions::{GasPrices, builder::MantleTxBuilder, states::Preverified},
@@ -154,7 +154,7 @@ async fn fund_self_transfer(
 fn assemble_funded_transaction(
     response: WalletFundResponseBody,
     step: &Step,
-) -> Result<SignedMantleTx<Preverified>, StepError> {
+) -> Result<MantleTransaction<Preverified>, StepError> {
     let transfer_proof = response
         .transfer_proof
         .ok_or_else(|| StepError::LogicalError {
@@ -163,7 +163,7 @@ fn assemble_funded_transaction(
                 step.value
             ),
         })?;
-    SignedMantleTx::new(response.funded_tx, [transfer_proof].into())
+    MantleTransaction::new(response.funded_tx, [transfer_proof].into())
         .preverify()
         .map_err(|source| StepError::StepFail {
             message: format!(
@@ -176,7 +176,7 @@ fn assemble_funded_transaction(
 fn record_prepared_priority_fee(
     world: &CucumberWorld,
     step: &Step,
-    signed_tx: &SignedMantleTx<Preverified>,
+    signed_tx: &MantleTransaction<Preverified>,
     prices: &GasPrices,
     priority_fee_percent: u64,
 ) -> Result<PreparedPriorityFee, StepError> {

--- a/tests/src/cucumber/steps/manual_mempool/actions.rs
+++ b/tests/src/cucumber/steps/manual_mempool/actions.rs
@@ -5,7 +5,7 @@ use lb_core::{
     mantle::{
         MantleTransaction, TxHash,
         traits::Hashable as _,
-        transactions::{OpsProofs, states::Preverified},
+        transactions::{OpProofs, states::Preverified},
     },
 };
 use lb_key_management_system_service::keys::ZkPublicKey;
@@ -53,7 +53,7 @@ pub async fn prepare_transfer_transaction(
     let prepared =
         prepare_user_wallet_transaction_submission(world, step, &sender_wallet_name, intent, None)
             .await?;
-    let signed = sign_prepared_user_wallet_transaction(step, prepared, OpsProofs::empty())?;
+    let signed = sign_prepared_user_wallet_transaction(step, prepared, OpProofs::empty())?;
     let tx_hash = record_prepared_transaction(world, transaction_alias.clone(), &signed)?;
 
     report_prepared_transaction(

--- a/tests/src/cucumber/steps/manual_mempool/actions.rs
+++ b/tests/src/cucumber/steps/manual_mempool/actions.rs
@@ -3,7 +3,7 @@ use std::{collections::BTreeSet, time::Duration};
 use lb_core::{
     codec::DeserializeOp as _,
     mantle::{
-        SignedMantleTx, TxHash,
+        MantleTransaction, TxHash,
         traits::Hashable as _,
         transactions::{OpsProofs, states::Preverified},
     },
@@ -320,7 +320,7 @@ async fn submit_prepared_transaction_to_node(
     world: &CucumberWorld,
     step: &str,
     transaction_alias: &str,
-    signed_tx: &SignedMantleTx<Preverified>,
+    signed_tx: &MantleTransaction<Preverified>,
     tx_hash: TxHash,
     node_name: &str,
 ) -> Result<(), StepError> {

--- a/tests/src/cucumber/steps/manual_transactions/drain_wallets.rs
+++ b/tests/src/cucumber/steps/manual_transactions/drain_wallets.rs
@@ -10,7 +10,7 @@ use lb_core::mantle::{
     ledger::MAX_TRANSACTION_INPUTS,
     transactions::{
         GENESIS_EXECUTION_GAS_PRICE, GasPrices, MantleTxBuilder, MantleTxContext,
-        MantleTxGasContext, OpsProofs,
+        MantleTxGasContext, OpProofs,
     },
 };
 use lb_key_management_system_service::keys::ZkPublicKey;
@@ -181,7 +181,7 @@ pub async fn drain_user_wallet(
                 world,
                 step,
                 prepared,
-                OpsProofs::empty(),
+                OpProofs::empty(),
                 None,
                 Some(&mut available),
             )

--- a/tests/src/cucumber/steps/manual_transactions/tracked_transactions.rs
+++ b/tests/src/cucumber/steps/manual_transactions/tracked_transactions.rs
@@ -2,7 +2,7 @@ use std::{collections::HashSet, time::Duration};
 
 use lb_common_http_client::ApiBlock;
 use lb_core::mantle::{
-    Note, NoteId, Op, OpProof, SignedMantleTx,
+    MantleTransaction, Note, NoteId, Op, OpProof,
     ledger::{Inputs, Outputs},
     ops::transfer::TransferOp,
     traits::Hashable as _,
@@ -252,7 +252,7 @@ async fn transaction_is_in_chain(
 
 /// Builds a transaction that fails stateless validation: a `TransferOp` with no
 /// inputs.
-pub fn create_stateless_invalid_transaction() -> SignedMantleTx<Unverified> {
+pub fn create_stateless_invalid_transaction() -> MantleTransaction<Unverified> {
     let output_note = Note::new(1000, ZkPublicKey::new(1u8.into()));
     let transfer_op = TransferOp::new(Inputs::empty(), Outputs::new([output_note]));
 
@@ -261,7 +261,7 @@ pub fn create_stateless_invalid_transaction() -> SignedMantleTx<Unverified> {
 
 /// Builds a transaction that passes stateless validation but is invalid against
 /// ledger state: its input note id does not correspond to any real UTXO.
-fn create_stateful_invalid_transaction() -> SignedMantleTx<Unverified> {
+fn create_stateful_invalid_transaction() -> MantleTransaction<Unverified> {
     let nonexistent_input = NoteId(Fr::from(0xDEAD_BEEFu64));
     let output_note = Note::new(1000, ZkPublicKey::new(1u8.into()));
     let transfer_op = TransferOp::new(
@@ -272,11 +272,11 @@ fn create_stateful_invalid_transaction() -> SignedMantleTx<Unverified> {
     build_signed_transfer(transfer_op)
 }
 
-fn build_signed_transfer(transfer_op: TransferOp) -> SignedMantleTx<Unverified> {
+fn build_signed_transfer(transfer_op: TransferOp) -> MantleTransaction<Unverified> {
     let mantle_tx = RawMantleTx([Op::Transfer(transfer_op)].into());
 
     let transfer_proof = ZkKey::multi_sign(&[], &mantle_tx.hash().to_fr())
         .expect("invalid transfer proof should still be constructible");
 
-    SignedMantleTx::new(mantle_tx, [OpProof::ZkSig(transfer_proof)].into())
+    MantleTransaction::new(mantle_tx, [OpProof::ZkSig(transfer_proof)].into())
 }

--- a/tests/src/cucumber/steps/manual_zone/support.rs
+++ b/tests/src/cucumber/steps/manual_zone/support.rs
@@ -26,7 +26,7 @@ use lb_core::mantle::{
         transfer::TransferOp,
     },
     traits::Hashable as _,
-    transactions::{OpsProofs, builder::MantleTxBuilder, states::Unverified},
+    transactions::{OpProofs, builder::MantleTxBuilder, states::Unverified},
 };
 use lb_http_api_common::bodies::{
     channel::{ChannelDepositRequestBody, ChannelDepositResponseBody},
@@ -1606,7 +1606,7 @@ async fn build_funded_custom_tx(
     let funded_tx = response.funded_tx;
     let signature = signing_key.sign_payload(funded_tx.hash().as_signing_bytes().as_ref());
     let mut ops_proofs =
-        OpsProofs::new_unchecked(vec![OpProof::Ed25519Sig(signature); payloads.len()]);
+        OpProofs::new_unchecked(vec![OpProof::Ed25519Sig(signature); payloads.len()]);
     if let Some(proof) = response.transfer_proof {
         ops_proofs
             .try_push(proof)

--- a/tests/src/cucumber/steps/manual_zone/support.rs
+++ b/tests/src/cucumber/steps/manual_zone/support.rs
@@ -36,7 +36,7 @@ use lb_http_api_common::bodies::{
     },
 };
 use lb_key_management_system_service::keys::{Ed25519Key, ZkPublicKey, ZkPublicKeys, ZkSignature};
-use lb_node::SignedMantleTx;
+use lb_node::MantleTransaction;
 use lb_testing_framework::NodeHttpClient;
 use lb_zone_sdk::{
     adapter::NodeHttpClient as ZoneNodeHttpClient,
@@ -1538,7 +1538,7 @@ pub async fn submit_atomic_zone_deposit(
         })?;
 
     let user_sig = sign_tx_zk(node_url, &tx, vec![funding_public_key]).await?;
-    let signed_tx = SignedMantleTx::new(
+    let signed_tx = MantleTransaction::new(
         tx,
         [
             OpProof::ZkSig(user_sig.clone()),
@@ -1569,7 +1569,7 @@ async fn build_funded_custom_tx(
     funding_pk: ZkPublicKey,
     payloads: &[Inscription],
     mut parent: MsgId,
-) -> Result<(SignedMantleTx<Unverified>, MsgId), ZoneTestError> {
+) -> Result<(MantleTransaction<Unverified>, MsgId), ZoneTestError> {
     let signer = signing_key.public_key();
     let mut tx_builder = MantleTxBuilder::new();
     for payload in payloads {
@@ -1614,7 +1614,7 @@ async fn build_funded_custom_tx(
                 message: format!("too many operation proofs: {error:?}"),
             })?;
     }
-    let signed_tx = SignedMantleTx::new(funded_tx, ops_proofs);
+    let signed_tx = MantleTransaction::new(funded_tx, ops_proofs);
 
     Ok((signed_tx, parent))
 }
@@ -1892,7 +1892,7 @@ pub async fn submit_zone_withdraw(
 //             }
 //         };
 //
-//     let signed_tx = SignedMantleTx::new(
+//     let mantle_transaction = MantleTransaction::new(
 //         tx,
 //         vec![
 //             OpProof::ChannelMultiSigProof(withdraw_proof),
@@ -1904,7 +1904,7 @@ pub async fn submit_zone_withdraw(
 //     })?;
 //
 //     let (result, _cp) = client
-//         .submit_signed_tx(signed_tx, msg_id)
+//         .submit_signed_tx(mantle_transaction, msg_id)
 //         .await
 //         .map_err(|error| ZoneTestError::SubmitWithdraw {
 //             message: error.to_string(),

--- a/tests/src/cucumber/steps/wallet_fund.rs
+++ b/tests/src/cucumber/steps/wallet_fund.rs
@@ -7,7 +7,7 @@ use std::{collections::HashSet, time::Duration};
 use cucumber::{gherkin::Step, then, when};
 use lb_common_http_client::ApiBlock;
 use lb_core::mantle::{
-    Note, Op, OpProof, SignedMantleTx, TxHash,
+    MantleTransaction, Note, Op, OpProof, TxHash,
     gas::GasCost,
     ops::channel::{
         ChannelId, MsgId,
@@ -102,7 +102,7 @@ async fn fund_and_submit_payment(
         });
     }
 
-    let signed_tx = SignedMantleTx::new(response.funded_tx, [transfer_proof].into());
+    let signed_tx = MantleTransaction::new(response.funded_tx, [transfer_proof].into());
     let tx_hash = signed_tx.hash();
 
     world
@@ -478,7 +478,7 @@ async fn step_fund_inscription_transaction(
 
     let tx_hash = response.funded_tx.hash();
     let signature = signing_key.sign_payload(tx_hash.as_signing_bytes().as_ref());
-    let signed_tx = SignedMantleTx::new(
+    let signed_tx = MantleTransaction::new(
         response.funded_tx,
         [OpProof::Ed25519Sig(signature), transfer_proof].into(),
     );

--- a/tests/src/cucumber/wallet/submissions.rs
+++ b/tests/src/cucumber/wallet/submissions.rs
@@ -8,7 +8,7 @@ use std::{collections::HashSet, time::Duration};
 use lb_core::mantle::{
     MantleTransaction, TxGasCalculator as _, TxHash, Utxo,
     gas::MainnetGasProfile,
-    transactions::{GasPrices, OpsProofs, states::Preverified},
+    transactions::{GasPrices, OpProofs, states::Preverified},
 };
 use lb_http_api_common::bodies::wallet::transfer_funds::WalletTransferFundsRequestBody;
 use lb_key_management_system_service::keys::ZkPublicKey;
@@ -591,7 +591,7 @@ pub async fn submit_prepared_user_wallet_transaction(
     world: &mut CucumberWorld,
     step: &str,
     prepared: PreparedUserWalletSubmission,
-    extra_op_proofs: OpsProofs,
+    extra_op_proofs: OpProofs,
     best_node_info: Option<&BestNodeInfo>,
     in_memory_available_utxos: Option<&mut WalletUtxos>,
 ) -> Result<TxHash, StepError> {
@@ -626,7 +626,7 @@ pub async fn submit_prepared_user_wallet_transaction(
 pub(crate) fn sign_prepared_user_wallet_transaction(
     step: &str,
     prepared: PreparedUserWalletSubmission,
-    extra_op_proofs: OpsProofs,
+    extra_op_proofs: OpProofs,
 ) -> Result<SignedUserWalletSubmission, StepError> {
     let PreparedUserWalletSubmission { wallet, submission } = prepared;
     let signed_submission = submission
@@ -656,7 +656,7 @@ fn finalize_reserved_user_wallet_submission(
     sign_prepared_user_wallet_transaction(
         step,
         PreparedUserWalletSubmission { wallet, submission },
-        OpsProofs::empty(),
+        OpProofs::empty(),
     )
 }
 
@@ -844,7 +844,7 @@ async fn submit_user_wallet_transaction(
         world,
         step,
         prepared,
-        OpsProofs::empty(),
+        OpProofs::empty(),
         best_node_info,
         in_memory_available_utxos,
     )

--- a/tests/src/cucumber/wallet/submissions.rs
+++ b/tests/src/cucumber/wallet/submissions.rs
@@ -6,7 +6,7 @@
 use std::{collections::HashSet, time::Duration};
 
 use lb_core::mantle::{
-    SignedMantleTx, TxGasCalculator as _, TxHash, Utxo,
+    MantleTransaction, TxGasCalculator as _, TxHash, Utxo,
     gas::MainnetGasProfile,
     transactions::{GasPrices, OpsProofs, states::Preverified},
 };
@@ -77,7 +77,7 @@ impl SignedUserWalletSubmission {
         self.submission.tx_hash()
     }
 
-    pub(crate) const fn signed_tx(&self) -> &SignedMantleTx<Preverified> {
+    pub(crate) const fn signed_tx(&self) -> &MantleTransaction<Preverified> {
         self.submission.signed_tx()
     }
 

--- a/tests/src/cucumber/world.rs
+++ b/tests/src/cucumber/world.rs
@@ -15,7 +15,7 @@ use lb_core::{
     codec::DeserializeOp as _,
     header::HeaderId,
     mantle::{
-        GenesisTime, SignedMantleTx, Utxo, Value,
+        GenesisTime, MantleTransaction, Utxo, Value,
         ops::channel::{
             ChannelId, deposit::DepositOp, inscribe::Inscription, withdraw::ChannelWithdrawOp,
         },
@@ -915,7 +915,7 @@ pub struct CucumberWorld {
     /// than on later inclusion.
     pub submission_outcomes: HashMap<String, Result<(), String>>,
     /// Manual: Exact signed transactions prepared for later submission.
-    pub prepared_transactions: HashMap<String, SignedMantleTx<Preverified>>,
+    pub prepared_transactions: HashMap<String, MantleTransaction<Preverified>>,
     /// Manual: Initial fee arithmetic for percentage-funded transactions
     /// prepared by the fee-market steps.
     pub prepared_priority_fees: HashMap<String, PreparedPriorityFee>,
@@ -2030,7 +2030,7 @@ impl CucumberWorld {
     pub fn remember_prepared_transaction(
         &mut self,
         alias: String,
-        signed_tx: SignedMantleTx<Preverified>,
+        signed_tx: MantleTransaction<Preverified>,
     ) {
         self.prepared_transactions.insert(alias, signed_tx);
     }
@@ -2053,7 +2053,7 @@ impl CucumberWorld {
     pub fn resolve_prepared_transaction(
         &self,
         alias: &str,
-    ) -> Result<SignedMantleTx<Preverified>, StepError> {
+    ) -> Result<MantleTransaction<Preverified>, StepError> {
         self.prepared_transactions
             .get(alias)
             .cloned()
@@ -2083,7 +2083,7 @@ impl CucumberWorld {
     pub async fn submit_transaction<State>(
         &self,
         wallet: &WalletInfo,
-        signed_tx: &SignedMantleTx<State>,
+        signed_tx: &MantleTransaction<State>,
         node_client: &NodeHttpClient,
     ) -> Result<(), StepError>
     where

--- a/tests/testing_framework/src/node/http_client.rs
+++ b/tests/testing_framework/src/node/http_client.rs
@@ -9,7 +9,7 @@ use lb_chain_service::ChainServiceInfo;
 use lb_core::{
     header::HeaderId,
     mantle::{
-        NoteId, SignedMantleTx,
+        MantleTransaction, NoteId,
         transactions::{hash::TxHash, states::VerificationState},
     },
     sdp::{Declaration, DeclarationId, Locator},
@@ -166,7 +166,10 @@ impl NodeHttpClient {
         Ok(Box::pin(stream))
     }
 
-    pub async fn submit_transaction<State>(&self, tx: &SignedMantleTx<State>) -> Result<(), Error>
+    pub async fn submit_transaction<State>(
+        &self,
+        tx: &MantleTransaction<State>,
+    ) -> Result<(), Error>
     where
         State: VerificationState + Send + Sync + Clone + 'static,
     {
@@ -180,7 +183,7 @@ impl NodeHttpClient {
 
     pub async fn blend_transaction<State>(
         &self,
-        tx: &SignedMantleTx<State>,
+        tx: &MantleTransaction<State>,
     ) -> Result<TxHash, Error>
     where
         State: VerificationState + Send + Sync + Clone + 'static,

--- a/tests/testing_framework/src/workloads/inscription/workload.rs
+++ b/tests/testing_framework/src/workloads/inscription/workload.rs
@@ -8,7 +8,7 @@ use std::{
 
 use async_trait::async_trait;
 use lb_core::mantle::{
-    SignedMantleTx,
+    MantleTransaction,
     ops::{
         Op, OpProof,
         channel::{
@@ -377,7 +377,7 @@ fn channel_id_from_signing_key(signing_key: &Ed25519Key) -> ChannelId {
 fn build_inscription_transaction(
     channel: &mut ChannelState,
     payload_bytes: usize,
-) -> Result<(SignedMantleTx<Preverified>, MsgId, TxHash), DynError> {
+) -> Result<(MantleTransaction<Preverified>, MsgId, TxHash), DynError> {
     let op = InscriptionOp {
         channel_id: channel.channel_id,
         inscription: build_payload(channel, payload_bytes),
@@ -393,9 +393,10 @@ fn build_inscription_transaction(
         .signing_key
         .sign_payload(tx_hash.as_signing_bytes().as_ref());
 
-    let signed_tx = SignedMantleTx::new(mantle_tx, [OpProof::Ed25519Sig(ed25519_signature)].into())
-        .preverify()
-        .map_err(|error| InscriptionWorkloadError::SignedTransactionBuild(error.to_string()))?;
+    let signed_tx =
+        MantleTransaction::new(mantle_tx, [OpProof::Ed25519Sig(ed25519_signature)].into())
+            .preverify()
+            .map_err(|error| InscriptionWorkloadError::SignedTransactionBuild(error.to_string()))?;
 
     channel.next_nonce = channel.next_nonce.saturating_add(1);
 
@@ -420,7 +421,7 @@ fn build_payload(channel: &ChannelState, payload_bytes: usize) -> Inscription {
 
 async fn submit_transaction_via_cluster(
     ctx: &RunContext<impl LbcScenarioEnv>,
-    tx: Arc<SignedMantleTx<Preverified>>,
+    tx: Arc<MantleTransaction<Preverified>>,
 ) -> Result<(), DynError> {
     let mut clients = ctx.node_clients().snapshot();
     if clients.is_empty() {
@@ -442,7 +443,7 @@ async fn submit_transaction_via_cluster(
 
 async fn submit_to_clients(
     clients: &mut [NodeHttpClient],
-    tx: &SignedMantleTx<Preverified>,
+    tx: &MantleTransaction<Preverified>,
     attempt: usize,
 ) -> Result<(), DynError> {
     let tx_hash = tx.hash();

--- a/tests/testing_framework/src/workloads/transaction/workload.rs
+++ b/tests/testing_framework/src/workloads/transaction/workload.rs
@@ -9,7 +9,7 @@ use std::{
 
 use async_trait::async_trait;
 use lb_core::mantle::{
-    Note, OpProof, SignedMantleTx, Utxo,
+    MantleTransaction, Note, OpProof, Utxo,
     gas::MainnetGasProfile,
     ops::OpId as _,
     traits::{GenesisTx as _, Hashable as _},
@@ -218,7 +218,7 @@ const SUBMIT_RETRY_DELAY: Duration = Duration::from_millis(500);
 
 async fn submit_transaction_via_cluster(
     ctx: &RunContext<impl LbcScenarioEnv>,
-    tx: Arc<SignedMantleTx<Preverified>>,
+    tx: Arc<MantleTransaction<Preverified>>,
 ) -> Result<(), DynError> {
     let tx_hash = tx.hash();
     debug!(?tx_hash, "submitting transaction via cluster (nodes first)");
@@ -247,7 +247,7 @@ const fn has_submission_retry(attempt: usize) -> bool {
 
 async fn submit_to_clients(
     clients: &mut [NodeHttpClient],
-    tx: &SignedMantleTx<Preverified>,
+    tx: &MantleTransaction<Preverified>,
     attempt: usize,
 ) -> Result<(), DynError> {
     let tx_hash = tx.hash();
@@ -277,7 +277,7 @@ fn cluster_client_exhausted_error() -> DynError {
 fn build_wallet_transaction(
     input: &WalletInput,
     gas_context: &MantleTxGasContext,
-) -> Result<SignedMantleTx<Preverified>, DynError> {
+) -> Result<MantleTransaction<Preverified>, DynError> {
     let receiver = input.account.public_key();
 
     let provisional_tx = MantleTxBuilder::new()
@@ -312,7 +312,7 @@ fn build_wallet_transaction(
     )
     .map_err(|err| format!("failed to sign transaction: {err}"))?;
 
-    SignedMantleTx::new(tx, [OpProof::ZkSig(signature)].into())
+    MantleTransaction::new(tx, [OpProof::ZkSig(signature)].into())
         .preverify()
         .map_err(|err| format!("failed to build signed transaction: {err}").into())
 }

--- a/tools/config/src/consensus.rs
+++ b/tools/config/src/consensus.rs
@@ -21,7 +21,7 @@ use lb_groth16::{AdditiveGroup as _, CompressedGroth16Proof, Fr};
 use lb_key_management_system_service::keys::{
     Ed25519Key, Ed25519Signature, ZkKey, ZkPublicKey, ZkSignature,
 };
-use lb_node::{Hashable as _, SignedMantleTx};
+use lb_node::{Hashable as _, MantleTransaction};
 use num_bigint::BigUint;
 
 use crate::unique::unique_test_context;
@@ -327,7 +327,7 @@ pub fn create_genesis_block_with_declarations(
             .expect("genesis transaction proofs are bounded");
     }
 
-    let signed_mantle_tx = SignedMantleTx::new_trusted(mantle_tx, ops_proofs);
+    let signed_mantle_tx = MantleTransaction::new_trusted(mantle_tx, ops_proofs);
 
     // TODO: Maybe use the builder instead of trusting the signed mantle tx
     GenesisBlockBuilder::new()

--- a/tools/config/src/consensus.rs
+++ b/tools/config/src/consensus.rs
@@ -13,7 +13,7 @@ use lb_core::{
             },
             transfer::TransferOp,
         },
-        transactions::{GenesisTx, Ops, OpsProofs},
+        transactions::{GenesisTx, OpProofs, Ops},
     },
     sdp::{DeclarationMessage, Locator, ProviderId, ServiceType},
 };
@@ -304,7 +304,7 @@ pub fn create_genesis_block_with_declarations(
     let mantle_tx = RawMantleTx(Ops::new_unchecked(ops));
 
     let mantle_tx_hash = mantle_tx.hash();
-    let mut ops_proofs = OpsProofs::from([
+    let mut ops_proofs = OpProofs::from([
         OpProof::ZkSig(ZkSignature::new(CompressedGroth16Proof::from_bytes(
             &EMPTY_GROTH16_PROOF_BYTES,
         ))),

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -883,7 +883,7 @@ mod tests {
                 deposit::Metadata,
                 inscribe::{Inscription, InscriptionOp},
             },
-            transactions::{GasPrices, MantleTxGasContext, Ops, OpsProofs, states::Unverified},
+            transactions::{GasPrices, MantleTxGasContext, OpProofs, Ops, states::Unverified},
         },
         proofs::leader_proof::{Groth16LeaderProof, LeaderPrivate, LeaderPublic},
         sdp::{MinStake, ServiceParameters, ServiceType},
@@ -2341,7 +2341,7 @@ mod tests {
     }
 
     fn signed_test_tx(ops: Vec<Op>) -> MantleTransaction<Unverified> {
-        let proofs = OpsProofs::try_from_iter(ops.iter().map(|op| match op {
+        let proofs = OpProofs::try_from_iter(ops.iter().map(|op| match op {
             Op::ChannelInscribe(_) => OpProof::Ed25519Sig(Ed25519Signature::zero()),
             _ => OpProof::ZkSig(ZkSignature::new(CompressedGroth16Proof::from_bytes(
                 &[0; 128],

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -874,7 +874,7 @@ mod tests {
     use lb_core::{
         crypto::ZkDigest as _,
         mantle::{
-            Note, OpProof, RawMantleTx, SignedMantleTx,
+            MantleTransaction, Note, OpProof, RawMantleTx,
             channel::Channels,
             gas::MainnetGasProfile as Gas,
             ledger::{Inputs, Outputs},
@@ -2296,7 +2296,7 @@ mod tests {
             signer: Ed25519Key::from_bytes(&[0; 32]).public_key(),
         });
 
-        let source_transactions: BlockTransactions<SignedMantleTx<Unverified>> = [
+        let source_transactions: BlockTransactions<MantleTransaction<Unverified>> = [
             signed_test_tx(vec![transfer, deposit]),
             signed_test_tx(vec![ignored_inscription]),
         ]
@@ -2340,7 +2340,7 @@ mod tests {
         assert!(second_wallet_tx.ops.is_empty());
     }
 
-    fn signed_test_tx(ops: Vec<Op>) -> SignedMantleTx<Unverified> {
+    fn signed_test_tx(ops: Vec<Op>) -> MantleTransaction<Unverified> {
         let proofs = OpsProofs::try_from_iter(ops.iter().map(|op| match op {
             Op::ChannelInscribe(_) => OpProof::Ed25519Sig(Ed25519Signature::zero()),
             _ => OpProof::ZkSig(ZkSignature::new(CompressedGroth16Proof::from_bytes(
@@ -2349,7 +2349,7 @@ mod tests {
         }))
         .expect("test proofs should fit");
 
-        SignedMantleTx::new(
+        MantleTransaction::new(
             RawMantleTx(Ops::try_from(ops).expect("test operations should fit")),
             proofs,
         )

--- a/zone-sdk/BRIDGING.md
+++ b/zone-sdk/BRIDGING.md
@@ -195,7 +195,7 @@ The proposing sequencer needs the current `withdraw_nonce` and its own accredite
 
 ```rust
 use lb_core::mantle::{
-    Op, SignedMantleTx,
+    Op, MantleTransaction,
     ops::{OpProof, channel::withdraw::ChannelWithdrawOp},
 };
 use lb_core::proofs::channel_multi_sig_proof::{ChannelMultiSigProof, IndexedSignature};
@@ -230,7 +230,7 @@ let signatures: Vec<IndexedSignature> = collect_signatures_from_committee(
 
 // 4. Assemble the threshold proof and submit.
 let withdraw_proof = ChannelMultiSigProof::new(signatures)?;
-let signed_tx = SignedMantleTx::new(
+let signed_tx = MantleTransaction::new(
     tx,
     vec![
         OpProof::ChannelMultiSigProof(withdraw_proof),

--- a/zone-sdk/DECENTRALIZED_SEQUENCING.md
+++ b/zone-sdk/DECENTRALIZED_SEQUENCING.md
@@ -199,7 +199,7 @@ The flow mirrors the multi-sig withdraw flow described in [`BRIDGING.md`](BRIDGI
 
 ```rust
 use lb_core::mantle::{
-    Op, SignedMantleTx,
+    Op, MantleTransaction,
     ops::{OpProof, channel::config::ChannelConfigOp},
 };
 use lb_core::proofs::channel_multi_sig_proof::{ChannelMultiSigProof, IndexedSignature};
@@ -231,7 +231,7 @@ let signatures: Vec<IndexedSignature> = collect_signatures_from_committee(
 
 // 4. Assemble the threshold proof and submit.
 let config_proof = ChannelMultiSigProof::new(signatures)?;
-let signed_tx = SignedMantleTx::new(
+let signed_tx = MantleTransaction::new(
     tx,
     vec![
         OpProof::ChannelMultiSigProof(config_proof),
@@ -269,7 +269,7 @@ The integration tests provide reference policies that run this re-publish loop a
 
 If the orphan policy is too aggressive — e.g., the orphan was caused by genuine application-level conflict, not a race — the consumer can choose to drop the payload, deduplicate against a higher-level transaction stream, or apply any other custom rule. The SDK only surfaces the event; the resolution policy is yours.
 
-Channel txs built outside the publish API are classified by shape, not by how they were submitted: a tx that looks like publish output (a single inscription, optionally with withdraws and one funding transfer) surfaces as `ChannelUpdateTx::Inscription` / `ChannelUpdateTx::AtomicWithdraw`; anything else surfaces as `ChannelUpdateTx::Custom(SignedMantleTx)` — the SDK hands back the whole transaction and it is up to the consumer to parse it (the `channel_inscriptions` helper extracts its inscriptions) and decide how to recover it. The main API is `publish` and `publish_atomic_withdraw`.
+Channel txs built outside the publish API are classified by shape, not by how they were submitted: a tx that looks like publish output (a single inscription, optionally with withdraws and one funding transfer) surfaces as `ChannelUpdateTx::Inscription` / `ChannelUpdateTx::AtomicWithdraw`; anything else surfaces as `ChannelUpdateTx::Custom(MantleTransaction)` — the SDK hands back the whole transaction and it is up to the consumer to parse it (the `channel_inscriptions` helper extracts its inscriptions) and decide how to recover it. The main API is `publish` and `publish_atomic_withdraw`.
 
 
 ## Current limitations

--- a/zone-sdk/src/adapter.rs
+++ b/zone-sdk/src/adapter.rs
@@ -11,7 +11,7 @@ use lb_core::{
     events::{DepositRecreatedNotes, TxEvent},
     header::HeaderId,
     mantle::{
-        Op, SignedMantleTx, Value,
+        MantleTransaction, Op, Value,
         channel::ChannelState,
         ops::{OpId as _, channel::ChannelId},
         traits::Hashable as _,
@@ -74,7 +74,7 @@ pub trait Node {
         slot_to: Slot,
     ) -> Result<Vec<ApiBlock>, Error>;
 
-    async fn post_transaction(&self, tx: SignedMantleTx<Unverified>) -> Result<(), Error>;
+    async fn post_transaction(&self, tx: MantleTransaction<Unverified>) -> Result<(), Error>;
 
     /// Fund a transaction from the node's wallet.
     ///
@@ -204,7 +204,7 @@ impl Node for NodeHttpClient {
             .await
     }
 
-    async fn post_transaction(&self, tx: SignedMantleTx<Unverified>) -> Result<(), Error> {
+    async fn post_transaction(&self, tx: MantleTransaction<Unverified>) -> Result<(), Error> {
         self.client
             .post_transaction(self.base_url.clone(), tx)
             .await
@@ -220,7 +220,7 @@ impl Node for NodeHttpClient {
 
 /// Returns true if `transactions` contains any deposit op on `channel_id`.
 pub(crate) fn has_channel_deposit<State: VerificationState>(
-    transactions: &[SignedMantleTx<State>],
+    transactions: &[MantleTransaction<State>],
     channel_id: ChannelId,
 ) -> bool {
     transactions.iter().any(|tx| {
@@ -277,7 +277,7 @@ pub(crate) fn build_deposit_events(events: &Events) -> DepositEvents {
 /// Walks a block's transactions and emits the [`ZoneMessage`]s relevant to
 /// `channel_id`, looking up deposit amounts and notes from `deposit_events`.
 fn block_to_messages<State: VerificationState>(
-    transactions: Vec<SignedMantleTx<State>>,
+    transactions: Vec<MantleTransaction<State>>,
     channel_id: ChannelId,
     deposit_events: &DepositEvents,
 ) -> Vec<ZoneMessage> {

--- a/zone-sdk/src/lib.rs
+++ b/zone-sdk/src/lib.rs
@@ -95,7 +95,7 @@ pub mod node_types {
         events::DepositRecreatedNotes,
         header::HeaderId,
         mantle::{
-            SignedMantleTx, TxHash, Value,
+            MantleTransaction, TxHash, Value,
             channel::ChannelState,
             ledger::Inputs,
             ops::channel::{ChannelId, MsgId, deposit::Metadata, inscribe::Inscription},

--- a/zone-sdk/src/sequencer/actor.rs
+++ b/zone-sdk/src/sequencer/actor.rs
@@ -637,7 +637,7 @@ mod tests {
                 },
             },
             traits::Hashable as _,
-            transactions::{Ops, OpsProofs, mantle_tx::MantleTx as _},
+            transactions::{OpProofs, Ops, mantle_tx::MantleTx as _},
         },
     };
     use lb_key_management_system_service::keys::{Ed25519Key, ZkKey};
@@ -1208,7 +1208,7 @@ mod tests {
             .unwrap(),
         );
         let tx_hash = mantle_tx.hash();
-        let signed_tx = MantleTransaction::new(mantle_tx, OpsProofs::empty());
+        let signed_tx = MantleTransaction::new(mantle_tx, OpProofs::empty());
 
         let mut state = TxState::new(HeaderId::from([0; 32]), MsgId::root());
         track_pending_tx(&mut state, signed_tx, channel_id);
@@ -1240,7 +1240,7 @@ mod tests {
         };
         let mantle_tx = RawMantleTx(Ops::try_from(vec![Op::ChannelInscribe(inscribe_op)]).unwrap());
         let tx_hash = mantle_tx.hash();
-        let signed_tx = MantleTransaction::new(mantle_tx, OpsProofs::empty());
+        let signed_tx = MantleTransaction::new(mantle_tx, OpProofs::empty());
 
         let mut state = TxState::new(HeaderId::from([0; 32]), MsgId::root());
         track_pending_tx(&mut state, signed_tx, channel_id);
@@ -1265,7 +1265,7 @@ mod tests {
         };
         let mantle_tx = RawMantleTx(Ops::try_from(vec![Op::ChannelInscribe(inscribe_op)]).unwrap());
         let tx_hash = mantle_tx.hash();
-        let signed_tx = MantleTransaction::new(mantle_tx, OpsProofs::empty());
+        let signed_tx = MantleTransaction::new(mantle_tx, OpProofs::empty());
 
         let mut state = TxState::new(HeaderId::from([0; 32]), MsgId::root());
         track_pending_tx(&mut state, signed_tx, our_channel);

--- a/zone-sdk/src/sequencer/actor.rs
+++ b/zone-sdk/src/sequencer/actor.rs
@@ -623,7 +623,7 @@ mod tests {
     use lb_core::{
         header::HeaderId,
         mantle::{
-            Note, Op, RawMantleTx, SignedMantleTx, Utxo,
+            MantleTransaction, Note, Op, RawMantleTx, Utxo,
             channel::{SlotTimeframe, SlotTimeout},
             ledger::Inputs,
             ops::{
@@ -708,7 +708,7 @@ mod tests {
         assert!(matches!(&tx.ops()[1], &Op::ChannelInscribe(_)));
 
         // Sign the `MantleTx`
-        let signed_tx = SignedMantleTx::new(
+        let signed_tx = MantleTransaction::new(
             tx.clone(),
             [
                 OpProof::ZkSig(
@@ -1208,7 +1208,7 @@ mod tests {
             .unwrap(),
         );
         let tx_hash = mantle_tx.hash();
-        let signed_tx = SignedMantleTx::new(mantle_tx, OpsProofs::empty());
+        let signed_tx = MantleTransaction::new(mantle_tx, OpsProofs::empty());
 
         let mut state = TxState::new(HeaderId::from([0; 32]), MsgId::root());
         track_pending_tx(&mut state, signed_tx, channel_id);
@@ -1240,7 +1240,7 @@ mod tests {
         };
         let mantle_tx = RawMantleTx(Ops::try_from(vec![Op::ChannelInscribe(inscribe_op)]).unwrap());
         let tx_hash = mantle_tx.hash();
-        let signed_tx = SignedMantleTx::new(mantle_tx, OpsProofs::empty());
+        let signed_tx = MantleTransaction::new(mantle_tx, OpsProofs::empty());
 
         let mut state = TxState::new(HeaderId::from([0; 32]), MsgId::root());
         track_pending_tx(&mut state, signed_tx, channel_id);
@@ -1265,7 +1265,7 @@ mod tests {
         };
         let mantle_tx = RawMantleTx(Ops::try_from(vec![Op::ChannelInscribe(inscribe_op)]).unwrap());
         let tx_hash = mantle_tx.hash();
-        let signed_tx = SignedMantleTx::new(mantle_tx, OpsProofs::empty());
+        let signed_tx = MantleTransaction::new(mantle_tx, OpsProofs::empty());
 
         let mut state = TxState::new(HeaderId::from([0; 32]), MsgId::root());
         track_pending_tx(&mut state, signed_tx, our_channel);

--- a/zone-sdk/src/sequencer/block_fetch.rs
+++ b/zone-sdk/src/sequencer/block_fetch.rs
@@ -4,7 +4,7 @@ use lb_common_http_client::{ApiBlock, ProcessedBlockEvent, Slot};
 use lb_core::{
     header::HeaderId,
     mantle::{
-        SignedMantleTx,
+        MantleTransaction,
         ops::{
             Op, OpId as _,
             channel::{ChannelId, MsgId, inscribe::Inscription},
@@ -301,9 +301,9 @@ fn apply_prepared_block_event(
 fn observe_channel_inscriptions(
     state: &mut TxState,
     classified: &[BlockChannelTx],
-    transactions: &[SignedMantleTx<Unverified>],
+    transactions: &[MantleTransaction<Unverified>],
 ) {
-    let by_hash: HashMap<TxHash, &SignedMantleTx<Unverified>> = transactions
+    let by_hash: HashMap<TxHash, &MantleTransaction<Unverified>> = transactions
         .iter()
         .map(|tx| (tx.mantle_tx().hash(), tx))
         .collect();
@@ -330,7 +330,7 @@ fn observe_channel_inscriptions(
 /// yield synthetic empty-payload entries (they reset the channel tip).
 #[must_use]
 pub fn channel_inscriptions(
-    tx: &SignedMantleTx<Unverified>,
+    tx: &MantleTransaction<Unverified>,
     channel_id: ChannelId,
 ) -> Vec<InscriptionInfo> {
     let tx_hash = tx.mantle_tx().hash();
@@ -525,7 +525,7 @@ where
 async fn fetch_block_deposit_events<Node>(
     node: &Node,
     block_id: HeaderId,
-    transactions: &[SignedMantleTx<Unverified>],
+    transactions: &[MantleTransaction<Unverified>],
     channel_id: ChannelId,
 ) -> Result<DepositEvents, Error>
 where
@@ -606,7 +606,7 @@ where
 ///
 /// Deposits without a matching event entry are skipped with a warning.
 fn extract_finalized_items(
-    transactions: &[SignedMantleTx<Unverified>],
+    transactions: &[MantleTransaction<Unverified>],
     channel_id: ChannelId,
     l1_slot: Slot,
     deposit_events: &DepositEvents,
@@ -855,7 +855,7 @@ fn apply_backfilled_block(
 /// subsequent entries. Downstream consumers that want unique-by-`this_msg`
 /// semantics dedup themselves.
 fn classify_channel_txs(
-    txs: &[SignedMantleTx<Unverified>],
+    txs: &[MantleTransaction<Unverified>],
     channel_id: ChannelId,
 ) -> Vec<BlockChannelTx> {
     // Running in-block channel tip, for the chain-order assertion and for
@@ -868,7 +868,7 @@ fn classify_channel_txs(
 
 /// Classify one tx's channel ops; `None` when the tx has no tip-advancing op.
 pub(super) fn classify_channel_tx(
-    tx: &SignedMantleTx<Unverified>,
+    tx: &MantleTransaction<Unverified>,
     channel_id: ChannelId,
     block_tip: &mut Option<MsgId>,
 ) -> Option<BlockChannelTx> {
@@ -960,7 +960,7 @@ pub(super) fn classify_channel_tx(
 /// (`ChannelInscribe` or `ChannelConfig`). Deposits and withdraws don't move
 /// the tip and so don't make a tx "ours" for tip-tracking purposes.
 fn touches_channel_tip<State: VerificationState>(
-    tx: &SignedMantleTx<State>,
+    tx: &MantleTransaction<State>,
     channel_id: ChannelId,
 ) -> bool {
     tx.mantle_tx().ops().iter().any(|op| match op {
@@ -1028,7 +1028,7 @@ mod tests {
     /// Extract deposits via the unified walker and filter to deposit entries
     /// for assertion clarity.
     fn extract_deposits_for_test(
-        transactions: &[SignedMantleTx<Unverified>],
+        transactions: &[MantleTransaction<Unverified>],
         channel_id: ChannelId,
         deposit_events: &DepositEvents,
     ) -> Vec<DepositInfo> {
@@ -1403,7 +1403,7 @@ mod tests {
         }
     }
 
-    fn dummy_pending_tx(seed: u8) -> SignedMantleTx<Unverified> {
+    fn dummy_pending_tx(seed: u8) -> MantleTransaction<Unverified> {
         let mantle_tx = RawMantleTx(
             [Op::ChannelInscribe(InscriptionOp {
                 channel_id: [0u8; 32].into(),
@@ -1413,7 +1413,7 @@ mod tests {
             })]
             .into(),
         );
-        SignedMantleTx::new(
+        MantleTransaction::new(
             mantle_tx,
             [OpProof::Ed25519Sig(Ed25519Signature::zero())].into(),
         )

--- a/zone-sdk/src/sequencer/channel_wallet.rs
+++ b/zone-sdk/src/sequencer/channel_wallet.rs
@@ -14,7 +14,7 @@ use lb_common_http_client::Slot;
 use lb_core::{
     header::HeaderId,
     mantle::{
-        SignedMantleTx,
+        MantleTransaction,
         ledger::NoteId,
         ops::{Op, OpId as _, channel::ChannelId},
         traits::Hashable as _,
@@ -115,7 +115,7 @@ impl ChannelWallet {
 /// `fetch_block_deposit_events` — it is guaranteed to contain every channel
 /// deposit op of these transactions.
 pub(super) fn note_ops_from_txs(
-    transactions: &[SignedMantleTx<Unverified>],
+    transactions: &[MantleTransaction<Unverified>],
     channel_id: ChannelId,
     deposit_events: &DepositEvents,
     slot: Slot,
@@ -205,7 +205,7 @@ mod tests {
     }
 
     fn deposit_events_for(
-        tx: &SignedMantleTx<Unverified>,
+        tx: &MantleTransaction<Unverified>,
         op: &DepositOp,
         amount: Value,
         notes: Vec<DepositNote>,

--- a/zone-sdk/src/sequencer/client.rs
+++ b/zone-sdk/src/sequencer/client.rs
@@ -1,5 +1,5 @@
 use lb_core::mantle::{
-    SignedMantleTx,
+    MantleTransaction,
     channel::{SlotTimeframe, SlotTimeout},
     ops::channel::{MsgId, config::Keys, inscribe::Inscription},
     transactions::{Ops, mantle_tx::RawMantleTx, states::Unverified},
@@ -99,7 +99,7 @@ impl SequencerClient {
         posting_timeout: SlotTimeout,
         configuration_threshold: u16,
         transfer_threshold: u16,
-    ) -> Result<(PublishReceipt, SignedMantleTx<Unverified>), Error> {
+    ) -> Result<(PublishReceipt, MantleTransaction<Unverified>), Error> {
         let (response_tx, response_rx) = oneshot::channel();
         self.send(ActorRequest::ChannelConfig {
             keys,
@@ -112,12 +112,12 @@ impl SequencerClient {
         Self::recv(response_rx).await?
     }
 
-    /// Enqueue a pre-signed [`SignedMantleTx`] for posting.
+    /// Enqueue a pre-signed [`MantleTransaction`] for posting.
     ///
     /// Async counterpart of [`super::SequencerHandle::submit_signed_tx`].
     pub async fn submit_signed_tx(
         &self,
-        tx: SignedMantleTx<Unverified>,
+        tx: MantleTransaction<Unverified>,
         msg_id: MsgId,
     ) -> Result<PublishReceipt, Error> {
         let (response_tx, response_rx) = oneshot::channel();

--- a/zone-sdk/src/sequencer/handle.rs
+++ b/zone-sdk/src/sequencer/handle.rs
@@ -1,5 +1,5 @@
 use lb_core::mantle::{
-    SignedMantleTx,
+    MantleTransaction,
     channel::{SlotTimeframe, SlotTimeout},
     ops::channel::{MsgId, config::Keys, inscribe::Inscription},
     transactions::{Ops, mantle_tx::RawMantleTx, states::Unverified},
@@ -102,7 +102,7 @@ where
         self.sequencer.do_sign_tx(tx)
     }
 
-    /// Enqueue a [`SignedMantleTx`] associated with a [`MsgId`] for posting.
+    /// Enqueue a [`MantleTransaction`] associated with a [`MsgId`] for posting.
     ///
     /// Synchronously records the tx as pending and queues a
     /// `post_transaction` future onto the drive loop's in-flight pool — the
@@ -111,7 +111,7 @@ where
     /// acknowledgement.
     pub fn submit_signed_tx(
         &mut self,
-        tx: SignedMantleTx<Unverified>,
+        tx: MantleTransaction<Unverified>,
         msg_id: MsgId,
     ) -> Result<PublishReceipt, Error> {
         self.sequencer.do_submit_signed_tx(tx, msg_id)
@@ -146,7 +146,7 @@ where
         posting_timeout: SlotTimeout,
         configuration_threshold: u16,
         transfer_threshold: u16,
-    ) -> Result<(PublishReceipt, SignedMantleTx<Unverified>), Error> {
+    ) -> Result<(PublishReceipt, MantleTransaction<Unverified>), Error> {
         self.sequencer
             .do_channel_config(
                 keys,

--- a/zone-sdk/src/sequencer/state.rs
+++ b/zone-sdk/src/sequencer/state.rs
@@ -3,7 +3,7 @@ use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 use lb_core::{
     header::HeaderId,
     mantle::{
-        SignedMantleTx,
+        MantleTransaction,
         ops::{
             Op,
             channel::{ChannelId, MsgId, inscribe::Inscription},
@@ -44,7 +44,7 @@ pub struct ChannelUpdateInfo {
 /// the tx is always mineable) — such entries are never shed.
 #[derive(Debug, Clone)]
 struct PendingOtherTx {
-    signed_tx: SignedMantleTx<Unverified>,
+    signed_tx: MantleTransaction<Unverified>,
     first_parent: Option<MsgId>,
     last_msg: Option<MsgId>,
     /// True when the tx bundles an inscription with its other ops (an atomic
@@ -58,7 +58,7 @@ struct PendingOtherTx {
 }
 
 fn opaque_lineage(
-    tx: &SignedMantleTx<Unverified>,
+    tx: &MantleTransaction<Unverified>,
     channel_id: ChannelId,
 ) -> (Option<MsgId>, Option<MsgId>, bool) {
     let mut first_parent = None;
@@ -93,7 +93,7 @@ fn opaque_lineage(
 #[derive(Debug, Clone)]
 pub struct PendingInscription {
     pub tx_hash: TxHash,
-    pub signed_tx: SignedMantleTx<Unverified>,
+    pub signed_tx: MantleTransaction<Unverified>,
     pub parent_msg: MsgId,
     pub this_msg: MsgId,
     pub payload: Inscription,
@@ -151,7 +151,7 @@ pub enum BlockChannelTx {
     /// caller's own recovery logic — along with its tip-advancing entries
     /// in op order.
     Custom {
-        tx: SignedMantleTx<Unverified>,
+        tx: MantleTransaction<Unverified>,
         entries: Vec<InscriptionInfo>,
     },
 }
@@ -211,7 +211,7 @@ impl TxState {
     /// [`Self::submit_atomic_withdraw`] for inscription+withdraw bundles.
     pub fn submit_inscription(
         &mut self,
-        signed_tx: SignedMantleTx<Unverified>,
+        signed_tx: MantleTransaction<Unverified>,
         parent_msg: MsgId,
         this_msg: MsgId,
         payload: Inscription,
@@ -223,7 +223,7 @@ impl TxState {
     /// must mirror the `Op::ChannelWithdraw` ops in the bundle, in tx order.
     pub fn submit_atomic_withdraw(
         &mut self,
-        signed_tx: SignedMantleTx<Unverified>,
+        signed_tx: MantleTransaction<Unverified>,
         parent_msg: MsgId,
         this_msg: MsgId,
         payload: Inscription,
@@ -234,7 +234,7 @@ impl TxState {
 
     fn insert_pending(
         &mut self,
-        signed_tx: SignedMantleTx<Unverified>,
+        signed_tx: MantleTransaction<Unverified>,
         parent_msg: MsgId,
         this_msg: MsgId,
         payload: Inscription,
@@ -272,7 +272,7 @@ impl TxState {
     /// chain, so they never count as first-time publishes.
     pub fn observe_channel_inscription(
         &mut self,
-        signed_tx: SignedMantleTx<Unverified>,
+        signed_tx: MantleTransaction<Unverified>,
         parent_msg: MsgId,
         this_msg: MsgId,
         payload: Inscription,
@@ -320,7 +320,7 @@ impl TxState {
     /// tip-advancing op), or `None` when it carries none for this channel.
     pub fn submit_other(
         &mut self,
-        signed_tx: SignedMantleTx<Unverified>,
+        signed_tx: MantleTransaction<Unverified>,
         channel_id: ChannelId,
     ) -> Option<MsgId> {
         let tx_hash = signed_tx.mantle_tx().hash();
@@ -484,7 +484,7 @@ impl TxState {
     /// (`pending_by_parent`), opaque txs by submission order (`seq`) — a
     /// locally chained bundle can only be built after the bundle that
     /// establishes its parent tip, so submission order is dependency order.
-    pub fn pending_txs(&self, tip: HeaderId) -> Vec<(TxHash, SignedMantleTx<Unverified>)> {
+    pub fn pending_txs(&self, tip: HeaderId) -> Vec<(TxHash, MantleTransaction<Unverified>)> {
         let safe = self
             .block_states
             .get(&tip)
@@ -636,7 +636,7 @@ impl TxState {
     pub fn shed_off_branch_pending_other(
         &mut self,
         tip: HeaderId,
-    ) -> Vec<SignedMantleTx<Unverified>> {
+    ) -> Vec<MantleTransaction<Unverified>> {
         if self.pending_other.is_empty() {
             return Vec::new();
         }
@@ -737,7 +737,7 @@ impl TxState {
 
     /// All pending transactions (for checkpoint serialization).
     #[must_use]
-    pub fn all_pending_txs(&self) -> Vec<(TxHash, SignedMantleTx<Unverified>)> {
+    pub fn all_pending_txs(&self) -> Vec<(TxHash, MantleTransaction<Unverified>)> {
         let inscriptions = self
             .pending
             .iter()
@@ -754,7 +754,7 @@ impl TxState {
     }
 
     /// Remove a pending inscription and return its signed tx.
-    pub fn remove_pending(&mut self, tx_hash: &TxHash) -> Option<SignedMantleTx<Unverified>> {
+    pub fn remove_pending(&mut self, tx_hash: &TxHash) -> Option<MantleTransaction<Unverified>> {
         if let Some(removed) = self.pending.remove(tx_hash) {
             if let Some(children) = self.pending_by_parent.get_mut(&removed.parent_msg) {
                 children.retain(|h| h != tx_hash);
@@ -1187,7 +1187,7 @@ mod tests {
     use super::*;
     use crate::test_support::header_id;
 
-    fn make_dummy_tx(data: u8) -> SignedMantleTx<Unverified> {
+    fn make_dummy_tx(data: u8) -> MantleTransaction<Unverified> {
         let mantle_tx = RawMantleTx(
             [ChannelInscribe(InscriptionOp {
                 channel_id: [0u8; 32].into(),
@@ -1197,7 +1197,7 @@ mod tests {
             })]
             .into(),
         );
-        SignedMantleTx::new(mantle_tx, OpsProofs::empty())
+        MantleTransaction::new(mantle_tx, OpsProofs::empty())
     }
 
     #[test]
@@ -1388,7 +1388,7 @@ mod tests {
     }
 
     /// Build an `[inscribe(parent), config]` bundle tx for the zero channel.
-    fn bundle_tx(parent: MsgId, data: u8) -> (SignedMantleTx<Unverified>, MsgId, MsgId) {
+    fn bundle_tx(parent: MsgId, data: u8) -> (MantleTransaction<Unverified>, MsgId, MsgId) {
         use lb_core::mantle::{
             channel::{SlotTimeframe, SlotTimeout},
             ops::channel::config::{ChannelConfigOp, Keys},
@@ -1409,7 +1409,7 @@ mod tests {
         };
         let inscribe_msg = inscribe.id();
         let config_msg = config.id();
-        let tx = SignedMantleTx::new(
+        let tx = MantleTransaction::new(
             RawMantleTx([ChannelInscribe(inscribe), Op::ChannelConfig(config)].into()),
             OpsProofs::empty(),
         );
@@ -1585,7 +1585,7 @@ mod tests {
             signer: Ed25519PublicKey::from_bytes(&[0u8; 32]).unwrap(),
         };
         let inscribe_msg = inscribe.id();
-        let tx = SignedMantleTx::new(
+        let tx = MantleTransaction::new(
             RawMantleTx([Op::ChannelConfig(config), ChannelInscribe(inscribe)].into()),
             OpsProofs::empty(),
         );
@@ -1628,7 +1628,7 @@ mod tests {
             configuration_threshold: 1,
             transfer_threshold: 1,
         };
-        let cut = SignedMantleTx::new(
+        let cut = MantleTransaction::new(
             RawMantleTx([Op::ChannelConfig(config)].into()),
             OpsProofs::empty(),
         );

--- a/zone-sdk/src/sequencer/state.rs
+++ b/zone-sdk/src/sequencer/state.rs
@@ -1180,7 +1180,7 @@ impl TxState {
 mod tests {
     use lb_core::mantle::{
         Op::ChannelInscribe, RawMantleTx, ops::channel::inscribe::InscriptionOp,
-        transactions::OpsProofs,
+        transactions::OpProofs,
     };
     use lb_key_management_system_service::keys::Ed25519PublicKey;
 
@@ -1197,7 +1197,7 @@ mod tests {
             })]
             .into(),
         );
-        MantleTransaction::new(mantle_tx, OpsProofs::empty())
+        MantleTransaction::new(mantle_tx, OpProofs::empty())
     }
 
     #[test]
@@ -1411,7 +1411,7 @@ mod tests {
         let config_msg = config.id();
         let tx = MantleTransaction::new(
             RawMantleTx([ChannelInscribe(inscribe), Op::ChannelConfig(config)].into()),
-            OpsProofs::empty(),
+            OpProofs::empty(),
         );
         (tx, inscribe_msg, config_msg)
     }
@@ -1587,7 +1587,7 @@ mod tests {
         let inscribe_msg = inscribe.id();
         let tx = MantleTransaction::new(
             RawMantleTx([Op::ChannelConfig(config), ChannelInscribe(inscribe)].into()),
-            OpsProofs::empty(),
+            OpProofs::empty(),
         );
 
         let derived = state.submit_other(tx, channel_id);
@@ -1630,7 +1630,7 @@ mod tests {
         };
         let cut = MantleTransaction::new(
             RawMantleTx([Op::ChannelConfig(config)].into()),
-            OpsProofs::empty(),
+            OpProofs::empty(),
         );
         state.submit_other(cut, channel_id);
 

--- a/zone-sdk/src/sequencer/tx_builder.rs
+++ b/zone-sdk/src/sequencer/tx_builder.rs
@@ -1,6 +1,6 @@
 use lb_core::{
     mantle::{
-        SignedMantleTx, TxHash,
+        MantleTransaction, TxHash,
         channel::{ChannelState, SlotTimeframe, SlotTimeout},
         ops::{
             Op, OpProof,
@@ -169,7 +169,7 @@ pub(super) async fn create_inscribe_tx<Node>(
     signing_key: &Ed25519Key,
     inscription: Inscription,
     parent: MsgId,
-) -> Result<(SignedMantleTx<Unverified>, MsgId), Error>
+) -> Result<(MantleTransaction<Unverified>, MsgId), Error>
 where
     Node: adapter::Node + Sync,
 {
@@ -194,7 +194,7 @@ where
         transfer_proof,
     )?;
 
-    let signed_tx = SignedMantleTx::new(inscribe_tx, ops_proofs);
+    let signed_tx = MantleTransaction::new(inscribe_tx, ops_proofs);
 
     Ok((signed_tx, msg_id))
 }
@@ -219,7 +219,7 @@ pub(super) async fn create_channel_config_tx<Node>(
     posting_timeout: SlotTimeout,
     configuration_threshold: u16,
     transfer_threshold: u16,
-) -> Result<SignedMantleTx<Unverified>, Error>
+) -> Result<MantleTransaction<Unverified>, Error>
 where
     Node: adapter::Node + Sync,
 {
@@ -251,7 +251,7 @@ where
         transfer_proof,
     )?;
 
-    Ok(SignedMantleTx::new(config_tx, ops_proofs))
+    Ok(MantleTransaction::new(config_tx, ops_proofs))
 }
 
 pub(super) fn prepare_tx(

--- a/zone-sdk/src/sequencer/tx_builder.rs
+++ b/zone-sdk/src/sequencer/tx_builder.rs
@@ -12,7 +12,7 @@ use lb_core::{
         },
         traits::Hashable as _,
         transactions::{
-            MantleTxBuilder, Ops, OpsProofs,
+            MantleTxBuilder, OpProofs, Ops,
             mantle_tx::{MantleTx, RawMantleTx},
             states::Unverified,
         },
@@ -64,9 +64,9 @@ where
 /// op).
 pub(super) fn attach_transfer_proof(
     tx: &impl MantleTx,
-    mut channel_proofs: OpsProofs,
+    mut channel_proofs: OpProofs,
     transfer_proof: Option<OpProof>,
-) -> Result<OpsProofs, Error> {
+) -> Result<OpProofs, Error> {
     let transfer_count = tx
         .ops()
         .iter()
@@ -106,11 +106,11 @@ pub(super) fn build_atomic_withdraw_ops_proofs(
     own_key_index: ChannelKeyIndex,
     own_sig: Ed25519Signature,
     transfer_proof: Option<&OpProof>,
-) -> Result<OpsProofs, Error> {
+) -> Result<OpProofs, Error> {
     let withdraw_proof =
         ChannelMultiSigProof::try_new([IndexedSignature::new(own_key_index, own_sig)].into())
             .map_err(|e| Error::Network(format!("multi-sig proof assembly failed: {e:?}")))?;
-    let mut ops_proofs = OpsProofs::empty();
+    let mut ops_proofs = OpProofs::empty();
     for op in tx.ops() {
         match op {
             Op::ChannelWithdraw(_) => {

--- a/zone-sdk/src/sequencer/types.rs
+++ b/zone-sdk/src/sequencer/types.rs
@@ -6,7 +6,7 @@ use lb_core::{
     events::DepositRecreatedNotes,
     header::HeaderId,
     mantle::{
-        SignedMantleTx, Value,
+        MantleTransaction, Value,
         channel::ChannelState,
         gas::GasCost,
         ledger::{Inputs, NoteId, Outputs},
@@ -34,7 +34,7 @@ pub struct SequencerCheckpoint {
     /// Last message ID for chain continuity.
     pub last_msg_id: MsgId,
     /// Pending transactions to restore.
-    pub pending_txs: Vec<(TxHash, SignedMantleTx<Unverified>)>,
+    pub pending_txs: Vec<(TxHash, MantleTransaction<Unverified>)>,
     /// Last known LIB.
     pub lib: HeaderId,
     /// Last known LIB slot (for backfill range queries).
@@ -93,7 +93,7 @@ pub struct WithdrawArg {
 ///   internally on each publish.
 /// - [`ChannelUpdateTx::Custom`] → the `prepare_tx` + `submit_signed_tx` flow:
 ///   the SDK cannot demystify the tx, so it hands back the whole
-///   [`SignedMantleTx`] and the caller's own logic decides how to parse and
+///   [`MantleTransaction`] and the caller's own logic decides how to parse and
 ///   whether/how to rebuild it (an orphaned tx cannot be re-posted as-is — its
 ///   parent slot is consumed).
 ///   [`channel_inscriptions`](super::channel_inscriptions) extracts the tx's
@@ -106,7 +106,7 @@ pub enum ChannelUpdateTx {
     AtomicWithdraw(AtomicWithdrawInfo),
     /// A tx shape the SDK cannot produce (bundled deposits, multi-inscribe,
     /// other custom-built txs), reported whole as a unit.
-    Custom(SignedMantleTx<Unverified>),
+    Custom(MantleTransaction<Unverified>),
 }
 
 impl ChannelUpdateTx {

--- a/zone-sdk/src/sequencer/zone_sequencer.rs
+++ b/zone-sdk/src/sequencer/zone_sequencer.rs
@@ -12,7 +12,7 @@ use lb_common_http_client::{ProcessedBlockEvent, Slot};
 use lb_core::{
     header::HeaderId,
     mantle::{
-        Op, SignedMantleTx,
+        MantleTransaction, Op,
         channel::{ChannelState, SlotTimeframe, SlotTimeout},
         ops::channel::{ChannelId, MsgId, config::Keys, inscribe::Inscription},
         traits::Hashable as _,
@@ -171,10 +171,11 @@ pub(super) enum ActorRequest {
         posting_timeout: SlotTimeout,
         configuration_threshold: u16,
         transfer_threshold: u16,
-        response_tx: oneshot::Sender<Result<(PublishReceipt, SignedMantleTx<Unverified>), Error>>,
+        response_tx:
+            oneshot::Sender<Result<(PublishReceipt, MantleTransaction<Unverified>), Error>>,
     },
     SubmitSignedTx {
-        tx: SignedMantleTx<Unverified>,
+        tx: MantleTransaction<Unverified>,
         msg_id: MsgId,
         response_tx: oneshot::Sender<Result<PublishReceipt, Error>>,
     },
@@ -779,7 +780,7 @@ where
     // build_sign_tx(tx.hash(), &self.signing_key);         let ops_proofs =
     //             build_atomic_withdraw_ops_proofs(&tx, own_key_index, own_sig,
     // transfer_proof.as_ref())?;         let signed_tx =
-    // SignedMantleTx::new(tx, ops_proofs)             .map_err(|e|
+    // MantleTransaction::new(tx, ops_proofs)             .map_err(|e|
     // Error::Network(format!("signed tx assembly failed: {e:?}")))?;
     //
     //         let tx_hash = signed_tx.mantle_tx.hash();
@@ -834,7 +835,7 @@ where
         posting_timeout: SlotTimeout,
         configuration_threshold: u16,
         transfer_threshold: u16,
-    ) -> Result<(PublishReceipt, SignedMantleTx<Unverified>), Error> {
+    ) -> Result<(PublishReceipt, MantleTransaction<Unverified>), Error> {
         self.ensure_ready()?;
         self.ensure_fundable()?;
 
@@ -913,7 +914,7 @@ where
 
     pub(super) fn do_submit_signed_tx(
         &mut self,
-        tx: SignedMantleTx<Unverified>,
+        tx: MantleTransaction<Unverified>,
         msg_id: MsgId,
     ) -> Result<PublishReceipt, Error> {
         self.ensure_ready()?;
@@ -1032,7 +1033,7 @@ where
     pub(super) fn queue_publish_post(
         &mut self,
         tx_hash: TxHash,
-        signed_tx: SignedMantleTx<Unverified>,
+        signed_tx: MantleTransaction<Unverified>,
     ) {
         self.posting.insert(tx_hash);
         self.in_flight.push(Box::pin(post_batch(
@@ -1047,7 +1048,7 @@ where
     /// `resubmit_pending` does this gate.
     pub(super) fn queue_resubmit_batch(
         &mut self,
-        batch: Vec<(TxHash, SignedMantleTx<Unverified>)>,
+        batch: Vec<(TxHash, MantleTransaction<Unverified>)>,
     ) {
         if batch.is_empty() {
             return;
@@ -1068,7 +1069,7 @@ where
 
 async fn post_batch<Node>(
     node: Node,
-    batch: Vec<(TxHash, SignedMantleTx<Unverified>)>,
+    batch: Vec<(TxHash, MantleTransaction<Unverified>)>,
 ) -> Vec<(TxHash, bool)>
 where
     Node: adapter::Node + Clone + Send + Sync + 'static,
@@ -1121,7 +1122,7 @@ pub(super) fn build_checkpoint(
 }
 
 fn restored_pending_channel_tip(
-    pending_txs: &[(TxHash, SignedMantleTx<Unverified>)],
+    pending_txs: &[(TxHash, MantleTransaction<Unverified>)],
     channel_id: ChannelId,
 ) -> Option<MsgId> {
     let mut parents = Vec::new();
@@ -1149,7 +1150,7 @@ fn restored_pending_channel_tip(
 /// tip-advancing op), or `None` when the tx carries none for this channel.
 pub(super) fn track_pending_tx(
     state: &mut TxState,
-    tx: SignedMantleTx<Unverified>,
+    tx: MantleTransaction<Unverified>,
     channel_id: ChannelId,
 ) -> Option<MsgId> {
     match classify_channel_tx(&tx, channel_id, &mut None) {

--- a/zone-sdk/src/test_support.rs
+++ b/zone-sdk/src/test_support.rs
@@ -28,7 +28,7 @@ use lb_core::{
             },
         },
         traits::Hashable as _,
-        transactions::{Ops, OpsProofs, states::Unverified},
+        transactions::{OpProofs, Ops, states::Unverified},
     },
     proofs::leader_proof::Groth16LeaderProof,
 };
@@ -404,7 +404,7 @@ pub fn unverified_tx_with_ops(ops: Vec<Op>) -> MantleTransaction<Unverified> {
     let mantle_tx = RawMantleTx(Ops::try_from(ops).expect("ops fit"));
     MantleTransaction::new(
         mantle_tx,
-        OpsProofs::new_unchecked(vec![OpProof::Ed25519Sig(Ed25519Signature::zero()); n]),
+        OpProofs::new_unchecked(vec![OpProof::Ed25519Sig(Ed25519Signature::zero()); n]),
     )
 }
 

--- a/zone-sdk/src/test_support.rs
+++ b/zone-sdk/src/test_support.rs
@@ -15,7 +15,7 @@ use lb_core::{
     events::{DepositNote, Event as ChainEvent, TxEvent, TxEventPayload},
     header::{ContentId, HeaderId},
     mantle::{
-        Op, RawMantleTx, SignedMantleTx, Value,
+        MantleTransaction, Op, RawMantleTx, Value,
         channel::ChannelState,
         gas::GasCost,
         ops::{
@@ -98,7 +98,7 @@ pub struct MockNode {
     /// the next `true -> false` transition, driving the reconnect path.
     pub up: Option<watch::Receiver<bool>>,
     /// Receives every `post_transaction` tx.
-    pub posted: Option<mpsc::Sender<SignedMantleTx<Unverified>>>,
+    pub posted: Option<mpsc::Sender<MantleTransaction<Unverified>>>,
     /// Served by `block_events()`, keyed by block id; absent ids yield `None`.
     pub events: HashMap<HeaderId, Events>,
     /// Receives the priority-fee percentages from funding requests.
@@ -133,7 +133,7 @@ impl Default for MockNode {
 
 impl MockNode {
     /// Default node plus a receiver for its posted transactions.
-    pub fn with_posted_channel() -> (Self, mpsc::Receiver<SignedMantleTx<Unverified>>) {
+    pub fn with_posted_channel() -> (Self, mpsc::Receiver<MantleTransaction<Unverified>>) {
         let (tx, rx) = mpsc::channel(10);
         (
             Self {
@@ -303,7 +303,7 @@ impl adapter::Node for MockNode {
 
     async fn post_transaction(
         &self,
-        tx: SignedMantleTx<Unverified>,
+        tx: MantleTransaction<Unverified>,
     ) -> Result<(), lb_common_http_client::Error> {
         if let Some(posted) = &self.posted {
             posted.send(tx).await.expect("posted receiver alive");
@@ -370,7 +370,7 @@ pub fn api_block(
     id: u8,
     parent: u8,
     slot: u64,
-    transactions: Vec<SignedMantleTx<Unverified>>,
+    transactions: Vec<MantleTransaction<Unverified>>,
 ) -> ApiBlock {
     ApiBlock {
         header: ApiHeader {
@@ -397,12 +397,12 @@ pub fn live_event(block: &ApiBlock) -> ProcessedBlockEvent {
     }
 }
 
-/// Build a `SignedMantleTx` carrying the given ops, with placeholder proofs.
+/// Build a `MantleTransaction` carrying the given ops, with placeholder proofs.
 /// Suitable for tests that only care about op extraction, not verification.
-pub fn unverified_tx_with_ops(ops: Vec<Op>) -> SignedMantleTx<Unverified> {
+pub fn unverified_tx_with_ops(ops: Vec<Op>) -> MantleTransaction<Unverified> {
     let n = ops.len();
     let mantle_tx = RawMantleTx(Ops::try_from(ops).expect("ops fit"));
-    SignedMantleTx::new(
+    MantleTransaction::new(
         mantle_tx,
         OpsProofs::new_unchecked(vec![OpProof::Ed25519Sig(Ed25519Signature::zero()); n]),
     )
@@ -420,7 +420,7 @@ pub fn inscribe_op(channel_id: ChannelId, parent: MsgId, payload: &[u8]) -> Insc
 
 /// A `Deposit` block event matching `op` inside `tx`, recreating `notes`.
 pub fn deposit_event(
-    tx: &SignedMantleTx<Unverified>,
+    tx: &MantleTransaction<Unverified>,
     op: &DepositOp,
     amount: Value,
     notes: Vec<DepositNote>,


### PR DESCRIPTION
> [!IMPORTANT]
> Review-only PR. Do not merge independently. The complete implementation is [#3383](https://github.com/logos-blockchain/
logos-blockchain/pull/3383).

## Changes
- Move lifecycle traits from raw operations onto `SignedOperation`, binding behaviour to its proof and typestate.
- Replace separate proof arguments with explicit `Unverified -> Preverified -> Verified` transitions.
- Preserve signed-operation ownership on verification and execution failures.
- Add a trusted state transition for genesis and tests.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>