### PR TITLE
fix(zone-sdk): fix last msg id in the checkpoint

### DIFF
--- a/zone-sdk/src/sequencer/actor.rs
+++ b/zone-sdk/src/sequencer/actor.rs
@@ -487,16 +487,12 @@ where
             Some(update) => {
                 Self::log_channel_update(&update);
 
-                let new_channel_tip = update.new_channel_tip;
                 let built = self.build_channel_update(update);
 
-                let has_pending = self
-                    .state
-                    .as_ref()
-                    .is_some_and(TxState::has_pending_inscriptions);
-
-                if !built.orphaned.is_empty() || !has_pending {
-                    self.last_msg_id = new_channel_tip;
+                // Advance the tip to the current valid publish parent (channel
+                // tip + our pending tail), the same value publishing chains on.
+                if let (Some(state), Some(tip)) = (self.state.as_ref(), self.current_tip) {
+                    self.last_msg_id = state.publish_parent(tip);
                 }
 
                 built

--- a/zone-sdk/src/sequencer/state.rs
+++ b/zone-sdk/src/sequencer/state.rs
@@ -536,12 +536,6 @@ impl TxState {
         self.pending.values().filter(|p| p.posted).count()
     }
 
-    /// Whether there are pending channel inscriptions.
-    #[must_use]
-    pub fn has_pending_inscriptions(&self) -> bool {
-        !self.pending.is_empty()
-    }
-
     /// Remove pending inscriptions whose lineage does NOT reach the current
     /// channel tip and that aren't already in a block on this branch.
     /// Returns the removed entries in **parent-before-child (BFS) order** so


### PR DESCRIPTION
## 1. What does this PR implement?

There is a bug in last msg id returned in the checkpoint. It was ignoring the true last channel tip in retrospect to pending txs as well.