### PR TITLE
feat(zone-sdk): config lineage

### DIFF
--- a/tests/cucumber_tests/features/zone.feature
+++ b/tests/cucumber_tests/features/zone.feature
@@ -395,6 +395,60 @@ Feature: Zone SDK
     And I stop all nodes
 
   @zone_ci
+  # A config landing changes the channel view without moving the message tip, so
+  # the sequencer sheds its pending inscriptions (reports them orphaned). With
+  # orphan-republish on, they must be re-posted respecting lineage and end up
+  # indexed in order — i.e. a config that lands while messages are pending must
+  # not lose or reorder them. SEQ_B holds three messages pending (it is off
+  # turn) while SEQ_A lands a second config, which triggers the shed.
+  Scenario: A config landing orphans pending inscriptions which then re-adopt in order
+    Given the genesis block has the following wallet resources:
+      | account_index | token_count | token_amount |
+      | 1             | 3           | 100000       |
+    And I have a cluster with capacity of 1 nodes
+    And I start nodes with wallet and sequencer resources:
+      | node_name | account_index | wallet_name | connected_to | sequencers   |
+      | NODE_1    | 1             | WALLET_1A   |              | SEQ_A, SEQ_B |
+    When node "NODE_1" is at height 1 in 120 seconds
+    And wallet "WALLET_1A" sends 30 notes of 1000 LGO to node "NODE_1" funding wallet as "FUNDING_TOPUP"
+    And transaction "FUNDING_TOPUP" is included on node "NODE_1" in 180 seconds
+    And I start zone sequencers:
+      | alias | indexer | pending_submit_depth | passive_republish_orphans |
+      | SEQ_A | true    | unlimited            | false                     |
+    And sequencer "SEQ_A" submits zone config transaction:
+      | config_name      | posting_timeframe | posting_timeout | authorized_sequencers |
+      | CHANNEL_CONFIG_1 | 2                 | 0               | SEQ_A, SEQ_B          |
+    Then zone transaction "CHANNEL_CONFIG_1" is finalized in 180 seconds
+    When I start zone sequencers:
+      | alias | indexer | pending_submit_depth | passive_republish_orphans |
+      | SEQ_B | false   | unlimited            | true                      |
+    Then sequencer "SEQ_B" reaches sequencing state:
+      | own_key_index | turn_to_write | pending_transactions | time_out |
+      | 1             | NOT_OUR_TURN  | 0                    | 120      |
+    # SEQ_B queues messages while off turn — they sit pending.
+    When sequencer "SEQ_B" submits the following zone messages to queue immediately:
+      | alias  | data          |
+      | MSG_B1 | cfg-orphan-b1 |
+      | MSG_B2 | cfg-orphan-b2 |
+      | MSG_B3 | cfg-orphan-b3 |
+    Then sequencer "SEQ_B" reaches sequencing state:
+      | own_key_index | turn_to_write | pending_transactions | time_out |
+      | 1             | NOT_OUR_TURN  | 3                    | 120      |
+    # A second config lands while SEQ_B's three messages are pending: the new
+    # config view sheds them, and orphan-republish must recover them.
+    When sequencer "SEQ_A" submits zone config transaction:
+      | config_name      | posting_timeframe | posting_timeout | authorized_sequencers |
+      | CHANNEL_CONFIG_2 | 2                 | 0               | SEQ_A, SEQ_B          |
+    Then zone transaction "CHANNEL_CONFIG_2" is finalized in 180 seconds
+    # The shed inscriptions survive: re-posted and indexed in lineage order.
+    And the zone indexer returns messages in this order:
+      | alias  |
+      | MSG_B1 |
+      | MSG_B2 |
+      | MSG_B3 |
+    And I stop all nodes
+
+  @zone_ci
   Scenario: Round-robin publishes immediately when it is our turn
     Given the genesis block has the following wallet resources:
       | account_index | token_count | token_amount |

--- a/tests/src/cucumber/steps/manual_zone/support.rs
+++ b/tests/src/cucumber/steps/manual_zone/support.rs
@@ -278,30 +278,19 @@ pub fn start_sorted_conflict_policy(
     to_policy_runtime(runner::spawn(sequencer, policy))
 }
 
-/// Inline policy: republish orphaned inscriptions that aren't already back on
-/// the canonical chain. Plain inscriptions only — bundles are not
-/// auto-republished (callers that issue bundles re-prepare with fresh withdraw
-/// nonces themselves). Assumes unique payloads, so the payload identifies the
-/// message; for repeating payloads see [`RepublishLineagePolicy`].
+/// Inline policy: republish orphaned inscriptions not already back on the
+/// canonical chain. Plain inscriptions only — bundles re-prepare themselves.
+/// Assumes unique payloads; for repeating payloads see
+/// [`RepublishLineagePolicy`].
 ///
-/// Maintains the on-chain state as two flat sets keyed by id (`this_msg`) — no
-/// intent-lineage map needed. Per block, in order: (1) remove orphaned by id,
-/// (2) add finalized by id (permanent — finalized entries can't be orphaned),
-/// (3) add adopted by id; then republish an orphan only if **no id in
-/// `canonical` still carries its payload**. Keying by id but deciding by
-/// payload is the trick: when an old twin is orphaned its id leaves while a
-/// live twin's id keeps the payload covered, so we never re-home a payload
-/// that's still on chain (the duplicate) yet still recover a payload that's
-/// genuinely gone. Carrying `canonical` cumulatively (not just this block's
-/// adopted) closes the reorg window where a copy adopted earlier hasn't
-/// finalized yet.
+/// Tracks canonical on-chain state keyed by id, decided by payload (see
+/// `on_event`): a dead twin's id leaves while a live twin keeps the payload
+/// covered, so a payload still on chain is never re-homed.
 #[derive(Default)]
 struct OrphanRepublishPolicy {
-    /// Canonical on-chain inscriptions by id: adopted-unfinalized + finalized.
+    /// Canonical on-chain inscriptions by id (adopted-unfinalized + finalized).
     canonical: HashMap<MsgId, Inscription>,
-    /// Permanent floor of finalized payloads — an independent guard so a
-    /// finalized payload is never re-homed even if the canonical accounting
-    /// churns.
+    /// Permanent floor of finalized payloads — never re-homed.
     finalized: HashSet<Inscription>,
 }
 

--- a/tests/src/cucumber/steps/manual_zone/support.rs
+++ b/tests/src/cucumber/steps/manual_zone/support.rs
@@ -289,9 +289,9 @@ pub fn start_sorted_conflict_policy(
 #[derive(Default)]
 struct OrphanRepublishPolicy {
     /// Canonical on-chain inscriptions by id (adopted-unfinalized + finalized).
+    /// Finalized entries are added and never removed — they can't be orphaned —
+    /// so this one set is the whole on-chain view.
     canonical: HashMap<MsgId, Inscription>,
-    /// Permanent floor of finalized payloads — never re-homed.
-    finalized: HashSet<Inscription>,
 }
 
 impl<Node> runner::Policy<Node> for OrphanRepublishPolicy
@@ -313,10 +313,9 @@ where
                 self.canonical.remove(&info.this_msg);
             }
         }
-        // 2. Add finalized by id, and record the payload in the permanent floor.
+        // 2. Add finalized by id (permanent — finalized can't be orphaned).
         for info in finalized_inscriptions(finalized) {
             self.canonical.insert(info.this_msg, info.payload.clone());
-            self.finalized.insert(info.payload.clone());
         }
         // 3. Add adopted by id (this block's new canonical).
         for info in channel_update
@@ -331,11 +330,10 @@ where
             let ChannelUpdateTx::Inscription(info) = entry else {
                 continue;
             };
-            if self.finalized.contains(&info.payload)
-                || self
-                    .canonical
-                    .values()
-                    .any(|payload| *payload == info.payload)
+            if self
+                .canonical
+                .values()
+                .any(|payload| *payload == info.payload)
             {
                 continue;
             }

--- a/tests/src/cucumber/steps/manual_zone/support.rs
+++ b/tests/src/cucumber/steps/manual_zone/support.rs
@@ -283,8 +283,25 @@ pub fn start_sorted_conflict_policy(
 /// auto-republished (callers that issue bundles re-prepare with fresh withdraw
 /// nonces themselves). Assumes unique payloads, so the payload identifies the
 /// message; for repeating payloads see [`RepublishLineagePolicy`].
+///
+/// Maintains the on-chain state as two flat sets keyed by id (`this_msg`) — no
+/// intent-lineage map needed. Per block, in order: (1) remove orphaned by id,
+/// (2) add finalized by id (permanent — finalized entries can't be orphaned),
+/// (3) add adopted by id; then republish an orphan only if **no id in
+/// `canonical` still carries its payload**. Keying by id but deciding by
+/// payload is the trick: when an old twin is orphaned its id leaves while a
+/// live twin's id keeps the payload covered, so we never re-home a payload
+/// that's still on chain (the duplicate) yet still recover a payload that's
+/// genuinely gone. Carrying `canonical` cumulatively (not just this block's
+/// adopted) closes the reorg window where a copy adopted earlier hasn't
+/// finalized yet.
 #[derive(Default)]
 struct OrphanRepublishPolicy {
+    /// Canonical on-chain inscriptions by id: adopted-unfinalized + finalized.
+    canonical: HashMap<MsgId, Inscription>,
+    /// Permanent floor of finalized payloads — an independent guard so a
+    /// finalized payload is never re-homed even if the canonical accounting
+    /// churns.
     finalized: HashSet<Inscription>,
 }
 
@@ -301,21 +318,36 @@ where
         else {
             return;
         };
-        // Add finalized payloads to state first.
-        self.finalized
-            .extend(finalized_inscriptions(finalized).map(|i| i.payload.clone()));
-        // Skip orphans whose payload is already on chain (adopted) or finalized
-        // — republishing them would duplicate.
-        let adopted: HashSet<&Inscription> = channel_update
+        // 1. Remove orphaned by id — a dead twin leaves, a live twin stays.
+        for entry in &channel_update.orphaned {
+            if let Some(info) = entry.inscription() {
+                self.canonical.remove(&info.this_msg);
+            }
+        }
+        // 2. Add finalized by id, and record the payload in the permanent floor.
+        for info in finalized_inscriptions(finalized) {
+            self.canonical.insert(info.this_msg, info.payload.clone());
+            self.finalized.insert(info.payload.clone());
+        }
+        // 3. Add adopted by id (this block's new canonical).
+        for info in channel_update
             .adopted
             .iter()
-            .filter_map(|tx| tx.inscription().map(|i| &i.payload))
-            .collect();
+            .filter_map(ChannelUpdateTx::inscription)
+        {
+            self.canonical.insert(info.this_msg, info.payload.clone());
+        }
+        // 4. Republish orphaned whose payload no canonical id still carries.
         for entry in &channel_update.orphaned {
             let ChannelUpdateTx::Inscription(info) = entry else {
                 continue;
             };
-            if adopted.contains(&info.payload) || self.finalized.contains(&info.payload) {
+            if self.finalized.contains(&info.payload)
+                || self
+                    .canonical
+                    .values()
+                    .any(|payload| *payload == info.payload)
+            {
                 continue;
             }
             if let Err(error) = sequencer.handle().publish(info.payload.clone()).await {

--- a/zone-sdk/src/sequencer/actor.rs
+++ b/zone-sdk/src/sequencer/actor.rs
@@ -6,11 +6,7 @@
 use std::collections::HashSet;
 
 use lb_common_http_client::{ProcessedBlockEvent, Slot};
-use lb_core::mantle::{
-    channel::ChannelState,
-    ops::channel::{ChannelId, MsgId},
-    traits::Hashable as _,
-};
+use lb_core::mantle::{channel::ChannelState, ops::channel::ChannelId, traits::Hashable as _};
 use tracing::{debug, error, warn};
 
 use super::{
@@ -515,13 +511,7 @@ where
         // block: a foreign config landing alone moves no message lineage and
         // reports no update, but still invalidates a pending config of ours.
         let stale_configs = match (self.state.as_mut(), self.current_tip) {
-            (Some(s), Some(tip)) => {
-                let config_tip = self
-                    .channel_state
-                    .as_ref()
-                    .map_or_else(MsgId::root, |channel| channel.config_tip_hash);
-                s.shed_stale_pending_configs(tip, config_tip)
-            }
+            (Some(s), Some(tip)) => s.shed_stale_pending_configs(tip),
             _ => Vec::new(),
         };
         let seen: HashSet<_> = channel_update
@@ -533,6 +523,39 @@ where
             if !seen.contains(&tx.mantle_tx().hash()) {
                 channel_update.orphaned.push(ChannelUpdateTx::Custom(tx));
             }
+        }
+
+        // A config landing is a new *possibility*, not a reorg: it changes the
+        // accredited-key view without moving the message tip. Adoption is
+        // observed by reading the block (`detect_channel_update` above adopts
+        // the inscriptions that took the new config). This pass handles the
+        // complement — the not-yet-mined pending tail *not on this branch* that
+        // a config may have invalidated — shedding it for orphan reporting.
+        // Because only never-mined entries are shed, their resubmits form at
+        // most a competing branch that adoption/finalization collapses to one
+        // chain, never a real duplicate.
+        let config_shed = match (self.state.as_mut(), self.current_tip) {
+            (Some(s), Some(tip)) => s.shed_pending_inscriptions_on_config(tip),
+            _ => Vec::new(),
+        };
+        let config_shed_any = !config_shed.is_empty();
+        let mut seen: HashSet<_> = channel_update
+            .orphaned
+            .iter()
+            .map(ChannelUpdateTx::tx_hash)
+            .collect();
+        for entry in config_shed {
+            let tx = orphan_from_shed(entry);
+            if seen.insert(tx.tx_hash()) {
+                channel_update.orphaned.push(tx);
+            }
+        }
+        // Shedding the pending tail invalidates the chaining pointer: reset it
+        // to the (unchanged) message tip so resubmits re-post there as a
+        // competing branch. This equals any reorg recovery tip the message
+        // shed set above, so the two never fight over `last_msg_id`.
+        if config_shed_any && let (Some(s), Some(tip)) = (self.state.as_ref(), self.current_tip) {
+            self.last_msg_id = s.channel_tip_at(tip);
         }
 
         (
@@ -658,6 +681,7 @@ mod tests {
             ops::{
                 OpProof,
                 channel::{
+                    MsgId,
                     config::{ChannelConfigOp, Keys},
                     deposit::DepositOp,
                     inscribe::{Inscription, InscriptionOp},
@@ -1103,7 +1127,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn config_only_block_keeps_pending_inscription_and_message_tip() {
+    async fn config_only_block_orphans_pending_inscription_but_keeps_message_tip() {
         let channel_id = ChannelId::from([0; 32]);
         let sequencer_key = Ed25519Key::from_bytes(&[0; 32]);
 
@@ -1165,7 +1189,6 @@ mod tests {
             .expect("publish must resolve")
             .expect("publish should be accepted after Ready");
         let p_hash = result.inscription_id();
-        let p_msg = result.tx.inscription().this_msg;
 
         // Keep driving between the toggles so the down-edge is observed. The
         // config block is recognized by the `OnChain` status of its tx; the
@@ -1201,18 +1224,23 @@ mod tests {
         .await
         .expect("the config-only block must be processed");
 
+        // The config changes the channel view, so the pending inscription is
+        // shed and reported orphaned (to be resubmitted against the new view).
         assert!(
-            update.orphaned.is_empty(),
-            "a config-only block must not orphan the pending inscription; got {:?}",
+            update.orphaned.iter().any(|tx| tx.tx_hash() == p_hash),
+            "a config block must orphan the pending inscription; got {:?}",
             update.orphaned
         );
-        assert_eq!(
-            checkpoint.last_msg_id, p_msg,
-            "the config must not move the message tip"
-        );
         assert!(
-            checkpoint.pending_txs.iter().any(|(h, _)| *h == p_hash),
-            "the pending inscription must survive the config block"
+            checkpoint.pending_txs.iter().all(|(h, _)| *h != p_hash),
+            "the pending inscription must be shed from the pending set"
+        );
+        // The chaining pointer resets to the (unchanged) message tip so the
+        // resubmit re-posts there. Nothing was mined, so the tip is root.
+        assert_eq!(
+            checkpoint.last_msg_id,
+            MsgId::root(),
+            "the pointer resets to the message tip (root)"
         );
     }
 

--- a/zone-sdk/src/sequencer/actor.rs
+++ b/zone-sdk/src/sequencer/actor.rs
@@ -525,15 +525,9 @@ where
             }
         }
 
-        // A config landing is a new *possibility*, not a reorg: it changes the
-        // accredited-key view without moving the message tip. Adoption is
-        // observed by reading the block (`detect_channel_update` above adopts
-        // the inscriptions that took the new config). This pass handles the
-        // complement — the not-yet-mined pending tail *not on this branch* that
-        // a config may have invalidated — shedding it for orphan reporting.
-        // Because only never-mined entries are shed, their resubmits form at
-        // most a competing branch that adoption/finalization collapses to one
-        // chain, never a real duplicate.
+        // Shed the not-on-branch pending tail a config change may have
+        // invalidated. Only never-mined entries are shed, so re-posts form at
+        // most a competing branch that adoption collapses — never a duplicate.
         let config_shed = match (self.state.as_mut(), self.current_tip) {
             (Some(s), Some(tip)) => s.shed_pending_inscriptions_on_config(tip),
             _ => Vec::new(),
@@ -550,10 +544,8 @@ where
                 channel_update.orphaned.push(tx);
             }
         }
-        // Shedding the pending tail invalidates the chaining pointer: reset it
-        // to the (unchanged) message tip so resubmits re-post there as a
-        // competing branch. This equals any reorg recovery tip the message
-        // shed set above, so the two never fight over `last_msg_id`.
+        // Reset the chaining pointer to the message tip so re-posts re-home
+        // there. This equals any reorg recovery tip, so the two don't conflict.
         if config_shed_any && let (Some(s), Some(tip)) = (self.state.as_ref(), self.current_tip) {
             self.last_msg_id = s.channel_tip_at(tip);
         }

--- a/zone-sdk/src/sequencer/block_fetch.rs
+++ b/zone-sdk/src/sequencer/block_fetch.rs
@@ -314,7 +314,7 @@ fn observe_channel_inscriptions(
         let (info, withdraws) = match block_tx {
             BlockChannelTx::Inscription(i) => (i, None),
             BlockChannelTx::AtomicWithdraw(a) => (&a.inscription, Some(a.withdraws.clone())),
-            BlockChannelTx::Custom { .. } => continue,
+            BlockChannelTx::Config(_) | BlockChannelTx::Custom { .. } => continue,
         };
         let tx = by_hash
             .get(&info.tx_hash)
@@ -876,6 +876,7 @@ pub(super) fn classify_channel_tx(
 ) -> Option<BlockChannelTx> {
     let tx_hash = tx.mantle_tx().hash();
     let mut entries: Vec<InscriptionInfo> = Vec::new();
+    let mut config_entries: Vec<InscriptionInfo> = Vec::new();
     let mut inscribes = 0usize;
     let mut configs = 0usize;
     let mut withdraws: Vec<WithdrawInfo> = Vec::new();
@@ -905,6 +906,17 @@ pub(super) fn classify_channel_tx(
             }
             Op::ChannelConfig(config) if config.channel == channel_id => {
                 configs += 1;
+                // Configs sit on the separate config lineage — `this_msg` is a
+                // config id, `parent_msg` its config parent, payload empty.
+                // Captured here (including inside mixed/custom txs) so the
+                // config-tip walk can see every landed config, not just the
+                // node's single tip.
+                config_entries.push(InscriptionInfo {
+                    tx_hash,
+                    parent_msg: config.parent,
+                    this_msg: config.id(),
+                    payload: [].into(),
+                });
             }
             Op::ChannelWithdraw(withdraw) if withdraw.channel_id == channel_id => {
                 withdraws.push(WithdrawInfo {
@@ -917,8 +929,8 @@ pub(super) fn classify_channel_tx(
         }
     }
 
-    if entries.is_empty() {
-        // No tip-advancing op — nothing to store for this tx.
+    if entries.is_empty() && config_entries.is_empty() {
+        // Neither a tip-advancing op nor a config — nothing to store.
         return None;
     }
 
@@ -934,10 +946,15 @@ pub(super) fn classify_channel_tx(
                 withdraws,
             })
         }
+    } else if clean && inscribes == 0 && configs == 1 && withdraws.is_empty() {
+        // A pure single-config tx — the config-lineage analogue of a clean
+        // single inscription.
+        BlockChannelTx::Config(config_entries.pop().expect("exactly one config entry"))
     } else {
         BlockChannelTx::Custom {
             tx: tx.clone(),
             entries,
+            config_entries,
         }
     })
 }

--- a/zone-sdk/src/sequencer/state.rs
+++ b/zone-sdk/src/sequencer/state.rs
@@ -136,10 +136,8 @@ pub struct TxState {
     /// [`Self::shed_stale_pending_configs`] so a pending config chaining on the
     /// finalized config tip is not falsely orphaned.
     finalized_config: MsgId,
-    /// The config tip at the branch when we last ran the config-driven
-    /// inscription shed. A change means a config landed (or the branch's config
-    /// lineage diverged on a reorg), so the accredited-key view changed and the
-    /// not-yet-mined pending tail is re-evaluated. Starts at [`MsgId::root`].
+    /// Config tip last seen by the config-driven inscription shed; a change
+    /// means a config landed (or the branch's config lineage diverged).
     observed_config_tip: MsgId,
     /// The channel's note set: finalized base + per-block overlay.
     wallet: ChannelWallet,
@@ -677,29 +675,13 @@ impl TxState {
         ordered
     }
 
-    /// Re-evaluate the not-yet-mined pending tail when the branch's config
-    /// view changes.
-    ///
-    /// A config landing is a new *possibility*, not a reorg: it changes the
-    /// accredited-key view without moving the message tip. Which pending
-    /// inscriptions actually took the new config is observed by reading the
-    /// block — [`Self::detect_channel_update`] adopts the ones that landed.
-    /// This pass handles only the complement: the pending entries **not on
-    /// this branch's tip** (not in the tip's safe set), i.e. the
-    /// not-yet-mined tail a config may have invalidated. They are shed
-    /// parent-first for orphan reporting; the caller resets the chaining
-    /// pointer to the (unchanged) message tip so their resubmits re-post
-    /// there as a competing branch.
-    ///
-    /// The exclusion of on-branch (mined) entries is what makes this
-    /// duplicate-free: a re-post is only ever of something that was **never on
-    /// chain**, so it forms at most a competing alternate — one copy is
-    /// adopted, the dead branch is cleaned by adoption/finalization, never a
-    /// real duplicate. Orphaning a mined inscription instead would re-post an
-    /// on-chain original as a second copy — the bug this scoping avoids. (A
-    /// later refinement can narrow further to only the entries the new
-    /// accredited keys actually invalidate — pure optimization.) No change to
-    /// the config tip → empty.
+    /// On a config-tip change, shed the pending entries **not on this branch's
+    /// tip** (not in the safe set) — the not-yet-mined tail a config may have
+    /// invalidated. Mined/on-branch entries are excluded: a config never
+    /// invalidates a landed inscription, so orphaning one would re-post an
+    /// on-chain original as a duplicate. The caller resets the chaining pointer
+    /// to the message tip so re-posts land as a competing branch. Unchanged
+    /// config tip → empty.
     pub fn shed_pending_inscriptions_on_config(&mut self, tip: HeaderId) -> Vec<PendingTx> {
         let config_tip = self.config_tip_at(tip);
         if config_tip == self.observed_config_tip {
@@ -2043,12 +2025,9 @@ mod tests {
         assert!(state.pending_other_contains(&c_hash));
     }
 
-    /// A config landing sheds only the not-yet-mined pending tail
-    /// (parent-first) for orphan reporting, and leaves an inscription
-    /// already mined on this branch alone: it is on chain, so re-posting it
-    /// would be a real duplicate, whereas the never-mined tail forms only a
-    /// competing branch. A later block with the same config tip sheds
-    /// nothing more.
+    /// A config landing sheds only the not-yet-mined pending tail; an
+    /// inscription already mined on this branch is kept (re-posting an on-chain
+    /// entry would duplicate). Same config tip on a later block sheds nothing.
     #[test]
     fn config_land_sheds_pending_tail_but_keeps_mined_inscription() {
         let genesis = header_id(0);

--- a/zone-sdk/src/sequencer/state.rs
+++ b/zone-sdk/src/sequencer/state.rs
@@ -130,6 +130,17 @@ pub struct TxState {
     /// restore); the finalized-prefix search then matches nothing (see
     /// [`Self::finalized_prefix_ids`]).
     finalized_parent_msg: Option<MsgId>,
+    /// The config-lineage tip at LIB — the newest config finalized so far, or
+    /// [`MsgId::root`] when none has finalized (or is unknown after a
+    /// checkpoint restore). Seeds the landable set in
+    /// [`Self::shed_stale_pending_configs`] so a pending config chaining on the
+    /// finalized config tip is not falsely orphaned.
+    finalized_config: MsgId,
+    /// The config tip at the branch when we last ran the config-driven
+    /// inscription shed. A change means a config landed (or the branch's config
+    /// lineage diverged on a reorg), so the accredited-key view changed and the
+    /// not-yet-mined pending tail is re-evaluated. Starts at [`MsgId::root`].
+    observed_config_tip: MsgId,
     /// The channel's note set: finalized base + per-block overlay.
     wallet: ChannelWallet,
 }
@@ -142,13 +153,20 @@ pub enum BlockChannelTx {
     Inscription(InscriptionInfo),
     /// `publish_atomic_withdraw` shape: an inscription + its withdraws.
     AtomicWithdraw(AtomicWithdrawInfo),
+    /// A pure `channel_config` tx: a single config on the config lineage
+    /// (`this_msg` = config id, `parent_msg` = config parent), which does not
+    /// advance the message tip.
+    Config(InscriptionInfo),
     /// A shape the SDK cannot produce (bundled deposits, multi-inscribe,
     /// custom-built txs). Kept whole — updates hand the tx back to the
     /// caller's own recovery logic — along with its tip-advancing entries
-    /// in op order.
+    /// in op order. `config_entries` holds any `ChannelConfig` ops it carries,
+    /// which sit on the separate config lineage and never advance the message
+    /// tip.
     Custom {
         tx: SignedMantleTx<Unverified>,
         entries: Vec<InscriptionInfo>,
+        config_entries: Vec<InscriptionInfo>,
     },
 }
 
@@ -158,7 +176,21 @@ impl BlockChannelTx {
         match self {
             Self::Inscription(i) => std::slice::from_ref(i),
             Self::AtomicWithdraw(a) => std::slice::from_ref(&a.inscription),
+            Self::Config(_) => &[],
             Self::Custom { entries, .. } => entries,
+        }
+    }
+
+    /// The `ChannelConfig` entries this tx carries, in op order. These are on
+    /// the config lineage (`this_msg` = config id, `parent_msg` = config
+    /// parent) and do not advance the message tip. The clean
+    /// `Inscription`/`AtomicWithdraw` shapes carry none; a pure config is a
+    /// [`Self::Config`]; mixed/unknown configs ride in [`Self::Custom`].
+    pub fn config_entries(&self) -> &[InscriptionInfo] {
+        match self {
+            Self::Inscription(_) | Self::AtomicWithdraw(_) => &[],
+            Self::Config(c) => std::slice::from_ref(c),
+            Self::Custom { config_entries, .. } => config_entries,
         }
     }
 
@@ -169,7 +201,10 @@ impl BlockChannelTx {
 
     #[must_use]
     pub fn tx_hash(&self) -> Option<TxHash> {
-        self.infos().first().map(|i| i.tx_hash)
+        self.infos()
+            .first()
+            .or_else(|| self.config_entries().first())
+            .map(|i| i.tx_hash)
     }
 }
 
@@ -189,6 +224,8 @@ impl TxState {
             block_txs: HashMap::new(),
             finalized_msg,
             finalized_parent_msg: None,
+            finalized_config: MsgId::root(),
+            observed_config_tip: MsgId::root(),
             wallet: ChannelWallet::default(),
             next_other_seq: 0,
         }
@@ -412,6 +449,11 @@ impl TxState {
                 self.finalized_msg = msg;
                 self.finalized_parent_msg = Some(parent);
             }
+            // Advance the finalized config tip too (same pre-prune walk), so a
+            // pending config chaining on it stays landable after LIB moves.
+            if let Some(config) = self.config_tip_entry_at(lib) {
+                self.finalized_config = config.this_msg;
+            }
 
             // Prune ancestors of new lib (but not lib itself)
             let mut prune_cursor = self.parent_map.get(&lib).copied();
@@ -572,6 +614,13 @@ impl TxState {
             .filter(|h| !on_branch.contains(h) && !safe.contains(h))
             .copied()
             .collect();
+        self.drain_pending_in_lineage_order(&eligible)
+    }
+
+    /// Remove the given pending inscriptions/bundles in parent-first lineage
+    /// order, returning them as [`PendingTx`] for orphan reporting. Shared by
+    /// the off-branch and config-driven sheds.
+    fn drain_pending_in_lineage_order(&mut self, eligible: &HashSet<TxHash>) -> Vec<PendingTx> {
         if eligible.is_empty() {
             return Vec::new();
         }
@@ -626,6 +675,50 @@ impl TxState {
             self.remove_pending(&entry.tx_hash());
         }
         ordered
+    }
+
+    /// Re-evaluate the not-yet-mined pending tail when the branch's config
+    /// view changes.
+    ///
+    /// A config landing is a new *possibility*, not a reorg: it changes the
+    /// accredited-key view without moving the message tip. Which pending
+    /// inscriptions actually took the new config is observed by reading the
+    /// block — [`Self::detect_channel_update`] adopts the ones that landed.
+    /// This pass handles only the complement: the pending entries **not on
+    /// this branch's tip** (not in the tip's safe set), i.e. the
+    /// not-yet-mined tail a config may have invalidated. They are shed
+    /// parent-first for orphan reporting; the caller resets the chaining
+    /// pointer to the (unchanged) message tip so their resubmits re-post
+    /// there as a competing branch.
+    ///
+    /// The exclusion of on-branch (mined) entries is what makes this
+    /// duplicate-free: a re-post is only ever of something that was **never on
+    /// chain**, so it forms at most a competing alternate — one copy is
+    /// adopted, the dead branch is cleaned by adoption/finalization, never a
+    /// real duplicate. Orphaning a mined inscription instead would re-post an
+    /// on-chain original as a second copy — the bug this scoping avoids. (A
+    /// later refinement can narrow further to only the entries the new
+    /// accredited keys actually invalidate — pure optimization.) No change to
+    /// the config tip → empty.
+    pub fn shed_pending_inscriptions_on_config(&mut self, tip: HeaderId) -> Vec<PendingTx> {
+        let config_tip = self.config_tip_at(tip);
+        if config_tip == self.observed_config_tip {
+            return Vec::new();
+        }
+        self.observed_config_tip = config_tip;
+
+        let safe: HashSet<TxHash> = self
+            .block_states
+            .get(&tip)
+            .map(|s| s.iter().copied().collect())
+            .unwrap_or_default();
+        let eligible: HashSet<TxHash> = self
+            .pending
+            .keys()
+            .filter(|h| !safe.contains(h))
+            .copied()
+            .collect();
+        self.drain_pending_in_lineage_order(&eligible)
     }
 
     /// Shed pending opaque txs whose first inscription's parent slot was
@@ -688,16 +781,16 @@ impl TxState {
     /// Shed pending config-carrying txs whose config parent can no longer
     /// reach the mined config tip: removed from retry and returned whole for
     /// orphan reporting.
-    pub fn shed_stale_pending_configs(
-        &mut self,
-        tip: HeaderId,
-        config_tip: MsgId,
-    ) -> Vec<SignedMantleTx<Unverified>> {
+    pub fn shed_stale_pending_configs(&mut self, tip: HeaderId) -> Vec<SignedMantleTx<Unverified>> {
         if self.pending_other.is_empty() {
             return Vec::new();
         }
+        // Seed with the config tip we have actually processed on this branch —
+        // not the node's config tip, which can race ahead of the blocks we have
+        // processed and falsely orphan a pending config that merely extends our
+        // local tip (its block just hasn't arrived yet).
         let mut landable: HashSet<MsgId> = HashSet::new();
-        landable.insert(config_tip);
+        landable.insert(self.config_tip_at(tip));
         // A viable entry makes its own last config landable, so entries
         // chained on it are kept too.
         loop {
@@ -724,10 +817,9 @@ impl TxState {
             .pending_other
             .iter()
             .filter(|(hash, entry)| {
-                // `config_tip` comes from the node's tip, which can be ahead
-                // of the blocks we processed: an entry whose own config IS
-                // the tip landed on chain, even if we have not seen its
-                // block yet and it is therefore not in the safe set.
+                // An entry whose own config already landed on this branch (its
+                // `last_config` is in `landable`) stays — even if its block is
+                // not yet in the safe set.
                 let landed = entry
                     .last_config
                     .is_some_and(|last_config| landable.contains(&last_config));
@@ -929,6 +1021,39 @@ impl TxState {
         }
     }
 
+    /// The config-lineage tip entry at a block: the most recent config in the
+    /// walked window (block → LIB). Mirrors [`Self::channel_tip_entry_at`] but
+    /// over the config lineage; `None` when no config exists in the window.
+    fn config_tip_entry_at(&self, block_id: HeaderId) -> Option<&InscriptionInfo> {
+        let mut current = block_id;
+        loop {
+            if let Some(txs) = self.block_txs.get(&current)
+                && let Some(entry) = txs.iter().rev().find_map(|tx| tx.config_entries().last())
+            {
+                return Some(entry);
+            }
+
+            if current == self.current_lib {
+                return None;
+            }
+
+            match self.parent_map.get(&current) {
+                Some(&parent) => current = parent,
+                None => return None,
+            }
+        }
+    }
+
+    /// The config-lineage tip at a block: the most recent config in the walked
+    /// window (block → LIB), or [`Self::finalized_config`] if none. Derived
+    /// only from blocks we have processed, so — unlike the node's single config
+    /// tip — it never races ahead of local state.
+    #[must_use]
+    pub fn config_tip_at(&self, block_id: HeaderId) -> MsgId {
+        self.config_tip_entry_at(block_id)
+            .map_or(self.finalized_config, |entry| entry.this_msg)
+    }
+
     /// Detect a channel update between old and new L1 tips.
     ///
     /// Diffs the two channel *lineages*. `old_lineage` must be captured by the
@@ -1042,7 +1167,9 @@ impl TxState {
                     Some(ChannelUpdateTx::AtomicWithdraw(a.clone()))
                 }
                 BlockChannelTx::Inscription(_) => Some(ChannelUpdateTx::Inscription(info.clone())),
-                BlockChannelTx::Custom { tx, entries } => entries
+                // A pure config carries no message-lineage entry to report.
+                BlockChannelTx::Config(_) => None,
+                BlockChannelTx::Custom { tx, entries, .. } => entries
                     .iter()
                     .any(|entry| !entry.payload.is_empty())
                     .then(|| ChannelUpdateTx::Custom(tx.clone())),
@@ -1743,45 +1870,118 @@ mod tests {
         (tx, config_msg)
     }
 
-    /// A landed config supersedes a pending config whose parent no longer
-    /// reaches the config tip; a pending config chained on the new tip
-    /// survives.
+    /// Wrap a config tx as it is classified when mined: a `Custom` block tx
+    /// carrying the config on the config lineage (no message-tip entry).
+    fn config_block_tx(
+        tx: &SignedMantleTx<Unverified>,
+        this_msg: MsgId,
+        parent: MsgId,
+    ) -> BlockChannelTx {
+        BlockChannelTx::Custom {
+            tx: tx.clone(),
+            entries: Vec::new(),
+            config_entries: vec![InscriptionInfo {
+                tx_hash: tx.mantle_tx().hash(),
+                parent_msg: parent,
+                this_msg,
+                payload: [].into(),
+            }],
+        }
+    }
+
+    /// Once a rival config lands on-branch and moves the config tip, our
+    /// pending config chained on the superseded parent is shed.
     #[test]
     fn shed_stale_pending_configs_removes_superseded_config() {
         let genesis = header_id(0);
-        let tip = header_id(1);
+        let b1 = header_id(1);
+        let b2 = header_id(2);
         let channel_id = ChannelId::from([0u8; 32]);
         let mut state = TxState::new(genesis, MsgId::root());
-        state.process_block(tip, genesis, genesis, vec![], vec![], Vec::new());
 
+        // Our pending config chains on the (root) config tip.
         let (stale, _) = config_tx(MsgId::root(), 1);
         let stale_hash = stale.mantle_tx().hash();
         state.submit_other(stale, channel_id);
 
-        // While the config tip is still ZERO the pending config is viable.
-        assert!(
-            state
-                .shed_stale_pending_configs(tip, MsgId::root())
-                .is_empty()
+        // No config has landed yet — the local config tip is root, so ours is
+        // still viable.
+        state.process_block(b1, genesis, genesis, vec![], vec![], Vec::new());
+        assert!(state.shed_stale_pending_configs(b1).is_empty());
+        assert!(state.pending_other_contains(&stale_hash));
+
+        // A rival config (also chaining on root) lands on-branch and moves the
+        // config tip: our pending config's parent is now superseded → shed.
+        let (rival, rival_msg) = config_tx(MsgId::root(), 2);
+        state.process_block(
+            b2,
+            b1,
+            genesis,
+            vec![],
+            vec![config_block_tx(&rival, rival_msg, MsgId::root())],
+            Vec::new(),
         );
 
-        // Another config landed and moved the config tip: the pending one
-        // can no longer land, while one chained on the new tip can.
-        let landed_tip = msg_id(42);
-        let (live, _) = config_tx(landed_tip, 2);
-        let live_hash = live.mantle_tx().hash();
-        state.submit_other(live, channel_id);
-
-        let shed = state.shed_stale_pending_configs(tip, landed_tip);
+        let shed = state.shed_stale_pending_configs(b2);
         assert_eq!(shed.len(), 1);
         assert_eq!(shed[0].mantle_tx().hash(), stale_hash);
         assert!(!state.pending_other_contains(&stale_hash));
-        assert!(state.pending_other_contains(&live_hash));
     }
 
-    /// A pending config mined on the current branch sits in the tip's safe
-    /// set and is not shed, even though the config tip it moved makes its
-    /// own parent stale.
+    /// Many configs can land in one block as a chain (`root → C1 → C2`). The
+    /// config walk must resolve the *tip* of that chain, not the first entry,
+    /// so the shed evaluates pending configs against the correct parent.
+    #[test]
+    fn config_chain_in_one_block_resolves_tip_and_sheds_superseded() {
+        let genesis = header_id(0);
+        let b1 = header_id(1);
+        let channel_id = ChannelId::from([0u8; 32]);
+        let mut state = TxState::new(genesis, MsgId::root());
+
+        // Two chained configs land in a single block: C1 on root, C2 on C1.
+        let (c1, c1_msg) = config_tx(MsgId::root(), 1);
+        let (c2, c2_msg) = config_tx(c1_msg, 2);
+
+        // One pending config chains on the now-superseded root; another chains
+        // on the chain tip C2.
+        let (stale, _) = config_tx(MsgId::root(), 3);
+        let stale_hash = stale.mantle_tx().hash();
+        let (on_tip, _) = config_tx(c2_msg, 4);
+        let on_tip_hash = on_tip.mantle_tx().hash();
+        state.submit_other(stale, channel_id);
+        state.submit_other(on_tip, channel_id);
+
+        state.process_block(
+            b1,
+            genesis,
+            genesis,
+            vec![],
+            vec![
+                config_block_tx(&c1, c1_msg, MsgId::root()),
+                config_block_tx(&c2, c2_msg, c1_msg),
+            ],
+            Vec::new(),
+        );
+
+        // The walk resolves the chain tip (C2), not C1 or root.
+        assert_eq!(
+            state.config_tip_at(b1),
+            c2_msg,
+            "config_tip_at must resolve the last config in the block's chain"
+        );
+
+        // The shed evaluates against that tip: the root-parented config is
+        // superseded and shed; the C2-parented one still chains on the tip and
+        // is kept.
+        let shed = state.shed_stale_pending_configs(b1);
+        assert_eq!(shed.len(), 1);
+        assert_eq!(shed[0].mantle_tx().hash(), stale_hash);
+        assert!(!state.pending_other_contains(&stale_hash));
+        assert!(state.pending_other_contains(&on_tip_hash));
+    }
+
+    /// A pending config mined on the current branch sits in the tip's safe set
+    /// and is not shed.
     #[test]
     fn shed_stale_pending_configs_keeps_safe_on_branch_config() {
         let genesis = header_id(0);
@@ -1791,34 +1991,121 @@ mod tests {
 
         let (config, config_msg) = config_tx(MsgId::root(), 1);
         let config_hash = config.mantle_tx().hash();
+        // Build the block entry before `submit_other` moves the tx.
+        let block_tx = config_block_tx(&config, config_msg, MsgId::root());
         state.submit_other(config, channel_id);
 
-        // The config lands on-branch, so it enters the block's safe set.
-        state.process_block(tip, genesis, genesis, vec![config_hash], vec![], Vec::new());
+        // The config lands on-branch: in the block's safe set and on the config
+        // lineage.
+        state.process_block(
+            tip,
+            genesis,
+            genesis,
+            vec![config_hash],
+            vec![block_tx],
+            Vec::new(),
+        );
 
-        assert!(state.shed_stale_pending_configs(tip, config_msg).is_empty());
+        assert!(state.shed_stale_pending_configs(tip).is_empty());
         assert!(state.pending_other_contains(&config_hash));
     }
 
-    /// The config tip is read from the node, which can be ahead of the blocks
-    /// we processed. A config of ours that already moved that tip landed on
-    /// chain, so it must survive even before its block reaches our safe set.
+    /// Regression (youngjoon): a pending config that merely extends our local
+    /// config tip must survive while its own block is still unprocessed — even
+    /// though the node may report a further-ahead config tip. We seed from the
+    /// local tip, so an ahead-of-us node tip never sheds it.
     #[test]
-    fn shed_stale_pending_configs_keeps_config_that_moved_the_tip() {
+    fn shed_stale_pending_configs_keeps_pending_extending_local_tip() {
         let genesis = header_id(0);
-        let tip = header_id(1);
+        let b1 = header_id(1);
         let channel_id = ChannelId::from([0u8; 32]);
         let mut state = TxState::new(genesis, MsgId::root());
-        state.process_block(tip, genesis, genesis, vec![], vec![], Vec::new());
 
-        let (config, config_msg) = config_tx(MsgId::root(), 1);
-        let config_hash = config.mantle_tx().hash();
-        state.submit_other(config, channel_id);
+        // Config B lands on-branch → the local config tip is B.
+        let (b_config, b_msg) = config_tx(MsgId::root(), 1);
+        state.process_block(
+            b1,
+            genesis,
+            genesis,
+            vec![],
+            vec![config_block_tx(&b_config, b_msg, MsgId::root())],
+            Vec::new(),
+        );
 
-        // The node reports our config as the tip while its block is still
-        // unprocessed here, so nothing put it in the safe set.
-        assert!(state.shed_stale_pending_configs(tip, config_msg).is_empty());
-        assert!(state.pending_other_contains(&config_hash));
+        // Our config C chains on B and is pending; its block hasn't arrived, so
+        // it is in no safe set.
+        let (c_config, _c_msg) = config_tx(b_msg, 2);
+        let c_hash = c_config.mantle_tx().hash();
+        state.submit_other(c_config, channel_id);
+
+        // C extends the local tip B, so it survives.
+        assert!(state.shed_stale_pending_configs(b1).is_empty());
+        assert!(state.pending_other_contains(&c_hash));
+    }
+
+    /// A config landing sheds only the not-yet-mined pending tail
+    /// (parent-first) for orphan reporting, and leaves an inscription
+    /// already mined on this branch alone: it is on chain, so re-posting it
+    /// would be a real duplicate, whereas the never-mined tail forms only a
+    /// competing branch. A later block with the same config tip sheds
+    /// nothing more.
+    #[test]
+    fn config_land_sheds_pending_tail_but_keeps_mined_inscription() {
+        let genesis = header_id(0);
+        let b1 = header_id(1);
+        let mut state = TxState::new(genesis, MsgId::root());
+
+        // p1 is published and mined on-branch — it enters the block's safe set.
+        let p1 = submit_fake_inscription(&mut state, 1, MsgId::root(), msg_id(1));
+        let m1 = InscriptionInfo {
+            tx_hash: p1,
+            parent_msg: MsgId::root(),
+            this_msg: msg_id(1),
+            payload: [1].into(),
+        };
+        state.process_block(
+            b1,
+            genesis,
+            genesis,
+            vec![p1],
+            vec![BlockChannelTx::Inscription(m1)],
+            Vec::new(),
+        );
+
+        // p2, p3 chain on the mined tip but are not yet mined (pending).
+        let p2 = submit_fake_inscription(&mut state, 2, msg_id(1), msg_id(2));
+        let p3 = submit_fake_inscription(&mut state, 3, msg_id(2), msg_id(3));
+
+        // No config has landed → the config tip is unchanged → nothing shed.
+        assert!(state.shed_pending_inscriptions_on_config(b1).is_empty());
+
+        // A config lands, moving the config tip.
+        let (cfg, cfg_msg) = config_tx(MsgId::root(), 9);
+        let b2 = header_id(2);
+        state.process_block(
+            b2,
+            b1,
+            genesis,
+            vec![],
+            vec![config_block_tx(&cfg, cfg_msg, MsgId::root())],
+            Vec::new(),
+        );
+
+        // Only the not-yet-mined tail is shed, parent-first; the mined p1 is on
+        // chain and must not be orphaned (re-posting it would duplicate).
+        let shed: Vec<TxHash> = state
+            .shed_pending_inscriptions_on_config(b2)
+            .iter()
+            .map(PendingTx::tx_hash)
+            .collect();
+        assert_eq!(shed, vec![p2, p3], "shed only the not-yet-mined tail");
+        assert!(
+            state.pending_inscription(&p1).is_some(),
+            "the mined inscription must not be orphaned"
+        );
+
+        // Same config tip on the next call → nothing more to shed.
+        assert!(state.shed_pending_inscriptions_on_config(b2).is_empty());
     }
 
     /// A config-only block does not touch the message lineage: no update is

--- a/zone-sdk/src/sequencer/zone_sequencer.rs
+++ b/zone-sdk/src/sequencer/zone_sequencer.rs
@@ -870,15 +870,20 @@ where
             }
         };
 
-        // The configuration extends the mined config tip — the same view the
-        // signer above was picked from. Chaining onto a config of ours still
-        // in flight would pair that config's parent with a proof built for
-        // the pre-config key set, which the ledger rejects either way: a
+        // The configuration extends our *local* config tip — the same view the
+        // config shed evaluates against — so a config we submit is never
+        // transiently orphaned by an ahead-of-us node config tip. If we are
+        // behind the node the parent is stale, so the config simply does not
+        // land (parent mismatch) and is orphaned and resubmitted once we catch
+        // up — the same self-healing path an inscription takes. Single-signer
+        // only, so we always sign with our own key; multi-sig configs are
+        // rejected above and go through the consumer's `submit_signed_tx` flow.
+        // We chain on the mined tip, not a config of ours still in flight: a
         // reconfiguration lands one at a time.
-        let parent = self
-            .channel_state
-            .as_ref()
-            .map_or_else(MsgId::root, |channel| channel.config_tip_hash);
+        let parent = match (self.state.as_ref(), self.current_tip) {
+            (Some(state), Some(tip)) => state.config_tip_at(tip),
+            _ => MsgId::root(),
+        };
 
         let signed_tx = create_channel_config_tx(
             &self.node,


### PR DESCRIPTION
## 1. What does this PR implement?

A channel has two lineages — message (inscriptions) and config — and a config landing changes the accredited-key view without moving the message tip. This tracks the config lineage per-block and re-evaluates pending work when it changes, without ever emitting a false orphan.

Also, we support config only entry (tx with only config, usually submitted through zone-sdk), which surfaces as Config variant, and we also treat custom tx that have config inside with other ops, as Custom but still get config information from it and orphan the same as the regular config tx. This allows for users to use the advance flows such as multi atomic txs, or multi sig tx.

The current implementation sheds all pending (not mined) inscriptions when config lands on a branch. The improvement (for the different PR) would be to go through inscriptions, check accredited keys, and orphan the first invalid inscription based on keys and it's children. This would be just optimization (a little less republishes) and the current logic should work correctly without it.

- Per-block config tracking: `BlockChannelTx::Config` / `config_entries`; config_tip_at walks to the config-chain tip (handles many configs per block).
- Config-driven shed: on a config-tip change, shed only the pending tail not on this branch (not in the safe set) — the never-mined entries a config may invalidate. A mined inscription is never orphaned (a config can't invalidate a landed one), so re-posts form at most a competing branch that adoption collapses. The chaining pointer resets to the message tip.
-﻿ Client policy: OrphanRepublishPolicy rewritten to a  canonical-set model (remove orphaned by id → add finalized/adopted by id → republish decision  by payload), closing a reorg-window duplicate.

Contract: the SDK never emits a false orphan of an on-chain entry; the client never re-homes a payload still carried by a canonical id.

## 2. Does the code have enough context to be clearly understood?

Yes
## 3. Who are the specification authors and who is accountable for this PR?

@pradovic 

## 4. Is the specification accurate and complete?

Yes

## 5. Does the implementation introduce changes in the specification?

No

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [ ] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [ ] 2. Description added.
* [ ] 3. Context and links to Specification document(s) added.
* [ ] 4. Main contact(s) (developers and specification authors) added
* [ ] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [ ] 6. Link PR to a specific milestone.
* [ ] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
