### PR TITLE
feat: add fee horizon to wallet funding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -265,7 +265,7 @@ serde                 = { default-features = false, version = "1.0" }
 serde-big-array       = { default-features = false, version = "0.5" }
 serde_arrays          = { default-features = false, version = "0.2.0" }
 serde_ignored         = { default-features = false, version = "0.1" }
-serde_json            = { default-features = false, features = ["raw_value"], version = "1.0" }
+serde_json            = { default-features = false, version = "1.0" }
 serde_urlencoded      = { default-features = false, version = "0.7.1" }
 serde_with            = { default-features = false, version = "3.14.0" }
 serde_yaml            = { default-features = false, version = "0.9.33" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -265,7 +265,7 @@ serde                 = { default-features = false, version = "1.0" }
 serde-big-array       = { default-features = false, version = "0.5" }
 serde_arrays          = { default-features = false, version = "0.2.0" }
 serde_ignored         = { default-features = false, version = "0.1" }
-serde_json            = { default-features = false, version = "1.0" }
+serde_json            = { default-features = false, features = ["raw_value"], version = "1.0" }
 serde_urlencoded      = { default-features = false, version = "0.7.1" }
 serde_with            = { default-features = false, version = "3.14.0" }
 serde_yaml            = { default-features = false, version = "0.9.33" }

--- a/c-bindings/src/api/wallet.rs
+++ b/c-bindings/src/api/wallet.rs
@@ -964,12 +964,14 @@ pub(crate) fn channel_deposit_with_notes_sync(
             tip: funded_tip,
             response: funded_tx_builder,
         } = api
-            .fund_tx(
+            .fund_tx_with_policy(
                 Some(tip),
                 tx_builder,
                 change_public_key,
                 funding_public_keys,
                 0,
+                None,
+                Some(max_tx_fee),
             )
             .await
             .map_err(|error| {
@@ -1466,12 +1468,14 @@ pub(crate) fn wallet_fund_tx_sync(
             tip,
             response: funded_tx_builder,
         } = api
-            .fund_tx(
+            .fund_tx_with_policy(
                 request.tip,
                 request.tx_builder,
                 request.change_public_key,
                 request.funding_public_keys,
                 request.priority_fee_percent,
+                request.fee_horizon_hours,
+                Some(request.max_tx_fee),
             )
             .await
             .map_err(|error| {
@@ -1548,14 +1552,15 @@ pub type FfiWalletFundResult = FfiStatusResult<*mut c_char>;
 /// The request and response are JSON strings with the exact same schemas as
 /// the node's `POST /wallet/fund` HTTP request and response bodies. The
 /// optional `priority_fee_percent` field (default 0) is interpreted as a
-/// percentage of the final mandatory fee, including execution and storage
-/// cost. The rounded-up percentage is reserved as excess balance above that
-/// fee; only the unused reserve is paid to the block producer as the effective
-/// priority tip. The Zone SDK and TUI default to 12%, a practical reserve
-/// intended to absorb normal fee movement, including approximately one
-/// storage-market epoch increase at normal price levels. This is not a
-/// protocol guarantee at very low prices or when execution fees also rise
-/// materially; integer storage-price arithmetic can make 1 become 2.
+/// percentage of the mandatory fee at preparation-time prices, including
+/// execution and storage cost. Its rounded-up amount is an absolute priority
+/// reserve and is not reapplied to future prices. The optional
+/// `fee_horizon_hours` field independently adds deterministic storage-market
+/// coverage through the protocol slot ticker. An omitted horizon defaults to
+/// one hour; `null` or `0.0` disables it. The default policy is therefore 0%
+/// explicit priority reserve plus one hour of storage coverage. Unused horizon
+/// reserve is effective tip immediately and is consumed as mandatory storage
+/// fees rise.
 ///
 /// # Arguments
 ///

--- a/core/src/mantle/gas.rs
+++ b/core/src/mantle/gas.rs
@@ -1,9 +1,9 @@
 use std::{
-    fmt::{self, Display},
+    fmt::{self, Display, Formatter},
     ops::Add,
 };
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer, de::Visitor};
 
 use crate::mantle::Value;
 
@@ -65,6 +65,228 @@ impl From<Value> for GasPrice {
     }
 }
 
+/// Maximum upward storage-price transition applied at an epoch boundary.
+pub const STORAGE_PRICE_MAX_INCREASE_NUMERATOR: u128 = 9;
+pub const STORAGE_PRICE_MAX_INCREASE_DENOMINATOR: u128 = 8;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FeeHorizonParseError {
+    NonNegative,
+    InvalidDecimal,
+    ExceedsMaximum,
+    NonFinite,
+    ExpectedInput,
+}
+
+impl Display for FeeHorizonParseError {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::NonNegative => "fee_horizon_hours must be non-negative",
+            Self::InvalidDecimal => "fee_horizon_hours must be a plain decimal number",
+            Self::ExceedsMaximum => {
+                "fee_horizon_hours exceeds the supported maximum of 168 hours (7 days)"
+            }
+            Self::NonFinite => "fee_horizon_hours must be finite",
+            Self::ExpectedInput => {
+                "a non-negative decimal number of hours rounded up to 0.1 hour, with a maximum of 168 hours (7 days)"
+            }
+        })
+    }
+}
+
+impl std::error::Error for FeeHorizonParseError {}
+
+/// Applies the protocol's maximum upward storage-price transition with checked
+/// arithmetic and rounding at this boundary.
+pub fn max_storage_price_after_epoch(price: GasPrice) -> Result<GasPrice, GasOverflow> {
+    let projected = u128::from(price.into_inner())
+        .checked_mul(STORAGE_PRICE_MAX_INCREASE_NUMERATOR)
+        .ok_or(GasOverflow)?
+        .div_ceil(STORAGE_PRICE_MAX_INCREASE_DENOMINATOR);
+    Value::try_from(projected)
+        .map(GasPrice::new)
+        .map_err(|_| GasOverflow)
+}
+
+/// A non-negative duration in hours stored internally in tenths of an hour.
+///
+/// User-facing decimal values are rounded up to the next 0.1 hour so funded
+/// coverage is never shorter than requested. The maximum supported horizon is
+/// 168 hours (7 days); larger values are rejected.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Ord, PartialOrd)]
+pub struct FeeHorizonHours {
+    tenths: u16,
+}
+
+impl FeeHorizonHours {
+    pub const MAX_TENTHS: u16 = 1_680;
+
+    #[must_use]
+    pub const fn from_tenths(tenths: u16) -> Self {
+        Self { tenths }
+    }
+
+    #[must_use]
+    pub const fn tenths(self) -> u16 {
+        self.tenths
+    }
+
+    fn parse_decimal(value: &str) -> Result<Self, FeeHorizonParseError> {
+        if value.starts_with('-') {
+            return Err(FeeHorizonParseError::NonNegative);
+        }
+        if value.is_empty() {
+            return Err(FeeHorizonParseError::InvalidDecimal);
+        }
+
+        let (whole, fraction) = value
+            .split_once('.')
+            .map_or((value, None), |(whole, fraction)| (whole, Some(fraction)));
+        if whole.is_empty() || !whole.bytes().all(|byte| byte.is_ascii_digit()) {
+            return Err(FeeHorizonParseError::InvalidDecimal);
+        }
+        if let Some(fraction) = fraction
+            && (fraction.is_empty() || !fraction.bytes().all(|byte| byte.is_ascii_digit()))
+        {
+            return Err(FeeHorizonParseError::InvalidDecimal);
+        }
+
+        let whole = whole
+            .parse::<u128>()
+            .map_err(|_| FeeHorizonParseError::ExceedsMaximum)?;
+        let first_fractional_digit = fraction
+            .and_then(|fraction| fraction.as_bytes().first().copied())
+            .map_or(0, |digit| u128::from(digit - b'0'));
+        let fractional_remainder_is_nonzero = fraction
+            .is_some_and(|fraction| fraction.as_bytes()[1..].iter().any(|&digit| digit != b'0'));
+
+        let tenths = whole
+            .checked_mul(10)
+            .and_then(|value| value.checked_add(first_fractional_digit))
+            .and_then(|value| {
+                if fractional_remainder_is_nonzero {
+                    value.checked_add(1)
+                } else {
+                    Some(value)
+                }
+            })
+            .ok_or(FeeHorizonParseError::ExceedsMaximum)?;
+        if tenths > u128::from(Self::MAX_TENTHS) {
+            return Err(FeeHorizonParseError::ExceedsMaximum);
+        }
+        Ok(Self::from_tenths(tenths as u16))
+    }
+}
+
+impl std::str::FromStr for FeeHorizonHours {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Self::parse_decimal(value).map_err(|error| error.to_string())
+    }
+}
+
+impl Serialize for FeeHorizonHours {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_f64(f64::from(self.tenths) / 10.0)
+    }
+}
+
+impl<'de> Deserialize<'de> for FeeHorizonHours {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct FeeHorizonHoursVisitor;
+
+        impl Visitor<'_> for FeeHorizonHoursVisitor {
+            type Value = FeeHorizonHours;
+
+            fn expecting(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+                FeeHorizonParseError::ExpectedInput.fmt(formatter)
+            }
+
+            fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                let tenths = value
+                    .checked_mul(10)
+                    .ok_or(FeeHorizonParseError::ExceedsMaximum)
+                    .map_err(E::custom)?;
+                if tenths > u64::from(FeeHorizonHours::MAX_TENTHS) {
+                    return Err(E::custom(FeeHorizonParseError::ExceedsMaximum));
+                }
+                Ok(FeeHorizonHours::from_tenths(tenths as u16))
+            }
+
+            fn visit_i64<E>(self, value: i64) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                if value < 0 {
+                    return Err(E::custom(FeeHorizonParseError::NonNegative));
+                }
+                self.visit_u64(value as u64)
+            }
+
+            fn visit_u128<E>(self, value: u128) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                let tenths = value
+                    .checked_mul(10)
+                    .ok_or(FeeHorizonParseError::ExceedsMaximum)
+                    .map_err(E::custom)?;
+                if tenths > u128::from(FeeHorizonHours::MAX_TENTHS) {
+                    return Err(E::custom(FeeHorizonParseError::ExceedsMaximum));
+                }
+                Ok(FeeHorizonHours::from_tenths(tenths as u16))
+            }
+
+            fn visit_i128<E>(self, value: i128) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                if value < 0 {
+                    return Err(E::custom(FeeHorizonParseError::NonNegative));
+                }
+                self.visit_u128(value as u128)
+            }
+
+            fn visit_f64<E>(self, value: f64) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                if !value.is_finite() {
+                    return Err(E::custom(FeeHorizonParseError::NonFinite));
+                }
+                if value.is_sign_negative() {
+                    return Err(E::custom(FeeHorizonParseError::NonNegative));
+                }
+
+                let normalized = (value * 10.0).ceil();
+                if !normalized.is_finite() || normalized > f64::from(FeeHorizonHours::MAX_TENTHS) {
+                    return Err(E::custom(FeeHorizonParseError::ExceedsMaximum));
+                }
+                Ok(FeeHorizonHours::from_tenths(normalized as u16))
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                FeeHorizonHours::parse_decimal(value).map_err(E::custom)
+            }
+        }
+
+        deserializer.deserialize_any(FeeHorizonHoursVisitor)
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct GasCost(Value);
 
@@ -102,7 +324,7 @@ impl From<Value> for GasCost {
 }
 
 impl Display for GasCost {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         self.0.fmt(f)
     }
 }
@@ -154,5 +376,199 @@ pub trait SignedOperationExecutionGas {
         Self: OperationGas<Profile>,
     {
         Self::GAS_COST.checked_mul(self.gas_multiplier())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maximum_storage_transition_rounds_at_each_boundary() {
+        assert_eq!(
+            max_storage_price_after_epoch(GasPrice::new(1)),
+            Ok(GasPrice::new(2))
+        );
+        assert_eq!(
+            max_storage_price_after_epoch(GasPrice::new(9)),
+            Ok(GasPrice::new(11))
+        );
+    }
+
+    #[test]
+    fn fee_horizon_hours_decimal_input_rounds_up_to_tenths() {
+        let cases = [
+            ("0", 0),
+            ("0.01", 1),
+            ("0.0000", 0),
+            ("0.09", 1),
+            ("0.1", 1),
+            ("0.10", 1),
+            ("0.1000", 1),
+            ("0.1001", 2),
+            ("0.11", 2),
+            ("0.25", 3),
+            ("1.01", 11),
+            ("1", 10),
+            ("1.0", 10),
+            ("1.00000", 10),
+            ("1.5", 15),
+            ("1.50", 15),
+            ("1.5000", 15),
+            ("1.5001", 16),
+            ("1.50001", 16),
+            ("1.999", 20),
+            ("167.999", 1_680),
+            ("168", 1_680),
+            ("168.0", 1_680),
+            ("168.00000", 1_680),
+        ];
+
+        for (input, expected_tenths) in cases {
+            assert_eq!(
+                input.parse::<FeeHorizonHours>().unwrap().tenths(),
+                expected_tenths,
+                "input: {input}"
+            );
+        }
+        for input in ["", "-0.1", ".1", "1.", "1.2.3", "1e2", "alphabetic"] {
+            assert!(
+                input.parse::<FeeHorizonHours>().is_err(),
+                "input should be rejected: {input}"
+            );
+        }
+        for input in ["168.00001", "168.1", "169", "1000"] {
+            assert_eq!(
+                input.parse::<FeeHorizonHours>().unwrap_err(),
+                FeeHorizonParseError::ExceedsMaximum.to_string(),
+                "input: {input}"
+            );
+        }
+    }
+
+    #[test]
+    fn fee_horizon_hours_deserializer_covers_all_visitor_paths() {
+        use serde::de::{IntoDeserializer, value};
+
+        fn deserialize_value<T>(input: T) -> Result<FeeHorizonHours, value::Error>
+        where
+            T: IntoDeserializer<'static, value::Error>,
+        {
+            FeeHorizonHours::deserialize(input.into_deserializer())
+        }
+
+        let valid_cases = [
+            (deserialize_value(1u64), 10),
+            (deserialize_value(1i64), 10),
+            (deserialize_value(1u128), 10),
+            (deserialize_value(1i128), 10),
+            (deserialize_value(0.25f64), 3),
+            (deserialize_value("0.25".to_owned()), 3),
+        ];
+        for (result, expected_tenths) in valid_cases {
+            assert_eq!(result.unwrap().tenths(), expected_tenths);
+        }
+
+        for (input, expected_tenths) in [
+            ("0.01", 1),
+            ("0.25", 3),
+            ("1", 10),
+            ("1.0", 10),
+            ("1.00000", 10),
+            ("1.5001", 16),
+            ("167.999", 1_680),
+            ("168.0", 1_680),
+        ] {
+            assert_eq!(
+                serde_json::from_str::<FeeHorizonHours>(input)
+                    .unwrap()
+                    .tenths(),
+                expected_tenths,
+                "input: {input}"
+            );
+        }
+
+        let error_cases = [
+            (
+                deserialize_value(-1i64).unwrap_err().to_string(),
+                FeeHorizonParseError::NonNegative.to_string(),
+            ),
+            (
+                deserialize_value(-1i128).unwrap_err().to_string(),
+                FeeHorizonParseError::NonNegative.to_string(),
+            ),
+            (
+                deserialize_value(-0.1f64).unwrap_err().to_string(),
+                FeeHorizonParseError::NonNegative.to_string(),
+            ),
+            (
+                deserialize_value(f64::INFINITY).unwrap_err().to_string(),
+                FeeHorizonParseError::NonFinite.to_string(),
+            ),
+            (
+                deserialize_value(f64::NAN).unwrap_err().to_string(),
+                FeeHorizonParseError::NonFinite.to_string(),
+            ),
+            (
+                deserialize_value(f64::MAX).unwrap_err().to_string(),
+                FeeHorizonParseError::ExceedsMaximum.to_string(),
+            ),
+            (
+                deserialize_value(168.1f64).unwrap_err().to_string(),
+                FeeHorizonParseError::ExceedsMaximum.to_string(),
+            ),
+            (
+                deserialize_value(u64::MAX).unwrap_err().to_string(),
+                FeeHorizonParseError::ExceedsMaximum.to_string(),
+            ),
+            (
+                deserialize_value(169u64).unwrap_err().to_string(),
+                FeeHorizonParseError::ExceedsMaximum.to_string(),
+            ),
+            (
+                deserialize_value(u128::MAX).unwrap_err().to_string(),
+                FeeHorizonParseError::ExceedsMaximum.to_string(),
+            ),
+            (
+                deserialize_value(169u128).unwrap_err().to_string(),
+                FeeHorizonParseError::ExceedsMaximum.to_string(),
+            ),
+            (
+                deserialize_value("1e2".to_owned()).unwrap_err().to_string(),
+                FeeHorizonParseError::InvalidDecimal.to_string(),
+            ),
+        ];
+        for (error, expected_message) in error_cases {
+            assert!(
+                error.contains(&expected_message),
+                "expected {expected_message:?} in {error:?}"
+            );
+        }
+
+        for input in ["-0.1", "168.00001", "169"] {
+            assert!(
+                serde_json::from_str::<FeeHorizonHours>(input).is_err(),
+                "input should be rejected: {input}"
+            );
+        }
+
+        let expecting = deserialize_value(true).unwrap_err().to_string();
+        assert!(expecting.contains(&FeeHorizonParseError::ExpectedInput.to_string()));
+    }
+
+    #[test]
+    fn fee_horizon_hours_serializes_normalized_values_canonically() {
+        assert_eq!(
+            serde_json::to_string(&FeeHorizonHours::from_tenths(0)).unwrap(),
+            "0.0"
+        );
+        assert_eq!(
+            serde_json::to_string(&FeeHorizonHours::from_tenths(3)).unwrap(),
+            "0.3"
+        );
+        assert_eq!(
+            serde_json::to_string(&FeeHorizonHours::from_tenths(15)).unwrap(),
+            "1.5"
+        );
     }
 }

--- a/core/src/mantle/gas.rs
+++ b/core/src/mantle/gas.rs
@@ -3,7 +3,8 @@ use std::{
     ops::Add,
 };
 
-use serde::{Deserialize, Deserializer, Serialize, Serializer, de::Visitor};
+use serde::{Deserialize, Serialize, Serializer};
+use thiserror::Error;
 
 use crate::mantle::Value;
 
@@ -69,32 +70,15 @@ impl From<Value> for GasPrice {
 pub const STORAGE_PRICE_MAX_INCREASE_NUMERATOR: u128 = 9;
 pub const STORAGE_PRICE_MAX_INCREASE_DENOMINATOR: u128 = 8;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
 enum FeeHorizonParseError {
+    #[error("fee_horizon_hours must be non-negative")]
     NonNegative,
+    #[error("fee_horizon_hours must be a plain decimal number")]
     InvalidDecimal,
+    #[error("fee_horizon_hours exceeds the supported maximum of 168 hours (7 days)")]
     ExceedsMaximum,
-    NonFinite,
-    ExpectedInput,
 }
-
-impl Display for FeeHorizonParseError {
-    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
-        formatter.write_str(match self {
-            Self::NonNegative => "fee_horizon_hours must be non-negative",
-            Self::InvalidDecimal => "fee_horizon_hours must be a plain decimal number",
-            Self::ExceedsMaximum => {
-                "fee_horizon_hours exceeds the supported maximum of 168 hours (7 days)"
-            }
-            Self::NonFinite => "fee_horizon_hours must be finite",
-            Self::ExpectedInput => {
-                "a non-negative decimal number of hours rounded up to 0.1 hour, with a maximum of 168 hours (7 days)"
-            }
-        })
-    }
-}
-
-impl std::error::Error for FeeHorizonParseError {}
 
 /// Applies the protocol's maximum upward storage-price transition with checked
 /// arithmetic and rounding at this boundary.
@@ -108,7 +92,12 @@ pub fn max_storage_price_after_epoch(price: GasPrice) -> Result<GasPrice, GasOve
         .map_err(|_| GasOverflow)
 }
 
-/// A non-negative duration in hours stored internally in tenths of an hour.
+/// A non-negative, deployment-independent duration in hours stored internally
+/// in tenths of an hour.
+///
+/// The wallet resolves this elapsed-time policy to protocol slots using the
+/// deployment's configured slot duration; tenths are only the normalized
+/// representation of the public 0.1-hour precision.
 ///
 /// User-facing decimal values are rounded up to the next 0.1 hour so funded
 /// coverage is never shorter than requested. The maximum supported horizon is
@@ -192,98 +181,6 @@ impl Serialize for FeeHorizonHours {
         S: Serializer,
     {
         serializer.serialize_f64(f64::from(self.tenths) / 10.0)
-    }
-}
-
-impl<'de> Deserialize<'de> for FeeHorizonHours {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        struct FeeHorizonHoursVisitor;
-
-        impl Visitor<'_> for FeeHorizonHoursVisitor {
-            type Value = FeeHorizonHours;
-
-            fn expecting(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
-                FeeHorizonParseError::ExpectedInput.fmt(formatter)
-            }
-
-            fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E>
-            where
-                E: serde::de::Error,
-            {
-                let tenths = value
-                    .checked_mul(10)
-                    .ok_or(FeeHorizonParseError::ExceedsMaximum)
-                    .map_err(E::custom)?;
-                if tenths > u64::from(FeeHorizonHours::MAX_TENTHS) {
-                    return Err(E::custom(FeeHorizonParseError::ExceedsMaximum));
-                }
-                Ok(FeeHorizonHours::from_tenths(tenths as u16))
-            }
-
-            fn visit_i64<E>(self, value: i64) -> Result<Self::Value, E>
-            where
-                E: serde::de::Error,
-            {
-                if value < 0 {
-                    return Err(E::custom(FeeHorizonParseError::NonNegative));
-                }
-                self.visit_u64(value as u64)
-            }
-
-            fn visit_u128<E>(self, value: u128) -> Result<Self::Value, E>
-            where
-                E: serde::de::Error,
-            {
-                let tenths = value
-                    .checked_mul(10)
-                    .ok_or(FeeHorizonParseError::ExceedsMaximum)
-                    .map_err(E::custom)?;
-                if tenths > u128::from(FeeHorizonHours::MAX_TENTHS) {
-                    return Err(E::custom(FeeHorizonParseError::ExceedsMaximum));
-                }
-                Ok(FeeHorizonHours::from_tenths(tenths as u16))
-            }
-
-            fn visit_i128<E>(self, value: i128) -> Result<Self::Value, E>
-            where
-                E: serde::de::Error,
-            {
-                if value < 0 {
-                    return Err(E::custom(FeeHorizonParseError::NonNegative));
-                }
-                self.visit_u128(value as u128)
-            }
-
-            fn visit_f64<E>(self, value: f64) -> Result<Self::Value, E>
-            where
-                E: serde::de::Error,
-            {
-                if !value.is_finite() {
-                    return Err(E::custom(FeeHorizonParseError::NonFinite));
-                }
-                if value.is_sign_negative() {
-                    return Err(E::custom(FeeHorizonParseError::NonNegative));
-                }
-
-                let normalized = (value * 10.0).ceil();
-                if !normalized.is_finite() || normalized > f64::from(FeeHorizonHours::MAX_TENTHS) {
-                    return Err(E::custom(FeeHorizonParseError::ExceedsMaximum));
-                }
-                Ok(FeeHorizonHours::from_tenths(normalized as u16))
-            }
-
-            fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
-            where
-                E: serde::de::Error,
-            {
-                FeeHorizonHours::parse_decimal(value).map_err(E::custom)
-            }
-        }
-
-        deserializer.deserialize_any(FeeHorizonHoursVisitor)
     }
 }
 
@@ -444,116 +341,6 @@ mod tests {
                 "input: {input}"
             );
         }
-    }
-
-    #[test]
-    fn fee_horizon_hours_deserializer_covers_all_visitor_paths() {
-        use serde::de::{IntoDeserializer, value};
-
-        fn deserialize_value<T>(input: T) -> Result<FeeHorizonHours, value::Error>
-        where
-            T: IntoDeserializer<'static, value::Error>,
-        {
-            FeeHorizonHours::deserialize(input.into_deserializer())
-        }
-
-        let valid_cases = [
-            (deserialize_value(1u64), 10),
-            (deserialize_value(1i64), 10),
-            (deserialize_value(1u128), 10),
-            (deserialize_value(1i128), 10),
-            (deserialize_value(0.25f64), 3),
-            (deserialize_value("0.25".to_owned()), 3),
-        ];
-        for (result, expected_tenths) in valid_cases {
-            assert_eq!(result.unwrap().tenths(), expected_tenths);
-        }
-
-        for (input, expected_tenths) in [
-            ("0.01", 1),
-            ("0.25", 3),
-            ("1", 10),
-            ("1.0", 10),
-            ("1.00000", 10),
-            ("1.5001", 16),
-            ("167.999", 1_680),
-            ("168.0", 1_680),
-        ] {
-            assert_eq!(
-                serde_json::from_str::<FeeHorizonHours>(input)
-                    .unwrap()
-                    .tenths(),
-                expected_tenths,
-                "input: {input}"
-            );
-        }
-
-        let error_cases = [
-            (
-                deserialize_value(-1i64).unwrap_err().to_string(),
-                FeeHorizonParseError::NonNegative.to_string(),
-            ),
-            (
-                deserialize_value(-1i128).unwrap_err().to_string(),
-                FeeHorizonParseError::NonNegative.to_string(),
-            ),
-            (
-                deserialize_value(-0.1f64).unwrap_err().to_string(),
-                FeeHorizonParseError::NonNegative.to_string(),
-            ),
-            (
-                deserialize_value(f64::INFINITY).unwrap_err().to_string(),
-                FeeHorizonParseError::NonFinite.to_string(),
-            ),
-            (
-                deserialize_value(f64::NAN).unwrap_err().to_string(),
-                FeeHorizonParseError::NonFinite.to_string(),
-            ),
-            (
-                deserialize_value(f64::MAX).unwrap_err().to_string(),
-                FeeHorizonParseError::ExceedsMaximum.to_string(),
-            ),
-            (
-                deserialize_value(168.1f64).unwrap_err().to_string(),
-                FeeHorizonParseError::ExceedsMaximum.to_string(),
-            ),
-            (
-                deserialize_value(u64::MAX).unwrap_err().to_string(),
-                FeeHorizonParseError::ExceedsMaximum.to_string(),
-            ),
-            (
-                deserialize_value(169u64).unwrap_err().to_string(),
-                FeeHorizonParseError::ExceedsMaximum.to_string(),
-            ),
-            (
-                deserialize_value(u128::MAX).unwrap_err().to_string(),
-                FeeHorizonParseError::ExceedsMaximum.to_string(),
-            ),
-            (
-                deserialize_value(169u128).unwrap_err().to_string(),
-                FeeHorizonParseError::ExceedsMaximum.to_string(),
-            ),
-            (
-                deserialize_value("1e2".to_owned()).unwrap_err().to_string(),
-                FeeHorizonParseError::InvalidDecimal.to_string(),
-            ),
-        ];
-        for (error, expected_message) in error_cases {
-            assert!(
-                error.contains(&expected_message),
-                "expected {expected_message:?} in {error:?}"
-            );
-        }
-
-        for input in ["-0.1", "168.00001", "169"] {
-            assert!(
-                serde_json::from_str::<FeeHorizonHours>(input).is_err(),
-                "input should be rejected: {input}"
-            );
-        }
-
-        let expecting = deserialize_value(true).unwrap_err().to_string();
-        assert!(expecting.contains(&FeeHorizonParseError::ExpectedInput.to_string()));
     }
 
     #[test]

--- a/core/src/mantle/transactions/builder.rs
+++ b/core/src/mantle/transactions/builder.rs
@@ -244,6 +244,13 @@ impl MantleTxBuilder {
         Ok(self.net_balance() - i128::from(self.minimum_gas_cost::<G>(context)?.into_inner()))
     }
 
+    pub fn funding_delta_to_required_fee(
+        &self,
+        required_fee: GasCost,
+    ) -> Result<i128, TxBuilderError> {
+        Ok(self.net_balance() - i128::from(required_fee.into_inner()))
+    }
+
     /// Returns the balance remaining after the mandatory fee and the
     /// percentage-based priority fee reserve.
     pub fn funding_delta_with_priority_fee<G: GasProfile>(

--- a/core/src/mantle/transactions/mantle_tx.rs
+++ b/core/src/mantle/transactions/mantle_tx.rs
@@ -323,6 +323,15 @@ impl MantleTxGasContext {
     pub fn get_gas_prices(&self) -> GasPrices {
         self.gas_prices.clone()
     }
+
+    #[must_use]
+    pub fn with_gas_prices(&self, gas_prices: GasPrices) -> Self {
+        Self {
+            transfer_thresholds: self.transfer_thresholds.clone(),
+            configuration_thresholds: self.configuration_thresholds.clone(),
+            gas_prices,
+        }
+    }
 }
 
 pub trait MantleTx {

--- a/deployment/tui-zone/src/cli.rs
+++ b/deployment/tui-zone/src/cli.rs
@@ -1,6 +1,7 @@
 use std::{error::Error, path::PathBuf};
 
 use clap::{Args, Parser, Subcommand};
+use lb_core::mantle::gas::FeeHorizonHours;
 
 use crate::run_commands::{
     run_balance::run_state_full,
@@ -103,13 +104,11 @@ pub struct NodeKeyArgs {
     #[arg(long, default_value_t = 1_000_000, env = "MAX_TX_FEE")]
     pub max_tx_fee: u64,
 
-    /// Percentage of the final mandatory fee reserved when funding via
-    /// `--funding-pk`. The percentage covers execution plus storage cost; only
-    /// unused reserve becomes an effective priority tip. The 12% default is a
-    /// practical reserve for normal fee movement, including approximately one
-    /// storage-market epoch at normal price levels, not a protocol guarantee
-    /// at very low prices or when execution fees also rise materially. Storage
-    /// prices use integer arithmetic, so 1 can become 2. Capped in total by
+    /// Percentage of the mandatory fee at preparation-time prices reserved as
+    /// an absolute priority incentive when funding via `--funding-pk`. The
+    /// percentage covers execution plus storage cost and is not reapplied to
+    /// future prices. The default is no explicit priority reserve; callers can
+    /// opt into one independently of the storage horizon. Capped in total by
     /// `--max-tx-fee`.
     #[arg(
         long,
@@ -117,6 +116,13 @@ pub struct NodeKeyArgs {
         env = "PRIORITY_FEE_PERCENT"
     )]
     pub priority_fee_percent: u64,
+
+    /// Storage-fee coverage horizon. Omitted values default to 1.0 hour.
+    /// Decimal values are rounded up to the next 0.1 hour. Values above 168
+    /// hours (7 days) are rejected. Set to `0.0` to disable coverage. Capped
+    /// in total by `--max-tx-fee`.
+    #[arg(long, default_value = "1.0", env = "FEE_HORIZON_HOURS")]
+    pub fee_horizon_hours: FeeHorizonHours,
 }
 
 #[derive(Args, Debug)]

--- a/deployment/tui-zone/src/run_commands/utils.rs
+++ b/deployment/tui-zone/src/run_commands/utils.rs
@@ -342,6 +342,7 @@ pub fn funding_config(args: &NodeKeyArgs) -> RunResult<FundingConfig> {
         funding_pk: decode_zk_public_key_hex(&args.funding_pk)?,
         max_tx_fee: args.max_tx_fee.into(),
         priority_fee_percent: args.priority_fee_percent,
+        fee_horizon_hours: (args.fee_horizon_hours.tenths() != 0).then_some(args.fee_horizon_hours),
     })
 }
 

--- a/ledger/src/cryptarchia/mod.rs
+++ b/ledger/src/cryptarchia/mod.rs
@@ -11,7 +11,10 @@ use lb_core::{
     events::TxEvent,
     mantle::{
         NoteId, Utxo, Value,
-        gas::{Gas, GasCost, GasOverflow, GasPrice, GasProfile},
+        gas::{
+            Gas, GasCost, GasOverflow, GasPrice, GasProfile,
+            STORAGE_PRICE_MAX_INCREASE_DENOMINATOR, STORAGE_PRICE_MAX_INCREASE_NUMERATOR,
+        },
         ledger::ExecutableOperation as _,
         ops::{pow::PowTarget, transfer::TransferOp},
         traits::GenesisTx,
@@ -48,12 +51,8 @@ const EXECUTION_MARKET_BASE_FEE_DENOMINATOR: u128 = 12_773_840;
 
 // Corresponds to the denominator of 1/beta
 const STORAGE_MARKET_EMA_DENOMINATOR: u128 = 2;
-// Corresponds to the denominator of 1+ alpha and 1-alpha
-const STORAGE_MARKET_CLAMP_DENOMINATOR: u128 = 8;
 // Corresponds to the numerator of 1-alpha
 const STORAGE_MARKET_CLAMP_DOWN_NUMERATOR: u128 = 7;
-// Corresponds to the numerator of 1+alpha
-const STORAGE_MARKET_CLAMP_UP_NUMERATOR: u128 = 9;
 
 pub type UtxoTree = lb_utxotree::UtxoTree<NoteId, Utxo, ZkHasher>;
 use super::{Balance, Config, LedgerError, mantle};
@@ -810,14 +809,14 @@ fn update_storage_market(
     if new_ema_unsigned == 0 {
         return (storage_gas_price, new_ema);
     }
-    let comparator = STORAGE_MARKET_CLAMP_DENOMINATOR * total_storage_gas;
+    let comparator = STORAGE_PRICE_MAX_INCREASE_DENOMINATOR * total_storage_gas;
     let new_price = if comparator <= STORAGE_MARKET_CLAMP_DOWN_NUMERATOR * new_ema_unsigned {
         ((previous_price * STORAGE_MARKET_CLAMP_DOWN_NUMERATOR)
-            .div_ceil(STORAGE_MARKET_CLAMP_DENOMINATOR) as Value)
+            .div_ceil(STORAGE_PRICE_MAX_INCREASE_DENOMINATOR) as Value)
             .into()
-    } else if comparator >= STORAGE_MARKET_CLAMP_UP_NUMERATOR * new_ema_unsigned {
-        ((previous_price * STORAGE_MARKET_CLAMP_UP_NUMERATOR)
-            .div_ceil(STORAGE_MARKET_CLAMP_DENOMINATOR) as Value)
+    } else if comparator >= STORAGE_PRICE_MAX_INCREASE_NUMERATOR * new_ema_unsigned {
+        ((previous_price * STORAGE_PRICE_MAX_INCREASE_NUMERATOR)
+            .div_ceil(STORAGE_PRICE_MAX_INCREASE_DENOMINATOR) as Value)
             .into()
     } else {
         ((previous_price * total_storage_gas).div_ceil(new_ema_unsigned) as Value).into()

--- a/logos_sql/examples/password_manager/config.rs
+++ b/logos_sql/examples/password_manager/config.rs
@@ -28,7 +28,8 @@ struct Options {
     #[arg(long, env = "LOGOS_SQL_MAX_TX_FEE")]
     max_tx_fee: u64,
 
-    /// Percentage of the maximum fee offered as priority fee.
+    /// Percentage of the mandatory fee at preparation-time prices reserved
+    /// as an explicit priority incentive.
     #[arg(
         long,
         env = "LOGOS_SQL_PRIORITY_FEE_PERCENT",
@@ -57,6 +58,7 @@ pub fn from_args() -> LogosSqlConfig {
             funding_pk: options.funding_key,
             max_tx_fee: options.max_tx_fee.into(),
             priority_fee_percent: options.priority_fee_percent,
+            fee_horizon_hours: Some(FundingConfig::DEFAULT_FEE_HORIZON_HOURS),
         },
         state_dir: options.state_dir,
     }

--- a/nodes/api-common/Cargo.toml
+++ b/nodes/api-common/Cargo.toml
@@ -19,7 +19,7 @@ lb-key-management-system-keys = { workspace = true }
 lb-log-targets                = { workspace = true }
 lb-tracing                    = { workspace = true }
 serde                         = { features = ["alloc", "derive"], workspace = true }
-serde_json                    = { workspace = true }
+serde_json                    = { features = ["raw_value"], workspace = true }
 serde_urlencoded              = { workspace = true }
 serde_with                    = { features = ["macros"], workspace = true }
 time                          = { workspace = true }

--- a/nodes/api-common/src/bodies/wallet.rs
+++ b/nodes/api-common/src/bodies/wallet.rs
@@ -150,12 +150,39 @@ pub mod fund {
         header::HeaderId,
         mantle::{
             OpProof,
-            gas::GasCost,
+            gas::{FeeHorizonHours, GasCost},
             transactions::{RawMantleTx, builder::MantleTxBuilder},
         },
     };
     use lb_key_management_system_keys::keys::ZkPublicKey;
-    use serde::{Deserialize, Serialize};
+    use serde::{Deserialize, Serialize, de::Error as _};
+    use serde_json::value::RawValue;
+
+    #[expect(
+        clippy::unnecessary_wraps,
+        reason = "Serde requires the default function to return the optional field type."
+    )]
+    const fn default_fee_horizon_hours() -> Option<FeeHorizonHours> {
+        Some(FeeHorizonHours::from_tenths(10))
+    }
+
+    fn deserialize_fee_horizon_hours<'de, D>(
+        deserializer: D,
+    ) -> Result<Option<FeeHorizonHours>, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let Some(raw) = Option::<Box<RawValue>>::deserialize(deserializer)? else {
+            return Ok(None);
+        };
+        let raw = raw.get();
+        let value = if raw.starts_with('"') {
+            serde_json::from_str::<String>(raw).map_err(D::Error::custom)?
+        } else {
+            raw.to_owned()
+        };
+        value.parse().map(Some).map_err(D::Error::custom)
+    }
 
     #[derive(Serialize, Deserialize)]
     pub struct WalletFundRequestBody {
@@ -165,19 +192,27 @@ pub mod fund {
         pub funding_public_keys: Vec<ZkPublicKey>,
         /// Absolute hard cap on the final funded transaction fee.
         pub max_tx_fee: GasCost,
-        /// Percentage of the final mandatory fee reserved as a priority fee.
-        /// The percentage applies to the complete mandatory fee (execution
-        /// plus storage), not to storage alone. Only the unused reserve is an
-        /// effective priority tip. The default used by the Zone SDK and TUI
-        /// is 12%, a practical reserve intended to absorb normal fee movement,
-        /// including approximately one storage-market epoch increase at
-        /// normal price levels. It is not a protocol guarantee at very low
-        /// prices or when execution fees also rise materially. Storage prices
-        /// use integer arithmetic, so a low price can jump proportionally more
-        /// (for example, 1 to 2). `0` funds exactly to the mandatory fee; the
+        /// Percentage of the mandatory fee at preparation-time prices reserved
+        /// as an absolute priority incentive. The percentage applies to the
+        /// complete mandatory fee (execution plus storage), not to storage
+        /// alone, and is not reapplied to future prices. When omitted, it
+        /// defaults to `0`; that requests no explicit priority reserve. The
         /// value is not capped at 100.
         #[serde(default)]
         pub priority_fee_percent: u64,
+        /// Optional elapsed-time horizon for deterministic storage-market fee
+        /// coverage. This reserve is independent of the priority reserve. An
+        /// omitted field defaults to one hour; `null` or `0.0` explicitly
+        /// disables horizon coverage. This accepts non-negative decimal hours;
+        /// values are rounded up to the next 0.1 hour. The maximum supported
+        /// horizon is 168 hours (7 days); larger values are rejected. Any
+        /// unused horizon reserve is effective tip immediately and is consumed
+        /// as the mandatory storage fee rises.
+        #[serde(
+            default = "default_fee_horizon_hours",
+            deserialize_with = "deserialize_fee_horizon_hours"
+        )]
+        pub fee_horizon_hours: Option<FeeHorizonHours>,
     }
 
     #[derive(Serialize, Deserialize)]
@@ -191,6 +226,124 @@ pub mod fund {
         /// transaction hash. `None` if funding required no transfer (zero
         /// fee and no inputs pulled in).
         pub transfer_proof: Option<OpProof>,
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        fn request_json() -> String {
+            let key = ZkPublicKey::zero();
+            let request = WalletFundRequestBody {
+                tip: None,
+                tx_builder: MantleTxBuilder::new(),
+                change_public_key: key,
+                funding_public_keys: vec![key],
+                max_tx_fee: GasCost::new(0),
+                priority_fee_percent: 0,
+                fee_horizon_hours: None,
+            };
+            serde_json::to_string(&request).unwrap()
+        }
+
+        #[test]
+        fn omitted_fee_horizon_defaults_to_one_hour_but_null_and_zero_disable_it() {
+            let key = ZkPublicKey::zero();
+            let request = WalletFundRequestBody {
+                tip: None,
+                tx_builder: MantleTxBuilder::new(),
+                change_public_key: key,
+                funding_public_keys: vec![key],
+                max_tx_fee: GasCost::new(0),
+                priority_fee_percent: 0,
+                fee_horizon_hours: None,
+            };
+            let mut json = serde_json::to_value(&request).unwrap();
+            let object = json.as_object_mut().unwrap();
+            object.remove("priority_fee_percent");
+            object.remove("fee_horizon_hours");
+
+            let parsed: WalletFundRequestBody =
+                serde_json::from_str(&serde_json::to_string(&json).unwrap()).unwrap();
+            assert_eq!(parsed.priority_fee_percent, 0);
+            assert_eq!(
+                parsed.fee_horizon_hours,
+                Some(FeeHorizonHours::from_tenths(10))
+            );
+
+            json["fee_horizon_hours"] = serde_json::Value::Null;
+            let parsed: WalletFundRequestBody =
+                serde_json::from_str(&serde_json::to_string(&json).unwrap()).unwrap();
+            assert_eq!(parsed.fee_horizon_hours, None);
+
+            json["fee_horizon_hours"] = serde_json::json!(0.0);
+            let parsed: WalletFundRequestBody =
+                serde_json::from_str(&serde_json::to_string(&json).unwrap()).unwrap();
+            assert_eq!(
+                parsed.fee_horizon_hours,
+                Some(FeeHorizonHours::from_tenths(0))
+            );
+        }
+
+        #[test]
+        fn fee_horizon_hours_api_normalizes_decimal_numbers() {
+            let json =
+                request_json().replace("\"fee_horizon_hours\":null", "\"fee_horizon_hours\":0.25");
+
+            let parsed: WalletFundRequestBody = serde_json::from_str(&json).unwrap();
+            assert_eq!(
+                parsed.fee_horizon_hours,
+                Some(FeeHorizonHours::from_tenths(3))
+            );
+        }
+
+        #[test]
+        fn fee_horizon_hours_api_reports_supported_maximum() {
+            let json = request_json().replace(
+                "\"fee_horizon_hours\":null",
+                "\"fee_horizon_hours\":168.00001",
+            );
+
+            let error = match serde_json::from_str::<WalletFundRequestBody>(&json) {
+                Ok(_) => panic!("fee horizon above the supported maximum was accepted"),
+                Err(error) => error.to_string(),
+            };
+            let expected_error = "168.00001"
+                .parse::<FeeHorizonHours>()
+                .expect_err("test horizon should exceed the supported maximum");
+            assert!(
+                error.contains(&expected_error),
+                "unexpected validation error: {error}"
+            );
+        }
+
+        #[test]
+        fn fee_horizon_hours_api_preserves_decimal_token_precision() {
+            let json = request_json();
+
+            let json = json.replace(
+                "\"fee_horizon_hours\":null",
+                "\"fee_horizon_hours\":1.00000000000000001",
+            );
+            let parsed: WalletFundRequestBody = serde_json::from_str(&json).unwrap();
+            assert_eq!(
+                parsed.fee_horizon_hours,
+                Some(FeeHorizonHours::from_tenths(11))
+            );
+
+            let json = json.replace("1.00000000000000001", "168.00000000000000001");
+            let error = match serde_json::from_str::<WalletFundRequestBody>(&json) {
+                Ok(_) => panic!("fee horizon above the supported maximum was accepted"),
+                Err(error) => error.to_string(),
+            };
+            let expected_error = "168.00000000000000001"
+                .parse::<FeeHorizonHours>()
+                .expect_err("test horizon should exceed the supported maximum");
+            assert!(
+                error.contains(&expected_error),
+                "unexpected validation error: {error}"
+            );
+        }
     }
 }
 

--- a/nodes/node/binary/src/api/handlers.rs
+++ b/nodes/node/binary/src/api/handlers.rs
@@ -1066,12 +1066,14 @@ where
             tip,
             response: funded_tx_builder,
         } = wallet
-            .fund_tx(
+            .fund_tx_with_policy(
                 None,
                 tx_builder,
                 req.change_public_key,
                 req.funding_public_keys,
                 0,
+                None,
+                Some(req.max_tx_fee),
             )
             .await?;
 
@@ -2114,12 +2116,14 @@ pub mod wallet {
                 tip,
                 response: funded_tx_builder,
             } = wallet
-                .fund_tx(
+                .fund_tx_with_policy(
                     req.tip,
                     req.tx_builder,
                     req.change_public_key,
                     req.funding_public_keys,
                     req.priority_fee_percent,
+                    req.fee_horizon_hours,
+                    Some(req.max_tx_fee),
                 )
                 .await?;
 

--- a/nodes/node/binary/src/config/tests.rs
+++ b/nodes/node/binary/src/config/tests.rs
@@ -252,7 +252,10 @@ fn service_settings_receive_recovery_data() {
     let wallet_service_settings = WalletServiceConfig {
         user: user_config.wallet.clone(),
     }
-    .into_wallet_service_settings(recovery_data.clone());
+    .into_wallet_service_settings(
+        recovery_data.clone(),
+        deployment_settings.time.slot_duration,
+    );
     assert_eq!(
         wallet_service_settings
             .recovery_data

--- a/nodes/node/binary/src/config/wallet/mod.rs
+++ b/nodes/node/binary/src/config/wallet/mod.rs
@@ -1,3 +1,5 @@
+use core::time::Duration;
+
 use lb_services_utils::overwatch::RecoveryData;
 use lb_wallet_service::WalletServiceSettings;
 
@@ -14,12 +16,16 @@ impl ServiceConfig {
     pub fn into_wallet_service_settings(
         self,
         recovery_data: RecoveryData,
+        slot_duration: Duration,
     ) -> WalletServiceSettings {
+        let slot_duration_ms = u64::try_from(slot_duration.as_millis())
+            .expect("configured slot duration must fit in milliseconds");
         WalletServiceSettings {
             known_keys: self.user.known_keys,
             voucher_master_key_id: self.user.voucher_master_key_id,
             recovery_data,
             pending_note_expiry_blocks: self.user.pending_note_expiry_blocks,
+            slot_duration_ms,
         }
     }
 }

--- a/nodes/node/binary/src/generic_services/sdp/wallet.rs
+++ b/nodes/node/binary/src/generic_services/sdp/wallet.rs
@@ -1,6 +1,7 @@
 use lb_core::{
     mantle::{
         Op, SignedMantleTx,
+        gas::FeeHorizonHours,
         transactions::{MantleTxBuilder, states::Preverified},
     },
     sdp::{ActiveMessage, DeclarationMessage, WithdrawMessage},
@@ -13,6 +14,8 @@ use lb_wallet_service::{
     api::{WalletApi, WalletServiceData},
 };
 use overwatch::services::{AsServiceId, ServiceData, relay::OutboundRelay};
+
+const SDP_FEE_HORIZON_HOURS: FeeHorizonHours = FeeHorizonHours::from_tenths(15);
 
 pub struct SdpWalletAdapter<Service, RuntimeServiceId>
 where
@@ -49,12 +52,14 @@ where
             response: funded,
         } = self
             .api
-            .fund_tx(
+            .fund_tx_with_policy(
                 None,
                 tx_builder,
                 config.funding_pk,
                 vec![config.funding_pk],
                 0,
+                Some(SDP_FEE_HORIZON_HOURS),
+                Some(config.max_tx_fee),
             )
             .await
             .map_err(|e| SdpWalletError::WalletApi(e.into()))?;
@@ -90,12 +95,14 @@ where
             response: funded,
         } = self
             .api
-            .fund_tx(
+            .fund_tx_with_policy(
                 None,
                 tx_builder,
                 config.funding_pk,
                 vec![config.funding_pk],
                 0,
+                Some(SDP_FEE_HORIZON_HOURS),
+                Some(config.max_tx_fee),
             )
             .await
             .map_err(|e| SdpWalletError::WalletApi(e.into()))?;
@@ -131,12 +138,14 @@ where
             response: funded,
         } = self
             .api
-            .fund_tx(
+            .fund_tx_with_policy(
                 None,
                 tx_builder,
                 config.funding_pk,
                 vec![config.funding_pk],
                 0,
+                Some(SDP_FEE_HORIZON_HOURS),
+                Some(config.max_tx_fee),
             )
             .await
             .map_err(|e| SdpWalletError::WalletApi(e.into()))?;
@@ -157,5 +166,181 @@ where
             .response;
 
         Ok(signed_tx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fmt::{self, Display, Formatter};
+
+    use lb_blend::proofs::{quota::VerifiedProofOfQuota, selection::VerifiedProofOfSelection};
+    use lb_core::{
+        mantle::gas::GasCost,
+        sdp::{
+            ActivityMetadata, DeclarationId, Locator, ProviderId, ServiceType, blend::ActivityProof,
+        },
+    };
+    use lb_cryptarchia_engine::Epoch;
+    use lb_groth16::Fr;
+    use lb_key_management_system_service::keys::{Ed25519Key, ZkPublicKey};
+    use lb_wallet_service::{WalletMsg, WalletServiceError, WalletServiceSettings};
+    use overwatch::services::state::{NoOperator, NoState};
+    use tokio::sync::mpsc;
+
+    use super::*;
+
+    struct DummyWallet;
+
+    impl ServiceData for DummyWallet {
+        type Settings = WalletServiceSettings;
+        type State = NoState<Self::Settings>;
+        type StateOperator = NoOperator<Self::State>;
+        type Message = WalletMsg;
+    }
+
+    impl WalletServiceData for DummyWallet {
+        type Kms = ();
+        type Cryptarchia = ();
+        type Tx = ();
+        type Storage = ();
+    }
+
+    #[derive(Debug)]
+    struct TestRuntimeServiceId;
+
+    impl AsServiceId<DummyWallet> for TestRuntimeServiceId {
+        const SERVICE_ID: Self = Self;
+    }
+
+    impl Display for TestRuntimeServiceId {
+        fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+            write!(formatter, "TestRuntimeServiceId")
+        }
+    }
+
+    fn test_config() -> SdpWalletConfig {
+        SdpWalletConfig {
+            max_tx_fee: GasCost::new(1234),
+            funding_pk: ZkPublicKey::zero(),
+        }
+    }
+
+    fn declaration() -> DeclarationMessage {
+        DeclarationMessage {
+            service_type: ServiceType::BlendNetwork,
+            locators: [Locator::new_unchecked(
+                "/ip4/127.0.0.1/udp/3000/quic-v1".parse().unwrap(),
+            )]
+            .into(),
+            provider_id: ProviderId(Ed25519Key::from_bytes(&[0u8; _]).public_key()),
+            zk_id: ZkPublicKey::zero(),
+            locked_note_id: Fr::from(0u64).into(),
+        }
+    }
+
+    fn active() -> ActiveMessage {
+        ActiveMessage {
+            declaration_id: DeclarationId([0; 32]),
+            nonce: 0,
+            metadata: ActivityMetadata::Blend(Box::new(ActivityProof {
+                epoch: Epoch::new(0),
+                signing_key: Ed25519Key::from_bytes(&[0u8; _]).public_key(),
+                proof_of_quota: VerifiedProofOfQuota::from_bytes_unchecked([0; _]).into(),
+                proof_of_selection: VerifiedProofOfSelection::from_bytes_unchecked([0; _]).into(),
+            })),
+        }
+    }
+
+    fn withdraw() -> WithdrawMessage {
+        WithdrawMessage {
+            declaration_id: DeclarationId([0; 32]),
+            nonce: 0,
+            locked_note_id: Fr::from(0u64).into(),
+        }
+    }
+
+    async fn assert_funding_policy(
+        receiver: &mut mpsc::Receiver<WalletMsg>,
+        expected_max_tx_fee: GasCost,
+    ) {
+        let WalletMsg::FundTx {
+            priority_fee_percent,
+            fee_horizon_hours,
+            max_tx_fee,
+            resp_tx,
+            ..
+        } = receiver.recv().await.expect("SDP funding request")
+        else {
+            panic!("expected SDP funding request");
+        };
+
+        assert_eq!(priority_fee_percent, 0);
+        assert_eq!(fee_horizon_hours, Some(SDP_FEE_HORIZON_HOURS));
+        assert_eq!(max_tx_fee, Some(expected_max_tx_fee));
+
+        resp_tx
+            .send(Err(WalletServiceError::KmsApi(
+                std::io::Error::other("test").into(),
+            )))
+            .expect("SDP adapter should still await the funding response");
+    }
+
+    async fn assert_operation<Operation, OperationFuture>(
+        operation: Operation,
+        config: &SdpWalletConfig,
+    ) where
+        Operation: FnOnce(
+                SdpWalletAdapter<DummyWallet, TestRuntimeServiceId>,
+                SdpWalletConfig,
+            ) -> OperationFuture
+            + Send
+            + 'static,
+        OperationFuture: Future + Send + 'static,
+        OperationFuture::Output: Send + 'static,
+    {
+        let (sender, mut receiver) = mpsc::channel(1);
+        let adapter =
+            <SdpWalletAdapter<DummyWallet, TestRuntimeServiceId> as SdpWalletAdapterTrait>::new(
+                OutboundRelay::new(sender),
+            );
+        let operation = tokio::spawn(operation(adapter, config.clone()));
+
+        assert_funding_policy(&mut receiver, config.max_tx_fee).await;
+        operation
+            .await
+            .expect("SDP operation should finish after wallet response");
+    }
+
+    #[tokio::test]
+    async fn all_sdp_operations_use_zero_priority_and_one_and_a_half_hour_horizon() {
+        let config = test_config();
+
+        assert_operation(
+            async |adapter, config| {
+                adapter
+                    .declare_tx(MantleTxBuilder::new(), declaration(), &config)
+                    .await
+            },
+            &config,
+        )
+        .await;
+        assert_operation(
+            async |adapter, config| {
+                adapter
+                    .active_tx(MantleTxBuilder::new(), active(), &config)
+                    .await
+            },
+            &config,
+        )
+        .await;
+        assert_operation(
+            async |adapter, config| {
+                adapter
+                    .withdraw_tx(MantleTxBuilder::new(), withdraw(), &config)
+                    .await
+            },
+            &config,
+        )
+        .await;
     }
 }

--- a/nodes/node/binary/src/generic_services/sdp/wallet.rs
+++ b/nodes/node/binary/src/generic_services/sdp/wallet.rs
@@ -15,6 +15,11 @@ use lb_wallet_service::{
 };
 use overwatch::services::{AsServiceId, ServiceData, relay::OutboundRelay};
 
+// The horizon covers deterministic storage-fee movement; the independent
+// priority reserve remains an explicit incentive. Any retry/rebuild would
+// handle only exceptional lifetime, execution-fee, submission, or
+// state-invalidating cases.
+const SDP_PRIORITY_FEE_PERCENT: u64 = 12;
 const SDP_FEE_HORIZON_HOURS: FeeHorizonHours = FeeHorizonHours::from_tenths(15);
 
 pub struct SdpWalletAdapter<Service, RuntimeServiceId>
@@ -57,7 +62,7 @@ where
                 tx_builder,
                 config.funding_pk,
                 vec![config.funding_pk],
-                0,
+                SDP_PRIORITY_FEE_PERCENT,
                 Some(SDP_FEE_HORIZON_HOURS),
                 Some(config.max_tx_fee),
             )
@@ -100,7 +105,7 @@ where
                 tx_builder,
                 config.funding_pk,
                 vec![config.funding_pk],
-                0,
+                SDP_PRIORITY_FEE_PERCENT,
                 Some(SDP_FEE_HORIZON_HOURS),
                 Some(config.max_tx_fee),
             )
@@ -143,7 +148,7 @@ where
                 tx_builder,
                 config.funding_pk,
                 vec![config.funding_pk],
-                0,
+                SDP_PRIORITY_FEE_PERCENT,
                 Some(SDP_FEE_HORIZON_HOURS),
                 Some(config.max_tx_fee),
             )
@@ -274,7 +279,7 @@ mod tests {
             panic!("expected SDP funding request");
         };
 
-        assert_eq!(priority_fee_percent, 0);
+        assert_eq!(priority_fee_percent, SDP_PRIORITY_FEE_PERCENT);
         assert_eq!(fee_horizon_hours, Some(SDP_FEE_HORIZON_HOURS));
         assert_eq!(max_tx_fee, Some(expected_max_tx_fee));
 
@@ -312,7 +317,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn all_sdp_operations_use_zero_priority_and_one_and_a_half_hour_horizon() {
+    async fn all_sdp_operations_use_twelve_percent_priority_and_one_and_a_half_hour_horizon() {
         let config = test_config();
 
         assert_operation(

--- a/nodes/node/binary/src/lib.rs
+++ b/nodes/node/binary/src/lib.rs
@@ -157,6 +157,7 @@ pub fn run_node_from_config(
         &config.deployment.time,
         &config.deployment.cryptarchia,
     );
+    let slot_duration = config.deployment.time.slot_duration;
 
     let time_service_config = TimeConfig {
         user: config.user.time,
@@ -184,7 +185,7 @@ pub fn run_node_from_config(
     let wallet_config = WalletConfig {
         user: config.user.wallet,
     }
-    .into_wallet_service_settings(recovery_data.clone());
+    .into_wallet_service_settings(recovery_data.clone(), slot_duration);
 
     let kms_config = KmsConfig {
         user: config.user.kms,

--- a/services/blend/src/lib.rs
+++ b/services/blend/src/lib.rs
@@ -330,7 +330,9 @@ async fn submit_blend_sdp_declaration<SdpService>(
 where
     SdpService: ServiceData<Message = SdpMessage>,
 {
-    tracing::info!(
+    // SDP's wallet adapter applies the internal 12% priority incentive plus
+    // the 1.5-hour storage-fee horizon when it funds this declaration.
+    info!(
         target: LOG_TARGET,
         "Submitting Blend service declaration to SDP with locator {locator:?} and locked note id {locked_note_id:?}",
     );

--- a/services/chain/chain-service/src/api.rs
+++ b/services/chain/chain-service/src/api.rs
@@ -98,6 +98,22 @@ where
         })
     }
 
+    /// Get the current slot from the chain service's slot ticker.
+    pub async fn current_slot(&self) -> Result<Slot, ApiError> {
+        let (reply_channel, rx) = oneshot::channel();
+
+        self.relay
+            .send(Query::CurrentSlot { reply_channel }.into())
+            .await
+            .map_err(|(relay_error, _)| {
+                ApiError::CommsFailure(format!("{relay_error} while sending CurrentSlot"))
+            })?;
+
+        rx.await.map_err(|relay_error| {
+            ApiError::CommsFailure(format!("{relay_error} while receiving CurrentSlot"))
+        })
+    }
+
     /// Subscribe to new blocks
     pub async fn subscribe_new_blocks(
         &self,

--- a/services/chain/chain-service/src/lib.rs
+++ b/services/chain/chain-service/src/lib.rs
@@ -166,6 +166,9 @@ pub enum Query {
     Info {
         reply_channel: oneshot::Sender<ChainServiceInfo>,
     },
+    CurrentSlot {
+        reply_channel: oneshot::Sender<Slot>,
+    },
     NewBlockSubscribe {
         sender: oneshot::Sender<broadcast::Receiver<ProcessedBlockEvent>>,
     },

--- a/services/chain/chain-service/src/service/mod.rs
+++ b/services/chain/chain-service/src/service/mod.rs
@@ -173,6 +173,11 @@ where
                         error!("Could not send consensus info through channel: {:?}", e);
                     });
             }
+            Query::CurrentSlot { reply_channel } => {
+                reply_channel.send(self.current_slot).unwrap_or_else(|_| {
+                    error!("Could not send current slot through channel");
+                });
+            }
             Query::NewBlockSubscribe { sender } => {
                 sender
                     .send(self.new_block_subscription_sender.subscribe())

--- a/services/wallet/src/api.rs
+++ b/services/wallet/src/api.rs
@@ -2,7 +2,7 @@ use lb_core::{
     header::HeaderId,
     mantle::{
         Note, SignedMantleTx, Value,
-        gas::GasCost,
+        gas::{FeeHorizonHours, GasCost},
         ops::leader_claim::{RewardsRoot, VoucherCm},
         transactions::{
             MantleTxBuilder, MantleTxContext, TxBuilderError, hash::TxHash, states::Preverified,
@@ -146,6 +146,32 @@ where
         funding_pks: Vec<ZkPublicKey>,
         priority_fee_percent: u64,
     ) -> Result<TipResponse<MantleTxBuilder>, WalletApiError> {
+        self.fund_tx_with_policy(
+            tip,
+            tx_builder,
+            change_pk,
+            funding_pks,
+            priority_fee_percent,
+            None,
+            None,
+        )
+        .await
+    }
+
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "The funding policy parameters are intentionally independent."
+    )]
+    pub async fn fund_tx_with_policy(
+        &self,
+        tip: Option<HeaderId>,
+        tx_builder: MantleTxBuilder,
+        change_pk: ZkPublicKey,
+        funding_pks: Vec<ZkPublicKey>,
+        priority_fee_percent: u64,
+        fee_horizon_hours: Option<FeeHorizonHours>,
+        max_tx_fee: Option<GasCost>,
+    ) -> Result<TipResponse<MantleTxBuilder>, WalletApiError> {
         let (resp_tx, rx) = oneshot::channel();
 
         self.relay
@@ -155,6 +181,8 @@ where
                 change_pk,
                 funding_pks,
                 priority_fee_percent,
+                fee_horizon_hours,
+                max_tx_fee,
                 resp_tx,
             })
             .await?;

--- a/services/wallet/src/fee.rs
+++ b/services/wallet/src/fee.rs
@@ -27,6 +27,8 @@ pub enum FeeProjectionError {
     TxBuilder(#[from] lb_core::mantle::transactions::TxBuilderError),
 }
 
+/// Resolve the caller's elapsed-time fee policy to protocol slots using the
+/// deployment's configured slot duration.
 pub fn horizon_slots(
     horizon: FeeHorizonHours,
     slot_duration_ms: u64,

--- a/services/wallet/src/fee.rs
+++ b/services/wallet/src/fee.rs
@@ -1,0 +1,238 @@
+use lb_core::mantle::{
+    gas::{
+        FeeHorizonHours, GasCost, GasOverflow, GasPrice, MainnetGasProfile,
+        max_storage_price_after_epoch,
+    },
+    transactions::{MantleTxBuilder, MantleTxContext},
+};
+use thiserror::Error;
+
+const MILLIS_PER_HOUR: u128 = 3_600_000;
+
+#[derive(Debug, Error)]
+pub enum FeeProjectionError {
+    #[error("slot duration must be greater than zero")]
+    InvalidSlotDuration,
+    #[error("fee horizon slot arithmetic overflow")]
+    SlotOverflow,
+    #[error("fee horizon epoch arithmetic overflow")]
+    EpochOverflow,
+    #[error("fee horizon storage-price arithmetic overflow")]
+    PriceOverflow,
+    #[error("fee target arithmetic overflow")]
+    FeeOverflow,
+    #[error(transparent)]
+    Gas(#[from] GasOverflow),
+    #[error(transparent)]
+    TxBuilder(#[from] lb_core::mantle::transactions::TxBuilderError),
+}
+
+pub fn horizon_slots(
+    horizon: FeeHorizonHours,
+    slot_duration_ms: u64,
+) -> Result<u64, FeeProjectionError> {
+    if slot_duration_ms == 0 {
+        return Err(FeeProjectionError::InvalidSlotDuration);
+    }
+
+    let numerator = u128::from(horizon.tenths())
+        .checked_mul(MILLIS_PER_HOUR)
+        .ok_or(FeeProjectionError::SlotOverflow)?;
+    let denominator = u128::from(slot_duration_ms)
+        .checked_mul(10)
+        .ok_or(FeeProjectionError::SlotOverflow)?;
+    u64::try_from(numerator.div_ceil(denominator)).map_err(|_| FeeProjectionError::SlotOverflow)
+}
+
+pub fn horizon_end_slot(
+    preparation_slot: u64,
+    current_slot: u64,
+    horizon_slots: u64,
+) -> Result<u64, FeeProjectionError> {
+    preparation_slot
+        .max(current_slot)
+        .checked_add(horizon_slots)
+        .ok_or(FeeProjectionError::SlotOverflow)
+}
+
+pub fn storage_boundaries(
+    preparation_epoch: u32,
+    horizon_end_epoch: u32,
+) -> Result<u64, FeeProjectionError> {
+    horizon_end_epoch
+        .checked_sub(preparation_epoch)
+        .map(u64::from)
+        .ok_or(FeeProjectionError::EpochOverflow)
+}
+
+pub fn project_storage_price(
+    mut storage_price: GasPrice,
+    boundaries: u64,
+) -> Result<GasPrice, FeeProjectionError> {
+    for _ in 0..boundaries {
+        storage_price = max_storage_price_after_epoch(storage_price)
+            .map_err(|_| FeeProjectionError::PriceOverflow)?;
+    }
+    Ok(storage_price)
+}
+
+pub fn projected_context(
+    current_context: &MantleTxContext,
+    storage_price: GasPrice,
+) -> MantleTxContext {
+    let mut prices = current_context.gas_context.get_gas_prices();
+    prices.storage_gas_price = storage_price;
+    MantleTxContext {
+        gas_context: current_context.gas_context.with_gas_prices(prices),
+        leader_reward_amount: current_context.leader_reward_amount,
+    }
+}
+
+pub fn target_fee_from_mandatory_fees(
+    mandatory_current: GasCost,
+    mandatory_horizon: GasCost,
+    priority_fee_percent: u64,
+) -> Result<GasCost, FeeProjectionError> {
+    let priority_reserve = u128::from(mandatory_current.into_inner())
+        .checked_mul(u128::from(priority_fee_percent))
+        .and_then(|value| value.checked_add(99))
+        .ok_or(FeeProjectionError::FeeOverflow)?
+        / 100;
+    let priority_reserve =
+        u64::try_from(priority_reserve).map_err(|_| FeeProjectionError::FeeOverflow)?;
+    mandatory_horizon
+        .checked_add(GasCost::new(priority_reserve))
+        .map_err(|_| FeeProjectionError::FeeOverflow)
+}
+
+pub fn target_fee(
+    tx_builder: &MantleTxBuilder,
+    current_context: &MantleTxContext,
+    horizon_context: &MantleTxContext,
+    priority_fee_percent: u64,
+) -> Result<GasCost, FeeProjectionError> {
+    let mandatory_current = tx_builder.minimum_gas_cost::<MainnetGasProfile>(current_context)?;
+    let mandatory_horizon = tx_builder.minimum_gas_cost::<MainnetGasProfile>(horizon_context)?;
+    target_fee_from_mandatory_fees(mandatory_current, mandatory_horizon, priority_fee_percent)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fixed_point_hours_round_up_to_slots() {
+        assert_eq!(
+            horizon_slots(FeeHorizonHours::from_tenths(0), 1_000).unwrap(),
+            0
+        );
+        assert_eq!(
+            horizon_slots(FeeHorizonHours::from_tenths(1), 1_000).unwrap(),
+            360
+        );
+        assert_eq!(
+            horizon_slots(FeeHorizonHours::from_tenths(2), 1_000).unwrap(),
+            720
+        );
+        assert_eq!(
+            horizon_slots(FeeHorizonHours::from_tenths(1), 333).unwrap(),
+            1_082
+        );
+    }
+
+    #[test]
+    fn stale_tip_includes_ticker_elapsed_epochs_in_storage_horizon() {
+        let horizon = horizon_slots(FeeHorizonHours::from_tenths(1), 1_000).unwrap();
+        let preparation_slot = 100;
+        let current_ticker_slot = 150;
+        let end = horizon_end_slot(preparation_slot, current_ticker_slot, horizon).unwrap();
+        assert_eq!(end, 510);
+
+        let preparation_epoch = u32::try_from(preparation_slot / 50).unwrap();
+        let current_ticker_epoch = u32::try_from(current_ticker_slot / 50).unwrap();
+        let horizon_end_epoch = u32::try_from(end / 50).unwrap();
+        assert_eq!(preparation_epoch, 2);
+        assert_eq!(current_ticker_epoch, 3);
+        assert_eq!(
+            storage_boundaries(preparation_epoch, horizon_end_epoch).unwrap(),
+            8
+        );
+    }
+
+    #[test]
+    fn storage_projection_rounds_each_boundary() {
+        assert_eq!(
+            project_storage_price(GasPrice::new(1), 3).unwrap(),
+            GasPrice::new(4)
+        );
+        assert_eq!(
+            project_storage_price(GasPrice::new(9), 1).unwrap(),
+            GasPrice::new(11)
+        );
+    }
+
+    #[test]
+    fn priority_is_based_on_current_mandatory_fee_only() {
+        let target =
+            target_fee_from_mandatory_fees(GasCost::new(794), GasCost::new(998), 12).unwrap();
+        assert_eq!(target, GasCost::new(1_094));
+    }
+
+    #[test]
+    fn zero_horizon_and_zero_priority_are_independent() {
+        assert_eq!(
+            target_fee_from_mandatory_fees(GasCost::new(794), GasCost::new(794), 12).unwrap(),
+            GasCost::new(890)
+        );
+        assert_eq!(
+            target_fee_from_mandatory_fees(GasCost::new(794), GasCost::new(794), 0).unwrap(),
+            GasCost::new(794)
+        );
+        assert_eq!(
+            target_fee_from_mandatory_fees(GasCost::new(794), GasCost::new(998), 0).unwrap(),
+            GasCost::new(998)
+        );
+    }
+
+    #[test]
+    fn zero_priority_horizon_reserve_is_immediate_tip_until_consumed() {
+        let funded_fee =
+            target_fee_from_mandatory_fees(GasCost::new(794), GasCost::new(998), 0).unwrap();
+
+        assert_eq!(funded_fee, GasCost::new(998));
+        assert_eq!(funded_fee.into_inner() - 794, 204);
+        assert_eq!(funded_fee.into_inner() - 998, 0);
+    }
+
+    #[test]
+    fn several_boundaries_do_not_reapply_priority_to_projected_fee() {
+        let projected_storage = project_storage_price(GasPrice::new(1), 3).unwrap();
+        assert_eq!(projected_storage, GasPrice::new(4));
+
+        // The fixture mandatory fee is 590 + 204 * storage price.
+        let target =
+            target_fee_from_mandatory_fees(GasCost::new(794), GasCost::new(1_406), 12).unwrap();
+        assert_eq!(target, GasCost::new(1_502));
+        assert_eq!(target.into_inner() - 1_406, 96);
+    }
+
+    #[test]
+    fn arithmetic_overflow_is_reported() {
+        assert!(matches!(
+            target_fee_from_mandatory_fees(
+                GasCost::new(u64::MAX),
+                GasCost::new(u64::MAX),
+                u64::MAX
+            ),
+            Err(FeeProjectionError::FeeOverflow)
+        ));
+        assert!(matches!(
+            project_storage_price(GasPrice::new(u64::MAX), 1),
+            Err(FeeProjectionError::PriceOverflow)
+        ));
+        assert!(matches!(
+            horizon_end_slot(u64::MAX, u64::MAX, 1),
+            Err(FeeProjectionError::SlotOverflow)
+        ));
+    }
+}

--- a/services/wallet/src/lib.rs
+++ b/services/wallet/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod api;
+mod fee;
 mod states;
 
 use std::{collections::HashMap, num::NonZeroU64, time::Duration};
@@ -118,6 +119,12 @@ pub enum WalletServiceError {
     #[error("Transaction fee exceeded the configured max fee. tx_fee={tx_fee} > max_fee={max_fee}")]
     TxFeeExceedsMaxFee { max_fee: GasCost, tx_fee: GasCost },
 
+    #[error(transparent)]
+    FeeProjection(#[from] fee::FeeProjectionError),
+
+    #[error("fee funding did not converge")]
+    FeeFundingDidNotConverge,
+
     #[error("PoC generation failed: {0:?}")]
     PoCGenerationFailed(#[from] lb_core::proofs::leader_claim_proof::Error),
 
@@ -161,6 +168,8 @@ pub enum WalletMsg {
         /// Percentage of the final mandatory fee reserved as a priority-fee
         /// reserve; only the unused reserve becomes the effective tip.
         priority_fee_percent: u64,
+        fee_horizon_hours: Option<lb_core::mantle::gas::FeeHorizonHours>,
+        max_tx_fee: Option<GasCost>,
         resp_tx: Sender<Result<TipResponse<MantleTxBuilder>, WalletServiceError>>,
     },
     BuildLeaderClaimTx {
@@ -271,11 +280,19 @@ pub struct WalletServiceSettings {
     /// blocks have passed since the reservation.
     #[serde(default = "default_pending_note_expiry_blocks")]
     pub pending_note_expiry_blocks: u64,
+    /// Slot duration used to convert a fee horizon to protocol slots.
+    #[serde(default = "default_slot_duration_ms")]
+    pub slot_duration_ms: u64,
 }
 
 #[must_use]
 pub const fn default_pending_note_expiry_blocks() -> u64 {
     10
+}
+
+#[must_use]
+pub const fn default_slot_duration_ms() -> u64 {
+    1_000
 }
 
 impl StorageRecoverySettings for WalletServiceSettings {
@@ -453,7 +470,7 @@ where
         loop {
             tokio::select! {
                 Some(msg) = service_resources_handle.inbound_relay.recv() => {
-                    Box::pin(Self::handle_wallet_message(msg, &mut state, &voucher_master_key_id, &storage_adapter, &cryptarchia_api, &kms, &epoch_config)).await;
+                    Box::pin(Self::handle_wallet_message(msg, &mut state, &voucher_master_key_id, &storage_adapter, &cryptarchia_api, &kms, &epoch_config, settings.slot_duration_ms)).await;
                 }
                 Ok(event) = new_block_receiver.recv() => {
                     Self::handle_new_block(event.block_id, &mut state, &storage_adapter, &cryptarchia_api, &epoch_config).await;
@@ -508,6 +525,10 @@ where
         clippy::cognitive_complexity,
         reason = "TODO: address this in a dedicated refactor"
     )]
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "The wallet message handler receives the service dependencies it dispatches to."
+    )]
     async fn handle_wallet_message(
         msg: WalletMsg,
         state: &mut ServiceState<'_>,
@@ -516,6 +537,7 @@ where
         cryptarchia: &CryptarchiaServiceApi<Cryptarchia, RuntimeServiceId>,
         kms: &KmsServiceApi<Kms, RuntimeServiceId>,
         epoch_config: &EpochConfig,
+        slot_duration_ms: u64,
     ) {
         if let Err(err) =
             Self::backfill_if_not_in_sync(msg.tip(), state, storage, cryptarchia, epoch_config)
@@ -538,6 +560,8 @@ where
                 change_pk,
                 funding_pks,
                 priority_fee_percent,
+                fee_horizon_hours,
+                max_tx_fee,
                 resp_tx,
             } => {
                 let tip = match Self::msg_tip_or_latest(tip, cryptarchia).await {
@@ -551,28 +575,69 @@ where
                 // Fetch the tx context (gas prices) fresh at fund time. It is
                 // tip-dependent, so a builder handed to us earlier must be funded
                 // against the current context rather than a stale one.
-                let context = match Self::ledger_state_at(tip, cryptarchia).await {
-                    Ok(ledger) => ledger.tx_context(),
+                let ledger = match Self::ledger_state_at(tip, cryptarchia).await {
+                    Ok(ledger) => ledger,
                     Err(err) => {
                         Self::send_err(resp_tx, err);
                         return;
                     }
                 };
+                let preparation_slot = ledger.slot();
+                let context = ledger.tx_context();
 
-                let funded = match state.fund_tx::<MainnetGasProfile>(
+                let current_slot = if fee_horizon_hours.is_some_and(|horizon| horizon.tenths() > 0)
+                {
+                    match cryptarchia.current_slot().await {
+                        Ok(current_slot) => Some(current_slot),
+                        Err(err) => {
+                            Self::send_err(resp_tx, err.into());
+                            return;
+                        }
+                    }
+                } else {
+                    None
+                };
+
+                let funded = match Self::fund_transaction(
+                    state,
                     tip,
                     &tx_builder,
                     change_pk,
                     funding_pks,
                     &context,
                     priority_fee_percent,
+                    fee_horizon_hours,
+                    current_slot,
+                    preparation_slot,
+                    epoch_config,
+                    slot_duration_ms,
                 ) {
                     Ok(funded) => funded,
                     Err(err) => {
-                        Self::send_err(resp_tx, WalletServiceError::from(err));
+                        Self::send_err(resp_tx, err);
                         return;
                     }
                 };
+
+                if let Some(max_tx_fee) = max_tx_fee {
+                    let tx_fee = match funded.tx_fee() {
+                        Ok(tx_fee) => tx_fee,
+                        Err(err) => {
+                            Self::send_err(resp_tx, WalletServiceError::from(err));
+                            return;
+                        }
+                    };
+                    if tx_fee > max_tx_fee {
+                        Self::send_err(
+                            resp_tx,
+                            WalletServiceError::TxFeeExceedsMaxFee {
+                                max_fee: max_tx_fee,
+                                tx_fee,
+                            },
+                        );
+                        return;
+                    }
+                }
 
                 let funded_notes: Vec<NoteId> = funded.consumed_or_locked_notes().collect();
                 state.reserve_pending_notes(funded_notes.iter().copied());
@@ -724,6 +789,73 @@ where
                 Self::get_tx_context(block_id, resp_tx, cryptarchia).await;
             }
         }
+    }
+
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "The funding policy inputs are kept explicit to preserve chain-context separation."
+    )]
+    fn fund_transaction(
+        state: &ServiceState<'_>,
+        tip: HeaderId,
+        tx_builder: &MantleTxBuilder,
+        change_pk: ZkPublicKey,
+        funding_pks: Vec<ZkPublicKey>,
+        context: &MantleTxContext,
+        priority_fee_percent: u64,
+        fee_horizon_hours: Option<lb_core::mantle::gas::FeeHorizonHours>,
+        current_slot: Option<Slot>,
+        preparation_slot: Slot,
+        epoch_config: &EpochConfig,
+        slot_duration_ms: u64,
+    ) -> Result<MantleTxBuilder, WalletServiceError> {
+        let Some(horizon) = fee_horizon_hours.filter(|horizon| horizon.tenths() > 0) else {
+            return Ok(state.fund_tx::<MainnetGasProfile>(
+                tip,
+                tx_builder,
+                change_pk,
+                funding_pks,
+                context,
+                priority_fee_percent,
+            )?);
+        };
+
+        let current_slot = current_slot.ok_or(WalletServiceError::FeeFundingDidNotConverge)?;
+        let horizon_slots = fee::horizon_slots(horizon, slot_duration_ms)?;
+        let horizon_end_slot = fee::horizon_end_slot(
+            preparation_slot.into_inner(),
+            current_slot.into_inner(),
+            horizon_slots,
+        )?;
+        let preparation_epoch = epoch_config.epoch_checked(preparation_slot)?.into_inner();
+        let horizon_end_epoch = epoch_config
+            .epoch_checked(Slot::new(horizon_end_slot))?
+            .into_inner();
+        let boundaries = fee::storage_boundaries(preparation_epoch, horizon_end_epoch)?;
+        let projected_storage_price = fee::project_storage_price(
+            context.gas_context.get_gas_prices().storage_gas_price,
+            boundaries,
+        )?;
+        let horizon_context = fee::projected_context(context, projected_storage_price);
+
+        let mut required_fee = GasCost::new(0);
+        for _ in 0..64 {
+            let candidate = state.fund_tx_to_required_fee(
+                tip,
+                tx_builder,
+                change_pk,
+                funding_pks.clone(),
+                required_fee,
+            )?;
+            let target_fee =
+                fee::target_fee(&candidate, context, &horizon_context, priority_fee_percent)?;
+            if candidate.tx_fee()?.into_inner() >= target_fee.into_inner() {
+                return Ok(candidate);
+            }
+            required_fee = target_fee;
+        }
+
+        Err(WalletServiceError::FeeFundingDidNotConverge)
     }
 
     async fn handle_get_balance(
@@ -1650,5 +1782,15 @@ impl EpochConfig {
     fn epoch(&self, slot: Slot) -> Epoch {
         self.epoch_config
             .epoch(slot, self.consensus_config.base_period_length())
+    }
+
+    fn epoch_checked(&self, slot: Slot) -> Result<Epoch, fee::FeeProjectionError> {
+        let epoch = u64::from(slot)
+            / self
+                .epoch_config
+                .epoch_length(self.consensus_config.base_period_length());
+        u32::try_from(epoch)
+            .map(Epoch::new)
+            .map_err(|_| fee::FeeProjectionError::EpochOverflow)
     }
 }

--- a/services/wallet/src/states.rs
+++ b/services/wallet/src/states.rs
@@ -7,6 +7,7 @@ use lb_core::{
     header::HeaderId,
     mantle::{
         GasProfile, NoteId,
+        gas::GasCost,
         ops::leader_claim::{VoucherCm, VoucherNullifier},
         transactions::{MantleTxBuilder, MantleTxContext},
     },
@@ -379,6 +380,24 @@ impl<'u> ServiceState<'u> {
             context,
             &self.pending_notes.note_ids(),
             priority_fee_percent,
+        )
+    }
+
+    pub fn fund_tx_to_required_fee(
+        &self,
+        tip: HeaderId,
+        tx_builder: &MantleTxBuilder,
+        change_pk: ZkPublicKey,
+        funding_pks: impl IntoIterator<Item = impl Borrow<ZkPublicKey>>,
+        required_fee: GasCost,
+    ) -> Result<MantleTxBuilder, WalletError> {
+        self.wallet.fund_tx_to_required_fee(
+            tip,
+            tx_builder,
+            change_pk,
+            funding_pks,
+            &self.pending_notes.note_ids(),
+            required_fee,
         )
     }
 

--- a/tests/cucumber_tests/features/fees.feature
+++ b/tests/cucumber_tests/features/fees.feature
@@ -49,9 +49,9 @@ Feature: Fees
   # k=3 and f=1/2 below, each epoch is 60 slots long. The traffic transactions
   # use zero tip because tips do not drive prices. A separate transaction is
   # prepared through /wallet/fund with a percentage reserve before the
-  # storage-price update and submitted afterwards to show that the effective
-  # reserve absorbs the higher mandatory fee. The acceptance reserve is 50%
-  # because genesis storage price 1 can double to 2 under integer pricing.
+  # storage-price update and submitted afterwards to show that an independent
+  # storage horizon reserve absorbs the higher mandatory fee. The priority
+  # reserve remains the normal 12% of the mandatory fee at preparation time.
   @fees_ci
   Scenario: Execution and storage gas prices respond according to the fee market rules
     Given the cluster uses cryptarchia security parameter 3
@@ -70,7 +70,7 @@ Feature: Fees
       | NODE_1    | 2             | WALLET_2A   |              |
       | NODE_1    | 3             | WALLET_3A   |              |
     When node "NODE_1" is at height 1 in 180 seconds
-    And I prepare a wallet-funded self-transfer with a 50% priority fee reserve from wallet "WALLET_3A" via node "NODE_1" as "BUFFERED"
+    And I prepare a wallet-funded self-transfer with a 12% priority fee reserve and a 0.2 hour fee horizon from wallet "WALLET_3A" via node "NODE_1" as "BUFFERED"
     And I submit an exactly funded self-transfer from wallet "WALLET_1A" via node "NODE_1" as "TRAFFIC_A"
     And I submit an exactly funded self-transfer from wallet "WALLET_2A" via node "NODE_1" as "TRAFFIC_B"
     And I record per-block gas prices on node "NODE_1" for 125 slots in 300 seconds
@@ -79,7 +79,7 @@ Feature: Fees
     And recorded gas prices cross a 60-slot epoch boundary
     And recorded execution gas prices follow the execution market spec reference
     And recorded storage gas prices respond to network usage
-    And transaction "BUFFERED" prepared with a 50% priority fee reserve remains funded with a smaller reserve at current prices on node "NODE_1"
+    And transaction "BUFFERED" prepared with a 12% priority fee reserve and a 0.2 hour fee horizon remains funded with its original priority reserve at current prices on node "NODE_1"
     When I submit prepared transaction "BUFFERED" via node "NODE_1"
     Then transaction "BUFFERED" is included on node "NODE_1" in 60 seconds
     Then I stop all nodes

--- a/tests/src/cucumber/steps/fees/actions.rs
+++ b/tests/src/cucumber/steps/fees/actions.rs
@@ -10,7 +10,7 @@ use lb_core::{
     header::HeaderId,
     mantle::{
         SignedMantleTx,
-        gas::{GasCost, MainnetGasProfile, TxGasCalculator as _},
+        gas::{FeeHorizonHours, GasCost, MainnetGasProfile, TxGasCalculator as _},
         traits::Hashable as _,
         transactions::{GasPrices, builder::MantleTxBuilder, states::Preverified},
     },
@@ -24,7 +24,7 @@ use lb_http_api_common::{
 };
 use lb_key_management_system_service::keys::ZkPublicKey;
 use lb_testing_framework::{NodeHttpClient, configs::wallet::WalletAccount};
-use tokio::time::timeout;
+use tokio::time::{Instant, sleep, timeout};
 use tracing::info;
 
 use crate::{
@@ -85,8 +85,8 @@ pub async fn prepare_wallet_funded_self_transfer_with_priority_fee(
     let account = user_wallet_account(world, step, wallet_name)?;
     let client = world.resolve_node_http_client(node_name)?;
     let funding_pk = account.public_key();
-    let (response, prices) =
-        fund_self_transfer(&client, step, funding_pk, priority_fee_percent).await?;
+    let (response, prices, _) =
+        fund_self_transfer(&client, step, funding_pk, priority_fee_percent, None).await?;
     let signed_tx = assemble_funded_transaction(response, step)?;
     let prepared_fee =
         record_prepared_priority_fee(world, step, &signed_tx, &prices, priority_fee_percent)?;
@@ -110,12 +110,130 @@ pub async fn prepare_wallet_funded_self_transfer_with_priority_fee(
     Ok(())
 }
 
+/// Funds a self-transfer with independent priority and storage-horizon
+/// controls. The expected fee is calculated below from the final transaction
+/// shape and an independent storage-price projection.
+pub async fn prepare_wallet_funded_self_transfer_with_fee_horizon(
+    world: &mut CucumberWorld,
+    step: &Step,
+    wallet_name: &str,
+    node_name: &str,
+    transaction_alias: String,
+    priority_fee_percent: u64,
+    fee_horizon_hours: FeeHorizonHours,
+) -> StepResult {
+    let account = user_wallet_account(world, step, wallet_name)?;
+    let client = world.resolve_node_http_client(node_name)?;
+    wait_until_inside_fee_horizon_epoch(&client, step, world.slots_per_epoch.get()).await?;
+    let funding_pk = account.public_key();
+    let (response, prices, horizon_data) = fund_self_transfer(
+        &client,
+        step,
+        funding_pk,
+        priority_fee_percent,
+        Some(fee_horizon_hours),
+    )
+    .await?;
+    let signed_tx = assemble_funded_transaction(response, step)?;
+    let (preparation_slot, current_slot, slot_duration_ms) =
+        horizon_data.ok_or_else(|| StepError::LogicalError {
+            message: format!(
+                "Step `{}` error: missing fee-horizon timing data",
+                step.value
+            ),
+        })?;
+    let slots_per_epoch = world.slots_per_epoch.get();
+    let prepared_fee = record_prepared_priority_fee_with_horizon(
+        world,
+        step,
+        &signed_tx,
+        &prices,
+        priority_fee_percent,
+        fee_horizon_hours,
+        preparation_slot,
+        current_slot,
+        slot_duration_ms,
+        slots_per_epoch,
+    )?;
+
+    info!(
+        target: TARGET,
+        "Prepared wallet-funded self-transfer `{transaction_alias}` ({:?}) from wallet \
+         '{wallet_name}' with {priority_fee_percent}% priority and {} tenths-hour horizon: \
+         mandatory={}, priority reserve={}, horizon reserve={}, funded={}",
+        signed_tx.hash(),
+        fee_horizon_hours.tenths(),
+        prepared_fee.initial_mandatory_fee,
+        prepared_fee.initial_reserve,
+        prepared_fee.horizon_reserve,
+        prepared_fee.funded_fee,
+    );
+
+    world.remember_prepared_priority_fee(transaction_alias.clone(), prepared_fee);
+    world.remember_prepared_transaction(transaction_alias, signed_tx);
+    Ok(())
+}
+
+async fn wait_until_inside_fee_horizon_epoch(
+    client: &NodeHttpClient,
+    step: &Step,
+    slots_per_epoch: u64,
+) -> StepResult {
+    if slots_per_epoch < 3 {
+        return Err(StepError::InvalidArgument {
+            message: format!(
+                "Step `{}` error: at least 3 slots per epoch are required to avoid epoch-boundary timing races",
+                step.value
+            ),
+        });
+    }
+
+    // Keep several configured slots between the sample and either boundary
+    // without delaying this early-chain scenario into historical-state pruning.
+    let boundary_guard = (slots_per_epoch / 6).max(1);
+    let deadline = Instant::now() + Duration::from_secs(60);
+
+    loop {
+        let time = client
+            .time_info()
+            .await
+            .map_err(|source| StepError::StepFail {
+                message: format!(
+                    "Step `{}` error: time query while waiting for a stable epoch failed: {source}",
+                    step.value
+                ),
+            })?;
+        let offset = time.current_slot % slots_per_epoch;
+        if offset >= boundary_guard && offset < slots_per_epoch - boundary_guard {
+            info!(
+                target: TARGET,
+                "Current slot {} is safely inside epoch ({} slots per epoch) before fee-horizon funding",
+                time.current_slot,
+                slots_per_epoch,
+            );
+            return Ok(());
+        }
+
+        if Instant::now() >= deadline {
+            return Err(StepError::StepFail {
+                message: format!(
+                    "Step `{}` error: current slot {} did not reach the safe interior of an epoch within 60 seconds",
+                    step.value, time.current_slot
+                ),
+            });
+        }
+
+        sleep(Duration::from_millis(100)).await;
+    }
+}
+
 async fn fund_self_transfer(
     client: &NodeHttpClient,
     step: &Step,
     funding_pk: ZkPublicKey,
     priority_fee_percent: u64,
-) -> Result<(WalletFundResponseBody, GasPrices), StepError> {
+    fee_horizon_hours: Option<FeeHorizonHours>,
+) -> Result<(WalletFundResponseBody, GasPrices, Option<(u64, u64, u64)>), StepError> {
     let response = client
         .fund_tx(WalletFundRequestBody {
             tip: None,
@@ -124,6 +242,7 @@ async fn fund_self_transfer(
             funding_public_keys: vec![funding_pk],
             max_tx_fee: GasCost::new(u64::MAX),
             priority_fee_percent,
+            fee_horizon_hours,
         })
         .await
         .map_err(|source| StepError::StepFail {
@@ -142,12 +261,44 @@ async fn fund_self_transfer(
             ),
         })?;
 
+    let horizon_data = if fee_horizon_hours.is_some() {
+        let block = client
+            .block(&response.tip)
+            .await
+            .map_err(|source| StepError::StepFail {
+                message: format!(
+                    "Step `{}` error: preparation tip block query failed: {source}",
+                    step.value
+                ),
+            })?
+            .ok_or_else(|| StepError::LogicalError {
+                message: format!(
+                    "Step `{}` error: preparation tip {} is not available",
+                    step.value, response.tip
+                ),
+            })?;
+        let time = client
+            .time_info()
+            .await
+            .map_err(|source| StepError::StepFail {
+                message: format!("Step `{}` error: time query failed: {source}", step.value),
+            })?;
+        Some((
+            block.header.slot.into_inner(),
+            time.current_slot,
+            time.slot_duration_ms,
+        ))
+    } else {
+        None
+    };
+
     Ok((
         response,
         GasPrices {
             execution_base_gas_price: prices_at_funding_tip.execution_base_gas_price,
             storage_gas_price: prices_at_funding_tip.storage_gas_price,
         },
+        horizon_data,
     ))
 }
 
@@ -223,6 +374,155 @@ fn record_prepared_priority_fee(
         initial_mandatory_fee,
         initial_reserve,
         funded_fee,
+        horizon_reserve: 0,
+        projected_mandatory_fee: initial_mandatory_fee,
+        fee_horizon_tenths: 0,
+        initial_execution_price: prices.execution_base_gas_price.into_inner(),
+        initial_storage_price: prices.storage_gas_price.into_inner(),
+    })
+}
+
+#[expect(
+    clippy::too_many_arguments,
+    clippy::too_many_lines,
+    reason = "The acceptance oracle keeps all preparation inputs visible and independent."
+)]
+fn record_prepared_priority_fee_with_horizon(
+    world: &CucumberWorld,
+    step: &Step,
+    signed_tx: &SignedMantleTx<Preverified>,
+    prices: &GasPrices,
+    priority_fee_percent: u64,
+    fee_horizon_hours: FeeHorizonHours,
+    preparation_slot: u64,
+    current_slot: u64,
+    slot_duration_ms: u64,
+    slots_per_epoch: u64,
+) -> Result<PreparedPriorityFee, StepError> {
+    let initial_mandatory_fee = signed_tx
+        .total_gas_cost::<MainnetGasProfile>(prices)
+        .map_err(|source| StepError::StepFail {
+            message: format!(
+                "Step `{}` error: initial mandatory fee calculation failed: {source}",
+                step.value
+            ),
+        })?
+        .into_inner();
+    let initial_reserve =
+        fee_spec::priority_fee_amount(initial_mandatory_fee, priority_fee_percent).map_err(
+            |message| StepError::StepFail {
+                message: format!("Step `{}` error: {message}", step.value),
+            },
+        )?;
+
+    let denominator = u128::from(slot_duration_ms)
+        .checked_mul(10)
+        .ok_or_else(|| StepError::StepFail {
+            message: format!(
+                "Step `{}` error: slot-duration arithmetic overflowed",
+                step.value
+            ),
+        })?;
+    if denominator == 0 || slots_per_epoch == 0 {
+        return Err(StepError::InvalidArgument {
+            message: "slot duration and slots per epoch must be greater than zero".to_owned(),
+        });
+    }
+    let horizon_slots = u64::try_from(
+        (u128::from(fee_horizon_hours.tenths()) * 3_600_000u128).div_ceil(denominator),
+    )
+    .map_err(|_| StepError::StepFail {
+        message: format!(
+            "Step `{}` error: horizon slot arithmetic overflowed",
+            step.value
+        ),
+    })?;
+    let horizon_end_slot = preparation_slot
+        .max(current_slot)
+        .checked_add(horizon_slots)
+        .ok_or_else(|| StepError::StepFail {
+            message: format!("Step `{}` error: horizon end slot overflowed", step.value),
+        })?;
+    let preparation_epoch = preparation_slot / slots_per_epoch;
+    let horizon_end_epoch = horizon_end_slot / slots_per_epoch;
+    let boundaries = horizon_end_epoch
+        .checked_sub(preparation_epoch)
+        .ok_or_else(|| StepError::StepFail {
+            message: format!(
+                "Step `{}` error: horizon epoch arithmetic underflowed",
+                step.value
+            ),
+        })?;
+
+    let mut projected_storage_price = prices.storage_gas_price.into_inner();
+    for _ in 0..boundaries {
+        projected_storage_price =
+            u64::try_from((u128::from(projected_storage_price) * 9).div_ceil(8)).map_err(|_| {
+                StepError::StepFail {
+                    message: format!(
+                        "Step `{}` error: projected storage price overflowed",
+                        step.value
+                    ),
+                }
+            })?;
+    }
+    let projected_prices = GasPrices {
+        execution_base_gas_price: prices.execution_base_gas_price,
+        storage_gas_price: projected_storage_price.into(),
+    };
+    let projected_mandatory_fee = signed_tx
+        .total_gas_cost::<MainnetGasProfile>(&projected_prices)
+        .map_err(|source| StepError::StepFail {
+            message: format!(
+                "Step `{}` error: projected mandatory fee failed: {source}",
+                step.value
+            ),
+        })?
+        .into_inner();
+    let horizon_reserve = projected_mandatory_fee
+        .checked_sub(initial_mandatory_fee)
+        .ok_or_else(|| StepError::StepFail {
+            message: format!(
+                "Step `{}` error: projected fee fell below current fee",
+                step.value
+            ),
+        })?;
+    let expected_target = projected_mandatory_fee
+        .checked_add(initial_reserve)
+        .ok_or_else(|| StepError::StepFail {
+            message: format!(
+                "Step `{}` error: expected target fee overflowed",
+                step.value
+            ),
+        })?;
+    let funded_fee = fee_spec::net_balance_against(&world.genesis_block_utxos, signed_tx).map_err(
+        |message| StepError::StepFail {
+            message: format!("Step `{}` error: {message}", step.value),
+        },
+    )?;
+    if funded_fee != expected_target {
+        return Err(StepError::StepFail {
+            message: format!(
+                "Step `{}` error: funded fee {funded_fee} != projected mandatory {} + \
+                 priority reserve {} (current mandatory {}, horizon reserve {}, boundaries {})",
+                step.value,
+                projected_mandatory_fee,
+                initial_reserve,
+                initial_mandatory_fee,
+                horizon_reserve,
+                boundaries,
+            ),
+        });
+    }
+
+    Ok(PreparedPriorityFee {
+        percent: priority_fee_percent,
+        initial_mandatory_fee,
+        initial_reserve,
+        funded_fee,
+        horizon_reserve,
+        projected_mandatory_fee,
+        fee_horizon_tenths: fee_horizon_hours.tenths(),
         initial_execution_price: prices.execution_base_gas_price.into_inner(),
         initial_storage_price: prices.storage_gas_price.into_inner(),
     })

--- a/tests/src/cucumber/steps/fees/assertions.rs
+++ b/tests/src/cucumber/steps/fees/assertions.rs
@@ -166,9 +166,10 @@ pub async fn prepared_transaction_tip_absorbed_fee_increase(
     Ok(())
 }
 
-/// Recalculates the mandatory fee of a percentage-funded transaction at the
-/// current prices and verifies that the price increase consumed part of its
-/// original reserve without making it underfunded.
+/// Recalculates the mandatory fee of a funded transaction at current prices.
+///
+/// For horizon-funded transactions this verifies that the original absolute
+/// priority reserve remains available after the storage reserve is consumed.
 pub async fn prepared_transaction_percentage_reserve_absorbed_fee_increase(
     world: &CucumberWorld,
     step: &Step,
@@ -210,7 +211,28 @@ pub async fn prepared_transaction_percentage_reserve_absorbed_fee_increase(
             ),
         })?;
 
-    if remaining_reserve >= prepared_fee.initial_reserve {
+    if prepared_fee.fee_horizon_tenths > 0 {
+        if current_mandatory_fee <= prepared_fee.initial_mandatory_fee
+            || remaining_reserve < prepared_fee.initial_reserve
+        {
+            return Err(StepError::StepFail {
+                message: format!(
+                    "Step `{}` error: transaction `{transaction_alias}` did not preserve its \
+                     original absolute priority reserve: initial mandatory={}, priority \
+                     reserve={}, projected mandatory={}, horizon reserve={}, funded={}, \
+                     current mandatory={}, remaining reserve={}",
+                    step.value,
+                    prepared_fee.initial_mandatory_fee,
+                    prepared_fee.initial_reserve,
+                    prepared_fee.projected_mandatory_fee,
+                    prepared_fee.horizon_reserve,
+                    prepared_fee.funded_fee,
+                    current_mandatory_fee,
+                    remaining_reserve,
+                ),
+            });
+        }
+    } else if remaining_reserve >= prepared_fee.initial_reserve {
         return Err(StepError::StepFail {
             message: format!(
                 "Step `{}` error: transaction `{transaction_alias}` reserve did not shrink: \
@@ -228,12 +250,13 @@ pub async fn prepared_transaction_percentage_reserve_absorbed_fee_increase(
 
     info!(
         target: TARGET,
-        "Transaction `{transaction_alias}` retained a smaller effective reserve: \
-         {}% of initial mandatory {} => reserve {}, funded {}; prices execution {} -> {}, \
-         storage {} -> {}; current mandatory {}, remaining reserve {}",
+        "Transaction `{transaction_alias}` retained its original absolute priority reserve: \
+         {}% of initial mandatory {} => priority reserve {}, horizon reserve {}, funded {}; \
+         prices execution {} -> {}, storage {} -> {}; current mandatory {}, remaining reserve {}",
         prepared_fee.percent,
         prepared_fee.initial_mandatory_fee,
         prepared_fee.initial_reserve,
+        prepared_fee.horizon_reserve,
         prepared_fee.funded_fee,
         prepared_fee.initial_execution_price,
         prices.execution_base_gas_price.into_inner(),

--- a/tests/src/cucumber/steps/fees/steps.rs
+++ b/tests/src/cucumber/steps/fees/steps.rs
@@ -5,7 +5,7 @@ use std::str::FromStr;
 
 use cucumber::{Parameter, gherkin::Step, then, when};
 use lb_core::mantle::{
-    gas::GasPrice,
+    gas::{FeeHorizonHours, GasPrice},
     transactions::{GENESIS_EXECUTION_GAS_PRICE, GENESIS_STORAGE_GAS_PRICE},
 };
 
@@ -221,6 +221,37 @@ async fn step_prepare_wallet_funded_self_transfer_with_priority_fee(
     .await
 }
 
+#[when(
+    expr = "I prepare a wallet-funded self-transfer with a {int}% priority fee reserve and a \
+            {float} hour fee horizon from wallet {string} via node {string} as {string}"
+)]
+async fn step_prepare_wallet_funded_self_transfer_with_fee_horizon(
+    world: &mut CucumberWorld,
+    step: &Step,
+    priority_fee_percent: u64,
+    fee_horizon_hours: f64,
+    wallet_name: String,
+    node_name: String,
+    transaction_alias: String,
+) -> StepResult {
+    let fee_horizon_hours =
+        FeeHorizonHours::from_str(&fee_horizon_hours.to_string()).map_err(|message| {
+            StepError::InvalidArgument {
+                message: format!("invalid fee horizon {fee_horizon_hours}: {message}"),
+            }
+        })?;
+    actions::prepare_wallet_funded_self_transfer_with_fee_horizon(
+        world,
+        step,
+        &wallet_name,
+        &node_name,
+        transaction_alias,
+        priority_fee_percent,
+        fee_horizon_hours,
+    )
+    .await
+}
+
 #[when(expr = "I submit prepared transaction {string} via node {string}")]
 async fn step_submit_prepared_transaction(
     world: &mut CucumberWorld,
@@ -271,6 +302,51 @@ async fn step_prepared_transaction_percentage_reserve_absorbed_fee_increase(
     configured_percent: u64,
     node_name: String,
 ) -> StepResult {
+    assertions::prepared_transaction_percentage_reserve_absorbed_fee_increase(
+        world,
+        step,
+        &transaction_alias,
+        configured_percent,
+        &node_name,
+    )
+    .await
+}
+
+#[then(
+    expr = "transaction {string} prepared with a {int}% priority fee reserve and a {float} \
+            hour fee horizon remains funded with its original priority reserve at current \
+            prices on node {string}"
+)]
+#[expect(
+    clippy::needless_pass_by_ref_mut,
+    reason = "cucumber step entrypoints must take `&mut World`"
+)]
+async fn step_prepared_transaction_fee_horizon_reserve_absorbed_fee_increase(
+    world: &mut CucumberWorld,
+    step: &Step,
+    transaction_alias: String,
+    configured_percent: u64,
+    fee_horizon_hours: f64,
+    node_name: String,
+) -> StepResult {
+    let fee_horizon_hours =
+        FeeHorizonHours::from_str(&fee_horizon_hours.to_string()).map_err(|message| {
+            StepError::InvalidArgument {
+                message: format!("invalid fee horizon {fee_horizon_hours}: {message}"),
+            }
+        })?;
+    let prepared_fee = world.resolve_prepared_priority_fee(&transaction_alias)?;
+    if prepared_fee.fee_horizon_tenths != fee_horizon_hours.tenths() {
+        return Err(StepError::StepFail {
+            message: format!(
+                "Step `{}` error: transaction `{transaction_alias}` was prepared with {} \
+                 tenths of an hour, expected {}",
+                step.value,
+                prepared_fee.fee_horizon_tenths,
+                fee_horizon_hours.tenths(),
+            ),
+        });
+    }
     assertions::prepared_transaction_percentage_reserve_absorbed_fee_increase(
         world,
         step,

--- a/tests/src/cucumber/steps/manual_zone/actions.rs
+++ b/tests/src/cucumber/steps/manual_zone/actions.rs
@@ -65,8 +65,8 @@ const SEQUENCER_READY_POLL_TIMEOUT: Duration = Duration::from_secs(10);
 const SEQUENCER_READY_HEIGHT_ADVANCE_TIMEOUT: Duration = Duration::from_secs(30);
 const ZONE_SECURITY_PARAM: u32 = 5;
 // These high-volume scenarios can move storage prices before all queued
-// publishes are included. Keep their test funding comfortably above the
-// public 12% default so they exercise sequencing rather than fee starvation.
+// publishes are included. Keep their test funding at an explicit 50% priority
+// reserve so they exercise sequencing rather than fee starvation.
 const ZONE_TEST_PRIORITY_FEE_PERCENT: u64 = 50;
 
 pub(super) enum DriveMode {
@@ -798,6 +798,7 @@ fn sequencer_funding(
         funding_pk,
         max_tx_fee: GasCost::new(u64::MAX),
         priority_fee_percent: ZONE_TEST_PRIORITY_FEE_PERCENT,
+        fee_horizon_hours: None,
     })
 }
 

--- a/tests/src/cucumber/steps/manual_zone/support.rs
+++ b/tests/src/cucumber/steps/manual_zone/support.rs
@@ -989,6 +989,7 @@ pub async fn replay_finalized_history(
         funding_pk: lb_groth16::Fr::from(1u64).into(),
         max_tx_fee: GasCost::new(u64::MAX),
         priority_fee_percent: FundingConfig::DEFAULT_PRIORITY_FEE_PERCENT,
+        fee_horizon_hours: Some(FundingConfig::DEFAULT_FEE_HORIZON_HOURS),
     };
     let mut sequencer = ZoneSequencer::init(reader.channel_id, keygen(), node, funding, None);
 
@@ -1595,6 +1596,7 @@ async fn build_funded_custom_tx(
             change_public_key: funding_pk,
             funding_public_keys: vec![funding_pk],
             max_tx_fee: GasCost::new(u64::MAX),
+            fee_horizon_hours: None,
         })
         .await
         .map_err(|error| ZoneTestError::SubmitCustomTx {

--- a/tests/src/cucumber/steps/wallet_fund.rs
+++ b/tests/src/cucumber/steps/wallet_fund.rs
@@ -511,6 +511,7 @@ async fn fund_via_node(
             funding_public_keys: vec![funding_pk],
             max_tx_fee: GasCost::new(u64::MAX),
             priority_fee_percent: 0,
+            fee_horizon_hours: None,
         })
         .await
         .map_err(|source| StepError::StepFail {

--- a/tests/src/cucumber/world.rs
+++ b/tests/src/cucumber/world.rs
@@ -1217,6 +1217,9 @@ pub struct PreparedPriorityFee {
     pub initial_mandatory_fee: u64,
     pub initial_reserve: u64,
     pub funded_fee: u64,
+    pub horizon_reserve: u64,
+    pub projected_mandatory_fee: u64,
+    pub fee_horizon_tenths: u16,
     pub initial_execution_price: u64,
     pub initial_storage_price: u64,
 }

--- a/tests/testing_framework/src/node/http_client.rs
+++ b/tests/testing_framework/src/node/http_client.rs
@@ -15,6 +15,7 @@ use lb_core::{
     sdp::{Declaration, DeclarationId, Locator},
 };
 use lb_http_api_common::{
+    TimeInfo,
     bodies::{
         blend::JoinBlendRequestBody,
         mantle::GasPricesResponseBody,
@@ -84,6 +85,14 @@ impl NodeHttpClient {
         self.with_timeout(
             "Gas prices request",
             self.http_client.gas_prices(self.base_url.clone(), tip),
+        )
+        .await
+    }
+
+    pub async fn time_info(&self) -> Result<TimeInfo, Error> {
+        self.with_timeout(
+            "Time info request",
+            self.http_client.time_info(self.base_url.clone()),
         )
         .await
     }

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -15,7 +15,8 @@ use lb_core::{
     events::{Event, Events, HeaderEvent, TxEvent, TxEventPayload},
     header::HeaderId,
     mantle::{
-        GasProfile, NoteId, TxHash, Utxo, Value,
+        GasProfile, Note, NoteId, TxHash, Utxo, Value,
+        gas::GasCost,
         ops::{
             Op, OpId as _,
             channel::{
@@ -324,6 +325,93 @@ impl WalletState {
         Err(WalletError::InsufficientFunds {
             available: utxos.iter().map(|u| u.note.value).sum::<u64>(),
         })
+    }
+
+    /// Funds the transaction to an explicit absolute fee. The caller may
+    /// derive that amount from the final transaction shape and repeat this
+    /// operation if adding inputs or change changes the required fee.
+    pub fn fund_tx_to_required_fee(
+        &self,
+        tx_builder: &MantleTxBuilder,
+        change_pk: ZkPublicKey,
+        pks: impl IntoIterator<Item = impl Borrow<ZkPublicKey>>,
+        excluded_notes: &HashSet<NoteId>,
+        required_fee: GasCost,
+    ) -> Result<MantleTxBuilder, WalletError> {
+        let excluded_notes = tx_builder
+            .consumed_or_locked_notes()
+            .chain(self.locked_notes.iter().copied())
+            .chain(self.channel_notes.iter().copied())
+            .chain(excluded_notes.iter().copied())
+            .collect::<HashSet<_>>();
+        let mut utxos = self
+            .utxos_owned_by_pks(pks)
+            .into_iter()
+            .filter(|utxo| !excluded_notes.contains(&utxo.id()))
+            .collect::<Vec<_>>();
+
+        utxos.sort_by_key(|utxo| -i128::from(utxo.note.value));
+
+        match tx_builder
+            .funding_delta_to_required_fee(required_fee)?
+            .cmp(&0)
+        {
+            Ordering::Equal => return Ok(tx_builder.clone()),
+            Ordering::Greater => {
+                if let Some(tx_with_change) =
+                    Self::return_change_to_required_fee(tx_builder, change_pk, required_fee)?
+                {
+                    return Ok(tx_with_change);
+                }
+            }
+            Ordering::Less => {}
+        }
+
+        for i in 0..utxos.len() {
+            let funded_tx_builder = tx_builder
+                .clone()
+                .extend_ledger_inputs(utxos[..=i].iter().copied())?;
+
+            match funded_tx_builder
+                .funding_delta_to_required_fee(required_fee)?
+                .cmp(&0)
+            {
+                Ordering::Less => {}
+                Ordering::Equal => return Ok(funded_tx_builder),
+                Ordering::Greater => {
+                    if let Some(tx_with_change) = Self::return_change_to_required_fee(
+                        &funded_tx_builder,
+                        change_pk,
+                        required_fee,
+                    )? {
+                        return Ok(tx_with_change);
+                    }
+                }
+            }
+        }
+
+        Err(WalletError::InsufficientFunds {
+            available: utxos.iter().map(|u| u.note.value).sum::<u64>(),
+        })
+    }
+
+    fn return_change_to_required_fee(
+        tx_builder: &MantleTxBuilder,
+        change_pk: ZkPublicKey,
+        required_fee: GasCost,
+    ) -> Result<Option<MantleTxBuilder>, WalletError> {
+        let candidate = tx_builder.with_dummy_change_note()?;
+        let available_change = candidate.funding_delta_to_required_fee(required_fee)?;
+
+        if available_change < 1 {
+            return Ok(None);
+        }
+
+        let change = u64::try_from(available_change).expect("change must fit in u64");
+        Ok(Some(tx_builder.clone().add_ledger_output(Note {
+            value: change,
+            pk: change_pk,
+        })?))
     }
 
     #[must_use]
@@ -814,6 +902,24 @@ where
         )
     }
 
+    pub fn fund_tx_to_required_fee(
+        &self,
+        tip: HeaderId,
+        tx_builder: &MantleTxBuilder,
+        change_pk: ZkPublicKey,
+        funding_pks: impl IntoIterator<Item = impl Borrow<ZkPublicKey>>,
+        excluded_notes: &HashSet<NoteId>,
+        required_fee: GasCost,
+    ) -> Result<MantleTxBuilder, WalletError> {
+        self.wallet_state_at(tip)?.fund_tx_to_required_fee(
+            tx_builder,
+            change_pk,
+            funding_pks,
+            excluded_notes,
+            required_fee,
+        )
+    }
+
     pub fn wallet_state_at(&self, tip: HeaderId) -> Result<WalletState, WalletError> {
         self.wallet_states
             .get(&tip)
@@ -874,7 +980,7 @@ mod tests {
     use lb_core::{
         crypto::ZkDigest as _,
         mantle::{
-            Note, OpProof, RawMantleTx, SignedMantleTx,
+            OpProof, RawMantleTx, SignedMantleTx,
             channel::Channels,
             gas::MainnetGasProfile as Gas,
             ledger::{Inputs, Outputs},
@@ -1536,6 +1642,46 @@ mod tests {
         } else {
             panic!("last op must be a transfer")
         }
+    }
+
+    #[test]
+    fn test_fund_tx_to_required_fee_rechecks_the_final_change_shape() {
+        let alice = pk(1);
+        let utxo = Utxo::new(tx_hash(0), 0, Note::new(5000, alice));
+        let ledger_state = LedgerState::from_utxos([utxo], &ledger_config());
+        let wallet_state =
+            WalletState::from_ledger(&HashMap::from_iter([(alice, 1)]), &ledger_state);
+        let context = MantleTxContext {
+            gas_context: MantleTxGasContext::from_channels(
+                &Channels::default(),
+                GasPrices::new(1, 1),
+            ),
+            leader_reward_amount: 0,
+        };
+        let horizon_context = MantleTxContext {
+            gas_context: context.gas_context.with_gas_prices(GasPrices::new(1, 2)),
+            leader_reward_amount: 0,
+        };
+
+        let funded = wallet_state
+            .fund_tx_to_required_fee(
+                &MantleTxBuilder::new(),
+                alice,
+                [alice],
+                &HashSet::new(),
+                GasCost::new(1_094),
+            )
+            .unwrap();
+
+        assert_eq!(funded.net_balance(), 1_094);
+        assert_eq!(
+            funded.minimum_gas_cost::<Gas>(&context).unwrap(),
+            GasCost::new(794)
+        );
+        assert_eq!(
+            funded.minimum_gas_cost::<Gas>(&horizon_context).unwrap(),
+            GasCost::new(998)
+        );
     }
 
     #[test]

--- a/zone-sdk/BRIDGING.md
+++ b/zone-sdk/BRIDGING.md
@@ -46,6 +46,7 @@ let funding = FundingConfig {
     funding_pk,
     max_tx_fee: 1_000_000.into(),
     priority_fee_percent: FundingConfig::DEFAULT_PRIORITY_FEE_PERCENT,
+    fee_horizon_hours: Some(FundingConfig::DEFAULT_FEE_HORIZON_HOURS),
 };
 let mut sequencer = ZoneSequencer::init(channel_id, signing_key, node, funding, None);
 
@@ -55,14 +56,16 @@ let (result, checkpoint) = sequencer.handle().publish(genesis_zone_block).await?
 ```
 
 `priority_fee_percent` is a percentage reserve over the complete mandatory
-fee, which consists of execution plus storage cost. Only the reserve left
-after the transaction's final mandatory fee is charged becomes the effective
-priority tip. The Zone SDK default is 12%: a practical reserve intended to
-absorb normal fee movement, including approximately one storage-market epoch
-increase under normal price levels. It is not a protocol guarantee at very low
-prices or when execution fees also rise materially. Storage prices use integer
-arithmetic, so low prices can make proportionally larger jumps (for example,
-1 to 2); 12% is therefore a safety margin, not a guaranteed one-epoch bound.
+fee at preparation-time prices, which consists of execution plus storage cost.
+Its rounded-up amount is an absolute priority reserve and is not reapplied to
+future prices. `fee_horizon_hours` is an independent optional duration that
+adds enough reserve for the deterministic maximum storage-price transition at
+each covered epoch boundary. The default policy is a one-hour storage horizon
+with no explicit priority reserve. Callers can opt into a priority percentage
+independently, or use `None`/`0.0` to disable horizon coverage and retain
+percentage-only funding. The horizon reserve is not a separate refundable
+bucket: any amount not yet needed for mandatory storage fees is effective tip
+immediately, and is consumed as storage prices rise.
 
 To override other sequencer settings, build the config explicitly —
 `SequencerConfig::new(funding)` fills in the defaults for everything else:

--- a/zone-sdk/src/sequencer/tx_builder.rs
+++ b/zone-sdk/src/sequencer/tx_builder.rs
@@ -52,6 +52,7 @@ where
             // The public request field is a percentage of the final
             // mandatory fee, not an absolute fee amount.
             priority_fee_percent: funding.priority_fee_percent,
+            fee_horizon_hours: funding.fee_horizon_hours,
         })
         .await
         .map_err(|e| Error::Network(format!("funding failed: {e}")))?;
@@ -301,6 +302,9 @@ mod tests {
 
         fund_ops(&node, &funding, Vec::new()).await.unwrap();
 
-        assert_eq!(priority_fees_rx.recv().await, Some(12));
+        assert_eq!(
+            priority_fees_rx.recv().await,
+            Some(FundingConfig::DEFAULT_PRIORITY_FEE_PERCENT)
+        );
     }
 }

--- a/zone-sdk/src/sequencer/types.rs
+++ b/zone-sdk/src/sequencer/types.rs
@@ -8,7 +8,7 @@ use lb_core::{
     mantle::{
         SignedMantleTx, Value,
         channel::ChannelState,
-        gas::GasCost,
+        gas::{FeeHorizonHours, GasCost},
         ledger::{Inputs, NoteId, Outputs},
         ops::channel::{
             ChannelId, MsgId, channel_transfer::ChannelTransferOp, deposit::Metadata,
@@ -143,21 +143,42 @@ pub struct FundingConfig {
     pub funding_pk: ZkPublicKey,
     /// Absolute hard cap on the fee of a single funded transaction.
     pub max_tx_fee: GasCost,
-    /// Percentage of the final mandatory fee reserved as a priority reserve
-    /// when funding a transaction. The mandatory fee is execution plus
-    /// storage cost, and only the unused reserve becomes an effective tip.
-    /// The 12% default is a practical reserve intended to absorb normal fee
-    /// movement, including approximately one storage-market epoch increase
-    /// at normal price levels. It is not a protocol guarantee at very low
-    /// prices or when execution fees also rise materially: storage prices use
-    /// integer arithmetic, so a low price can jump proportionally more (for
-    /// example, 1 to 2). [`Self::max_tx_fee`] caps the total.
+    /// Percentage of the mandatory fee at preparation-time prices reserved as
+    /// an absolute priority incentive when funding a transaction. The
+    /// percentage covers execution plus storage cost and is not reapplied to
+    /// future prices. The default is no explicit priority reserve; callers
+    /// can opt into one independently of the storage horizon.
+    /// [`Self::max_tx_fee`] caps the total.
     pub priority_fee_percent: u64,
+    /// Optional elapsed-time horizon for independent storage-fee coverage.
+    /// The default policy uses [`Self::DEFAULT_FEE_HORIZON_HOURS`]. `None` or
+    /// zero explicitly preserves percentage-only funding. Any unused horizon
+    /// reserve is effective tip immediately and is consumed as mandatory
+    /// storage fees rise.
+    pub fee_horizon_hours: Option<FeeHorizonHours>,
 }
 
 impl FundingConfig {
-    /// Default percentage reserve for normal fee movement.
-    pub const DEFAULT_PRIORITY_FEE_PERCENT: Value = 12;
+    /// Default preparation-time priority reserve percentage.
+    pub const DEFAULT_PRIORITY_FEE_PERCENT: Value = 0;
+    /// Default deterministic storage-fee coverage horizon.
+    pub const DEFAULT_FEE_HORIZON_HOURS: FeeHorizonHours = FeeHorizonHours::from_tenths(10);
+}
+
+#[cfg(test)]
+mod tests {
+    use lb_core::mantle::gas::FeeHorizonHours;
+
+    use super::FundingConfig;
+
+    #[test]
+    fn default_funding_policy_is_one_hour_without_explicit_priority() {
+        assert_eq!(FundingConfig::DEFAULT_PRIORITY_FEE_PERCENT, 0);
+        assert_eq!(
+            FundingConfig::DEFAULT_FEE_HORIZON_HOURS,
+            FeeHorizonHours::from_tenths(10)
+        );
+    }
 }
 
 /// Configuration for the zone sequencer.

--- a/zone-sdk/src/test_support.rs
+++ b/zone-sdk/src/test_support.rs
@@ -341,6 +341,7 @@ pub fn funding_config() -> FundingConfig {
         funding_pk: Fr::from(1u64).into(),
         max_tx_fee: GasCost::new(u64::MAX),
         priority_fee_percent: FundingConfig::DEFAULT_PRIORITY_FEE_PERCENT,
+        fee_horizon_hours: Some(FundingConfig::DEFAULT_FEE_HORIZON_HOURS),
     }
 }
 


### PR DESCRIPTION
## 1. What does this PR implement?

Add independent wallet funding controls for priority fees and storage-fee horizons.

- Add optional `fee_horizon_hours` to `/wallet/fund`.
- Keep `priority_fee_percent` as an absolute reserve based on the mandatory fee at preparation-time prices.
- Project only storage-price increases across the requested horizon while keeping the execution gas price unchanged.
- Fund transactions to: `M_horizon + ceil(M_current * priority_fee_percent / 100)`.
- Use fixed-point tenths-of-an-hour internally, rounding user-provided decimal horizons up to the next 0.1 hour.
- Limit the supported horizon to 168 hours (7 days) and return a clear error when exceeded.
- Default wallet funding to 0% explicit priority reserve with a 1-hour storage-fee horizon; explicit `null` or zero disables horizon coverage.
- Re-evaluate the required fee against the final transaction shape as funding inputs and change outputs are added.
- Use the current protocol slot together with the preparation tip so stale tips do not undercount covered epoch boundaries.
- Propagate the funding policy through the node API, C bindings, Zone SDK, TUI, and test clients.
- Give SDP declare, active, and withdraw transactions a fixed 12% priority reserve plus a 1.5-hour storage-fee horizon.
- Update the fee-market Cucumber scenario to exercise independent 12% priority and 0.2-hour horizon reserves with an independent fee oracle.

Fixes #3316.

**Note:** See related fix for testnet release 0.2.2 in #3359.

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@hansieodendaal and @davidrusu 

## 4. Is the specification accurate and complete?

Yes

## 5. Does the implementation introduce changes in the specification?

No

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [X] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [X] 2. Description added.
* [X] 3. Context and links to Specification document(s) added.
* [X] 4. Main contact(s) (developers and specification authors) added
* [X] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [X] 6. Link PR to a specific milestone.
* [X] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
