### PR TITLE
feat(logos-sql): recover live state after forks

### DIFF
--- a/logos_sql/Cargo.toml
+++ b/logos_sql/Cargo.toml
@@ -23,7 +23,7 @@ lb-utils                         = { workspace = true }
 lb-zone-sdk                      = { workspace = true }
 rand                             = { features = ["getrandom"], workspace = true }
 reqwest                          = { workspace = true }
-rusqlite                         = { features = ["bundled", "functions", "hooks"], workspace = true }
+rusqlite                         = { features = ["backup", "bundled", "functions", "hooks"], workspace = true }
 thiserror                        = { workspace = true }
 tokio                            = { features = ["macros", "rt", "sync", "time"], workspace = true }
 tracing                          = { workspace = true }

--- a/logos_sql/src/applier.rs
+++ b/logos_sql/src/applier.rs
@@ -4,31 +4,69 @@ use lb_zone_sdk::{
     node_types::ChannelId,
     sequencer::{
         ChannelUpdate, ChannelUpdateTx, Event, FinalizedOp, FinalizedTx, InscriptionInfo,
-        channel_inscriptions,
+        SequencerCheckpoint, channel_inscriptions,
     },
 };
 
 use crate::{
-    db::Databases,
+    db::{Databases, PendingPublish, SuffixWrite},
     error::Error,
     protocol::{self, ChannelInscription, TxId},
 };
 
 const TARGET: &str = lb_log_targets::logos_sql::APPLIER;
 
+/// Selects which replicated database receives a channel write.
 #[derive(Clone, Copy, Debug)]
-enum WriteState {
-    Adopted,
-    Finalized,
+enum ApplyTarget {
+    /// Apply only to the current live state.
+    Live,
+    /// Apply only to finalized state.
+    Lib,
+    /// Apply to finalized and live state.
+    LibAndLive,
 }
 
-impl WriteState {
+/// Why this event requires `LIVE.db` to be rebuilt.
+enum RebuildCause {
+    /// The pending local write executed against live history that this event
+    /// changes. Keeping its effect would leave `LIVE.db` in the wrong order or
+    /// based on an abandoned branch. Logos SQL does not rerun the application
+    /// transaction automatically, so the rebuild removes its effect and
+    /// reports it as displaced. This also resumes a rebuild interrupted after
+    /// the displacement was recorded.
+    PendingWriteInvalidated(PendingPublish),
+    /// Canonical channel history changed and `LIVE.db` must drop orphaned SQL.
+    ChannelFork,
+}
+
+/// Selects how one block event is reflected in `LIVE.db`.
+enum ApplicationPlan {
+    /// Apply the finalized and adopted changes directly.
+    ApplyChanges,
+    /// Reconstruct live state because existing effects must be reordered or
+    /// removed.
+    Rebuild(RebuildCause),
+}
+
+impl ApplyTarget {
     fn apply(self, db: &mut Databases, write: &ChannelInscription) -> Result<(), Error> {
         match self {
-            Self::Adopted => db.apply_adopted_write(write),
-            Self::Finalized => db.apply_finalized_write(write),
+            Self::Live => db.apply_adopted_write(write),
+            Self::Lib => db.apply_finalized_write_to_lib(write),
+            Self::LibAndLive => db.apply_finalized_write(write),
         }
     }
+}
+
+/// Logos SQL inscriptions carried by one processed-block event.
+///
+/// Normalizing the `ZoneSDK` event once keeps planning and execution on the
+/// same set of writes, regardless of their underlying transaction shape.
+struct SqlChanges {
+    adopted: Vec<InscriptionInfo>,
+    orphaned: Vec<InscriptionInfo>,
+    finalized: Vec<InscriptionInfo>,
 }
 
 /// Handles one sequencer event.
@@ -37,41 +75,20 @@ impl WriteState {
 /// contain no `λSQL` writes, so restart resumes from the latest processed
 /// block.
 /// Finalized writes apply to both finalized and live state, while newly
-/// adopted writes apply only to live state. Orphan recovery is deferred.
+/// adopted writes apply only to live state. A branch change reconstructs live
+/// state from finalized history and the retained canonical suffix.
 ///
 /// # Errors
 ///
 /// Returns an error if SQL cannot be applied, a channel payload cannot be
 /// decoded, or the checkpoint cannot be persisted.
-///
-/// # Panics
-///
-/// Panics when an orphaned `λSQL` transaction reaches the unfinished rebuild
-/// path.
 pub fn on_event(db: &mut Databases, event: &Event, channel_id: ChannelId) -> Result<(), Error> {
     match event {
         Event::BlocksProcessed {
             checkpoint,
             channel_update,
             finalized,
-        } => {
-            tracing::debug!(
-                target: TARGET,
-                adopted_txs = channel_update.adopted.len(),
-                orphaned_txs = channel_update.orphaned.len(),
-                finalized_txs = finalized.len(),
-                "blocks processed"
-            );
-
-            if orphaned_contains_logos_sql(channel_update, channel_id) {
-                todo!("reconcile orphaned \u{3bb}SQL transactions");
-            }
-
-            apply_finalized(db, finalized)?;
-            apply_adopted(db, &channel_update.adopted, channel_id)?;
-
-            db.persist_checkpoint(checkpoint)?;
-        }
+        } => process_blocks(db, checkpoint, channel_update, finalized, channel_id)?,
         Event::Ready => {
             tracing::info!(target: TARGET, "sequencer ready");
         }
@@ -81,67 +98,274 @@ pub fn on_event(db: &mut Databases, event: &Event, channel_id: ChannelId) -> Res
     Ok(())
 }
 
-fn orphaned_contains_logos_sql(channel_update: &ChannelUpdate, channel_id: ChannelId) -> bool {
-    channel_update
-        .orphaned
-        .iter()
-        .any(|transaction| transaction_contains_logos_sql(transaction, channel_id))
+/// Applies one block event before advancing its checkpoint.
+///
+/// If any state change fails, the checkpoint remains behind and `ZoneSDK`
+/// delivers the same channel position again after retry or restart.
+fn process_blocks(
+    db: &mut Databases,
+    checkpoint: &SequencerCheckpoint,
+    channel_update: &ChannelUpdate,
+    finalized: &[FinalizedTx],
+    channel_id: ChannelId,
+) -> Result<(), Error> {
+    let changes = SqlChanges::from_block(channel_update, finalized, channel_id);
+
+    tracing::debug!(
+        target: TARGET,
+        adopted_writes = changes.adopted.len(),
+        orphaned_writes = changes.orphaned.len(),
+        finalized_writes = changes.finalized.len(),
+        "blocks processed"
+    );
+
+    let plan = changes.application_plan(db)?;
+
+    match plan {
+        ApplicationPlan::ApplyChanges => changes.apply(db)?,
+        ApplicationPlan::Rebuild(cause) => changes.rebuild(db, &cause)?,
+    }
+
+    db.persist_checkpoint(checkpoint)
 }
 
-fn apply_finalized(db: &mut Databases, finalized: &[FinalizedTx]) -> Result<(), Error> {
-    for transaction in finalized {
-        for operation in &transaction.ops {
-            let FinalizedOp::Inscription(inscription) = operation else {
-                continue;
-            };
+impl SqlChanges {
+    /// Extracts only Logos SQL inscriptions from the three channel-history
+    /// sets.
+    fn from_block(
+        channel_update: &ChannelUpdate,
+        finalized: &[FinalizedTx],
+        channel_id: ChannelId,
+    ) -> Self {
+        let finalized = finalized
+            .iter()
+            .flat_map(|transaction| &transaction.ops)
+            .filter_map(|operation| match operation {
+                FinalizedOp::Inscription(inscription) => Some(inscription.clone()),
+                _ => None,
+            })
+            .filter(is_logos_sql_inscription)
+            .collect();
 
-            apply_inscription(db, inscription, WriteState::Finalized)?;
+        Self {
+            adopted: Self::collect_channel_inscriptions(&channel_update.adopted, channel_id),
+            orphaned: Self::collect_channel_inscriptions(&channel_update.orphaned, channel_id),
+            finalized,
         }
     }
 
-    Ok(())
-}
+    fn collect_channel_inscriptions(
+        transactions: &[ChannelUpdateTx],
+        channel_id: ChannelId,
+    ) -> Vec<InscriptionInfo> {
+        transactions
+            .iter()
+            .flat_map(|transaction| Self::transaction_inscriptions(transaction, channel_id))
+            .filter(is_logos_sql_inscription)
+            .collect()
+    }
 
-fn apply_adopted(
-    db: &mut Databases,
-    adopted: &[ChannelUpdateTx],
-    channel_id: ChannelId,
-) -> Result<(), Error> {
-    for transaction in adopted {
+    fn transaction_inscriptions(
+        transaction: &ChannelUpdateTx,
+        channel_id: ChannelId,
+    ) -> Vec<InscriptionInfo> {
         if let Some(inscription) = transaction.inscription() {
-            apply_inscription(db, inscription, WriteState::Adopted)?;
-            continue;
+            return vec![inscription.clone()];
         }
 
         let ChannelUpdateTx::Custom(transaction) = transaction else {
-            continue;
+            return Vec::new();
         };
 
-        for inscription in channel_inscriptions(transaction, channel_id) {
-            apply_inscription(db, &inscription, WriteState::Adopted)?;
+        channel_inscriptions(transaction, channel_id)
+    }
+
+    /// Chooses between direct application and reconstructing `LIVE.db`.
+    ///
+    /// Planning performs no mutations. A rebuild is required whenever the
+    /// optimistic local effect must move or disappear, or canonical history
+    /// removes an effect that is already present in `LIVE.db`.
+    fn application_plan(&self, db: &Databases) -> Result<ApplicationPlan, Error> {
+        if let Some(pending) = db.pending_publish()? {
+            // The rebuild records the displacement first, then replaces
+            // `LIVE.db`, which removes its pending-write record. If both records
+            // still exist, the process stopped between those two steps and the
+            // rebuild must resume.
+            if db.is_write_displaced(pending.tx_id)? {
+                return Ok(ApplicationPlan::Rebuild(
+                    RebuildCause::PendingWriteInvalidated(pending),
+                ));
+            }
+
+            if self.changes_pending_base(db)? {
+                return Ok(ApplicationPlan::Rebuild(
+                    RebuildCause::PendingWriteInvalidated(pending),
+                ));
+            }
+        }
+
+        if !self.orphaned.is_empty() {
+            return Ok(ApplicationPlan::Rebuild(RebuildCause::ChannelFork));
+        }
+
+        Ok(ApplicationPlan::ApplyChanges)
+    }
+
+    /// Reports whether this event changed the history below a pending local
+    /// write.
+    ///
+    /// Adoptions and orphans always change that base. Finalizing a write
+    /// already retained in the live suffix only moves the finalized
+    /// boundary and does not invalidate the pending write's execution
+    /// order.
+    fn changes_pending_base(&self, db: &Databases) -> Result<bool, Error> {
+        if !self.adopted.is_empty() || !self.orphaned.is_empty() {
+            return Ok(true);
+        }
+
+        for inscription in &self.finalized {
+            if !db.live_suffix_contains(inscription.this_msg)? {
+                return Ok(true);
+            }
+        }
+
+        Ok(false)
+    }
+
+    /// Applies an event whose existing `LIVE.db` effects remain correctly
+    /// ordered.
+    fn apply(&self, db: &mut Databases) -> Result<(), Error> {
+        Self::apply_inscriptions(db, &self.finalized, ApplyTarget::LibAndLive)?;
+        Self::apply_inscriptions(db, &self.adopted, ApplyTarget::Live)?;
+        self.apply_history_delta(db)
+    }
+
+    /// Records displacement, advances finalized state, and reconstructs LIVE.
+    ///
+    /// The displacement, when applicable, and suffix are persisted before
+    /// replacing `LIVE.db` so an interrupted rebuild can be recognized and
+    /// safely repeated.
+    fn rebuild(&self, db: &mut Databases, cause: &RebuildCause) -> Result<(), Error> {
+        match cause {
+            RebuildCause::PendingWriteInvalidated(pending) => {
+                db.record_unpublished_displacement(pending)?;
+            }
+            RebuildCause::ChannelFork => {}
+        }
+
+        Self::apply_inscriptions(db, &self.finalized, ApplyTarget::Lib)?;
+        self.apply_history_delta(db)?;
+        rebuild_live_from_suffix(db)
+    }
+
+    fn apply_inscriptions(
+        db: &mut Databases,
+        inscriptions: &[InscriptionInfo],
+        target: ApplyTarget,
+    ) -> Result<(), Error> {
+        for inscription in inscriptions {
+            apply_inscription(db, inscription, target)?;
+        }
+
+        Ok(())
+    }
+
+    /// Applies this event to the replayable suffix and local displacement
+    /// outcomes.
+    fn apply_history_delta(&self, db: &mut Databases) -> Result<(), Error> {
+        let finalized = self
+            .finalized
+            .iter()
+            .map(|inscription| inscription.this_msg)
+            .collect::<Vec<_>>();
+        let orphaned = self
+            .orphaned
+            .iter()
+            .map(|inscription| inscription.this_msg)
+            .collect::<Vec<_>>();
+        let adopted = self.collect_adopted_suffix(db)?;
+
+        db.apply_history_delta(&finalized, &orphaned, &adopted)
+    }
+
+    /// Prepares newly adopted writes for durable replay during a later rebuild.
+    fn collect_adopted_suffix(&self, db: &Databases) -> Result<Vec<SuffixWrite>, Error> {
+        let mut writes = Vec::new();
+
+        for inscription in &self.adopted {
+            let payload = inscription.payload.as_ref();
+            let write = match ChannelInscription::decode(payload) {
+                Ok(write) => write,
+                Err(error) => {
+                    handle_write_error(db, inscription, None, error)?;
+                    continue;
+                }
+            };
+
+            writes.push(SuffixWrite {
+                this_msg: inscription.this_msg,
+                tx_id: write.tx_id,
+                payload: payload.to_vec(),
+                local: false,
+            });
+        }
+
+        Ok(writes)
+    }
+}
+
+/// Reconstructs `LIVE.db` as finalized state followed by the canonical suffix.
+///
+/// Stored payloads are local durable state: malformed or mismatched records
+/// indicate corruption. Deterministically rejected SQL is recorded and skipped
+/// exactly as it is during normal channel application.
+fn rebuild_live_from_suffix(db: &mut Databases) -> Result<(), Error> {
+    let suffix = db.live_suffix()?;
+    let mut rebuild = db.begin_live_rebuild()?;
+
+    for retained in suffix {
+        let write = ChannelInscription::decode(&retained.payload)
+            .map_err(|_| Error::InvalidLocalState("stored live suffix payload is malformed"))?;
+
+        if write.tx_id != retained.tx_id {
+            return Err(Error::InvalidLocalState(
+                "stored live suffix transaction id does not match its payload",
+            ));
+        }
+
+        match rebuild.apply_write(&write) {
+            Ok(()) => {}
+            Err(error) if is_rejected_write(&error) => {
+                db.record_rejected_write(retained.this_msg, Some(write.tx_id), &error.to_string())?;
+            }
+            Err(error) => return Err(error),
         }
     }
+
+    db.finish_live_rebuild(rebuild)?;
+
+    tracing::info!(
+        target: TARGET,
+        "live database rebuilt after channel branch change"
+    );
 
     Ok(())
 }
 
+/// Decodes and applies one inscription, recording deterministic rejections.
 fn apply_inscription(
     db: &mut Databases,
     inscription: &InscriptionInfo,
-    state: WriteState,
+    target: ApplyTarget,
 ) -> Result<(), Error> {
     let payload = inscription.payload.as_ref();
-
-    if !protocol::is_logos_sql_payload(payload) {
-        return Ok(());
-    }
 
     let write = match ChannelInscription::decode(payload) {
         Ok(write) => write,
         Err(error) => return handle_write_error(db, inscription, None, error),
     };
 
-    if let Err(error) = state.apply(db, &write) {
+    if let Err(error) = target.apply(db, &write) {
         return handle_write_error(db, inscription, Some(write.tx_id), error);
     }
 
@@ -149,13 +373,17 @@ fn apply_inscription(
         target: TARGET,
         tx_id = ?write.tx_id,
         statements = write.transaction.statements().len(),
-        ?state,
+        ?target,
         "channel write processed"
     );
 
     Ok(())
 }
 
+/// Records errors that every replica must reject and propagates local failures.
+///
+/// Propagated failures leave the checkpoint behind so the event is retried;
+/// recording an input rejection allows processing to continue consistently.
 fn handle_write_error(
     db: &Databases,
     inscription: &InscriptionInfo,
@@ -192,18 +420,8 @@ const fn is_rejected_write(error: &Error) -> bool {
     matches!(error, Error::InvalidPayload(_) | Error::RejectedSql(_))
 }
 
-fn transaction_contains_logos_sql(transaction: &ChannelUpdateTx, channel_id: ChannelId) -> bool {
-    if let Some(inscription) = transaction.inscription() {
-        return protocol::is_logos_sql_payload(inscription.payload.as_ref());
-    }
-
-    let ChannelUpdateTx::Custom(transaction) = transaction else {
-        return false;
-    };
-
-    channel_inscriptions(transaction, channel_id)
-        .iter()
-        .any(|inscription| protocol::is_logos_sql_payload(inscription.payload.as_ref()))
+fn is_logos_sql_inscription(inscription: &InscriptionInfo) -> bool {
+    protocol::is_logos_sql_payload(inscription.payload.as_ref())
 }
 
 #[cfg(test)]
@@ -220,10 +438,10 @@ mod tests {
 
     use super::on_event;
     use crate::{
-        db::Databases,
+        db::{Databases, SuffixWrite},
         protocol::{
             CapturedFunctionCalls, ChannelInscription, EncodedWrite, PAYLOAD_MARKER, Statement,
-            Transaction,
+            Transaction, TxId,
         },
     };
 
@@ -280,8 +498,12 @@ mod tests {
     }
 
     fn encoded_write(transaction: &Transaction) -> EncodedWrite {
-        EncodedWrite::new(transaction, CapturedFunctionCalls::empty())
-            .expect("payload should encode")
+        EncodedWrite::new(
+            TxId::generate(),
+            transaction,
+            CapturedFunctionCalls::empty(),
+        )
+        .expect("payload should encode")
     }
 
     fn item_count(path: &std::path::Path) -> i64 {
@@ -304,6 +526,26 @@ mod tests {
                 |row| row.get(0),
             )
             .expect("schema should be readable")
+    }
+
+    fn journal_mode(path: &std::path::Path) -> String {
+        Databases::open_reader(path)
+            .expect("database should open for reading")
+            .query_row("PRAGMA journal_mode", [], |row| row.get(0))
+            .expect("journal mode should be readable")
+    }
+
+    fn text_values(path: &std::path::Path, table: &str) -> Vec<String> {
+        let connection = Databases::open_reader(path).expect("database should open for reading");
+        let mut statement = connection
+            .prepare(&format!("SELECT value FROM {table} ORDER BY value"))
+            .expect("query should prepare");
+
+        statement
+            .query_map([], |row| row.get(0))
+            .expect("query should execute")
+            .collect::<Result<_, _>>()
+            .expect("values should be readable")
     }
 
     #[test]
@@ -435,22 +677,31 @@ mod tests {
 
         let setup = transaction("CREATE TABLE items(value INTEGER NOT NULL)", Vec::new());
         let setup_tx_id = db
-            .commit_local_write(&setup)
+            .commit_local_write(TxId::generate(), &setup)
             .expect("setup write should commit");
-        db.mark_publish_complete(setup_tx_id)
+        let setup_pending = db
+            .pending_publish()
+            .expect("setup write should load")
+            .expect("setup write should be pending");
+        assert_eq!(setup_pending.tx_id, setup_tx_id);
+        db.complete_publish(&checkpoint(1, 1), MsgId::from([1; 32]), &setup_pending)
             .expect("setup publish should be complete");
 
         let insert = transaction(
             "INSERT INTO items(value) VALUES (?1)",
             vec![Value::Integer(1)],
         );
-        db.commit_local_write(&insert)
+        let insert_tx_id = db
+            .commit_local_write(TxId::generate(), &insert)
             .expect("insert write should commit");
-        let insert_payload = db
+        let insert_pending = db
             .pending_publish()
             .expect("pending write should load")
-            .expect("pending write should exist")
-            .payload;
+            .expect("pending write should exist");
+        assert_eq!(insert_pending.tx_id, insert_tx_id);
+        let insert_payload = insert_pending.payload.clone();
+        db.complete_publish(&checkpoint(1, 1), MsgId::from([2; 32]), &insert_pending)
+            .expect("insert publish should be complete");
 
         let event = blocks_processed(
             checkpoint(2, 2),
@@ -466,6 +717,60 @@ mod tests {
             .expect("local adoption should be recognized");
 
         assert_eq!(item_count(&live_path), 1);
+    }
+
+    #[test]
+    fn finalizing_an_earlier_local_write_preserves_the_next_pending_write() {
+        let dir = TempDir::new().expect("temporary directory should be created");
+        let mut db = Databases::open(dir.path()).expect("databases should open");
+        let live_path = db.live_path().to_owned();
+        let lib_path = db.lib_path().to_owned();
+
+        let create = transaction("CREATE TABLE items(value INTEGER NOT NULL)", Vec::new());
+        db.commit_local_write(TxId::generate(), &create)
+            .expect("schema write should commit");
+        let create_pending = db
+            .pending_publish()
+            .expect("schema write should load")
+            .expect("schema write should be pending");
+        let create_payload = create_pending.payload.clone();
+        let create_msg = MsgId::from([1; 32]);
+
+        db.complete_publish(&checkpoint(1, 1), create_msg, &create_pending)
+            .expect("schema publish should be complete");
+
+        let insert = transaction(
+            "INSERT INTO items(value) VALUES (?1)",
+            vec![Value::Integer(1)],
+        );
+        let insert_tx_id = db
+            .commit_local_write(TxId::generate(), &insert)
+            .expect("next write should commit");
+
+        let finalization = blocks_processed(
+            checkpoint(2, 2),
+            Vec::new(),
+            Vec::new(),
+            vec![finalized(&create_payload, 1)],
+        );
+
+        on_event(&mut db, &finalization, ChannelId::from(CHANNEL_ID))
+            .expect("earlier write should finalize");
+
+        assert_eq!(item_count(&live_path), 1);
+        assert_eq!(item_count(&lib_path), 0);
+        assert_eq!(
+            db.pending_publish()
+                .expect("pending write should load")
+                .expect("next write should remain pending")
+                .tx_id,
+            insert_tx_id
+        );
+        assert!(
+            db.displaced_writes()
+                .expect("displaced writes should load")
+                .is_empty()
+        );
     }
 
     #[test]
@@ -659,22 +964,39 @@ mod tests {
     }
 
     #[test]
-    fn orphaned_local_write_prevents_adopted_apply_until_rebuild() {
+    fn orphaned_local_write_rebuilds_live_and_reports_displacement() {
         let dir = TempDir::new().expect("temporary directory should be created");
         let mut db = Databases::open(dir.path()).expect("databases should open");
         let live_path = db.live_path().to_owned();
 
         let local = transaction("CREATE TABLE local_write(value INTEGER)", Vec::new());
         let local_tx_id = db
-            .commit_local_write(&local)
+            .commit_local_write(TxId::generate(), &local)
             .expect("local write should commit");
-        let local_payload = db
+        let local_pending = db
             .pending_publish()
             .expect("pending write should load")
-            .expect("pending write should exist")
-            .payload;
-        db.mark_publish_complete(local_tx_id)
+            .expect("pending write should exist");
+        let local_payload = local_pending.payload.clone();
+        db.complete_publish(&checkpoint(1, 1), MsgId::from([1; 32]), &local_pending)
             .expect("local publish should be complete");
+
+        let reader = Databases::open_reader(&live_path).expect("live reader should open");
+        reader
+            .execute_batch("BEGIN")
+            .expect("reader snapshot should begin");
+        let local_visible_before_rebuild: bool = reader
+            .query_row(
+                "SELECT EXISTS(
+                    SELECT 1 FROM sqlite_schema
+                    WHERE type = 'table' AND name = 'local_write'
+                )",
+                [],
+                |row| row.get(0),
+            )
+            .expect("reader snapshot should be established");
+
+        assert!(local_visible_before_rebuild);
 
         let adopted = encoded_write(&transaction(
             "CREATE TABLE adopted_too_early(value INTEGER)",
@@ -690,14 +1012,383 @@ mod tests {
             Vec::new(),
         );
 
-        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            on_event(&mut db, &event, ChannelId::from(CHANNEL_ID))
-        }));
+        on_event(&mut db, &event, ChannelId::from(CHANNEL_ID))
+            .expect("orphaned write should rebuild live state");
 
-        assert!(
-            result.is_err(),
-            "orphan recovery should reach its placeholder"
+        assert!(!table_exists(&live_path, "local_write"));
+        assert!(table_exists(&live_path, "adopted_too_early"));
+        assert_eq!(journal_mode(&live_path), "wal");
+        assert_eq!(
+            db.displaced_writes().expect("displaced writes should load"),
+            vec![local_tx_id]
         );
+
+        let local_still_visible: bool = reader
+            .query_row(
+                "SELECT EXISTS(
+                    SELECT 1 FROM sqlite_schema
+                    WHERE type = 'table' AND name = 'local_write'
+                )",
+                [],
+                |row| row.get(0),
+            )
+            .expect("active reader should retain its snapshot");
+
+        assert!(local_still_visible);
+
+        reader
+            .execute_batch("COMMIT")
+            .expect("reader snapshot should end");
+
+        let adopted_visible: bool = reader
+            .query_row(
+                "SELECT EXISTS(
+                    SELECT 1 FROM sqlite_schema
+                    WHERE type = 'table' AND name = 'adopted_too_early'
+                )",
+                [],
+                |row| row.get(0),
+            )
+            .expect("reader should observe rebuilt state after its snapshot");
+
+        assert!(adopted_visible);
+
+        let restore_original = blocks_processed(
+            checkpoint(3, 3),
+            vec![ChannelUpdateTx::Inscription(inscription(&local_payload, 1))],
+            vec![ChannelUpdateTx::Inscription(inscription(
+                &adopted.payload,
+                2,
+            ))],
+            Vec::new(),
+        );
+
+        on_event(&mut db, &restore_original, ChannelId::from(CHANNEL_ID))
+            .expect("restored branch should rebuild live state");
+
+        assert!(table_exists(&live_path, "local_write"));
         assert!(!table_exists(&live_path, "adopted_too_early"));
+        assert!(
+            db.displaced_writes()
+                .expect("displaced writes should load")
+                .is_empty(),
+            "restoring the original channel position clears displacement"
+        );
+    }
+
+    #[test]
+    fn branch_change_preserves_the_unchanged_live_suffix() {
+        let dir = TempDir::new().expect("temporary directory should be created");
+        let mut db = Databases::open(dir.path()).expect("databases should open");
+        let live_path = db.live_path().to_owned();
+
+        let create = encoded_write(&transaction(
+            "CREATE TABLE items(value TEXT PRIMARY KEY)",
+            Vec::new(),
+        ));
+        let old_branch = encoded_write(&transaction(
+            "INSERT INTO items(value) VALUES (?1)",
+            vec![Value::Text("old".to_owned())],
+        ));
+
+        let initial = blocks_processed(
+            checkpoint(1, 1),
+            vec![
+                ChannelUpdateTx::Inscription(inscription(&create.payload, 1)),
+                ChannelUpdateTx::Inscription(inscription(&old_branch.payload, 2)),
+            ],
+            Vec::new(),
+            Vec::new(),
+        );
+
+        on_event(&mut db, &initial, ChannelId::from(CHANNEL_ID))
+            .expect("initial suffix should apply");
+
+        drop(db);
+        let mut db = Databases::open(dir.path()).expect("databases should reopen");
+
+        let replacement = encoded_write(&transaction(
+            "INSERT INTO items(value) VALUES (?1)",
+            vec![Value::Text("new".to_owned())],
+        ));
+        let branch_change = blocks_processed(
+            checkpoint(2, 2),
+            vec![ChannelUpdateTx::Inscription(inscription(
+                &replacement.payload,
+                3,
+            ))],
+            vec![ChannelUpdateTx::Inscription(inscription(
+                &old_branch.payload,
+                2,
+            ))],
+            Vec::new(),
+        );
+
+        on_event(&mut db, &branch_change, ChannelId::from(CHANNEL_ID))
+            .expect("replacement suffix should rebuild");
+        on_event(&mut db, &branch_change, ChannelId::from(CHANNEL_ID))
+            .expect("replayed branch update should be idempotent");
+
+        assert_eq!(text_values(&live_path, "items"), vec!["new"]);
+        assert!(
+            db.displaced_writes()
+                .expect("displaced writes should load")
+                .is_empty(),
+            "foreign orphaned writes are not application outcomes"
+        );
+    }
+
+    #[test]
+    fn foreign_adoption_displaces_an_unpublished_local_write() {
+        let dir = TempDir::new().expect("temporary directory should be created");
+        let mut db = Databases::open(dir.path()).expect("databases should open");
+        let live_path = db.live_path().to_owned();
+
+        let local = transaction("CREATE TABLE local_write(value INTEGER)", Vec::new());
+        let local_tx_id = db
+            .commit_local_write(TxId::generate(), &local)
+            .expect("local write should commit");
+
+        let foreign = encoded_write(&transaction(
+            "CREATE TABLE foreign_write(value INTEGER)",
+            Vec::new(),
+        ));
+        let event = blocks_processed(
+            checkpoint(2, 2),
+            vec![ChannelUpdateTx::Inscription(inscription(
+                &foreign.payload,
+                2,
+            ))],
+            Vec::new(),
+            Vec::new(),
+        );
+
+        on_event(&mut db, &event, ChannelId::from(CHANNEL_ID))
+            .expect("foreign adoption should rebuild over unpublished local state");
+
+        assert!(!table_exists(&live_path, "local_write"));
+        assert!(table_exists(&live_path, "foreign_write"));
+        assert!(
+            db.pending_publish()
+                .expect("pending publication should load")
+                .is_none()
+        );
+        assert_eq!(
+            db.displaced_writes().expect("displaced writes should load"),
+            vec![local_tx_id]
+        );
+    }
+
+    #[test]
+    fn rollback_displaces_an_unpublished_write_based_on_removed_state() {
+        let dir = TempDir::new().expect("temporary directory should be created");
+        let mut db = Databases::open(dir.path()).expect("databases should open");
+        let live_path = db.live_path().to_owned();
+
+        let previous = encoded_write(&transaction(
+            "CREATE TABLE previous_write(value INTEGER)",
+            Vec::new(),
+        ));
+        let initial_event = blocks_processed(
+            checkpoint(1, 1),
+            vec![ChannelUpdateTx::Inscription(inscription(
+                &previous.payload,
+                1,
+            ))],
+            Vec::new(),
+            Vec::new(),
+        );
+        on_event(&mut db, &initial_event, ChannelId::from(CHANNEL_ID))
+            .expect("initial channel state should apply");
+
+        let local = transaction("CREATE TABLE local_write(value INTEGER)", Vec::new());
+        let local_tx_id = db
+            .commit_local_write(TxId::generate(), &local)
+            .expect("local write should commit");
+
+        let rollback = blocks_processed(
+            checkpoint(2, 2),
+            Vec::new(),
+            vec![ChannelUpdateTx::Inscription(inscription(
+                &previous.payload,
+                1,
+            ))],
+            Vec::new(),
+        );
+        on_event(&mut db, &rollback, ChannelId::from(CHANNEL_ID))
+            .expect("rollback should rebuild without unpublished local state");
+
+        assert!(!table_exists(&live_path, "previous_write"));
+        assert!(!table_exists(&live_path, "local_write"));
+        assert_eq!(
+            db.displaced_writes().expect("displaced writes should load"),
+            vec![local_tx_id]
+        );
+    }
+
+    #[test]
+    fn replay_finishes_a_rebuild_after_the_suffix_commit() {
+        let dir = TempDir::new().expect("temporary directory should be created");
+        let mut db = Databases::open(dir.path()).expect("databases should open");
+        let live_path = db.live_path().to_owned();
+
+        let local = transaction("CREATE TABLE local_write(value INTEGER)", Vec::new());
+        let local_tx_id = db
+            .commit_local_write(TxId::generate(), &local)
+            .expect("local write should commit");
+        let pending = db
+            .pending_publish()
+            .expect("pending write should load")
+            .expect("pending write should exist");
+
+        let foreign = encoded_write(&transaction(
+            "CREATE TABLE foreign_write(value INTEGER)",
+            Vec::new(),
+        ));
+        let foreign_inscription = inscription(&foreign.payload, 2);
+
+        // Simulate a crash after the control-state transaction commits but
+        // before the replacement LIVE database is installed.
+        db.record_unpublished_displacement(&pending)
+            .expect("displacement should be recorded");
+        db.apply_history_delta(
+            &[],
+            &[],
+            &[SuffixWrite {
+                this_msg: foreign_inscription.this_msg,
+                tx_id: ChannelInscription::decode(&foreign.payload)
+                    .expect("payload should decode")
+                    .tx_id,
+                payload: foreign.payload.clone(),
+                local: false,
+            }],
+        )
+        .expect("suffix update should commit");
+        drop(db);
+
+        let mut db = Databases::open(dir.path()).expect("databases should reopen");
+        let replayed_event = blocks_processed(
+            checkpoint(2, 2),
+            vec![ChannelUpdateTx::Inscription(foreign_inscription)],
+            Vec::new(),
+            Vec::new(),
+        );
+
+        on_event(&mut db, &replayed_event, ChannelId::from(CHANNEL_ID))
+            .expect("replayed event should finish the rebuild");
+
+        assert!(!table_exists(&live_path, "local_write"));
+        assert!(table_exists(&live_path, "foreign_write"));
+        assert!(
+            db.pending_publish()
+                .expect("pending publication should load")
+                .is_none()
+        );
+        assert_eq!(
+            db.displaced_writes().expect("displaced writes should load"),
+            vec![local_tx_id]
+        );
+    }
+
+    #[test]
+    fn finalized_backfill_finishes_a_rebuild_after_the_suffix_commit() {
+        let dir = TempDir::new().expect("temporary directory should be created");
+        let mut db = Databases::open(dir.path()).expect("databases should open");
+        let live_path = db.live_path().to_owned();
+
+        let local = transaction("CREATE TABLE local_write(value INTEGER)", Vec::new());
+        let local_tx_id = db
+            .commit_local_write(TxId::generate(), &local)
+            .expect("local write should commit");
+        let pending = db
+            .pending_publish()
+            .expect("pending write should load")
+            .expect("pending write should exist");
+
+        let foreign = encoded_write(&transaction(
+            "CREATE TABLE foreign_write(value INTEGER)",
+            Vec::new(),
+        ));
+        let foreign_inscription = inscription(&foreign.payload, 2);
+
+        // Simulate a crash after the control-state transaction commits but
+        // before the replacement LIVE database is installed.
+        db.record_unpublished_displacement(&pending)
+            .expect("displacement should be recorded");
+        db.apply_history_delta(
+            &[],
+            &[],
+            &[SuffixWrite {
+                this_msg: foreign_inscription.this_msg,
+                tx_id: ChannelInscription::decode(&foreign.payload)
+                    .expect("payload should decode")
+                    .tx_id,
+                payload: foreign.payload.clone(),
+                local: false,
+            }],
+        )
+        .expect("suffix update should commit");
+        drop(db);
+
+        let mut db = Databases::open(dir.path()).expect("databases should reopen");
+        let backfilled_event = blocks_processed(
+            checkpoint(2, 2),
+            Vec::new(),
+            Vec::new(),
+            vec![FinalizedTx {
+                tx_hash: foreign_inscription.tx_hash,
+                l1_slot: Slot::from(2),
+                ops: vec![FinalizedOp::Inscription(foreign_inscription)],
+            }],
+        );
+
+        on_event(&mut db, &backfilled_event, ChannelId::from(CHANNEL_ID))
+            .expect("finalized backfill should finish the rebuild");
+
+        assert!(!table_exists(&live_path, "local_write"));
+        assert!(table_exists(&live_path, "foreign_write"));
+        assert!(
+            db.pending_publish()
+                .expect("pending publication should load")
+                .is_none()
+        );
+        assert_eq!(
+            db.displaced_writes().expect("displaced writes should load"),
+            vec![local_tx_id]
+        );
+    }
+
+    #[test]
+    fn newly_discovered_finalized_write_displaces_an_unpublished_local_write() {
+        let dir = TempDir::new().expect("temporary directory should be created");
+        let mut db = Databases::open(dir.path()).expect("databases should open");
+        let live_path = db.live_path().to_owned();
+
+        let local = transaction("CREATE TABLE local_write(value INTEGER)", Vec::new());
+        let local_tx_id = db
+            .commit_local_write(TxId::generate(), &local)
+            .expect("local write should commit");
+
+        let foreign = encoded_write(&transaction(
+            "CREATE TABLE finalized_write(value INTEGER)",
+            Vec::new(),
+        ));
+        let event = blocks_processed(
+            checkpoint(2, 2),
+            Vec::new(),
+            Vec::new(),
+            vec![finalized(&foreign.payload, 2)],
+        );
+
+        on_event(&mut db, &event, ChannelId::from(CHANNEL_ID))
+            .expect("new finalized history should replace unpublished local state");
+
+        assert!(!table_exists(&live_path, "local_write"));
+        assert!(table_exists(&live_path, "finalized_write"));
+        assert!(table_exists(db.lib_path(), "finalized_write"));
+        assert_eq!(
+            db.displaced_writes().expect("displaced writes should load"),
+            vec![local_tx_id]
+        );
     }
 }

--- a/logos_sql/src/db.rs
+++ b/logos_sql/src/db.rs
@@ -11,6 +11,7 @@ use bincode::Options as _;
 use lb_zone_sdk::{node_types::MsgId, sequencer::SequencerCheckpoint};
 use rusqlite::{
     Connection, ErrorCode as SqliteErrorCode, OpenFlags, OptionalExtension as _, Row,
+    backup::Backup,
     hooks::{AuthAction, AuthContext, Authorization},
     params, params_from_iter,
 };
@@ -25,12 +26,15 @@ const DATABASE_BUSY_TIMEOUT: Duration = Duration::from_secs(5);
 const LIB_DATABASE_FILE: &str = "LIB.db";
 const LIVE_DATABASE_FILE: &str = "LIVE.db";
 const CONTROL_DATABASE_FILE: &str = "control.db";
+const REBUILD_DATABASE_FILE: &str = "LIVE.rebuild.db";
+const BACKUP_PAGES_PER_STEP: i32 = 128;
+const BACKUP_RETRY_DELAY: Duration = Duration::from_millis(10);
 const RESERVED_OBJECT_PREFIX: &str = "__logos_sql_";
 
 // Present in both state databases so replicated SQL observes the same schema.
 // Only LIVE.db stores a row, committed atomically with the local write.
-const PENDING_WRITE_SCHEMA: &str = "
-    CREATE TABLE IF NOT EXISTS __logos_sql_pending_write (
+const PENDING_PUBLISH_SCHEMA: &str = "
+    CREATE TABLE IF NOT EXISTS __logos_sql_pending_publish (
         singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
         tx_id BLOB NOT NULL UNIQUE CHECK (length(tx_id) = 32),
         payload BLOB NOT NULL
@@ -59,6 +63,19 @@ const CONTROL_SCHEMA: &str = "
         tx_id BLOB CHECK (tx_id IS NULL OR length(tx_id) = 32),
         reason TEXT NOT NULL
     ) STRICT;
+
+    CREATE TABLE IF NOT EXISTS __logos_sql_live_suffix (
+        position INTEGER PRIMARY KEY AUTOINCREMENT,
+        this_msg BLOB NOT NULL UNIQUE CHECK (length(this_msg) = 32),
+        tx_id BLOB NOT NULL CHECK (length(tx_id) = 32),
+        payload BLOB NOT NULL,
+        local INTEGER NOT NULL CHECK (local IN (0, 1))
+    ) STRICT;
+
+    CREATE TABLE IF NOT EXISTS __logos_sql_displaced_writes (
+        tx_id BLOB PRIMARY KEY CHECK (length(tx_id) = 32),
+        this_msg BLOB UNIQUE CHECK (this_msg IS NULL OR length(this_msg) = 32)
+    ) STRICT;
 ";
 
 const INITIALIZE_CONTROL_STATE: &str = "
@@ -84,20 +101,78 @@ const INSERT_REJECTED_WRITE: &str = "
     ON CONFLICT (this_msg) DO NOTHING
 ";
 
-const INSERT_PENDING_WRITE: &str = "
-    INSERT INTO __logos_sql_pending_write (singleton, tx_id, payload)
+const INSERT_PENDING_PUBLISH: &str = "
+    INSERT INTO __logos_sql_pending_publish (singleton, tx_id, payload)
     VALUES (1, ?1, ?2)
 ";
 
 const SELECT_PENDING_PUBLISH: &str = "
     SELECT tx_id, payload
-    FROM __logos_sql_pending_write
+    FROM __logos_sql_pending_publish
     WHERE singleton = 1
 ";
 
-const MARK_PUBLISH_COMPLETE: &str = "
-    DELETE FROM __logos_sql_pending_write
+const CLEAR_PENDING_PUBLISH: &str = "
+    DELETE FROM __logos_sql_pending_publish
     WHERE singleton = 1 AND tx_id = ?1
+";
+
+const INSERT_SUFFIX_WRITE: &str = "
+    INSERT INTO __logos_sql_live_suffix (this_msg, tx_id, payload, local)
+    VALUES (?1, ?2, ?3, ?4)
+    ON CONFLICT (this_msg) DO NOTHING
+";
+
+const DELETE_SUFFIX_WRITE: &str = "
+    DELETE FROM __logos_sql_live_suffix
+    WHERE this_msg = ?1
+";
+
+const SELECT_SUFFIX_WRITES: &str = "
+    SELECT this_msg, tx_id, payload, local
+    FROM __logos_sql_live_suffix
+    ORDER BY position
+";
+
+const SELECT_LOCAL_SUFFIX_WRITE: &str = "
+    SELECT tx_id
+    FROM __logos_sql_live_suffix
+    WHERE this_msg = ?1 AND local = 1
+";
+
+const SELECT_SUFFIX_WRITE_EXISTS: &str = "
+    SELECT EXISTS(
+        SELECT 1 FROM __logos_sql_live_suffix WHERE this_msg = ?1
+    )
+";
+
+const INSERT_DISPLACED_WRITE: &str = "
+    INSERT INTO __logos_sql_displaced_writes (tx_id, this_msg)
+    VALUES (?1, ?2)
+    ON CONFLICT (tx_id) DO UPDATE SET this_msg = excluded.this_msg
+";
+
+const INSERT_UNPUBLISHED_DISPLACED_WRITE: &str = "
+    INSERT INTO __logos_sql_displaced_writes (tx_id, this_msg)
+    VALUES (?1, NULL)
+    ON CONFLICT (tx_id) DO NOTHING
+";
+
+const DELETE_DISPLACED_WRITE: &str = "
+    DELETE FROM __logos_sql_displaced_writes
+    WHERE this_msg = ?1
+";
+
+const SELECT_DISPLACED_WRITES: &str = "
+    SELECT tx_id
+    FROM __logos_sql_displaced_writes
+    ORDER BY rowid
+";
+
+const SELECT_DISPLACED_WRITE_EXISTS: &str = "
+    SELECT EXISTS(
+        SELECT 1 FROM __logos_sql_displaced_writes WHERE tx_id = ?1
+    )
 ";
 
 const SELECT_APPLIED_WRITE: &str = "
@@ -116,6 +191,11 @@ const WRITER_PRAGMAS: &str = "
     PRAGMA synchronous = FULL;
 ";
 
+const REBUILD_PRAGMAS: &str = "
+    PRAGMA journal_mode = DELETE;
+    PRAGMA synchronous = OFF;
+";
+
 const FOREIGN_KEYS_PRAGMA: &str = "PRAGMA foreign_keys = ON;";
 
 // These functions depend on one connection, database file, or SQLite build.
@@ -131,7 +211,18 @@ const UNSUPPORTED_FUNCTIONS: [&str; 9] = [
     "sqlite_version",
     "total_changes",
 ];
-/// Raw database representation of a write waiting for publication.
+/// A locally committed write whose `ZoneSDK` checkpoint has not yet been
+/// persisted.
+///
+/// `ZoneSDK` may already hold the write in memory. Until its returned
+/// checkpoint and suffix entry commit, this record remains the durable source
+/// used to recover the publication.
+pub struct PendingPublish {
+    pub tx_id: TxId,
+    pub payload: Vec<u8>,
+}
+
+/// Raw database representation of a pending publication.
 struct StoredPendingPublish {
     tx_id: Vec<u8>,
     payload: Vec<u8>,
@@ -146,17 +237,30 @@ impl StoredPendingPublish {
     }
 }
 
-/// A write committed to `LIVE.db` but not yet present in the persisted
-/// `ZoneSDK` checkpoint.
-pub struct PendingPublish {
+/// One Logos SQL inscription retained above the finalized boundary.
+pub struct SuffixWrite {
+    pub this_msg: MsgId,
     pub tx_id: TxId,
     pub payload: Vec<u8>,
+    pub local: bool,
 }
 
 /// A replicated database connection and the function state attached to it.
 struct ReplicatedDatabase {
     connection: Connection,
     functions: FunctionOverrides,
+}
+
+/// An isolated replacement for `LIVE.db` while canonical history is replayed.
+pub struct LiveRebuild {
+    database: ReplicatedDatabase,
+    path: PathBuf,
+}
+
+impl LiveRebuild {
+    pub(crate) fn apply_write(&mut self, write: &ChannelInscription) -> Result<(), Error> {
+        apply_channel_write(&mut self.database, write)
+    }
 }
 
 impl Deref for ReplicatedDatabase {
@@ -184,13 +288,16 @@ impl Databases {
         let lib_path = directory.join(LIB_DATABASE_FILE);
         let live_path = directory.join(LIVE_DATABASE_FILE);
         let control_path = directory.join(CONTROL_DATABASE_FILE);
+        let rebuild_path = directory.join(REBUILD_DATABASE_FILE);
+
+        remove_rebuild_files(&rebuild_path)?;
 
         let lib = open_writer(&lib_path)?;
         let live = open_writer(&live_path)?;
         let control = open_connection(&control_path)?;
 
         for connection in [&lib, &live] {
-            connection.execute_batch(PENDING_WRITE_SCHEMA)?;
+            connection.execute_batch(PENDING_PUBLISH_SCHEMA)?;
             connection.execute_batch(APPLIED_WRITE_SCHEMA)?;
         }
 
@@ -242,6 +349,179 @@ impl Databases {
         Ok(())
     }
 
+    /// Persists `ZoneSDK` ownership of a local write and adds it to the live
+    /// suffix before removing the pending publication from `LIVE.db`.
+    pub(crate) fn complete_publish(
+        &mut self,
+        checkpoint: &SequencerCheckpoint,
+        this_msg: MsgId,
+        pending: &PendingPublish,
+    ) -> Result<(), Error> {
+        let encoded_checkpoint = checkpoint_options().serialize(checkpoint)?;
+        let transaction = self.control.transaction()?;
+
+        transaction.execute(UPDATE_CHECKPOINT, [encoded_checkpoint])?;
+        transaction.execute(
+            INSERT_SUFFIX_WRITE,
+            params![
+                this_msg.as_ref(),
+                pending.tx_id.as_ref(),
+                pending.payload,
+                true
+            ],
+        )?;
+        transaction.commit()?;
+
+        self.clear_pending_publish(pending.tx_id)
+    }
+
+    /// Applies one channel event to retained unfinalized history and local
+    /// write outcomes.
+    ///
+    /// Finalized writes leave the suffix and clear any provisional
+    /// displacement. Orphaned local writes become displaced, while restoring
+    /// their original channel position clears that outcome again. The whole
+    /// delta commits together so replay after a crash cannot observe only one
+    /// side of a branch change.
+    pub(crate) fn apply_history_delta(
+        &mut self,
+        finalized: &[MsgId],
+        orphaned: &[MsgId],
+        adopted: &[SuffixWrite],
+    ) -> Result<(), Error> {
+        let transaction = self.control.transaction()?;
+
+        for this_msg in finalized {
+            transaction.execute(DELETE_DISPLACED_WRITE, [this_msg.as_ref()])?;
+            transaction.execute(DELETE_SUFFIX_WRITE, [this_msg.as_ref()])?;
+        }
+
+        for this_msg in orphaned {
+            let local_tx_id = transaction
+                .query_row(SELECT_LOCAL_SUFFIX_WRITE, [this_msg.as_ref()], |row| {
+                    row.get::<_, Vec<u8>>(0)
+                })
+                .optional()?;
+
+            if let Some(tx_id) = local_tx_id {
+                transaction.execute(INSERT_DISPLACED_WRITE, params![tx_id, this_msg.as_ref()])?;
+            }
+
+            transaction.execute(DELETE_SUFFIX_WRITE, [this_msg.as_ref()])?;
+        }
+
+        for write in adopted {
+            let restored_local =
+                transaction.execute(DELETE_DISPLACED_WRITE, [write.this_msg.as_ref()])? != 0;
+
+            transaction.execute(
+                INSERT_SUFFIX_WRITE,
+                params![
+                    write.this_msg.as_ref(),
+                    write.tx_id.as_ref(),
+                    write.payload,
+                    write.local || restored_local
+                ],
+            )?;
+        }
+
+        transaction.commit()?;
+
+        Ok(())
+    }
+
+    pub(crate) fn live_suffix(&self) -> Result<Vec<SuffixWrite>, Error> {
+        let mut statement = self.control.prepare(SELECT_SUFFIX_WRITES)?;
+        let rows = statement.query_map([], |row| {
+            Ok((
+                row.get::<_, Vec<u8>>(0)?,
+                row.get::<_, Vec<u8>>(1)?,
+                row.get::<_, Vec<u8>>(2)?,
+                row.get::<_, bool>(3)?,
+            ))
+        })?;
+
+        rows.map(|row| {
+            let (this_msg, tx_id, payload, local) = row?;
+
+            Ok(SuffixWrite {
+                this_msg: decode_msg_id(this_msg)?,
+                tx_id: decode_tx_id(tx_id)?,
+                payload,
+                local,
+            })
+        })
+        .collect()
+    }
+
+    pub(crate) fn live_suffix_contains(&self, this_msg: MsgId) -> Result<bool, Error> {
+        self.control
+            .query_row(SELECT_SUFFIX_WRITE_EXISTS, [this_msg.as_ref()], |row| {
+                row.get(0)
+            })
+            .map_err(Error::from)
+    }
+
+    pub(crate) fn displaced_writes(&self) -> Result<Vec<TxId>, Error> {
+        let mut statement = self.control.prepare(SELECT_DISPLACED_WRITES)?;
+        let rows = statement.query_map([], |row| row.get::<_, Vec<u8>>(0))?;
+
+        rows.map(|row| decode_tx_id(row?)).collect()
+    }
+
+    pub(crate) fn is_write_displaced(&self, tx_id: TxId) -> Result<bool, Error> {
+        self.control
+            .query_row(SELECT_DISPLACED_WRITE_EXISTS, [tx_id.as_ref()], |row| {
+                row.get(0)
+            })
+            .map_err(Error::from)
+    }
+
+    /// Records a local write whose base changed before `ZoneSDK` accepted it.
+    ///
+    /// The pending record remains in `LIVE.db` until the rebuild replaces the
+    /// database. If recovery is interrupted, that record makes the same event
+    /// request another rebuild.
+    pub(crate) fn record_unpublished_displacement(
+        &self,
+        pending: &PendingPublish,
+    ) -> Result<(), Error> {
+        self.control
+            .execute(INSERT_UNPUBLISHED_DISPLACED_WRITE, [pending.tx_id.as_ref()])?;
+
+        Ok(())
+    }
+
+    /// Creates a replacement live database from the finalized image.
+    pub(crate) fn begin_live_rebuild(&self) -> Result<LiveRebuild, Error> {
+        let path = self
+            .live_path
+            .parent()
+            .ok_or(Error::InvalidLocalState("LIVE.db has no parent directory"))?
+            .join(REBUILD_DATABASE_FILE);
+
+        remove_rebuild_files(&path)?;
+
+        let mut database = open_rebuild_writer(&path)?;
+        backup_database(&self.lib.connection, &mut database.connection)?;
+        database.connection.execute_batch(REBUILD_PRAGMAS)?;
+        database.connection.execute_batch(PENDING_PUBLISH_SCHEMA)?;
+
+        Ok(LiveRebuild { database, path })
+    }
+
+    /// Atomically replaces the contents of `LIVE.db` for current and future
+    /// readers using `SQLite`'s online backup API.
+    pub(crate) fn finish_live_rebuild(&mut self, rebuild: LiveRebuild) -> Result<(), Error> {
+        backup_database(&rebuild.database.connection, &mut self.live.connection)?;
+
+        let path = rebuild.path.clone();
+        drop(rebuild);
+        remove_rebuild_files(&path)?;
+
+        Ok(())
+    }
+
     /// Records a channel write that every replica must skip.
     ///
     /// Keeping the rejection in participant-local state allows replay to
@@ -264,9 +544,13 @@ impl Databases {
 
         Ok(())
     }
-    /// Commits application effects and their pending publish record together in
-    /// `LIVE.db`.
-    pub(crate) fn commit_local_write(&mut self, transaction: &Transaction) -> Result<TxId, Error> {
+    /// Commits application effects and their pending publication together
+    /// in `LIVE.db`.
+    pub(crate) fn commit_local_write(
+        &mut self,
+        tx_id: TxId,
+        transaction: &Transaction,
+    ) -> Result<TxId, Error> {
         if self.pending_publish()?.is_some() {
             return Err(Error::PublishPending);
         }
@@ -276,7 +560,7 @@ impl Databases {
 
         apply_statements(&db_transaction, transaction)?;
         let captured_function_calls = capture.finish()?;
-        let encoded = EncodedWrite::new(transaction, captured_function_calls)?;
+        let encoded = EncodedWrite::new(tx_id, transaction, captured_function_calls)?;
 
         db_transaction.execute(
             INSERT_APPLIED_WRITE,
@@ -284,7 +568,7 @@ impl Databases {
         )?;
 
         db_transaction.execute(
-            INSERT_PENDING_WRITE,
+            INSERT_PENDING_PUBLISH,
             params![encoded.tx_id.as_ref(), encoded.payload],
         )?;
         db_transaction.commit()?;
@@ -295,6 +579,15 @@ impl Databases {
     /// Applies a newly adopted channel write to the live database.
     pub(crate) fn apply_adopted_write(&mut self, write: &ChannelInscription) -> Result<(), Error> {
         apply_channel_write(&mut self.live, write)
+    }
+
+    /// Applies a write only to finalized state while a replacement live image
+    /// is being built from that state.
+    pub(crate) fn apply_finalized_write_to_lib(
+        &mut self,
+        write: &ChannelInscription,
+    ) -> Result<(), Error> {
+        apply_channel_write(&mut self.lib, write)
     }
 
     /// Applies a finalized channel write to finalized and live state.
@@ -348,15 +641,15 @@ impl Databases {
         }))
     }
 
-    pub(crate) fn mark_publish_complete(&self, tx_id: TxId) -> Result<(), Error> {
+    pub(crate) fn clear_pending_publish(&self, tx_id: TxId) -> Result<(), Error> {
         let changed = self
             .live
             .connection
-            .execute(MARK_PUBLISH_COMPLETE, [tx_id.as_ref()])?;
+            .execute(CLEAR_PENDING_PUBLISH, [tx_id.as_ref()])?;
 
         if changed != 1 {
             return Err(Error::InvalidLocalState(
-                "pending publish record is missing",
+                "pending publication record is missing",
             ));
         }
 
@@ -382,6 +675,20 @@ fn open_writer(path: &Path) -> Result<ReplicatedDatabase, Error> {
     })
 }
 
+fn open_rebuild_writer(path: &Path) -> Result<ReplicatedDatabase, Error> {
+    let connection = Connection::open(path)?;
+
+    configure_connection(&connection)?;
+    connection.execute_batch(REBUILD_PRAGMAS)?;
+
+    let functions = FunctionOverrides::install(&connection)?;
+
+    Ok(ReplicatedDatabase {
+        connection,
+        functions,
+    })
+}
+
 fn open_connection(path: &Path) -> Result<Connection, Error> {
     let conn = Connection::open(path)?;
 
@@ -389,6 +696,30 @@ fn open_connection(path: &Path) -> Result<Connection, Error> {
     conn.execute_batch(WRITER_PRAGMAS)?;
 
     Ok(conn)
+}
+
+fn backup_database(source: &Connection, destination: &mut Connection) -> Result<(), Error> {
+    let backup = Backup::new(source, destination)?;
+    backup.run_to_completion(BACKUP_PAGES_PER_STEP, BACKUP_RETRY_DELAY, None)?;
+
+    Ok(())
+}
+
+fn remove_rebuild_files(path: &Path) -> Result<(), Error> {
+    for path in [
+        path.to_owned(),
+        PathBuf::from(format!("{}-journal", path.display())),
+        PathBuf::from(format!("{}-wal", path.display())),
+        PathBuf::from(format!("{}-shm", path.display())),
+    ] {
+        match fs::remove_file(path) {
+            Ok(()) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => return Err(error.into()),
+        }
+    }
+
+    Ok(())
 }
 
 fn configure_connection(conn: &Connection) -> Result<(), Error> {
@@ -609,6 +940,14 @@ fn decode_tx_id(bytes: Vec<u8>) -> Result<TxId, Error> {
     Ok(bytes.into())
 }
 
+fn decode_msg_id(bytes: Vec<u8>) -> Result<MsgId, Error> {
+    let bytes: [u8; 32] = bytes
+        .try_into()
+        .map_err(|_| Error::InvalidLocalState("stored message id is malformed"))?;
+
+    Ok(bytes.into())
+}
+
 fn checkpoint_options() -> impl bincode::Options {
     bincode::DefaultOptions::new()
         .with_little_endian()
@@ -682,7 +1021,7 @@ mod tests {
 
         let transaction = transaction(sql);
         let error = db
-            .commit_local_write(&transaction)
+            .commit_local_write(TxId::generate(), &transaction)
             .expect_err("application SQL should be rejected");
 
         assert!(
@@ -750,6 +1089,42 @@ mod tests {
     }
 
     #[test]
+    fn finalization_clears_a_provisional_displacement() {
+        let dir = TempDir::new().expect("temporary directory should be created");
+        let mut db = Databases::open(dir.path()).expect("databases should open");
+        let tx_id = db
+            .commit_local_write(
+                TxId::generate(),
+                &transaction("CREATE TABLE local_write(value INTEGER)"),
+            )
+            .expect("local write should commit");
+        let pending = db
+            .pending_publish()
+            .expect("pending write should load")
+            .expect("pending write should exist");
+        let this_msg = MsgId::from([7; 32]);
+
+        db.complete_publish(&checkpoint(1, 1), this_msg, &pending)
+            .expect("publish should be complete");
+        db.apply_history_delta(&[], &[this_msg], &[])
+            .expect("local write should be orphaned");
+
+        assert_eq!(
+            db.displaced_writes().expect("displaced writes should load"),
+            vec![tx_id]
+        );
+
+        db.apply_history_delta(&[this_msg], &[], &[])
+            .expect("finalized suffix should be removed");
+
+        assert!(
+            db.displaced_writes()
+                .expect("displaced writes should load")
+                .is_empty()
+        );
+    }
+
+    #[test]
     fn application_write_and_pending_publish_commit_together() {
         let dir = TempDir::new().expect("temporary directory should be created");
         let mut db = Databases::open(dir.path()).expect("databases should open");
@@ -760,7 +1135,7 @@ mod tests {
 
         let transaction = insert("hello");
         let tx_id = db
-            .commit_local_write(&transaction)
+            .commit_local_write(TxId::generate(), &transaction)
             .expect("write should commit");
 
         let count: i64 = db
@@ -771,8 +1146,8 @@ mod tests {
         assert_eq!(count, 1);
         assert_eq!(
             db.pending_publish()
-                .expect("pending publish should load")
-                .expect("pending publish should exist")
+                .expect("pending publication should load")
+                .expect("pending publication should exist")
                 .tx_id,
             tx_id
         );
@@ -797,13 +1172,13 @@ mod tests {
 
         let transaction = insert("hello");
         let first_tx_id = db
-            .commit_local_write(&transaction)
+            .commit_local_write(TxId::generate(), &transaction)
             .expect("first write should commit");
-        db.mark_publish_complete(first_tx_id)
+        db.clear_pending_publish(first_tx_id)
             .expect("first publication should complete");
 
         let second_tx_id = db
-            .commit_local_write(&transaction)
+            .commit_local_write(TxId::generate(), &transaction)
             .expect("second write should commit");
 
         assert_ne!(second_tx_id, first_tx_id);
@@ -857,13 +1232,13 @@ mod tests {
                 CURRENT_TIMESTAMP
             )",
         );
-        db.commit_local_write(&write)
+        db.commit_local_write(TxId::generate(), &write)
             .expect("local write should commit");
 
         let pending = db
             .pending_publish()
-            .expect("pending publish should load")
-            .expect("pending publish should exist");
+            .expect("pending publication should load")
+            .expect("pending publication should exist");
         let channel_inscription =
             ChannelInscription::decode(&pending.payload).expect("payload should decode");
         let functions = channel_inscription
@@ -922,13 +1297,13 @@ mod tests {
         }
 
         let write = transaction("INSERT INTO items(value) VALUES ('hello')");
-        db.commit_local_write(&write)
+        db.commit_local_write(TxId::generate(), &write)
             .expect("local write should commit");
 
         let pending = db
             .pending_publish()
-            .expect("pending publish should load")
-            .expect("pending publish should exist");
+            .expect("pending publication should load")
+            .expect("pending publication should exist");
         let channel_inscription =
             ChannelInscription::decode(&pending.payload).expect("payload should decode");
 
@@ -1086,7 +1461,7 @@ mod tests {
         let dir = TempDir::new().expect("temporary directory should be created");
         let mut db = Databases::open(dir.path()).expect("databases should open");
         let transaction = transaction("CREATE TABLE items(value TEXT NOT NULL)");
-        db.commit_local_write(&transaction)
+        db.commit_local_write(TxId::generate(), &transaction)
             .expect("schema write should commit");
 
         db.live
@@ -1113,7 +1488,7 @@ mod tests {
                 Statement::new(control.to_owned(), Vec::new()).expect("statement should be valid"),
             ])
             .expect("transaction should be valid");
-            db.commit_local_write(&transaction)
+            db.commit_local_write(TxId::generate(), &transaction)
                 .expect_err("transaction control should be rejected");
 
             let count: i64 = db
@@ -1183,7 +1558,7 @@ mod tests {
         let mut db = Databases::open(dir.path()).expect("databases should open");
         let transaction = transaction("CREATE TABLE aaaaaaaaaa\u{65e5}(value INTEGER)");
 
-        db.commit_local_write(&transaction)
+        db.commit_local_write(TxId::generate(), &transaction)
             .expect("non-reserved Unicode name should be accepted");
     }
 

--- a/logos_sql/src/error.rs
+++ b/logos_sql/src/error.rs
@@ -57,7 +57,8 @@ pub enum Error {
     #[error("LogosSql::start must be called from within a Tokio runtime")]
     RuntimeUnavailable,
 
-    /// The sequencer has not completed backfill and cannot accept writes yet.
+    /// The sequencer is starting or its latest readiness checkpoint has not
+    /// yet been applied.
     #[error("the zone sequencer is not ready to accept writes")]
     SequencerNotReady,
 

--- a/logos_sql/src/lib.rs
+++ b/logos_sql/src/lib.rs
@@ -3,7 +3,7 @@
 //! Applications read through a normal `SQLite` connection and submit replicated
 //! writes through [`LogosSql::execute`]. One runtime task owns the zone
 //! sequencer and database writer, so the SQL effects and pending publication
-//! record commit together before the payload is given to `ZoneSDK`.
+//! commit together before the payload is given to `ZoneSDK`.
 
 mod applier;
 mod db;

--- a/logos_sql/src/logos_sql.rs
+++ b/logos_sql/src/logos_sql.rs
@@ -95,13 +95,18 @@ impl LogosSql {
     /// )
     ///     .bind(42i64)
     ///     .bind("Write documentation");
+    /// let tx_id = transaction.tx_id();
     ///
-    /// logos_sql.execute(transaction).await
+    /// assert_eq!(logos_sql.execute(transaction).await?, tx_id);
+    /// Ok(tx_id)
     /// # }
     /// ```
     ///
     /// A successful return means the SQL effects and recovery record are
     /// committed locally. Publication and finality remain asynchronous.
+    /// [`TransactionBuilder::tx_id`] exposes the same identity before the
+    /// asynchronous call, allowing the application to record how transaction
+    /// outcomes map to its own operations.
     ///
     /// # Errors
     ///
@@ -109,12 +114,36 @@ impl LogosSql {
     /// protocol, validation or the local commit fails, the sequencer is not
     /// ready, or the runtime has halted.
     pub async fn execute(&self, transaction: TransactionBuilder) -> Result<TxId, Error> {
-        let transaction = transaction.finish()?;
+        let (tx_id, transaction) = transaction.finish()?;
 
         self.runtime
             .as_ref()
             .ok_or(Error::RuntimeStopped)?
-            .execute(transaction)
+            .execute(tx_id, transaction)
+            .await
+    }
+
+    /// Returns local writes whose channel position was removed by a conflict
+    /// or reorganization.
+    ///
+    /// Logos SQL does not execute these writes again. The returned set is
+    /// durable across restarts but provisional: a later reorganization that
+    /// restores the original channel position removes its `TxId` from the
+    /// set. This API does not yet report when a displacement becomes final.
+    /// Repeated calls return the same IDs until such a restoration because
+    /// the current API has no application acknowledgement operation.
+    /// An application that retries before finality must therefore make the
+    /// replacement safe if the original write returns.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the runtime is no longer available or its local
+    /// outcome state cannot be read.
+    pub async fn displaced_writes(&self) -> Result<Vec<TxId>, Error> {
+        self.runtime
+            .as_ref()
+            .ok_or(Error::RuntimeStopped)?
+            .displaced_writes()
             .await
     }
 

--- a/logos_sql/src/protocol/mod.rs
+++ b/logos_sql/src/protocol/mod.rs
@@ -37,7 +37,7 @@ impl Display for TxId {
 }
 
 impl TxId {
-    fn generate() -> Self {
+    pub(crate) fn generate() -> Self {
         let mut bytes = [0; 32];
         rand::rngs::OsRng.fill_bytes(&mut bytes);
 
@@ -303,11 +303,10 @@ pub struct EncodedWrite {
 
 impl EncodedWrite {
     pub fn new(
+        tx_id: TxId,
         transaction: &Transaction,
         captured_function_calls: CapturedFunctionCalls,
     ) -> Result<Self, Error> {
-        let tx_id = TxId::generate();
-
         let channel_inscription = ChannelInscription {
             tx_id,
             transaction: transaction.clone(),
@@ -370,8 +369,12 @@ mod tests {
         ])
         .expect("transaction should be valid");
 
-        let encoded = EncodedWrite::new(&transaction, CapturedFunctionCalls::empty())
-            .expect("payload should encode");
+        let encoded = EncodedWrite::new(
+            TxId::generate(),
+            &transaction,
+            CapturedFunctionCalls::empty(),
+        )
+        .expect("payload should encode");
         let decoded = ChannelInscription::decode(&encoded.payload)
             .expect("channel inscription should decode");
 
@@ -446,7 +449,11 @@ mod tests {
             .expect("statement should be valid"),
         ])
         .expect("transaction should be valid");
-        let result = EncodedWrite::new(&transaction, CapturedFunctionCalls::empty());
+        let result = EncodedWrite::new(
+            TxId::generate(),
+            &transaction,
+            CapturedFunctionCalls::empty(),
+        );
 
         assert!(matches!(result, Err(crate::Error::InscriptionTooLarge)));
     }

--- a/logos_sql/src/runtime.rs
+++ b/logos_sql/src/runtime.rs
@@ -14,7 +14,7 @@ use tokio::{
 
 use crate::{
     applier,
-    db::Databases,
+    db::{Databases, PendingPublish},
     error::Error,
     protocol::{Transaction, TxId},
 };
@@ -26,8 +26,12 @@ const TARGET: &str = lb_log_targets::logos_sql::RUNTIME;
 /// Requests processed by the task that owns the sequencer and database writer.
 enum Command {
     Execute {
+        tx_id: TxId,
         transaction: Transaction,
         response_tx: oneshot::Sender<Result<TxId, Error>>,
+    },
+    DisplacedWrites {
+        response_tx: oneshot::Sender<Result<Vec<TxId>, Error>>,
     },
     Shutdown,
 }
@@ -55,6 +59,7 @@ pub fn spawn(
         channel_id,
         command_rx,
         sequencer_ready: false,
+        ready_checkpoint_pending: false,
         ready_tx: Some(ready_tx),
         event_pending_retry: None,
         publish_state: PublishState::Idle,
@@ -85,13 +90,28 @@ impl RuntimeHandle {
         }
     }
 
-    pub(crate) async fn execute(&self, transaction: Transaction) -> Result<TxId, Error> {
+    pub(crate) async fn execute(
+        &self,
+        tx_id: TxId,
+        transaction: Transaction,
+    ) -> Result<TxId, Error> {
         let (response_tx, response_rx) = oneshot::channel();
         self.command_tx
             .send(Command::Execute {
+                tx_id,
                 transaction,
                 response_tx,
             })
+            .await
+            .map_err(|_| Error::RuntimeStopped)?;
+
+        response_rx.await.map_err(|_| Error::RuntimeStopped)?
+    }
+
+    pub(crate) async fn displaced_writes(&self) -> Result<Vec<TxId>, Error> {
+        let (response_tx, response_rx) = oneshot::channel();
+        self.command_tx
+            .send(Command::DisplacedWrites { response_tx })
             .await
             .map_err(|_| Error::RuntimeStopped)?;
 
@@ -114,8 +134,9 @@ impl RuntimeHandle {
 enum PublishState {
     Idle,
     CheckpointPending {
-        tx_id: TxId,
-        checkpoint: SequencerCheckpoint,
+        pending: PendingPublish,
+        this_msg: lb_zone_sdk::node_types::MsgId,
+        checkpoint: Box<SequencerCheckpoint>,
     },
 }
 
@@ -126,14 +147,21 @@ struct Runtime {
     channel_id: ChannelId,
     command_rx: mpsc::Receiver<Command>,
     sequencer_ready: bool,
+    ready_checkpoint_pending: bool,
     ready_tx: Option<oneshot::Sender<()>>,
-    event_pending_retry: Option<Event>,
+    event_pending_retry: Option<PendingEvent>,
     publish_state: PublishState,
+}
+
+/// A channel event retained with the error from its latest application attempt.
+struct PendingEvent {
+    event: Event,
+    error: Error,
 }
 
 impl Runtime {
     async fn run(mut self, restored_checkpoint: Option<SequencerCheckpoint>) -> Result<(), Error> {
-        self.reconcile_restored_publish(restored_checkpoint.as_ref())?;
+        self.recover_published_write(restored_checkpoint.as_ref())?;
 
         let mut retry = tokio::time::interval(PUBLISH_RETRY_INTERVAL);
         retry.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
@@ -141,6 +169,10 @@ impl Runtime {
         loop {
             let retry_needed = self.has_pending_work()?;
 
+            // `ZoneSDK::publish` only queues the node post; `next_event` drives
+            // it. Do not poll events until the returned checkpoint commits. A
+            // crash while the write remains pending therefore means it never
+            // reached the node, which the applier's recovery plan relies on.
             tokio::select! {
                 command = self.command_rx.recv() => {
                     let Some(command) = command else {
@@ -148,7 +180,7 @@ impl Runtime {
                     };
 
                     if !self.handle_command(command).await {
-                        return Ok(());
+                        return self.shutdown_result();
                     }
                 },
                 event = self.sequencer.next_event(), if self.event_pending_retry.is_none() && !matches!(self.publish_state, PublishState::CheckpointPending { .. }) => {
@@ -162,96 +194,144 @@ impl Runtime {
     }
 
     async fn handle_command(&mut self, command: Command) -> bool {
-        let Command::Execute {
-            transaction,
-            response_tx,
-        } = command
-        else {
-            return false;
-        };
+        match command {
+            Command::Execute {
+                tx_id,
+                transaction,
+                response_tx,
+            } => {
+                let result = self.execute(tx_id, transaction).await;
+                drop(response_tx.send(result));
 
-        let result = if self.event_pending_retry.is_some() {
-            Err(Error::RuntimeHalted)
-        } else if !self.sequencer_ready {
-            Err(Error::SequencerNotReady)
-        } else {
-            let committed = self.db.commit_local_write(&transaction);
-
-            if let Ok(tx_id) = committed {
-                tracing::trace!(
-                    target: TARGET,
-                    ?tx_id,
-                    statements = transaction.statements().len(),
-                    "local write committed"
-                );
-
-                if let Err(error) = self.advance_publish().await {
-                    tracing::warn!(
-                        target: TARGET,
-                        %error,
-                        ?tx_id,
-                        "write committed; ZoneSDK publish remains pending"
-                    );
-                }
+                true
             }
+            Command::DisplacedWrites { response_tx } => {
+                drop(response_tx.send(self.db.displaced_writes()));
 
-            committed
-        };
+                true
+            }
+            Command::Shutdown => false,
+        }
+    }
 
-        drop(response_tx.send(result));
+    async fn execute(&mut self, tx_id: TxId, transaction: Transaction) -> Result<TxId, Error> {
+        if self.event_pending_retry.is_some() {
+            return Err(Error::RuntimeHalted);
+        }
 
-        true
+        if !self.sequencer_ready || self.ready_checkpoint_pending {
+            return Err(Error::SequencerNotReady);
+        }
+
+        self.db.commit_local_write(tx_id, &transaction)?;
+
+        tracing::trace!(
+            target: TARGET,
+            ?tx_id,
+            statements = transaction.statements().len(),
+            "local write committed"
+        );
+
+        if let Err(error) = self.advance_publish().await {
+            tracing::warn!(
+                target: TARGET,
+                %error,
+                ?tx_id,
+                "write committed; publication remains pending"
+            );
+        }
+
+        Ok(tx_id)
     }
 
     async fn handle_event(&mut self, event: Event) {
         match applier::on_event(&mut self.db, &event, self.channel_id) {
             Ok(()) => {
-                self.mark_ready(&event);
+                self.record_applied_event(&event);
 
-                if self.sequencer_ready
+                if self.can_publish()
                     && let Err(error) = self.advance_publish().await
                 {
                     tracing::warn!(
                         target: TARGET,
                         %error,
-                        "ZoneSDK publish remains pending"
+                        "write publication remains pending"
                     );
                 }
             }
             Err(error) => {
                 tracing::error!(target: TARGET, %error, "applier halted");
-                self.event_pending_retry = Some(event);
+                self.event_pending_retry = Some(PendingEvent { event, error });
             }
         }
     }
 
     async fn retry_pending_work(&mut self) -> Result<(), Error> {
-        if let Some(event) = self.event_pending_retry.take() {
-            if let Err(error) = applier::on_event(&mut self.db, &event, self.channel_id) {
-                tracing::debug!(target: TARGET, %error, "applier retry failed");
-                self.event_pending_retry = Some(event);
-            } else {
-                self.mark_ready(&event);
-            }
-        } else if self.sequencer_ready
+        if let Some(pending) = self.event_pending_retry.take() {
+            return self.retry_event(pending).await;
+        }
+
+        if self.can_publish()
             && let Err(error) = self.advance_publish().await
         {
-            tracing::debug!(target: TARGET, %error, "ZoneSDK publish retry failed");
+            tracing::warn!(target: TARGET, %error, "pending publication retry failed");
         }
 
         Ok(())
     }
 
-    fn mark_ready(&mut self, event: &Event) {
-        if self.sequencer_ready || !matches!(event, Event::Ready) {
-            return;
+    async fn retry_event(&mut self, pending: PendingEvent) -> Result<(), Error> {
+        let event = pending.event;
+
+        if let Err(error) = applier::on_event(&mut self.db, &event, self.channel_id) {
+            if !is_retryable_apply_error(&error) {
+                return Err(error);
+            }
+
+            tracing::debug!(target: TARGET, %error, "applier retry failed");
+            self.event_pending_retry = Some(PendingEvent { event, error });
+            return Ok(());
         }
 
-        self.sequencer_ready = true;
+        self.record_applied_event(&event);
 
-        if let Some(ready_tx) = self.ready_tx.take() {
-            let _ = ready_tx.send(());
+        if self.can_publish()
+            && let Err(error) = self.advance_publish().await
+        {
+            tracing::warn!(target: TARGET, %error, "pending publication retry failed");
         }
+
+        Ok(())
+    }
+
+    fn record_applied_event(&mut self, event: &Event) {
+        match event {
+            Event::Ready => {
+                // ZoneSDK queues the checkpoint for the block that made it
+                // ready behind this event. Publishing before consuming that
+                // checkpoint would let the older buffered value overwrite the
+                // checkpoint returned by the publish.
+                self.ready_checkpoint_pending = true;
+            }
+            Event::BlocksProcessed { .. } if self.ready_checkpoint_pending => {
+                self.ready_checkpoint_pending = false;
+
+                if !self.sequencer_ready {
+                    self.sequencer_ready = true;
+
+                    if let Some(ready_tx) = self.ready_tx.take() {
+                        let _ = ready_tx.send(());
+                    }
+                }
+            }
+            Event::BlocksProcessed { .. }
+            | Event::MempoolPending(_)
+            | Event::TurnNotification { .. } => {}
+        }
+    }
+
+    const fn can_publish(&self) -> bool {
+        self.sequencer_ready && !self.ready_checkpoint_pending
     }
 
     async fn advance_publish(&mut self) -> Result<(), Error> {
@@ -263,10 +343,12 @@ impl Runtime {
 
         let inscription: Inscription = pending
             .payload
+            .clone()
             .try_into()
             .map_err(|_| Error::InscriptionTooLarge)?;
 
-        let (_, checkpoint) = self.sequencer.handle().publish(inscription).await?;
+        let (published, checkpoint) = self.sequencer.handle().publish(inscription).await?;
+        let this_msg = published.tx.inscription().this_msg;
 
         tracing::trace!(
             target: TARGET,
@@ -275,24 +357,29 @@ impl Runtime {
         );
 
         self.publish_state = PublishState::CheckpointPending {
-            tx_id: pending.tx_id,
-            checkpoint,
+            pending,
+            this_msg,
+            checkpoint: Box::new(checkpoint),
         };
 
         self.persist_publish_checkpoint()
     }
 
     fn persist_publish_checkpoint(&mut self) -> Result<(), Error> {
-        let PublishState::CheckpointPending { tx_id, checkpoint } = &self.publish_state else {
+        let PublishState::CheckpointPending {
+            pending,
+            this_msg,
+            checkpoint,
+        } = &self.publish_state
+        else {
             return Ok(());
         };
 
-        self.db.persist_checkpoint(checkpoint)?;
-        self.db.mark_publish_complete(*tx_id)?;
+        self.db.complete_publish(checkpoint, *this_msg, pending)?;
 
         tracing::trace!(
             target: TARGET,
-            ?tx_id,
+            tx_id = ?pending.tx_id,
             "write publication recorded"
         );
 
@@ -301,8 +388,8 @@ impl Runtime {
         Ok(())
     }
 
-    fn reconcile_restored_publish(
-        &self,
+    fn recover_published_write(
+        &mut self,
         checkpoint: Option<&SequencerCheckpoint>,
     ) -> Result<(), Error> {
         let Some(pending) = self.db.pending_publish()? else {
@@ -313,14 +400,15 @@ impl Runtime {
             return Ok(());
         };
 
-        let already_submitted = checkpoint.pending_txs.iter().any(|(_, transaction)| {
-            channel_inscriptions(transaction, self.channel_id)
-                .iter()
-                .any(|inscription| inscription.payload.as_ref() == pending.payload)
-        });
+        let submitted = checkpoint
+            .pending_txs
+            .iter()
+            .flat_map(|(_, transaction)| channel_inscriptions(transaction, self.channel_id))
+            .find(|inscription| inscription.payload.as_inner() == &pending.payload);
 
-        if already_submitted {
-            self.db.mark_publish_complete(pending.tx_id)?;
+        if let Some(inscription) = submitted {
+            self.db
+                .complete_publish(checkpoint, inscription.this_msg, &pending)?;
 
             tracing::debug!(
                 target: TARGET,
@@ -336,5 +424,128 @@ impl Runtime {
         Ok(self.event_pending_retry.is_some()
             || matches!(self.publish_state, PublishState::CheckpointPending { .. })
             || self.db.pending_publish()?.is_some())
+    }
+
+    fn shutdown_result(&mut self) -> Result<(), Error> {
+        match self.event_pending_retry.take() {
+            Some(pending) => Err(pending.error),
+            None => Ok(()),
+        }
+    }
+}
+
+const fn is_retryable_apply_error(error: &Error) -> bool {
+    !matches!(error, Error::InvalidLocalState(_))
+}
+
+#[cfg(test)]
+mod tests {
+    use lb_key_management_system_service::keys::Ed25519Key;
+    use lb_zone_sdk::{
+        CommonHttpClient,
+        adapter::NodeHttpClient,
+        node_types::{ChannelId, HeaderId, MsgId, Slot},
+        sequencer::{ChannelUpdate, Event, FundingConfig, SequencerCheckpoint, ZoneSequencer},
+    };
+    use tempfile::TempDir;
+    use tokio::sync::{mpsc, oneshot};
+
+    use super::{COMMAND_CHANNEL_CAPACITY, PendingEvent, PublishState, Runtime};
+    use crate::{db::Databases, error::Error};
+
+    #[tokio::test]
+    async fn ready_waits_for_its_block_checkpoint_before_enabling_writes() {
+        let (_dir, mut runtime, ready_rx) = runtime();
+
+        runtime.record_applied_event(&Event::Ready);
+
+        assert!(!runtime.can_publish());
+
+        runtime.record_applied_event(&blocks_processed());
+
+        assert!(runtime.can_publish());
+        ready_rx.await.expect("runtime should announce readiness");
+
+        runtime.record_applied_event(&Event::Ready);
+
+        assert!(!runtime.can_publish());
+
+        runtime.record_applied_event(&blocks_processed());
+
+        assert!(runtime.can_publish());
+    }
+
+    #[tokio::test]
+    async fn shutdown_returns_the_pending_applier_error() {
+        let (_dir, mut runtime, _ready_rx) = runtime();
+        runtime.event_pending_retry = Some(PendingEvent {
+            event: blocks_processed(),
+            error: Error::InvalidLocalState("test applier failure"),
+        });
+
+        let error = runtime
+            .shutdown_result()
+            .expect_err("shutdown should expose the applier failure");
+
+        assert!(matches!(
+            error,
+            Error::InvalidLocalState("test applier failure")
+        ));
+    }
+
+    fn runtime() -> (TempDir, Runtime, oneshot::Receiver<()>) {
+        let dir = TempDir::new().expect("temporary directory should be created");
+        let db = Databases::open(dir.path()).expect("databases should open");
+        let channel_id = ChannelId::from([9; 32]);
+        let node = NodeHttpClient::new(
+            CommonHttpClient::new(None),
+            "http://127.0.0.1:1"
+                .parse()
+                .expect("test node URL should parse"),
+        );
+        let sequencer = ZoneSequencer::init(
+            channel_id,
+            Ed25519Key::from_bytes(&[7; 32]),
+            node,
+            FundingConfig {
+                funding_pk: lb_groth16::Fr::from(1u64).into(),
+                change_pk: None,
+                max_tx_fee: u64::MAX.into(),
+                priority_fee_percent: FundingConfig::DEFAULT_PRIORITY_FEE_PERCENT,
+            },
+            None,
+        );
+        let (_command_tx, command_rx) = mpsc::channel(COMMAND_CHANNEL_CAPACITY);
+        let (ready_tx, ready_rx) = oneshot::channel();
+        let runtime = Runtime {
+            sequencer,
+            db,
+            channel_id,
+            command_rx,
+            sequencer_ready: false,
+            ready_checkpoint_pending: false,
+            ready_tx: Some(ready_tx),
+            event_pending_retry: None,
+            publish_state: PublishState::Idle,
+        };
+
+        (dir, runtime, ready_rx)
+    }
+
+    fn blocks_processed() -> Event {
+        Event::BlocksProcessed {
+            checkpoint: SequencerCheckpoint {
+                last_msg_id: MsgId::root(),
+                pending_txs: Vec::new(),
+                lib: HeaderId::from([1; 32]),
+                lib_slot: Slot::from(1),
+                channel_notes: Vec::new(),
+            },
+            channel_update: ChannelUpdate {
+                adopted: Vec::new(),
+                orphaned: Vec::new(),
+            },
+            finalized: Vec::new(),
+        }
     }
 }

--- a/logos_sql/src/sql.rs
+++ b/logos_sql/src/sql.rs
@@ -4,7 +4,7 @@ use rusqlite::types::{ToSql, ToSqlOutput, Value, ValueRef};
 
 use crate::{
     error::Error,
-    protocol::{Statement, Transaction},
+    protocol::{Statement, Transaction, TxId},
 };
 
 /// A replicated SQL transaction with a current query.
@@ -14,6 +14,7 @@ use crate::{
 /// [`Self::bind`].
 #[must_use = "the transaction must be passed to LogosSql::execute"]
 pub struct TransactionBuilder {
+    tx_id: TxId,
     transaction: TransactionDraft,
 }
 
@@ -27,8 +28,19 @@ impl TransactionBuilder {
     /// Starts a transaction with its first SQL query.
     pub fn new(sql: impl Into<String>) -> Self {
         Self {
+            tx_id: TxId::generate(),
             transaction: TransactionDraft::new(sql),
         }
+    }
+
+    /// Returns the identity that will follow this write through publication
+    /// and any later displacement.
+    ///
+    /// Applications can persist this value with their own operation before
+    /// awaiting [`crate::LogosSql::execute`].
+    #[must_use]
+    pub const fn tx_id(&self) -> TxId {
+        self.tx_id
     }
 
     /// Adds the next SQL query to this transaction.
@@ -52,8 +64,8 @@ impl TransactionBuilder {
         self
     }
 
-    pub(crate) fn finish(self) -> Result<Transaction, Error> {
-        self.transaction.finish()
+    pub(crate) fn finish(self) -> Result<(TxId, Transaction), Error> {
+        Ok((self.tx_id, self.transaction.finish()?))
     }
 }
 
@@ -156,7 +168,8 @@ mod tests {
                 .bind("email")
                 .bind(42i64)
                 .finish()
-                .unwrap();
+                .unwrap()
+                .1;
         let expected = Transaction::new(vec![
             Statement::new(
                 "INSERT INTO credentials (label, account) VALUES (?1, ?2)".to_owned(),
@@ -188,5 +201,15 @@ mod tests {
     #[test]
     fn converts_none_to_sql_null() {
         assert_eq!(to_owned_value(&Option::<i64>::None).unwrap(), Value::Null);
+    }
+
+    #[test]
+    fn transaction_identity_is_available_before_execution() {
+        let transaction = TransactionBuilder::new("INSERT INTO items VALUES (?1)").bind(1i64);
+        let tx_id = transaction.tx_id();
+
+        let (finished_tx_id, _) = transaction.finish().expect("transaction should finish");
+
+        assert_eq!(finished_tx_id, tx_id);
     }
 }


### PR DESCRIPTION
## 1. What does this PR implement?

This PR adds fork-aware state management to Logos SQL.

`LIB.db` contains finalized state. `LIVE.db` contains the current channel state together with local writes that have not landed yet. Logos SQL keeps the unfinalized channel suffix separately so it can reconstruct `LIVE.db` when channel history changes.

```mermaid
flowchart LR
    Event[ZoneSDK event] --> Plan{Rebuild needed?}
    Plan -->|No| Apply[Apply changes]
    Plan -->|Yes| Rebuild[Rebuild LIVE.db<br/>from LIB.db + suffix]
    Apply --> Checkpoint[Save checkpoint]
    Rebuild --> Checkpoint
```

When a write is finalized, it is applied to `LIB.db` and removed from the live suffix. When a fork removes or replaces unfinalized history, Logos SQL updates the suffix and rebuilds `LIVE.db` in channel order.

If channel history changes underneath a pending local write, its optimistic effect is removed and its `TxId` is reported through `displaced_writes()`. Logos SQL does not execute displaced writes again automatically; the application decides how to handle them.

The write `TxId` is available before `execute()` is awaited, allowing applications to associate their own operation with a later displacement.

Database changes are applied before advancing the ZoneSDK checkpoint, and interrupted rebuilds can resume after restart.

## 2. Does the code have enough context to be clearly understood?
Yes

## 3. Who are the specification authors and who is accountable for this PR?
@andrussal 

## 4. Is the specification accurate and complete?
N/A

## 5. Does the implementation introduce changes in the specification?
N/A

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
