### PR TITLE
chore(blend): return whole proof set for each message

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4140,6 +4140,7 @@ dependencies = [
  "multiaddr",
  "rand 0.8.6",
  "test-log",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]

--- a/blend/core/Cargo.toml
+++ b/blend/core/Cargo.toml
@@ -22,10 +22,12 @@ lb-blend-provers    = { workspace = true }
 lb-blend-scheduling = { workspace = true }
 
 [features]
-tokio-task-names = ["lb-blend-scheduling/tokio-task-names"]
+tokio-task-names = ["lb-blend-provers/tokio-task-names", "lb-blend-scheduling/tokio-task-names"]
 unsafe-test-functions = [
+  "lb-blend-membership/unsafe-test-functions",
   "lb-blend-message/unsafe-test-functions",
   "lb-blend-network/unsafe-test-functions",
   "lb-blend-proofs/unsafe-test-functions",
+  "lb-blend-provers/unsafe-test-functions",
   "lb-blend-scheduling/unsafe-test-functions",
 ]

--- a/blend/provers/Cargo.toml
+++ b/blend/provers/Cargo.toml
@@ -27,6 +27,7 @@ lb-key-management-system-keys = { workspace = true }
 lb-log-targets                = { workspace = true }
 lb-utils                      = { features = ["rng", "tokio"], workspace = true }
 rand                          = { features = ["alloc"], workspace = true }
+thiserror                     = { workspace = true }
 tokio                         = { workspace = true }
 tracing                       = { workspace = true }
 

--- a/blend/provers/src/crypto/core_and_leader/send.rs
+++ b/blend/provers/src/crypto/core_and_leader/send.rs
@@ -13,7 +13,7 @@ use lb_groth16::fr_to_bytes;
 use crate::{
     crypto::EncapsulatedMessageWithVerifiedPublicHeader,
     provers::{
-        BlendLayerProof, ProofsGeneratorSettings, WinningPolInfoStream,
+        EncapsulationProofs, ProofsGeneratorSettings, WinningPolInfoStream,
         core_leader_and_pow::CoreLeaderAndPowProofsGenerator,
     },
 };
@@ -129,7 +129,6 @@ where
     // TODO: Think about optimizing this by, e.g., using less encapsulations if
     // there are less than 3 proofs available, or use a proof from a different pool
     // if needed (core proof for leadership message or leadership proof for
-    // cover message, since the protocol does not enforce that).
     async fn encapsulate_payload(
         &mut self,
         payload_type: PayloadType,
@@ -137,18 +136,13 @@ where
     ) -> Result<EncapsulatedMessageWithVerifiedPublicHeader, Error> {
         // We validate the payload early on so we don't generate proofs unnecessarily.
         let validated_payload = PaddedPayloadBody::try_from(payload)?;
-        let mut proofs = Vec::with_capacity(self.num_blend_layers.get() as usize);
-
-        for _ in 0..self.num_blend_layers.into() {
-            let Some(proof) = self.next_proof_for(payload_type).await else {
-                return Err(Error::ProofNotAvailable);
-            };
-            proofs.push(proof);
-        }
+        let Some(proofs) = self.next_proofs_for(payload_type).await else {
+            return Err(Error::ProofNotAvailable);
+        };
 
         let membership_size = self.membership.size();
         let proofs_and_signing_keys = proofs
-            .into_iter()
+            .into_layers()
             // Collect remote (or local) index info for each PoSel.
             .map(|proof| {
                 let expected_index = proof
@@ -195,7 +189,7 @@ where
     }
 
     /// The `PoQ` branch each payload type draws its layer proofs from.
-    async fn next_proof_for(&mut self, payload_type: PayloadType) -> Option<BlendLayerProof> {
+    async fn next_proofs_for(&mut self, payload_type: PayloadType) -> Option<EncapsulationProofs> {
         match payload_type {
             PayloadType::Cover => self.proofs_generator.get_next_core_proof().await,
             PayloadType::BlockProposal => self.proofs_generator.get_next_leader_proof().await,

--- a/blend/provers/src/crypto/leader/send.rs
+++ b/blend/provers/src/crypto/leader/send.rs
@@ -11,7 +11,7 @@ use lb_cryptarchia_engine::Epoch;
 use crate::{
     crypto::EncapsulatedMessageWithVerifiedPublicHeader,
     provers::{
-        BlendLayerProof, ProofsGeneratorSettings, WinningPolInfoStream,
+        EncapsulationProofs, ProofsGeneratorSettings, WinningPolInfoStream,
         leader_and_pow::LeaderAndPowProofsGenerator,
     },
 };
@@ -107,18 +107,13 @@ where
     ) -> Result<EncapsulatedMessageWithVerifiedPublicHeader, Error> {
         // We validate the payload early on so we don't generate proofs unnecessarily.
         let validated_payload = PaddedPayloadBody::try_from(payload)?;
-        let mut proofs = Vec::with_capacity(self.num_blend_layers.get() as usize);
-
-        for _ in 0..self.num_blend_layers.into() {
-            let Some(proof) = self.next_proof_for(payload_type).await else {
-                return Err(Error::ProofNotAvailable);
-            };
-            proofs.push(proof);
-        }
+        let Some(proofs) = self.next_proofs_for(payload_type).await else {
+            return Err(Error::ProofNotAvailable);
+        };
 
         let membership_size = self.membership.size();
         let proofs_and_signing_keys = proofs
-            .into_iter()
+            .into_layers()
             // Collect remote (or local) index info for each PoSel.
             .map(|proof| {
                 let expected_index = proof
@@ -170,7 +165,7 @@ where
     ///
     /// An edge node has no core quota, so unlike a core node it has nothing to
     /// spend on cover traffic — and it generates none.
-    async fn next_proof_for(&mut self, payload_type: PayloadType) -> Option<BlendLayerProof> {
+    async fn next_proofs_for(&mut self, payload_type: PayloadType) -> Option<EncapsulationProofs> {
         match payload_type {
             PayloadType::BlockProposal => self.proofs_generator.get_next_leader_proof().await,
             PayloadType::Transaction => self.proofs_generator.get_next_pow_proof().await,

--- a/blend/provers/src/crypto/test_utils.rs
+++ b/blend/provers/src/crypto/test_utils.rs
@@ -16,7 +16,7 @@ use lb_key_management_system_keys::keys::Ed25519PublicKey;
 use crate::{
     CoreProofOfQuotaGenerator,
     provers::{
-        BlendLayerProof, ProofsGeneratorSettings, WinningPolInfoStream,
+        EncapsulationProofs, ProofsGeneratorSettings, WinningPolInfoStream,
         core_leader_and_pow::CoreLeaderAndPowProofsGenerator,
     },
 };
@@ -61,15 +61,15 @@ impl<CorePoQGenerator> CoreLeaderAndPowProofsGenerator<CorePoQGenerator>
         self.0 = Some(winning_pol_info_stream);
     }
 
-    async fn get_next_core_proof(&mut self) -> Option<BlendLayerProof> {
+    async fn get_next_core_proof(&mut self) -> Option<EncapsulationProofs> {
         None
     }
 
-    async fn get_next_leader_proof(&mut self) -> Option<BlendLayerProof> {
+    async fn get_next_leader_proof(&mut self) -> Option<EncapsulationProofs> {
         None
     }
 
-    async fn get_next_pow_proof(&mut self) -> Option<BlendLayerProof> {
+    async fn get_next_pow_proof(&mut self) -> Option<EncapsulationProofs> {
         None
     }
 }

--- a/blend/provers/src/lib.rs
+++ b/blend/provers/src/lib.rs
@@ -1,3 +1,6 @@
+use core::{future::ready, num::NonZeroU64};
+
+use futures::{Stream, StreamExt as _};
 use lb_blend_proofs::quota::{self, KeyIndex, VerifiedProofOfQuota, inputs::prove::PublicInputs};
 use lb_core::crypto::ZkHash;
 
@@ -14,6 +17,18 @@ pub trait CoreProofOfQuotaGenerator {
         public_inputs: &PublicInputs,
         key_index: KeyIndex,
     ) -> impl Future<Output = Result<(VerifiedProofOfQuota, ZkHash), quota::Error>> + Send + Sync;
+}
+
+/// Groups a stream of individual layer proofs into whole-message sets.
+pub(crate) fn into_encapsulation_sets(
+    proofs_stream: impl Stream<Item = provers::BlendLayerProof> + Send,
+    encapsulation_layers: NonZeroU64,
+) -> impl Stream<Item = provers::EncapsulationProofs> + Send {
+    proofs_stream
+        .chunks(encapsulation_layers.get() as usize)
+        .filter_map(move |run| {
+            ready(provers::EncapsulationProofs::try_new(run, encapsulation_layers).ok())
+        })
 }
 
 const fn buffer_size(encapsulation_layers: usize) -> usize {

--- a/blend/provers/src/provers/core/mod.rs
+++ b/blend/provers/src/provers/core/mod.rs
@@ -16,8 +16,8 @@ use lb_utils::tokio::{stream::Buffered, task::spawn};
 use tokio::time::Instant;
 
 use crate::{
-    CoreProofOfQuotaGenerator, buffer_size,
-    provers::{BlendLayerProof, ProofsGeneratorSettings},
+    CoreProofOfQuotaGenerator, buffer_size, into_encapsulation_sets,
+    provers::{BlendLayerProof, EncapsulationProofs, ProofsGeneratorSettings, message_cost},
 };
 
 #[cfg(test)]
@@ -36,7 +36,7 @@ pub trait CoreProofsGenerator<PoQGenerator>: Sized {
     ) -> Self;
     /// Request a new core proof from the prover. It returns `None` if the
     /// maximum core quota has already been reached for this epoch.
-    async fn get_next_proof(&mut self) -> Option<BlendLayerProof>;
+    async fn get_next_proof(&mut self) -> Option<EncapsulationProofs>;
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -48,7 +48,7 @@ pub struct CoreProofsGeneratorSettings {
 pub struct RealCoreProofsGenerator<PoQGenerator> {
     remaining_quota: Quota,
     pub(super) settings: CoreProofsGeneratorSettings,
-    proofs_stream: Pin<Box<dyn Stream<Item = BlendLayerProof> + Send + Sync>>,
+    proofs_stream: Pin<Box<dyn Stream<Item = EncapsulationProofs> + Send + Sync>>,
     _phantom: PhantomData<PoQGenerator>,
 }
 
@@ -63,11 +63,14 @@ where
         proof_of_quota_generator: PoQGenerator,
     ) -> Self {
         Self {
-            proofs_stream: Box::pin(create_proof_stream(
-                settings.public_inputs,
-                proof_of_quota_generator,
-                starting_key_index,
-                buffer_size(settings.encapsulation_layers.get() as usize),
+            proofs_stream: Box::pin(into_encapsulation_sets(
+                create_proof_stream(
+                    settings.public_inputs,
+                    proof_of_quota_generator,
+                    starting_key_index,
+                    buffer_size(settings.encapsulation_layers.get() as usize),
+                ),
+                settings.encapsulation_layers,
             )),
             remaining_quota: settings
                 .public_inputs
@@ -82,19 +85,20 @@ where
         }
     }
 
-    async fn get_next_proof(&mut self) -> Option<BlendLayerProof> {
+    async fn get_next_proof(&mut self) -> Option<EncapsulationProofs> {
         let start = Instant::now();
-        let Some(remaining_quota) = self.remaining_quota.checked_sub(Quota::ONE) else {
+        let message_cost = message_cost(self.settings.common.encapsulation_layers);
+        let Some(remaining_quota) = self.remaining_quota.checked_sub(message_cost) else {
             tracing::warn!(target: LOG_TARGET, "Core quota exhausted. No proof is generated.");
             return None;
         };
         self.remaining_quota = remaining_quota;
-        let Some(proof) = self.proofs_stream.next().await else {
-            tracing::warn!(target: LOG_TARGET, "No proof available from the stream.");
+        let Some(proofs) = self.proofs_stream.next().await else {
+            tracing::warn!(target: LOG_TARGET, "No proofs available from the stream.");
             return None;
         };
-        tracing::trace!(target: LOG_TARGET, "Generated core Blend layer proof with key nullifier {:?} addressed to node at index {:?} in {:?} ms.", hex::encode(fr_to_bytes(&proof.proof_of_quota.key_nullifier())), proof.proof_of_selection.expected_index(self.settings.common.membership_size), start.elapsed().as_millis());
-        Some(proof)
+        tracing::trace!(target: LOG_TARGET, "Generated core Blend layer proof with key nullifier {:?} addressed to node at index {:?} in {:?} ms.", hex::encode(fr_to_bytes(&proofs.outermost().proof_of_quota.key_nullifier())), proofs.outermost().proof_of_selection.expected_index(self.settings.common.membership_size), start.elapsed().as_millis());
+        Some(proofs)
     }
 }
 

--- a/blend/provers/src/provers/core/tests.rs
+++ b/blend/provers/src/provers/core/tests.rs
@@ -31,27 +31,34 @@ async fn proof_generation() {
         CorePoQGeneratorFromPrivateCoreQuotaInputs::new(private_inputs.clone()),
     );
 
+    // One layer per message here, so the quota buys exactly `core_quota` messages.
     for _ in 0..core_quota.get() {
-        let proof = core_proofs_generator.get_next_proof().await.unwrap();
-        let verified_proof_of_quota = proof
-            .proof_of_quota
-            .into_inner()
-            .verify(&poq_public_inputs_from_epoch_public_inputs_and_signing_key(
-                (public_inputs, proof.ephemeral_signing_key.public_key()),
-            ))
-            .unwrap();
-        proof
-            .proof_of_selection
-            .into_inner()
-            .verify(&VerifyInputs {
-                // Membership of 1 -> only a single index can be included
-                expected_node_index: 0,
-                key_nullifier: verified_proof_of_quota.key_nullifier(),
-                total_membership_size: 1,
-            })
-            .unwrap();
+        for proof in core_proofs_generator
+            .get_next_proof()
+            .await
+            .unwrap()
+            .into_layers()
+        {
+            let verified_proof_of_quota = proof
+                .proof_of_quota
+                .into_inner()
+                .verify(&poq_public_inputs_from_epoch_public_inputs_and_signing_key(
+                    (public_inputs, proof.ephemeral_signing_key.public_key()),
+                ))
+                .unwrap();
+            proof
+                .proof_of_selection
+                .into_inner()
+                .verify(&VerifyInputs {
+                    // Membership of 1 -> only a single index can be included
+                    expected_node_index: 0,
+                    key_nullifier: verified_proof_of_quota.key_nullifier(),
+                    total_membership_size: 1,
+                })
+                .unwrap();
+        }
     }
 
-    // Next proof should be `None` since we ran out of core quota.
+    // Next set should be `None` since we ran out of core quota.
     assert!(core_proofs_generator.get_next_proof().await.is_none());
 }

--- a/blend/provers/src/provers/core_and_leader/mod.rs
+++ b/blend/provers/src/provers/core_and_leader/mod.rs
@@ -7,7 +7,7 @@ use lb_log_targets::blend;
 use crate::{
     CoreProofOfQuotaGenerator,
     provers::{
-        BlendLayerProof, ProofsGeneratorSettings, WinningPolInfoStream,
+        EncapsulationProofs, ProofsGeneratorSettings, WinningPolInfoStream,
         core::{CoreProofsGenerator as _, RealCoreProofsGenerator},
         leader::{LeaderProofsGenerator as _, RealLeaderProofsGenerator},
     },
@@ -45,11 +45,11 @@ pub trait CoreAndLeaderProofsGenerator<CorePoQGenerator>: Sized {
     );
     /// Request a new core proof from the prover. It returns `None` if the
     /// maximum core quota has already been reached for this epoch.
-    async fn get_next_core_proof(&mut self) -> Option<BlendLayerProof>;
+    async fn get_next_core_proof(&mut self) -> Option<EncapsulationProofs>;
     /// Request a new leadership proof from the prover. It returns `None` if no
     /// secret `PoL` info has been provided for the current epoch or if all the
     /// winning slots for the current epoch have been used up.
-    async fn get_next_leader_proof(&mut self) -> Option<BlendLayerProof>;
+    async fn get_next_leader_proof(&mut self) -> Option<EncapsulationProofs>;
 }
 
 pub struct RealCoreAndLeaderProofsGenerator<CorePoQGenerator> {
@@ -144,36 +144,36 @@ where
         ));
     }
 
-    async fn get_next_core_proof(&mut self) -> Option<BlendLayerProof> {
-        let proof = self.core_proofs_generator.get_next_proof().await?;
+    async fn get_next_core_proof(&mut self) -> Option<EncapsulationProofs> {
+        let proofs = self.core_proofs_generator.get_next_proof().await?;
         tracing::trace!(
             target: LOG_TARGET,
             epoch = ?self.core_proofs_generator.settings.common.epoch,
             quota = %self.core_proofs_generator.settings.common.public_inputs.core.quota,
             membership_size = self.core_proofs_generator.settings.common.membership_size,
             local_node_index = ?self.core_proofs_generator.settings.common.local_node_index,
-            key_nullifier = ?proof.proof_of_quota.key_nullifier(),
-            signing_key = ?proof.ephemeral_signing_key.public_key(),
+            key_nullifier = ?proofs.outermost().proof_of_quota.key_nullifier(),
+            signing_key = ?proofs.outermost().ephemeral_signing_key.public_key(),
             "generated core PoQ"
         );
-        Some(proof)
+        Some(proofs)
     }
 
-    async fn get_next_leader_proof(&mut self) -> Option<BlendLayerProof> {
+    async fn get_next_leader_proof(&mut self) -> Option<EncapsulationProofs> {
         let Some(leader_proofs_generator) = &mut self.leader_proofs_generator else {
             return None;
         };
-        let proof = leader_proofs_generator.get_next_proof().await?;
+        let proofs = leader_proofs_generator.get_next_proof().await?;
         tracing::trace!(
             target: LOG_TARGET,
             epoch = ?leader_proofs_generator.settings.epoch,
             quota = %leader_proofs_generator.settings.public_inputs.core.quota,
             membership_size = leader_proofs_generator.settings.membership_size,
             local_node_index = ?leader_proofs_generator.settings.local_node_index,
-            key_nullifier = ?proof.proof_of_quota.key_nullifier(),
-            signing_key = ?proof.ephemeral_signing_key.public_key(),
+            key_nullifier = ?proofs.outermost().proof_of_quota.key_nullifier(),
+            signing_key = ?proofs.outermost().ephemeral_signing_key.public_key(),
             "generated leadership PoQ"
         );
-        Some(proof)
+        Some(proofs)
     }
 }

--- a/blend/provers/src/provers/core_and_leader/tests.rs
+++ b/blend/provers/src/provers/core_and_leader/tests.rs
@@ -38,7 +38,8 @@ async fn proof_generation() {
         let proof = core_and_leader_proofs_generator
             .get_next_core_proof()
             .await
-            .unwrap();
+            .unwrap()
+            .into_single_layer();
         let verified_proof_of_quota = proof
             .proof_of_quota
             .into_inner()
@@ -89,7 +90,8 @@ async fn proof_generation() {
         let proof = core_and_leader_proofs_generator
             .get_next_leader_proof()
             .await
-            .unwrap();
+            .unwrap()
+            .into_single_layer();
         let verified_proof_of_quota = proof
             .proof_of_quota
             .into_inner()
@@ -153,7 +155,8 @@ async fn epoch_private_info() {
     let proof = core_and_leader_proofs_generator
         .get_next_leader_proof()
         .await
-        .unwrap();
+        .unwrap()
+        .into_single_layer();
     let verified_proof_of_quota = proof
         .proof_of_quota
         .into_inner()
@@ -178,7 +181,8 @@ async fn epoch_private_info() {
     let proof = core_and_leader_proofs_generator
         .get_next_leader_proof()
         .await
-        .unwrap();
+        .unwrap()
+        .into_single_layer();
     let verified_proof_of_quota = proof
         .proof_of_quota
         .into_inner()
@@ -217,7 +221,8 @@ async fn epoch_private_info() {
     let proof = core_and_leader_proofs_generator
         .get_next_core_proof()
         .await
-        .unwrap();
+        .unwrap()
+        .into_single_layer();
     let verified_proof_of_quota = proof
         .proof_of_quota
         .into_inner()

--- a/blend/provers/src/provers/core_leader_and_pow/mod.rs
+++ b/blend/provers/src/provers/core_leader_and_pow/mod.rs
@@ -6,7 +6,7 @@ use lb_log_targets::blend;
 use crate::{
     CoreProofOfQuotaGenerator,
     provers::{
-        BlendLayerProof, ProofsGeneratorSettings, WinningPolInfoStream,
+        EncapsulationProofs, ProofsGeneratorSettings, WinningPolInfoStream,
         core_and_leader::{CoreAndLeaderProofsGenerator as _, RealCoreAndLeaderProofsGenerator},
         pow::{PowProofsGenerator as _, RealPowProofsGenerator},
     },
@@ -44,14 +44,14 @@ pub trait CoreLeaderAndPowProofsGenerator<CorePoQGenerator>: Sized {
     );
     /// Request a new core proof from the prover. It returns `None` if the
     /// maximum core quota has already been reached for this epoch.
-    async fn get_next_core_proof(&mut self) -> Option<BlendLayerProof>;
+    async fn get_next_core_proof(&mut self) -> Option<EncapsulationProofs>;
     /// Request a new leadership proof from the prover. It returns `None` if no
     /// secret `PoL` info has been provided for the current epoch or if all the
     /// winning slots for the current epoch have been used up.
-    async fn get_next_leader_proof(&mut self) -> Option<BlendLayerProof>;
+    async fn get_next_leader_proof(&mut self) -> Option<EncapsulationProofs>;
     /// Request a new proof of work backed proof from the prover. It returns
     /// `None` if the epoch's `PoW` public inputs admit no proof at all.
-    async fn get_next_pow_proof(&mut self) -> Option<BlendLayerProof>;
+    async fn get_next_pow_proof(&mut self) -> Option<EncapsulationProofs>;
 }
 
 pub struct RealCoreLeaderAndPowProofsGenerator<CorePoQGenerator> {
@@ -92,31 +92,31 @@ where
             .set_epoch_private(winning_pol_info_stream, reference_epoch);
     }
 
-    async fn get_next_core_proof(&mut self) -> Option<BlendLayerProof> {
+    async fn get_next_core_proof(&mut self) -> Option<EncapsulationProofs> {
         self.core_and_leader_proofs_generator
             .get_next_core_proof()
             .await
     }
 
-    async fn get_next_leader_proof(&mut self) -> Option<BlendLayerProof> {
+    async fn get_next_leader_proof(&mut self) -> Option<EncapsulationProofs> {
         self.core_and_leader_proofs_generator
             .get_next_leader_proof()
             .await
     }
 
-    async fn get_next_pow_proof(&mut self) -> Option<BlendLayerProof> {
+    async fn get_next_pow_proof(&mut self) -> Option<EncapsulationProofs> {
         let generator = &mut self.pow_proofs_generator;
-        let proof = generator.get_next_proof().await?;
+        let proofs = generator.get_next_proof().await?;
         tracing::trace!(
             target: LOG_TARGET,
             epoch = ?generator.settings.epoch,
             quota = %generator.settings.public_inputs.pow.pow_quota,
             membership_size = generator.settings.membership_size,
             local_node_index = ?generator.settings.local_node_index,
-            key_nullifier = ?proof.proof_of_quota.key_nullifier(),
-            signing_key = ?proof.ephemeral_signing_key.public_key(),
+            key_nullifier = ?proofs.outermost().proof_of_quota.key_nullifier(),
+            signing_key = ?proofs.outermost().ephemeral_signing_key.public_key(),
             "generated PoW PoQ"
         );
-        Some(proof)
+        Some(proofs)
     }
 }

--- a/blend/provers/src/provers/core_leader_and_pow/tests.rs
+++ b/blend/provers/src/provers/core_leader_and_pow/tests.rs
@@ -45,7 +45,11 @@ async fn pow_proof_generation() {
         CorePoQGeneratorFromPrivateCoreQuotaInputs::new(core_private_inputs),
     );
 
-    let proof = generator.get_next_pow_proof().await.unwrap();
+    let proof = generator
+        .get_next_pow_proof()
+        .await
+        .unwrap()
+        .into_single_layer();
     let verified_proof_of_quota = proof
         .proof_of_quota
         .into_inner()
@@ -89,7 +93,11 @@ async fn core_proofs_are_delegated() {
         CorePoQGeneratorFromPrivateCoreQuotaInputs::new(core_private_inputs),
     );
 
-    let proof = generator.get_next_core_proof().await.unwrap();
+    let proof = generator
+        .get_next_core_proof()
+        .await
+        .unwrap()
+        .into_single_layer();
     proof
         .proof_of_quota
         .into_inner()

--- a/blend/provers/src/provers/leader/mod.rs
+++ b/blend/provers/src/provers/leader/mod.rs
@@ -21,7 +21,9 @@ use tokio::time::Instant;
 
 use crate::{
     buffer_size,
-    provers::{BlendLayerProof, ProofsGeneratorSettings, WinningPolInfoStream},
+    provers::{
+        BlendLayerProof, EncapsulationProofs, ProofsGeneratorSettings, WinningPolInfoStream,
+    },
 };
 
 #[cfg(test)]
@@ -40,12 +42,12 @@ pub trait LeaderProofsGenerator: Sized {
         winning_pol_info_stream: WinningPolInfoStream,
     ) -> Self;
     /// Get the next leadership proof.
-    async fn get_next_proof(&mut self) -> Option<BlendLayerProof>;
+    async fn get_next_proof(&mut self) -> Option<EncapsulationProofs>;
 }
 
 pub struct RealLeaderProofsGenerator {
     pub(super) settings: ProofsGeneratorSettings,
-    proofs_stream: Pin<Box<dyn Stream<Item = BlendLayerProof> + Send>>,
+    proofs_stream: Pin<Box<dyn Stream<Item = EncapsulationProofs> + Send>>,
 }
 
 impl RealLeaderProofsGenerator {
@@ -63,22 +65,25 @@ impl LeaderProofsGenerator for RealLeaderProofsGenerator {
     ) -> Self {
         Self {
             settings,
-            proofs_stream: Box::pin(create_proof_stream(
-                settings.public_inputs,
-                winning_pol_info_stream,
-                buffer_size(settings.public_inputs.leader.message_quota.get() as usize),
+            proofs_stream: Box::pin(crate::into_encapsulation_sets(
+                create_proof_stream(
+                    settings.public_inputs,
+                    winning_pol_info_stream,
+                    buffer_size(settings.public_inputs.leader.message_quota.get() as usize),
+                ),
+                settings.encapsulation_layers,
             )),
         }
     }
 
-    async fn get_next_proof(&mut self) -> Option<BlendLayerProof> {
+    async fn get_next_proof(&mut self) -> Option<EncapsulationProofs> {
         let start = Instant::now();
-        let Some(proof) = self.proofs_stream.next().await else {
-            tracing::warn!(target: LOG_TARGET, "Leadership proof stream ended. No proof is generated.");
+        let Some(proofs) = self.proofs_stream.next().await else {
+            tracing::warn!(target: LOG_TARGET, "leadership proof stream ended. No proofs are generated.");
             return None;
         };
-        tracing::trace!(target: LOG_TARGET, "Generated leadership Blend layer proof with key nullifier {:?} addressed to node at index {:?} in {:?} ms.", hex::encode(fr_to_bytes(&proof.proof_of_quota.key_nullifier())), proof.proof_of_selection.expected_index(self.settings.membership_size), start.elapsed().as_millis());
-        Some(proof)
+        tracing::trace!(target: LOG_TARGET, "Generated a leadership Blend message's {} layer proofs with key nullifiers {:?} addressed to nodes at indices {:?} in {:?} ms.", proofs.layers().len(), proofs.layers().iter().map(|proof| hex::encode(fr_to_bytes(&proof.proof_of_quota.key_nullifier()))).collect::<Vec<_>>(), proofs.layers().iter().map(|proof| proof.proof_of_selection.expected_index(self.settings.membership_size)).collect::<Vec<_>>(), start.elapsed().as_millis());
+        Some(proofs)
     }
 }
 

--- a/blend/provers/src/provers/leader/tests.rs
+++ b/blend/provers/src/provers/leader/tests.rs
@@ -33,7 +33,11 @@ async fn proof_generation() {
     );
 
     for _ in 0..leadership_quota.get() {
-        let proof = leader_proofs_generator.get_next_proof().await.unwrap();
+        let proof = leader_proofs_generator
+            .get_next_proof()
+            .await
+            .unwrap()
+            .into_single_layer();
         let verified_proof_of_quota = proof
             .proof_of_quota
             .into_inner()

--- a/blend/provers/src/provers/leader_and_pow/mod.rs
+++ b/blend/provers/src/provers/leader_and_pow/mod.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 use lb_log_targets::blend;
 
 use crate::provers::{
-    BlendLayerProof, ProofsGeneratorSettings, WinningPolInfoStream,
+    EncapsulationProofs, ProofsGeneratorSettings, WinningPolInfoStream,
     leader::{LeaderProofsGenerator as _, RealLeaderProofsGenerator},
     pow::{PowProofsGenerator as _, RealPowProofsGenerator},
 };
@@ -28,10 +28,10 @@ pub trait LeaderAndPowProofsGenerator: Sized {
     ) -> Self;
     /// Request a new leadership proof from the prover. It returns `None` if all
     /// the winning slots for the current epoch have been used up.
-    async fn get_next_leader_proof(&mut self) -> Option<BlendLayerProof>;
+    async fn get_next_leader_proof(&mut self) -> Option<EncapsulationProofs>;
     /// Request a new proof of work backed proof from the prover. It returns
     /// `None` if the epoch's `PoW` public inputs admit no proof at all.
-    async fn get_next_pow_proof(&mut self) -> Option<BlendLayerProof>;
+    async fn get_next_pow_proof(&mut self) -> Option<EncapsulationProofs>;
 }
 
 /// The generator an edge node runs for the duration of an epoch.
@@ -59,18 +59,18 @@ impl LeaderAndPowProofsGenerator for RealLeaderAndPowProofsGenerator {
         }
     }
 
-    async fn get_next_leader_proof(&mut self) -> Option<BlendLayerProof> {
+    async fn get_next_leader_proof(&mut self) -> Option<EncapsulationProofs> {
         self.leader_proofs_generator.get_next_proof().await
     }
 
-    async fn get_next_pow_proof(&mut self) -> Option<BlendLayerProof> {
-        let proof = self.pow_proofs_generator.get_next_proof().await?;
+    async fn get_next_pow_proof(&mut self) -> Option<EncapsulationProofs> {
+        let proofs = self.pow_proofs_generator.get_next_proof().await?;
         tracing::trace!(
             target: LOG_TARGET,
-            key_nullifier = ?proof.proof_of_quota.key_nullifier(),
-            signing_key = ?proof.ephemeral_signing_key.public_key(),
+            key_nullifier = ?proofs.outermost().proof_of_quota.key_nullifier(),
+            signing_key = ?proofs.outermost().ephemeral_signing_key.public_key(),
             "generated PoW PoQ"
         );
-        Some(proof)
+        Some(proofs)
     }
 }

--- a/blend/provers/src/provers/leader_and_pow/tests.rs
+++ b/blend/provers/src/provers/leader_and_pow/tests.rs
@@ -31,7 +31,11 @@ async fn pow_proof_generation() {
         Box::pin(stream::empty()),
     );
 
-    let proof = generator.get_next_pow_proof().await.unwrap();
+    let proof = generator
+        .get_next_pow_proof()
+        .await
+        .unwrap()
+        .into_single_layer();
     let verified_proof_of_quota = proof
         .proof_of_quota
         .into_inner()
@@ -74,7 +78,11 @@ async fn leadership_proofs_are_delegated() {
         Box::pin(stream::repeat(leadership_private_inputs)),
     );
 
-    let proof = generator.get_next_leader_proof().await.unwrap();
+    let proof = generator
+        .get_next_leader_proof()
+        .await
+        .unwrap()
+        .into_single_layer();
     proof
         .proof_of_quota
         .into_inner()

--- a/blend/provers/src/provers/mod.rs
+++ b/blend/provers/src/provers/mod.rs
@@ -2,7 +2,7 @@ use ::core::{num::NonZeroU64, pin::Pin};
 use futures::Stream;
 use lb_blend_message::crypto::proofs::PoQVerificationInputsMinusSigningKey;
 use lb_blend_proofs::{
-    quota::{VerifiedProofOfQuota, inputs::prove::private::ProofOfLeadershipQuotaInputs},
+    quota::{Quota, VerifiedProofOfQuota, inputs::prove::private::ProofOfLeadershipQuotaInputs},
     selection::VerifiedProofOfSelection,
 };
 use lb_cryptarchia_engine::Epoch;
@@ -36,6 +36,79 @@ pub struct BlendLayerProof {
     pub ephemeral_signing_key: UnsecuredEd25519Key,
 }
 
+/// Every proof needed to encapsulate one message: one per blend layer.
+pub struct EncapsulationProofs(Box<[BlendLayerProof]>);
+
+impl EncapsulationProofs {
+    /// Builds a set, rejecting one that could not encapsulate a message.
+    ///
+    /// # Errors
+    ///
+    /// [`ProofCountMismatch`] if `layers` does not hold exactly
+    /// `encapsulation_layers` proofs.
+    pub fn try_new(
+        layers: Vec<BlendLayerProof>,
+        encapsulation_layers: NonZeroU64,
+    ) -> Result<Self, ProofCountMismatch> {
+        let expected = encapsulation_layers.get() as usize;
+        if layers.len() == expected {
+            Ok(Self(layers.into_boxed_slice()))
+        } else {
+            Err(ProofCountMismatch {
+                expected,
+                got: layers.len(),
+            })
+        }
+    }
+
+    /// The proofs, outermost layer first.
+    #[must_use]
+    pub fn into_layers(self) -> impl ExactSizeIterator<Item = BlendLayerProof> {
+        self.0.into_vec().into_iter()
+    }
+
+    #[must_use]
+    pub const fn layers(&self) -> &[BlendLayerProof] {
+        &self.0
+    }
+
+    #[must_use]
+    pub const fn outermost(&self) -> &BlendLayerProof {
+        self.0.first().unwrap()
+    }
+
+    #[must_use]
+    pub const fn innermost(&self) -> &BlendLayerProof {
+        self.0.last().unwrap()
+    }
+
+    /// The one proof in a set built for a single-layer epoch.
+    ///
+    /// # Panics
+    ///
+    /// If the set holds anything other than one proof. Only for tests that
+    /// configure `encapsulation_layers = 1`, where the distinction between a
+    /// message and a proof collapses.
+    #[cfg(test)]
+    #[must_use]
+    pub fn into_single_layer(self) -> BlendLayerProof {
+        assert_eq!(
+            self.0.len(),
+            1,
+            "into_single_layer is only meaningful for a single-layer epoch"
+        );
+        self.0.into_vec().pop().unwrap()
+    }
+}
+
+/// A proof set that does not match the epoch's encapsulation depth.
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+#[error("Expected {expected} layer proofs to encapsulate a message, got {got}.")]
+pub struct ProofCountMismatch {
+    pub expected: usize,
+    pub got: usize,
+}
+
 #[derive(Debug, Clone, Copy)]
 pub struct ProofsGeneratorSettings {
     pub local_node_index: Option<usize>,
@@ -43,4 +116,14 @@ pub struct ProofsGeneratorSettings {
     pub public_inputs: PoQVerificationInputsMinusSigningKey,
     pub encapsulation_layers: NonZeroU64,
     pub epoch: Epoch,
+}
+
+/// What one message costs the quota it is drawn from, in key indices.
+///
+/// One per layer: a message carries `encapsulation_layers` proofs and each is
+/// minted against its own index.
+#[must_use]
+pub fn message_cost(encapsulation_layers: NonZeroU64) -> Quota {
+    Quota::try_new(encapsulation_layers.get())
+        .expect("Number of blend layers must fit within the `PoQ` quota width.")
 }

--- a/blend/provers/src/provers/pow/mod.rs
+++ b/blend/provers/src/provers/pow/mod.rs
@@ -27,7 +27,7 @@ use lb_utils::tokio::{
 use rand::rngs::OsRng;
 use tokio::time::Instant;
 
-use crate::provers::{BlendLayerProof, ProofsGeneratorSettings};
+use crate::provers::{BlendLayerProof, EncapsulationProofs, ProofsGeneratorSettings};
 
 #[cfg(test)]
 mod tests;
@@ -45,12 +45,12 @@ pub trait PowProofsGenerator: Sized {
     /// Instantiate a new generator for the duration of an epoch.
     fn new(settings: ProofsGeneratorSettings) -> Self;
     /// Get the next `PoW` proof.
-    async fn get_next_proof(&mut self) -> Option<BlendLayerProof>;
+    async fn get_next_proof(&mut self) -> Option<EncapsulationProofs>;
 }
 
 pub struct RealPowProofsGenerator {
     pub(super) settings: ProofsGeneratorSettings,
-    proofs_stream: Pin<Box<dyn Stream<Item = BlendLayerProof> + Send>>,
+    proofs_stream: Pin<Box<dyn Stream<Item = EncapsulationProofs> + Send>>,
 }
 
 #[async_trait]
@@ -58,18 +58,21 @@ impl PowProofsGenerator for RealPowProofsGenerator {
     fn new(settings: ProofsGeneratorSettings) -> Self {
         Self {
             settings,
-            proofs_stream: create_proof_stream(settings.public_inputs),
+            proofs_stream: Box::pin(crate::into_encapsulation_sets(
+                create_proof_stream(settings.public_inputs),
+                settings.encapsulation_layers,
+            )),
         }
     }
 
-    async fn get_next_proof(&mut self) -> Option<BlendLayerProof> {
+    async fn get_next_proof(&mut self) -> Option<EncapsulationProofs> {
         let start = Instant::now();
-        let Some(proof) = self.proofs_stream.next().await else {
-            tracing::warn!(target: LOG_TARGET, "PoW proof stream ended. No proof is generated.");
+        let Some(proofs) = self.proofs_stream.next().await else {
+            tracing::warn!(target: LOG_TARGET, "PoW proof stream ended. No proofs are generated.");
             return None;
         };
-        tracing::trace!(target: LOG_TARGET, "Generated PoW Blend layer proof with key nullifier {:?} addressed to node at index {:?} in {:?} ms.", hex::encode(fr_to_bytes(&proof.proof_of_quota.key_nullifier())), proof.proof_of_selection.expected_index(self.settings.membership_size), start.elapsed().as_millis());
-        Some(proof)
+        tracing::trace!(target: LOG_TARGET, "Generated a PoW Blend message's {} layer proofs with key nullifiers {:?} addressed to nodes at indices {:?} in {:?} ms.", proofs.layers().len(), proofs.layers().iter().map(|proof| hex::encode(fr_to_bytes(&proof.proof_of_quota.key_nullifier()))).collect::<Vec<_>>(), proofs.layers().iter().map(|proof| proof.proof_of_selection.expected_index(self.settings.membership_size)).collect::<Vec<_>>(), start.elapsed().as_millis());
+        Some(proofs)
     }
 }
 

--- a/blend/provers/src/provers/pow/tests.rs
+++ b/blend/provers/src/provers/pow/tests.rs
@@ -45,35 +45,43 @@ async fn proof_generation() {
     let settings = settings(None);
     let mut pow_proofs_generator = RealPowProofsGenerator::new(settings);
 
-    // More than one solution's worth of proofs, so that the later ones come
-    // from a solution mined after the first one's quota ran out.
+    // The settings ask for more layers than one solution's quota covers, so each
+    // message spans several solutions — the generator's business, not an error.
+    // Two messages' worth exercises the boundary in both directions.
     let mut key_nullifiers = HashSet::new();
-    for _ in 0..2 * POW_QUOTA {
-        let proof = pow_proofs_generator.get_next_proof().await.unwrap();
-        let verified_proof_of_quota = proof
-            .proof_of_quota
-            .into_inner()
-            .verify(&poq_public_inputs_from_epoch_public_inputs_and_signing_key(
-                (
-                    settings.public_inputs,
-                    proof.ephemeral_signing_key.public_key(),
-                ),
-            ))
-            .unwrap();
-        proof
-            .proof_of_selection
-            .into_inner()
-            .verify(&VerifyInputs {
-                // Membership of 1 -> only a single index can be included
-                expected_node_index: 0,
-                key_nullifier: verified_proof_of_quota.key_nullifier(),
-                total_membership_size: 1,
-            })
-            .unwrap();
+    for _ in 0..2 {
+        let proofs = pow_proofs_generator.get_next_proof().await.unwrap();
+        assert_eq!(
+            proofs.layers().len(),
+            settings.encapsulation_layers.get() as usize,
+            "a set must hold exactly one proof per blend layer, however many solutions that took"
+        );
+        for proof in proofs.into_layers() {
+            let verified_proof_of_quota = proof
+                .proof_of_quota
+                .into_inner()
+                .verify(&poq_public_inputs_from_epoch_public_inputs_and_signing_key(
+                    (
+                        settings.public_inputs,
+                        proof.ephemeral_signing_key.public_key(),
+                    ),
+                ))
+                .unwrap();
+            proof
+                .proof_of_selection
+                .into_inner()
+                .verify(&VerifyInputs {
+                    // Membership of 1 -> only a single index can be included
+                    expected_node_index: 0,
+                    key_nullifier: verified_proof_of_quota.key_nullifier(),
+                    total_membership_size: 1,
+                })
+                .unwrap();
 
-        // A nullifier may be used only once, whether the proof comes from the
-        // same solution at another index or from a different solution.
-        assert!(key_nullifiers.insert(verified_proof_of_quota.key_nullifier()));
+            // A nullifier may be used only once, whether the proof comes from the
+            // same solution at another index or from a different solution.
+            assert!(key_nullifiers.insert(verified_proof_of_quota.key_nullifier()));
+        }
     }
 }
 

--- a/blend/scheduling/Cargo.toml
+++ b/blend/scheduling/Cargo.toml
@@ -34,4 +34,4 @@ lb-blend-proofs  = { features = ["unsafe-test-functions"], workspace = true }
 
 [features]
 tokio-task-names      = ["lb-utils/tokio-task-names"]
-unsafe-test-functions = []
+unsafe-test-functions = ["lb-blend-membership/unsafe-test-functions", "lb-blend-provers/unsafe-test-functions"]

--- a/nodes/node/binary/src/generic_services/blend/mod.rs
+++ b/nodes/node/binary/src/generic_services/blend/mod.rs
@@ -1,9 +1,11 @@
+use core::num::NonZeroU64;
+
 use axum::async_trait;
 use lb_blend::{
     message::crypto::key_ext::Ed25519SecretKeyExt as _,
     proofs::{quota::VerifiedProofOfQuota, selection::VerifiedProofOfSelection},
     scheduling::message_blend::provers::{
-        BlendLayerProof, ProofsGeneratorSettings, WinningPolInfoStream,
+        BlendLayerProof, EncapsulationProofs, ProofsGeneratorSettings, WinningPolInfoStream,
         core_leader_and_pow::RealCoreLeaderAndPowProofsGenerator, leader::LeaderProofsGenerator,
         leader_and_pow::RealLeaderAndPowProofsGenerator,
     },
@@ -57,23 +59,29 @@ pub type BlendCoreService<RuntimeServiceId> = lb_blend_service::core::BlendServi
 >;
 
 #[derive(Clone)]
-pub struct MockLeaderProofsGenerator;
+pub struct MockLeaderProofsGenerator(NonZeroU64);
 
 #[async_trait]
 impl LeaderProofsGenerator for MockLeaderProofsGenerator {
     fn new(
-        _settings: ProofsGeneratorSettings,
+        settings: ProofsGeneratorSettings,
         _winning_pol_info_stream: WinningPolInfoStream,
     ) -> Self {
-        Self
+        Self(settings.encapsulation_layers)
     }
 
-    async fn get_next_proof(&mut self) -> Option<BlendLayerProof> {
-        Some(BlendLayerProof {
-            proof_of_quota: VerifiedProofOfQuota::from_bytes_unchecked([0; _]),
-            proof_of_selection: VerifiedProofOfSelection::from_bytes_unchecked([0; _]),
-            ephemeral_signing_key: UnsecuredEd25519Key::generate_with_blake_rng(),
-        })
+    async fn get_next_proof(&mut self) -> Option<EncapsulationProofs> {
+        EncapsulationProofs::try_new(
+            core::iter::repeat_with(|| BlendLayerProof {
+                proof_of_quota: VerifiedProofOfQuota::from_bytes_unchecked([0; _]),
+                proof_of_selection: VerifiedProofOfSelection::from_bytes_unchecked([0; _]),
+                ephemeral_signing_key: UnsecuredEd25519Key::generate_with_blake_rng(),
+            })
+            .take(self.0.get() as usize)
+            .collect(),
+            self.0,
+        )
+        .ok()
     }
 }
 

--- a/services/blend/src/core/tests/utils.rs
+++ b/services/blend/src/core/tests/utils.rs
@@ -24,8 +24,8 @@ use lb_blend::{
         message_blend::{
             crypto::EpochCryptographicProcessorSettings,
             provers::{
-                BlendLayerProof, ProofsGeneratorSettings, WinningPolInfoStream,
-                core_leader_and_pow::CoreLeaderAndPowProofsGenerator,
+                BlendLayerProof, EncapsulationProofs, ProofsGeneratorSettings,
+                WinningPolInfoStream, core_leader_and_pow::CoreLeaderAndPowProofsGenerator,
             },
         },
         message_scheduler::{self, epoch_info::EpochInfo as SchedulerEpochInfo},
@@ -465,7 +465,7 @@ pub fn recorded_set_epoch_private_calls() -> Vec<Epoch> {
     SET_EPOCH_PRIVATE_CALLS.with(|calls| calls.borrow().clone())
 }
 
-pub struct MockCoreAndLeaderProofsGenerator(ZkHash);
+pub struct MockCoreAndLeaderProofsGenerator(ZkHash, NonZeroU64);
 
 #[async_trait]
 impl<CorePoQGenerator> CoreLeaderAndPowProofsGenerator<CorePoQGenerator>
@@ -476,23 +476,50 @@ impl<CorePoQGenerator> CoreLeaderAndPowProofsGenerator<CorePoQGenerator>
         _starting_key_index: KeyIndex,
         _core_proof_of_quota_generator: CorePoQGenerator,
     ) -> Self {
-        Self(settings.public_inputs.leader.pol_epoch_nonce)
+        Self(
+            settings.public_inputs.leader.pol_epoch_nonce,
+            settings.encapsulation_layers,
+        )
     }
 
     fn set_epoch_private(&mut self, _: WinningPolInfoStream, target_epoch: Epoch) {
         SET_EPOCH_PRIVATE_CALLS.with(|calls| calls.borrow_mut().push(target_epoch));
     }
 
-    async fn get_next_core_proof(&mut self) -> Option<BlendLayerProof> {
-        Some(epoch_based_dummy_proofs(self.0))
+    async fn get_next_core_proof(&mut self) -> Option<EncapsulationProofs> {
+        Some(
+            EncapsulationProofs::try_new(
+                core::iter::repeat_with(|| epoch_based_dummy_proofs(self.0))
+                    .take(self.1.get() as usize)
+                    .collect(),
+                self.1,
+            )
+            .expect("built with exactly one proof per layer"),
+        )
     }
 
-    async fn get_next_leader_proof(&mut self) -> Option<BlendLayerProof> {
-        Some(epoch_based_dummy_proofs(self.0))
+    async fn get_next_leader_proof(&mut self) -> Option<EncapsulationProofs> {
+        Some(
+            EncapsulationProofs::try_new(
+                core::iter::repeat_with(|| epoch_based_dummy_proofs(self.0))
+                    .take(self.1.get() as usize)
+                    .collect(),
+                self.1,
+            )
+            .expect("built with exactly one proof per layer"),
+        )
     }
 
-    async fn get_next_pow_proof(&mut self) -> Option<BlendLayerProof> {
-        Some(epoch_based_dummy_proofs(self.0))
+    async fn get_next_pow_proof(&mut self) -> Option<EncapsulationProofs> {
+        Some(
+            EncapsulationProofs::try_new(
+                core::iter::repeat_with(|| epoch_based_dummy_proofs(self.0))
+                    .take(self.1.get() as usize)
+                    .collect(),
+                self.1,
+            )
+            .expect("built with exactly one proof per layer"),
+        )
     }
 }
 

--- a/services/blend/src/edge/tests/utils.rs
+++ b/services/blend/src/edge/tests/utils.rs
@@ -9,7 +9,7 @@ use lb_blend::{
         epoch::UninitializedEpochEventStream,
         membership::Membership,
         message_blend::provers::{
-            BlendLayerProof, ProofsGeneratorSettings, WinningPolInfoStream,
+            EncapsulationProofs, ProofsGeneratorSettings, WinningPolInfoStream,
             leader_and_pow::LeaderAndPowProofsGenerator,
         },
     },
@@ -28,26 +28,28 @@ use crate::{
     },
     message::ServiceMessage,
     settings::TimingSettings,
-    test_utils::{crypto::mock_blend_proof, epoch::OncePolStreamProvider, membership::key},
+    test_utils::{
+        crypto::mock_encapsulation_proofs, epoch::OncePolStreamProvider, membership::key,
+    },
 };
 
-pub struct MockLeaderProofsGenerator;
+pub struct MockLeaderProofsGenerator(NonZeroU64);
 
 #[async_trait]
 impl LeaderAndPowProofsGenerator for MockLeaderProofsGenerator {
     fn new(
-        _settings: ProofsGeneratorSettings,
+        settings: ProofsGeneratorSettings,
         _winning_pol_info_stream: WinningPolInfoStream,
     ) -> Self {
-        Self
+        Self(settings.encapsulation_layers)
     }
 
-    async fn get_next_leader_proof(&mut self) -> Option<BlendLayerProof> {
-        Some(mock_blend_proof())
+    async fn get_next_leader_proof(&mut self) -> Option<EncapsulationProofs> {
+        Some(mock_encapsulation_proofs(self.0))
     }
 
-    async fn get_next_pow_proof(&mut self) -> Option<BlendLayerProof> {
-        Some(mock_blend_proof())
+    async fn get_next_pow_proof(&mut self) -> Option<EncapsulationProofs> {
+        Some(mock_encapsulation_proofs(self.0))
     }
 }
 

--- a/services/blend/src/test_utils/crypto.rs
+++ b/services/blend/src/test_utils/crypto.rs
@@ -1,6 +1,7 @@
 use core::{
     cell::{Cell, RefCell},
     convert::Infallible,
+    num::NonZeroU64,
 };
 
 use async_trait::async_trait;
@@ -14,7 +15,7 @@ use lb_blend::{
         selection::{ProofOfSelection, VerifiedProofOfSelection, inputs::VerifyInputs},
     },
     scheduling::message_blend::provers::{
-        BlendLayerProof, ProofsGeneratorSettings, WinningPolInfoStream,
+        BlendLayerProof, EncapsulationProofs, ProofsGeneratorSettings, WinningPolInfoStream,
         core_leader_and_pow::CoreLeaderAndPowProofsGenerator,
     },
 };
@@ -43,19 +44,30 @@ pub fn recorded_starting_core_key_indices() -> Vec<KeyIndex> {
     STARTING_CORE_KEY_INDICES.with(|indices| indices.borrow().clone())
 }
 
-pub struct MockCoreAndLeaderProofsGenerator;
+/// A whole message's worth of identical mock proofs.
+pub fn mock_encapsulation_proofs(encapsulation_layers: NonZeroU64) -> EncapsulationProofs {
+    EncapsulationProofs::try_new(
+        core::iter::repeat_with(mock_blend_proof)
+            .take(encapsulation_layers.get() as usize)
+            .collect(),
+        encapsulation_layers,
+    )
+    .expect("built with exactly one proof per layer")
+}
+
+pub struct MockCoreAndLeaderProofsGenerator(NonZeroU64);
 
 #[async_trait]
 impl<CorePoQGenerator> CoreLeaderAndPowProofsGenerator<CorePoQGenerator>
     for MockCoreAndLeaderProofsGenerator
 {
     fn new(
-        _settings: ProofsGeneratorSettings,
+        settings: ProofsGeneratorSettings,
         starting_key_index: KeyIndex,
         _core_proof_of_quota_generator: CorePoQGenerator,
     ) -> Self {
         STARTING_CORE_KEY_INDICES.with(|indices| indices.borrow_mut().push(starting_key_index));
-        Self
+        Self(settings.encapsulation_layers)
     }
 
     fn set_epoch_private(
@@ -65,16 +77,16 @@ impl<CorePoQGenerator> CoreLeaderAndPowProofsGenerator<CorePoQGenerator>
     ) {
     }
 
-    async fn get_next_core_proof(&mut self) -> Option<BlendLayerProof> {
-        Some(mock_blend_proof())
+    async fn get_next_core_proof(&mut self) -> Option<EncapsulationProofs> {
+        Some(mock_encapsulation_proofs(self.0))
     }
 
-    async fn get_next_leader_proof(&mut self) -> Option<BlendLayerProof> {
-        Some(mock_blend_proof())
+    async fn get_next_leader_proof(&mut self) -> Option<EncapsulationProofs> {
+        Some(mock_encapsulation_proofs(self.0))
     }
 
-    async fn get_next_pow_proof(&mut self) -> Option<BlendLayerProof> {
-        Some(mock_blend_proof())
+    async fn get_next_pow_proof(&mut self) -> Option<EncapsulationProofs> {
+        Some(mock_encapsulation_proofs(self.0))
     }
 }
 
@@ -173,7 +185,7 @@ pub fn mock_blend_proof() -> BlendLayerProof {
 /// that awaiting it anywhere on the event loop's critical path would stall the
 /// service. Core and leadership proofs stay immediate, as they are in
 /// production, so a test can tell the two apart.
-pub struct GatedPowProofsGenerator;
+pub struct GatedPowProofsGenerator(NonZeroU64);
 
 thread_local! {
     static POW_GATE: RefCell<Option<watch::Receiver<bool>>> = const { RefCell::new(None) };
@@ -206,11 +218,11 @@ impl<CorePoQGenerator> CoreLeaderAndPowProofsGenerator<CorePoQGenerator>
     for GatedPowProofsGenerator
 {
     fn new(
-        _settings: ProofsGeneratorSettings,
+        settings: ProofsGeneratorSettings,
         _starting_key_index: KeyIndex,
         _core_proof_of_quota_generator: CorePoQGenerator,
     ) -> Self {
-        Self
+        Self(settings.encapsulation_layers)
     }
 
     fn set_epoch_private(
@@ -220,19 +232,19 @@ impl<CorePoQGenerator> CoreLeaderAndPowProofsGenerator<CorePoQGenerator>
     ) {
     }
 
-    async fn get_next_core_proof(&mut self) -> Option<BlendLayerProof> {
-        Some(mock_blend_proof())
+    async fn get_next_core_proof(&mut self) -> Option<EncapsulationProofs> {
+        Some(mock_encapsulation_proofs(self.0))
     }
 
-    async fn get_next_leader_proof(&mut self) -> Option<BlendLayerProof> {
-        Some(mock_blend_proof())
+    async fn get_next_leader_proof(&mut self) -> Option<EncapsulationProofs> {
+        Some(mock_encapsulation_proofs(self.0))
     }
 
-    async fn get_next_pow_proof(&mut self) -> Option<BlendLayerProof> {
+    async fn get_next_pow_proof(&mut self) -> Option<EncapsulationProofs> {
         let mut gate = POW_GATE.with_borrow(Clone::clone)?;
         gate.wait_for(|open| *open)
             .await
             .expect("the gate should outlive the generator");
-        Some(mock_blend_proof())
+        Some(mock_encapsulation_proofs(self.0))
     }
 }


### PR DESCRIPTION
## 1. What does this PR implement?

The current way of dealing with proofs was quite fragile as the proof streams were yielding one proof at the time, while still assuming that those proofs would need to be consumed together for each message. I changed that here. Each proof stream now returns a set of proofs, equal to the number of encapsulation layers. 

At the moment, if not enough proofs are present, which should never happen under normal circumstances, the proof generator returns `None` and the crypto processor an error. As a future improvement, we can consume different quotas, falling back to PoW if necessary.

## 2. Does the code have enough context to be clearly understood?

Yes.

## 3. Who are the specification authors and who is accountable for this PR?

@ntn-x2 

## 4. Is the specification accurate and complete?

Yes.

## 5. Does the implementation introduce changes in the specification?

No.