### PR TITLE
fix(blend): properly deal with block proposals when PoL info is not ready

### DIFF
--- a/blend/scheduling/Cargo.toml
+++ b/blend/scheduling/Cargo.toml
@@ -34,4 +34,4 @@ lb-blend-proofs  = { features = ["unsafe-test-functions"], workspace = true }
 
 [features]
 tokio-task-names      = ["lb-utils/tokio-task-names"]
-unsafe-test-functions = []
+unsafe-test-functions = ["lb-blend-membership/unsafe-test-functions"]

--- a/libp2p/src/dial_error_ext.rs
+++ b/libp2p/src/dial_error_ext.rs
@@ -1,0 +1,35 @@
+use libp2p::{TransportError, swarm::DialError};
+
+pub trait DialErrorExt {
+    fn is_recoverable(&self) -> bool;
+}
+
+impl DialErrorExt for DialError {
+    fn is_recoverable(&self) -> bool {
+        match self {
+            // The host answering at the declared address presented a different
+            // identity than the expected one. Nothing we retry changes the key
+            // the remote holds — the declaration itself has to change.
+            Self::WrongPeerId { .. }
+            // The address handed resolves back to this node.
+            | Self::LocalPeerId { .. }
+            // There is no address to dial for this peer.
+            | Self::NoAddresses => false,
+
+            // Per-address transport failures. Permanent only when every address
+            // failed because we cannot speak its protocol at all; a timeout,
+            // refusal, or unreachable host is worth another attempt.
+            Self::Transport(errors) => {
+                errors.is_empty()
+                    || !errors
+                        .iter()
+                        .all(|(_, error)| matches!(error, TransportError::MultiaddrNotSupported(_)))
+            }
+
+            // Local, transient conditions.
+            Self::Denied { .. }
+            | Self::Aborted
+            | Self::DialPeerConditionFalse(_) => true,
+        }
+    }
+}

--- a/libp2p/src/lib.rs
+++ b/libp2p/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod behaviour;
 pub mod config;
+pub mod dial_error_ext;
 pub mod protocol_name;
 mod swarm;
 
@@ -7,6 +8,7 @@ pub use config::{
     AutonatClientSettings, ChainSyncSettings, GatewaySettings, IdentifySettings, KademliaSettings,
     NatMappingSettings, NatSettings, SwarmConfig, TraversalSettings, secret_key_serde,
 };
+pub use dial_error_ext::DialErrorExt;
 pub use lb_cryptarchia_sync::{self as cryptarchia_sync, Event};
 pub use libp2p::{
     self, PeerId, SwarmBuilder, Transport,

--- a/services/blend/src/core/backends/libp2p/swarm.rs
+++ b/services/blend/src/core/backends/libp2p/swarm.rs
@@ -28,7 +28,7 @@ use lb_blend::{
     scheduling::membership::Membership,
 };
 use lb_chain_service::Epoch;
-use lb_libp2p::{DialOpts, SwarmEvent};
+use lb_libp2p::{DialError, DialErrorExt as _, DialOpts, SwarmEvent};
 use libp2p::{Multiaddr, PeerId, Swarm, SwarmBuilder, swarm::dial_opts::PeerCondition};
 use rand::RngCore;
 use tokio::{
@@ -117,6 +117,9 @@ where
     rng: Rng,
     max_dial_attempts_per_connection: NonZeroU64,
     ongoing_dials: HashMap<PeerId, DialAttempt>,
+    /// Peers whose dial failed for a reason that retrying cannot fix. Excluded
+    /// from dialing until the next epoch rebuilds the membership.
+    unrecoverable_peers: HashSet<PeerId>,
     pending_retries: PendingRetries,
     pending_full_membership_retry: FullMembershipRetry,
     minimum_network_size: NonZeroUsize,
@@ -194,6 +197,7 @@ where
             current_epoch_info,
             rng,
             max_dial_attempts_per_connection: config.backend.max_dial_attempts_per_peer,
+            unrecoverable_peers: HashSet::new(),
             ongoing_dials: HashMap::with_capacity(
                 *config.backend.core_peering_degree.start() as usize
             ),
@@ -236,6 +240,7 @@ where
         let exclude_peers: HashSet<PeerId> = negotiated_peers
             .chain(self.swarm.behaviour().blocked_peers.blocked_peers())
             .chain(self.ongoing_dials.keys())
+            .chain(self.unrecoverable_peers.iter())
             .chain(except.iter())
             .copied()
             .collect();
@@ -258,7 +263,10 @@ where
         // schedule a single delayed retry. When `except` is empty there is
         // genuinely nobody left to dial (everyone is already negotiated,
         // in-flight, or blocked), so we stop.
-        if no_more_peers_to_dial && !except.is_empty() {
+        // Peers abandoned as unrecoverable count as "tried this cycle" too:
+        // without them a membership made entirely of undialable peers would
+        // look like "nobody left to dial" and stop silently.
+        if no_more_peers_to_dial && !(except.is_empty() && self.unrecoverable_peers.is_empty()) {
             self.schedule_full_membership_retry();
             return;
         }
@@ -288,8 +296,104 @@ where
         }));
     }
 
+    /// Drop a peer that can never be dialed successfully and immediately look
+    /// for a replacement, instead of retrying it with exponential backoff.
+    ///
+    /// The peer stays excluded for the rest of the epoch; a new epoch rebuilds
+    /// the membership and clears the set.
+    fn abandon_peer(&mut self, peer_id: PeerId, error: &DialError) {
+        let previously_failed = self
+            .ongoing_dials
+            .remove(&peer_id)
+            .map(|attempt| attempt.failed_peers)
+            .unwrap_or_default();
+        self.unrecoverable_peers.insert(peer_id);
+        tracing::debug!(
+            target: LOG_TARGET,
+            "Unrecoverable dial failure for peer {peer_id:?}: {error}. Not retrying; excluding it for this epoch and dialing another peer."
+        );
+        self.check_and_dial_new_peers_except(&previously_failed);
+    }
+
     fn check_and_dial_new_peers(&mut self) {
         self.check_and_dial_new_peers_except(&HashSet::new());
+    }
+
+    /// It tries to dial the specified peer.
+    ///
+    /// This function always tries to dial and update the counter of attempted
+    /// dials. Any checks about the maximum allowed dials must be performed in
+    /// the context of the calling function.
+    fn dial(&mut self, peer_id: PeerId, address: Multiaddr, failed_peers: HashSet<PeerId>) {
+        tracing::trace!(target: LOG_TARGET, "Dialing peer {peer_id:?} at address {address:?}.");
+        self.ongoing_dials.insert(
+            peer_id,
+            DialAttempt {
+                address: address.clone(),
+                attempt_number: 1.try_into().unwrap(),
+                failed_peers,
+            },
+        );
+
+        if let Err(e) = self.swarm.dial(
+            DialOpts::peer_id(peer_id)
+                .addresses(vec![address])
+                // We use `Always` since we want to be able to dial a peer even if we already have
+                // an established connection with it that belongs to the previous epoch.
+                .condition(PeerCondition::Always)
+                .build(),
+        ) {
+            tracing::error!(target: LOG_TARGET, "Failed to dial peer {peer_id:?}: {e:?}");
+            // `Swarm::dial` rejects some dials synchronously (our own id, no
+            // address, a behaviour refusing it). They carry the same
+            // recoverable/unrecoverable distinction as an asynchronous
+            // `OutgoingConnectionError` and must be classified identically.
+            if e.is_recoverable() {
+                self.schedule_retry(peer_id);
+            } else {
+                self.abandon_peer(peer_id, &e);
+            }
+        }
+    }
+
+    #[cfg(test)]
+    pub fn dial_peer_at_addr(&mut self, peer_id: PeerId, address: Multiaddr) {
+        self.dial(peer_id, address, HashSet::new());
+    }
+
+    /// Called when a pending retry fires. Re-checks peering degree before
+    /// actually dialing, so we don't waste a slot on a peer we no longer need.
+    fn execute_retry(&mut self, peer_id: PeerId, dial_attempt: DialAttempt) {
+        let num_new_conns_needed = self
+            .minimum_healthy_peering_degree()
+            .saturating_sub(self.num_healthy_peers());
+        if num_new_conns_needed == 0 {
+            tracing::debug!(
+                target: LOG_TARGET,
+                "Skipping retry for peer {peer_id:?}: peering degree already satisfied."
+            );
+            return;
+        }
+        tracing::debug!(
+            target: LOG_TARGET,
+            "Executing backoff retry for peer {peer_id:?} (attempt {}).",
+            dial_attempt.attempt_number
+        );
+        let address = dial_attempt.address.clone();
+        self.ongoing_dials.insert(peer_id, dial_attempt);
+        if let Err(e) = self.swarm.dial(
+            DialOpts::peer_id(peer_id)
+                .addresses(vec![address])
+                .condition(PeerCondition::Always)
+                .build(),
+        ) {
+            tracing::error!(target: LOG_TARGET, "Failed to redial peer {peer_id:?}: {e:?}");
+            if e.is_recoverable() {
+                self.schedule_retry(peer_id);
+            } else {
+                self.abandon_peer(peer_id, &e);
+            }
+        }
     }
 
     /// Dial new peers, if necessary, to maintain the peering degree.
@@ -462,6 +566,13 @@ where
                     return;
                 };
 
+                // A permanent failure is not worth a backoff ladder: drop the
+                // peer for this epoch and spend the dial budget on another one.
+                if !error.is_recoverable() {
+                    self.abandon_peer(peer_id, &error);
+                    return;
+                }
+
                 match self.schedule_retry(peer_id) {
                     EpochDialAttempt::PreviousEpoch => {
                         tracing::debug!(target: LOG_TARGET, "Received a dial error for peer {peer_id:?} that is not being tracked. This means that a new epoch has cleared the map of pending dials. No retry will be performed.");
@@ -500,6 +611,7 @@ where
                 );
                 self.ongoing_dials.clear();
                 self.pending_retries.clear();
+                self.unrecoverable_peers.clear();
                 self.pending_full_membership_retry = None;
                 self.check_and_dial_new_peers();
             }
@@ -585,38 +697,9 @@ where
         IntervalStreamProvider<IntervalStream: Unpin + Send, IntervalItem = RangeInclusive<u64>>,
     ProofsVerifier: ProofsVerifierTrait + Clone + Send + Sync + 'static,
 {
-    /// It tries to dial the specified peer.
-    ///
-    /// This function always tries to dial and update the counter of attempted
-    /// dials. Any checks about the maximum allowed dials must be performed in
-    /// the context of the calling function.
-    fn dial(&mut self, peer_id: PeerId, address: Multiaddr, failed_peers: HashSet<PeerId>) {
-        tracing::trace!(target: LOG_TARGET, "Dialing peer {peer_id:?} at address {address:?}.");
-        self.ongoing_dials.insert(
-            peer_id,
-            DialAttempt {
-                address: address.clone(),
-                attempt_number: 1.try_into().unwrap(),
-                failed_peers,
-            },
-        );
-
-        if let Err(e) = self.swarm.dial(
-            DialOpts::peer_id(peer_id)
-                .addresses(vec![address])
-                // We use `Always` since we want to be able to dial a peer even if we already have
-                // an established connection with it that belongs to the previous epoch.
-                .condition(PeerCondition::Always)
-                .build(),
-        ) {
-            tracing::error!(target: LOG_TARGET, "Failed to dial peer {peer_id:?}: {e:?}");
-            self.schedule_retry(peer_id);
-        }
-    }
-
     #[cfg(test)]
-    pub fn dial_peer_at_addr(&mut self, peer_id: PeerId, address: Multiaddr) {
-        self.dial(peer_id, address, HashSet::new());
+    pub const fn unrecoverable_peers(&self) -> &HashSet<PeerId> {
+        &self.unrecoverable_peers
     }
 
     #[cfg(test)]
@@ -691,37 +774,6 @@ where
             )
         }));
         EpochDialAttempt::OngoingEpoch(None)
-    }
-
-    /// Called when a pending retry fires. Re-checks peering degree before
-    /// actually dialing, so we don't waste a slot on a peer we no longer need.
-    fn execute_retry(&mut self, peer_id: PeerId, dial_attempt: DialAttempt) {
-        let num_new_conns_needed = self
-            .minimum_healthy_peering_degree()
-            .saturating_sub(self.num_healthy_peers());
-        if num_new_conns_needed == 0 {
-            tracing::debug!(
-                target: LOG_TARGET,
-                "Skipping retry for peer {peer_id:?}: peering degree already satisfied."
-            );
-            return;
-        }
-        tracing::debug!(
-            target: LOG_TARGET,
-            "Executing backoff retry for peer {peer_id:?} (attempt {}).",
-            dial_attempt.attempt_number
-        );
-        let address = dial_attempt.address.clone();
-        self.ongoing_dials.insert(peer_id, dial_attempt);
-        if let Err(e) = self.swarm.dial(
-            DialOpts::peer_id(peer_id)
-                .addresses(vec![address])
-                .condition(PeerCondition::Always)
-                .build(),
-        ) {
-            tracing::error!(target: LOG_TARGET, "Failed to redial peer {peer_id:?}: {e:?}");
-            self.schedule_retry(peer_id);
-        }
     }
 
     fn publish_received_edge_message(
@@ -893,6 +945,7 @@ where
             current_epoch_info,
             max_dial_attempts_per_connection,
             ongoing_dials: HashMap::new(),
+            unrecoverable_peers: HashSet::new(),
             pending_retries: FuturesUnordered::new(),
             pending_full_membership_retry: None,
             rng,

--- a/services/blend/src/core/backends/libp2p/tests/redials.rs
+++ b/services/blend/src/core/backends/libp2p/tests/redials.rs
@@ -594,3 +594,62 @@ async fn core_retry_skipped_when_peering_degree_satisfied() {
             >= 1
     );
 }
+
+#[test(tokio::test)]
+async fn core_does_not_retry_unrecoverable_dial_failure() {
+    let (mut identities, peer_ids) = new_nodes_with_empty_address(2);
+
+    // A real listening swarm whose address we pair with the wrong identity.
+    let TestSwarm {
+        swarm: mut listening_swarm,
+        ..
+    } = SwarmBuilder::new(identities.next().unwrap(), &peer_ids)
+        .build(|id, membership| BlendBehaviourBuilder::new(id, membership).build());
+    let (listening_node, _) = listening_swarm
+        .listen_and_return_membership_entry(None)
+        .await;
+    tokio::spawn(async move { listening_swarm.run().await });
+
+    let TestSwarm {
+        swarm: mut dialing_swarm,
+        ..
+    } = SwarmBuilder::new(identities.next().unwrap(), &peer_ids)
+        .build(|id, membership| BlendBehaviourBuilder::new(id, membership).build());
+
+    let wrong_peer_id = PeerId::random();
+    dialing_swarm.dial_peer_at_addr(wrong_peer_id, listening_node.address.clone());
+
+    dialing_swarm
+        .poll_next_until(|event| {
+            let SwarmEvent::OutgoingConnectionError { peer_id, .. } = event else {
+                return false;
+            };
+            *peer_id == Some(wrong_peer_id)
+        })
+        .await;
+
+    assert!(
+        dialing_swarm.unrecoverable_peers().contains(&wrong_peer_id),
+        "a wrong-peer-id failure must mark the peer unusable for this epoch"
+    );
+    assert!(
+        !dialing_swarm.ongoing_dials().contains_key(&wrong_peer_id),
+        "the abandoned peer must not be left in ongoing dials"
+    );
+
+    // The first backoff would be 2^1 = 2s; no further attempt may occur.
+    let no_second_attempt = time::timeout(
+        Duration::from_secs(4),
+        dialing_swarm.poll_next_until(|event| {
+            let SwarmEvent::OutgoingConnectionError { peer_id, .. } = event else {
+                return false;
+            };
+            *peer_id == Some(wrong_peer_id)
+        }),
+    )
+    .await;
+    assert!(
+        no_second_attempt.is_err(),
+        "an unrecoverable dial failure must not be retried"
+    );
+}

--- a/services/blend/src/core/mod.rs
+++ b/services/blend/src/core/mod.rs
@@ -1,3 +1,4 @@
+use core::num::NonZeroU64;
 use std::{
     collections::VecDeque,
     fmt::{Debug, Display},
@@ -97,6 +98,10 @@ use crate::{
     kms::PreloadKmsService,
     membership::{self, ZkInfo, chain::BlendEpochState},
     message::{BlendPayload, ProcessedMessage, ServiceMessage},
+    pending::{
+        Discarded, LocalEncapsulation, NextLocalMessage, PendingLocalMessages,
+        resolve_encapsulation,
+    },
 };
 
 pub mod backends;
@@ -392,7 +397,7 @@ where
             current_public_info,
             crypto_processor,
             current_recovery_checkpoint,
-            pending_transactions,
+            pending_messages,
             message_scheduler,
             mut backend,
             mut rng,
@@ -442,7 +447,7 @@ where
             &sdp_relay,
             message_scheduler.into(),
             &mut rng,
-            pending_transactions,
+            pending_messages,
             crypto_processor,
             current_public_info,
             current_recovery_checkpoint,
@@ -508,7 +513,7 @@ async fn initialize<
         ProofsVerifier,
     >,
     ServiceState<Backend::Settings, Dispatcher::Settings>,
-    VecDeque<Vec<u8>>,
+    PendingLocalMessages,
     SchedulerWrapper<BlakeRng, ProcessedMessage, EncapsulatedMessageWithVerifiedPublicHeader>,
     Backend,
     BlakeRng,
@@ -749,14 +754,19 @@ where
     // Rng for releasing messages.
     let rng = BlakeRng::from_entropy();
 
-    let pending_transactions = current_recovery_checkpoint.pending_transactions().clone();
+    // The transactions a previous run had queued, back in the shared queue that
+    // also holds proposals.
+    let mut pending_messages = PendingLocalMessages::new();
+    for transaction in current_recovery_checkpoint.pending_transactions() {
+        pending_messages.queue_transaction(transaction.clone());
+    }
 
     (
         remaining_epoch_stream,
         current_epoch_public_info,
         crypto_processor,
         current_recovery_checkpoint,
-        pending_transactions,
+        pending_messages,
         message_scheduler,
         backend,
         rng,
@@ -824,7 +834,7 @@ async fn run_event_loop<
         EncapsulatedMessageWithVerifiedPublicHeader,
     >,
     rng: &mut Rng,
-    mut pending_transactions: VecDeque<Vec<u8>>,
+    mut pending_messages: PendingLocalMessages,
     mut crypto_processor: CurrentEpochCryptographicProcessor<
         NodeId,
         CorePoQGenerator,
@@ -858,24 +868,39 @@ where
             Some(msg) = inbound_relay.next() => {
                 match msg {
                     ServiceMessage::Blend(BlendPayload::Transaction(transaction)) => {
-                        recovery_checkpoint = queue_transaction_for_encapsulation(transaction, &mut pending_transactions, recovery_checkpoint);
+                        recovery_checkpoint = queue_transaction_for_encapsulation(transaction, &mut pending_messages, recovery_checkpoint);
                     }
                     ServiceMessage::Blend(BlendPayload::BlockProposal(proposal)) => {
-                        recovery_checkpoint = handle_local_block_proposal(&proposal, blend_config.data_replication_factor, &mut crypto_processor, &mut message_scheduler, recovery_checkpoint).await;
+                        let copies = NonZeroU64::new(blend_config.data_replication_factor.strict_add(1)).unwrap();
+                        pending_messages.queue_proposal(proposal, copies);
                     }
                     ServiceMessage::GetNetworkInfo { reply } => {
                         let info = backend.network_info().await;
                         drop(reply.send(info));
                     }
                     ServiceMessage::GetPendingTransactions { reply } => {
-                        drop(reply.send(pending_transactions.iter().cloned().collect()));
+                        drop(reply.send(pending_messages.transactions().cloned().collect()));
                     }
                 }
             }
-            // A queued transaction leaves as soon as a `PoW` solution backs it. The
-            // search is awaited here, so the rest of the loop keeps turning while it runs.
-            Some(encapsulation) = encapsulate_next_transaction(&pending_transactions, &mut crypto_processor) => {
-                recovery_checkpoint = handle_local_transaction(&encapsulation, &mut pending_transactions, &crypto_processor, &mut message_scheduler, recovery_checkpoint);
+            // A queued message leaves as soon as proofs back it — a `PoW` solution
+            // for a transaction, this epoch's secret `PoL` info for a proposal. Both
+            // are awaited here so the rest of the loop keeps turning meanwhile, and
+            // both share one branch because both need the processor mutably and
+            // `select!` builds every branch future before any of them wins.
+            Some(encapsulation) = encapsulate_next_local_message(&pending_messages, &mut crypto_processor) => {
+                match encapsulation {
+                    Ok(LocalEncapsulation::ProposalCopy(message)) => {
+                        recovery_checkpoint = schedule_local_encapsulated_message(&message, &crypto_processor, &mut message_scheduler, recovery_checkpoint);
+                        pending_messages.mark_proposal_copy_as_sent();
+                    }
+                    Ok(LocalEncapsulation::Transaction(message)) => {
+                        recovery_checkpoint = handle_local_transaction(&message, &mut pending_messages, &crypto_processor, &mut message_scheduler, recovery_checkpoint);
+                    }
+                    Err(()) => {
+                        recovery_checkpoint = discard_unencapsulatable_message(&mut pending_messages, recovery_checkpoint);
+                    }
+                }
             }
             Some(incoming_message) = blend_messages.next() => {
                 let (old_cryptographic_processor, old_scheduler) = old_epoch_components
@@ -943,58 +968,86 @@ where
 /// proofs.
 fn queue_transaction_for_encapsulation<BackendSettings, NetworkSettings>(
     transaction: Vec<u8>,
-    pending_transactions: &mut VecDeque<Vec<u8>>,
+    pending_messages: &mut PendingLocalMessages,
     current_recovery_checkpoint: ServiceState<BackendSettings, NetworkSettings>,
 ) -> ServiceState<BackendSettings, NetworkSettings>
 where
     BackendSettings: Clone,
 {
-    pending_transactions.push_back(transaction.clone());
+    pending_messages.queue_transaction(transaction.clone());
     let mut state_updater = current_recovery_checkpoint.start_updating();
     state_updater.queue_unencapsulated_transaction(transaction);
     state_updater.commit_changes()
 }
 
-/// Encapsulates the transaction that has been waiting longest, once a `PoW`
-/// solution backs its layer proofs.
+/// Encapsulates one locally-originated message, once proofs back it.
 ///
-/// The transaction is only read here, never taken off the queue: `select!`
-/// drops this future whenever another branch wins the race, and a future that
-/// popped before awaiting would take the transaction down with it every time
-/// that happened. It comes off the queue in [`handle_local_transaction`]
-/// instead, which runs after the race is settled.
+/// Proposals go first: one is tied to the slot it was built for and goes stale,
+/// whereas a transaction keeps.
 ///
-/// Returns `None` when there is nothing to hand back — either nothing is
-/// queued, or the transaction at the head could not be encapsulated — which is
-/// what leaves the `select!` branch free to wait on the others. The two are not
-/// worth telling apart here: in both cases the right move is to do nothing this
-/// time round.
+/// Neither queue is popped here: `select!` drops this future whenever another
+/// branch wins the race, and a future that popped before awaiting would take
+/// the message down with it every time that happened. The caller updates the
+/// queues once the race is settled, which is also why only one copy of a
+/// proposal is wrapped per call.
 ///
-/// A transaction that fails to encapsulate therefore stays queued and is tried
-/// again.
-async fn encapsulate_next_transaction<NodeId, ProofsGenerator, ProofsVerifier, CorePoQGenerator>(
-    pending_transactions: &VecDeque<Vec<u8>>,
+/// Returns `None` when there is nothing to hand back — nothing queued, or the
+/// branch that would back the message has no proofs yet. Both mean "do nothing
+/// this time round", and the message stays queued for the next. `Err(())` means
+/// the head can never be encapsulated and has to go: the head is retried before
+/// anything else is looked at, so one that keeps failing would take everything
+/// queued behind it down with it.
+async fn encapsulate_next_local_message<NodeId, ProofsGenerator, ProofsVerifier, CorePoQGenerator>(
+    pending_messages: &PendingLocalMessages,
     cryptographic_processor: &mut CurrentEpochCryptographicProcessor<
         NodeId,
         CorePoQGenerator,
         ProofsGenerator,
         ProofsVerifier,
     >,
-) -> Option<EncapsulatedMessageWithVerifiedPublicHeader>
+) -> Option<Result<LocalEncapsulation, ()>>
 where
     NodeId: Eq + Hash + 'static,
     ProofsGenerator: CoreLeaderAndPowProofsGenerator<CorePoQGenerator>,
 {
-    let transaction = pending_transactions.front()?;
-    cryptographic_processor
-        .encapsulate_transaction_payload(transaction)
-        .await
-        // Reported here rather than handed back: the encapsulation error is not
-        // `Send`, and a `select!` branch output has to be.
-        .inspect_err(|e| {
-            tracing::error!(target: LOG_TARGET, "Failed to encapsulate transaction: {e:?}");
-        })
-        .ok()
+    type Wrap = fn(EncapsulatedMessageWithVerifiedPublicHeader) -> LocalEncapsulation;
+
+    let (encapsulated, wrap_fn): (_, Wrap) = match pending_messages.next()? {
+        NextLocalMessage::ProposalCopy(proposal) => (
+            cryptographic_processor
+                .encapsulate_block_proposal_payload(proposal)
+                .await,
+            LocalEncapsulation::ProposalCopy,
+        ),
+        NextLocalMessage::Transaction(transaction) => (
+            cryptographic_processor
+                .encapsulate_transaction_payload(transaction)
+                .await,
+            LocalEncapsulation::Transaction,
+        ),
+    };
+
+    resolve_encapsulation(encapsulated, wrap_fn)
+}
+
+/// Drops the queued message that cannot be encapsulated, taking it out of the
+/// recovery state too so a restart does not bring it back to fail again.
+fn discard_unencapsulatable_message<BackendSettings, NetworkSettings>(
+    pending_messages: &mut PendingLocalMessages,
+    current_recovery_checkpoint: ServiceState<BackendSettings, NetworkSettings>,
+) -> ServiceState<BackendSettings, NetworkSettings>
+where
+    BackendSettings: Clone,
+{
+    match pending_messages.discard_head() {
+        // Proposals are not persisted, so there is nothing else to undo.
+        Some(Discarded::Proposal(_)) | None => current_recovery_checkpoint,
+        Some(Discarded::Transaction(transaction)) => {
+            let mut state_updater = current_recovery_checkpoint.start_updating();
+            state_updater.dequeue_unencapsulated_transaction(&transaction);
+            state_updater.commit_changes()
+        }
+    }
 }
 
 /// Processes a transaction whose wait for a `PoW` solution is over.
@@ -1012,7 +1065,7 @@ fn handle_local_transaction<
     CorePoQGenerator,
 >(
     encapsulation: &EncapsulatedMessageWithVerifiedPublicHeader,
-    pending_transactions: &mut VecDeque<Vec<u8>>,
+    pending_messages: &mut PendingLocalMessages,
     cryptographic_processor: &CurrentEpochCryptographicProcessor<
         NodeId,
         CorePoQGenerator,
@@ -1039,9 +1092,7 @@ where
         current_recovery_checkpoint,
     );
 
-    let transaction = pending_transactions
-        .pop_front()
-        .expect("Branch only yields while a transaction is queued.");
+    let transaction = pending_messages.mark_transaction_as_sent();
     let mut state_updater = recovery_checkpoint.start_updating();
     state_updater.dequeue_unencapsulated_transaction(&transaction);
     state_updater.commit_changes()
@@ -1402,70 +1453,6 @@ enum HandleEpochEventOutput<
         /// of core.
         old_token_collector: OldEpochBlendingTokenCollector,
     },
-}
-
-/// Processes a block proposal handed over by another service.
-///
-/// Leadership proofs are ready the moment the epoch's secret `PoL` info is, so
-/// unlike a transaction this can be encapsulated where it arrives without
-/// holding up the event loop.
-///
-/// `data_replication_factor` extra copies go out alongside the first. Block
-/// proposals are replicated and transactions are not: the spec's per-solution
-/// `PoW` quota `Q_W` is `ß_max`, i.e. exactly one message's worth of
-/// encapsulations, whereas the leadership quota `Q_L` budgets for the extra
-/// copies on top.
-async fn handle_local_block_proposal<
-    NodeId,
-    Rng,
-    BackendSettings,
-    NetworkSettings,
-    ProofsGenerator,
-    ProofsVerifier,
-    CorePoQGenerator,
->(
-    proposal: &[u8],
-    data_replication_factor: u64,
-    cryptographic_processor: &mut CurrentEpochCryptographicProcessor<
-        NodeId,
-        CorePoQGenerator,
-        ProofsGenerator,
-        ProofsVerifier,
-    >,
-    scheduler: &mut EpochMessageScheduler<
-        Rng,
-        ProcessedMessage,
-        EncapsulatedMessageWithVerifiedPublicHeader,
-    >,
-    current_recovery_checkpoint: ServiceState<BackendSettings, NetworkSettings>,
-) -> ServiceState<BackendSettings, NetworkSettings>
-where
-    NodeId: Eq + Hash + Send + 'static,
-    Rng: RngCore + Clone + Send + Unpin,
-    BackendSettings: Clone + Send + Sync,
-    ProofsGenerator: CoreLeaderAndPowProofsGenerator<CorePoQGenerator>,
-    ProofsVerifier: ProofsVerifierTrait,
-{
-    let mut recovery_checkpoint = current_recovery_checkpoint;
-    for _ in 0..data_replication_factor.strict_add(1) {
-        let Ok(wrapped_message) = cryptographic_processor
-            .encapsulate_block_proposal_payload(proposal)
-            .await
-            .inspect_err(|e| {
-                tracing::error!(target: LOG_TARGET, "Failed to wrap message: {e:?}");
-            })
-        else {
-            return recovery_checkpoint;
-        };
-
-        recovery_checkpoint = schedule_local_encapsulated_message(
-            &wrapped_message,
-            cryptographic_processor,
-            scheduler,
-            recovery_checkpoint,
-        );
-    }
-    recovery_checkpoint
 }
 
 /// Schedules a locally-generated, already-encapsulated data message for

--- a/services/blend/src/core/mod.rs
+++ b/services/blend/src/core/mod.rs
@@ -936,7 +936,7 @@ where
                 }
             }
             Some(epoch_event) = remaining_epoch_stream.next() => {
-                match handle_epoch_event(epoch_event, blend_config, crypto_processor, message_scheduler, current_epoch_info, recovery_checkpoint, backend, sdp_relay, &mut latest_secret_pol_info).await {
+                match handle_epoch_event(epoch_event, blend_config, crypto_processor, message_scheduler, current_epoch_info, recovery_checkpoint, backend, sdp_relay, &mut latest_secret_pol_info, &mut pending_messages).await {
                     // Current epoch info updated to new one
                     HandleEpochEventOutput::Transitioning { new_crypto_processor, new_scheduler, new_epoch_info, new_recovery_checkpoint, old_epoch_components: transitioning_epoch } => {
                         crypto_processor = new_crypto_processor;
@@ -1028,6 +1028,18 @@ where
     };
 
     resolve_encapsulation(encapsulated, wrap_fn)
+}
+
+/// Drops proposals left over from the epoch that just ended, saying so if there
+/// were any.
+fn discard_stale_proposals(pending_messages: &mut PendingLocalMessages) {
+    let discarded_proposals = pending_messages.discard_proposals();
+    if discarded_proposals > 0 {
+        tracing::warn!(
+            target: LOG_TARGET,
+            "Dropping {discarded_proposals} block proposal(s) still queued when the epoch ended."
+        );
+    }
 }
 
 /// Drops the queued message that cannot be encapsulated, taking it out of the
@@ -1192,6 +1204,7 @@ async fn handle_epoch_event<
     backend: &mut Backend,
     sdp_relay: &OutboundRelay<SdpMessage>,
     current_secret_info: &mut Option<PolEpochInfo>,
+    pending_messages: &mut PendingLocalMessages,
 ) -> HandleEpochEventOutput<
     NodeId,
     Rng,
@@ -1218,6 +1231,14 @@ where
             // its processor into a receive-only one for the transition period drops
             // the generators, and with them the `PoW` mining they have in flight.
             let old_cryptographic_processor = current_cryptographic_processor.rotate_epoch();
+            // Queued proposals go with it, and for the same reason: the rotation
+            // is what makes them unsendable. Anything not yet encapsulated would
+            // now draw on the new epoch's leadership quota — one message's worth
+            // per winning slot — spending it on a block the chain has moved past
+            // instead of on the one this node is about to produce. What was
+            // already encapsulated is not here; it is in the old scheduler, which
+            // goes on releasing it for the transition period.
+            discard_stale_proposals(pending_messages);
             let (
                 _,
                 _,
@@ -1341,6 +1362,7 @@ where
             }
         }
         EpochEvent::NewEpoch(MaybeEmptyCoreEpochInfo::Empty { epoch, epoch_nonce }) => {
+            discard_stale_proposals(pending_messages);
             tracing::info!(target: LOG_TARGET, "New epoch event received, but no epoch info is available due to empty membership set.");
             let old_cryptographic_processor = current_cryptographic_processor.rotate_epoch();
             let (_, _, _, _, _, current_epoch_blending_token_collector, _, _) =

--- a/services/blend/src/core/tests/mod.rs
+++ b/services/blend/src/core/tests/mod.rs
@@ -3,7 +3,10 @@ use std::{collections::VecDeque, sync::Arc};
 
 use futures::{StreamExt as _, stream::repeat};
 use lb_blend::{
-    message::reward::{ActivityProof, BlendingToken, EpochBlendingTokenCollector},
+    message::{
+        MAX_PAYLOAD_BODY_SIZE,
+        reward::{ActivityProof, BlendingToken, EpochBlendingTokenCollector},
+    },
     proofs::{quota::VerifiedProofOfQuota, selection::VerifiedProofOfSelection},
     scheduling::{
         EpochMessageScheduler, epoch::EpochEvent,
@@ -18,6 +21,7 @@ use lb_poq::{CORE_MERKLE_TREE_HEIGHT, Quota};
 use lb_utils::blake_rng::BlakeRng;
 use rand::SeedableRng as _;
 use rayon::ThreadPoolBuilder;
+use tokio::sync::oneshot;
 
 use crate::{
     core::{
@@ -41,10 +45,10 @@ use crate::{
     message::{BlendPayload, ServiceMessage},
     test_utils::{
         crypto::{
-            GatedPowProofsGenerator, MockCoreAndLeaderProofsGenerator, PowGate,
-            recorded_starting_core_key_indices, reset_starting_core_key_indices,
+            GatedPowProofsGenerator, MockCoreAndLeaderProofsGenerator, PolAwareProofsGenerator,
+            PowGate, recorded_starting_core_key_indices, reset_starting_core_key_indices,
         },
-        epoch::OncePolStreamProvider,
+        epoch::{GatedPolStreamProvider, OncePolStreamProvider, PolGate},
     },
 };
 
@@ -1824,7 +1828,7 @@ async fn test_initialize_recovers_matching_saved_state() {
         _current_public_info2,
         _crypto_processor2,
         recovered_checkpoint2,
-        pending_transactions2,
+        pending_messages2,
         _message_scheduler2,
         _backend2,
         _rng2,
@@ -1866,7 +1870,7 @@ async fn test_initialize_recovers_matching_saved_state() {
         "Mismatched epoch: a queued transaction should outlive the state that carried it"
     );
     assert_eq!(
-        pending_transactions2.front(),
+        pending_messages2.transactions().next(),
         Some(&b"stale epoch transaction".to_vec()),
         "Mismatched epoch: the queue handed to the event loop should carry it too"
     );
@@ -2046,6 +2050,251 @@ async fn test_initialize_drops_activity_proof_older_than_one_epoch() {
         sdp_relay_receiver.try_recv().is_err(),
         "a collector more than one epoch old should be dropped, not submitted"
     );
+}
+
+/// A block proposal that arrives before this epoch's secret `PoL` info still
+/// goes out once it lands.
+///
+/// Leadership proofs only become possible when the secret `PoL` info reaches
+/// the processor, and that regularly happens *after* the first proposal does —
+/// most visibly at startup, when the node wins the very first slot it is asked
+/// to lead. The proposal used to be encapsulated where it arrived, fail, and be
+/// dropped with an error, silently losing a block this node had just produced.
+#[test_log::test(tokio::test)]
+async fn a_proposal_arriving_before_the_pol_info_is_still_sent() {
+    let minimal_network_size = 2;
+    let (membership, local_private_key) = new_membership(minimal_network_size);
+    let mut settings = settings(
+        local_private_key.clone(),
+        u64::from(minimal_network_size).try_into().unwrap(),
+        (),
+        0,
+    );
+    // No cover traffic, so the only message that can come out is the proposal.
+    // See the `PoW` liveness test for why this quota silences it.
+    settings.num_blend_layers = NonZeroU64::try_from(2).unwrap();
+    settings.scheduler.cover.message_frequency_per_round = 0.05.try_into().unwrap();
+
+    let (inbound_relay, inbound_message_sender) = new_stream();
+    let (mut blend_message_stream, _blend_message_sender) = new_stream();
+    let (membership_stream, membership_sender) = new_stream();
+
+    let membership_info = MembershipInfo {
+        membership,
+        zk: Some(ZkInfo {
+            root: ZkHash::ZERO,
+            core_and_path_selectors: Some([(ZkHash::ZERO, false); CORE_MERKLE_TREE_HEIGHT]),
+        }),
+    };
+    membership_sender
+        .send(test_blend_epoch_state(0, membership_info))
+        .await
+        .unwrap();
+
+    let (sdp_relay, _sdp_relay_receiver) = sdp_relay();
+    let (overwatch_handle, _overwatch_cmd_receiver, state_updater, _state_receiver) =
+        dummy_overwatch_resources();
+
+    // Both installed before the service exists, so nothing is missed.
+    let pol_gate = PolGate::setup();
+    let mut outgoing_messages = outgoing_messages_recorder();
+
+    let (
+        mut remaining_epoch_stream,
+        current_public_info,
+        crypto_processor,
+        current_recovery_checkpoint,
+        pending_transactions,
+        message_scheduler,
+        mut backend,
+        mut rng,
+    ) = initialize::<
+        NodeId,
+        TestBlendBackend,
+        TestPayloadDispatcher,
+        PolAwareProofsGenerator,
+        MockProofsVerifier,
+        MockKmsAdapter,
+        RuntimeServiceId,
+    >(
+        settings.clone(),
+        membership_stream,
+        overwatch_handle.clone(),
+        MockKmsAdapter,
+        &sdp_relay,
+        None,
+        state_updater,
+    )
+    .await;
+
+    tokio::spawn(async move {
+        let secret_pol_info_stream =
+            post_initialize::<GatedPolStreamProvider, RuntimeServiceId>(&overwatch_handle).await;
+        run_event_loop(
+            inbound_relay,
+            &mut blend_message_stream,
+            secret_pol_info_stream,
+            &mut remaining_epoch_stream,
+            &settings,
+            &mut backend,
+            &TestPayloadDispatcher,
+            &sdp_relay,
+            message_scheduler.into(),
+            &mut rng,
+            pending_transactions,
+            crypto_processor,
+            current_public_info,
+            current_recovery_checkpoint,
+        )
+        .await;
+    });
+
+    // The gate is shut, so the leadership branch has nothing to give: this is the
+    // window the proposal used to die in.
+    inbound_message_sender
+        .send(ServiceMessage::Blend(BlendPayload::BlockProposal(
+            b"proposal".to_vec(),
+        )))
+        .await
+        .unwrap();
+
+    // Answering a request proves the service went round the inbound arm again,
+    // so the proposal ahead of it has already been handled. Without this the
+    // gate could open first and the test would pass on a proposal that was
+    // never queued at all.
+    let (reply, answered) = oneshot::channel();
+    inbound_message_sender
+        .send(ServiceMessage::GetPendingTransactions { reply })
+        .await
+        .unwrap();
+    answered.await.unwrap();
+
+    pol_gate.release();
+
+    expect_outgoing_message(
+        &mut outgoing_messages,
+        "the proposal should have been held until leadership proofs were possible",
+    )
+    .await;
+}
+
+/// A block proposal that arrives before this epoch's secret `PoL` info still
+/// goes out once it lands.
+///
+/// Leadership proofs only become possible when the secret `PoL` info reaches
+/// the processor, and that regularly happens *after* the first proposal does —
+/// most visibly at startup, when the node wins the very first slot it is asked
+/// to lead. The proposal used to be encapsulated where it arrived, fail, and be
+/// dropped with an error, silently losing a block this node had just produced.
+#[test_log::test(tokio::test)]
+async fn a_message_that_can_never_be_sent_does_not_block_the_rest() {
+    let minimal_network_size = 2;
+    let (membership, local_private_key) = new_membership(minimal_network_size);
+    let mut settings = settings(
+        local_private_key.clone(),
+        u64::from(minimal_network_size).try_into().unwrap(),
+        (),
+        0,
+    );
+    // No cover traffic, so the only message that can come out is the one this
+    // test expects. See the `PoW` liveness test for why this quota silences it.
+    settings.num_blend_layers = NonZeroU64::try_from(2).unwrap();
+    settings.scheduler.cover.message_frequency_per_round = 0.05.try_into().unwrap();
+
+    let (inbound_relay, inbound_message_sender) = new_stream();
+    let (mut blend_message_stream, _blend_message_sender) = new_stream();
+    let (membership_stream, membership_sender) = new_stream();
+
+    let membership_info = MembershipInfo {
+        membership,
+        zk: Some(ZkInfo {
+            root: ZkHash::ZERO,
+            core_and_path_selectors: Some([(ZkHash::ZERO, false); CORE_MERKLE_TREE_HEIGHT]),
+        }),
+    };
+    membership_sender
+        .send(test_blend_epoch_state(0, membership_info))
+        .await
+        .unwrap();
+
+    let (sdp_relay, _sdp_relay_receiver) = sdp_relay();
+    let (overwatch_handle, _overwatch_cmd_receiver, state_updater, _state_receiver) =
+        dummy_overwatch_resources();
+
+    // Installed before the service exists, so nothing is missed.
+    let mut outgoing_messages = outgoing_messages_recorder();
+
+    let (
+        mut remaining_epoch_stream,
+        current_public_info,
+        crypto_processor,
+        current_recovery_checkpoint,
+        pending_transactions,
+        message_scheduler,
+        mut backend,
+        mut rng,
+    ) = initialize::<
+        NodeId,
+        TestBlendBackend,
+        TestPayloadDispatcher,
+        MockCoreAndLeaderProofsGenerator,
+        MockProofsVerifier,
+        MockKmsAdapter,
+        RuntimeServiceId,
+    >(
+        settings.clone(),
+        membership_stream,
+        overwatch_handle.clone(),
+        MockKmsAdapter,
+        &sdp_relay,
+        None,
+        state_updater,
+    )
+    .await;
+
+    tokio::spawn(async move {
+        let secret_pol_info_stream =
+            post_initialize::<OncePolStreamProvider, RuntimeServiceId>(&overwatch_handle).await;
+        run_event_loop(
+            inbound_relay,
+            &mut blend_message_stream,
+            secret_pol_info_stream,
+            &mut remaining_epoch_stream,
+            &settings,
+            &mut backend,
+            &TestPayloadDispatcher,
+            &sdp_relay,
+            message_scheduler.into(),
+            &mut rng,
+            pending_transactions,
+            crypto_processor,
+            current_public_info,
+            current_recovery_checkpoint,
+        )
+        .await;
+    });
+
+    // One byte over what a payload can hold, so encapsulating it fails the same
+    // way however long it waits.
+    inbound_message_sender
+        .send(ServiceMessage::Blend(BlendPayload::BlockProposal(vec![
+            0;
+            MAX_PAYLOAD_BODY_SIZE + 1
+        ])))
+        .await
+        .unwrap();
+    inbound_message_sender
+        .send(ServiceMessage::Blend(BlendPayload::Transaction(
+            b"transaction".to_vec(),
+        )))
+        .await
+        .unwrap();
+
+    expect_outgoing_message(
+        &mut outgoing_messages,
+        "the transaction behind the oversized proposal should still go out",
+    )
+    .await;
 }
 
 /// A transaction waits for a `PoW` solution without holding up anything else.

--- a/services/blend/src/core/tests/mod.rs
+++ b/services/blend/src/core/tests/mod.rs
@@ -43,6 +43,7 @@ use crate::{
     epoch_info::PolEpochInfo,
     membership::{MembershipInfo, ZkInfo, chain::BlendEpochState},
     message::{BlendPayload, ServiceMessage},
+    pending::{NextLocalMessage, PendingLocalMessages},
     test_utils::{
         crypto::{
             GatedPowProofsGenerator, MockCoreAndLeaderProofsGenerator, PolAwareProofsGenerator,
@@ -566,6 +567,95 @@ async fn test_handle_epoch_transition_expired() {
     assert_eq!(*activity_proof, (&ActivityProof::new(epoch, token)).into());
 }
 
+/// A proposal still queued when the epoch rotates is dropped; a transaction is
+/// not.
+///
+/// Leadership quota is one message's worth per winning slot, so a proposal that
+/// missed its epoch would spend the quota the new epoch's own block needs.
+/// Already-encapsulated messages are unaffected: they have left the queue for
+/// the scheduler, and the previous epoch's scheduler keeps releasing them for
+/// the transition period, when peers still hold that epoch's verifier.
+#[test_log::test(tokio::test)]
+async fn test_handle_epoch_event_discards_queued_proposals() {
+    let (overwatch_handle, _overwatch_cmd_receiver, state_updater, _state_receiver) =
+        dummy_overwatch_resources::<(), (), RuntimeServiceId>();
+
+    // Prepare components for epoch event handling.
+    let epoch = 0.into();
+    let minimal_network_size = 2;
+    let (membership, local_private_key) = new_membership(minimal_network_size);
+    let settings = settings(
+        local_private_key.clone(),
+        u64::from(minimal_network_size).try_into().unwrap(),
+        (),
+        0,
+    );
+    let public_info = new_epoch_info(epoch, membership.clone(), &settings);
+    let crypto_processor = new_crypto_processor(
+        EpochCryptographicProcessorSettings {
+            non_ephemeral_encryption_key: settings.non_ephemeral_signing_key.derive_x25519(),
+            num_blend_layers: settings.num_blend_layers,
+            pow_mining_pool: Arc::new(ThreadPoolBuilder::new().build().unwrap()),
+            spent_core_quota: Quota::ZERO,
+        },
+        &public_info,
+        (),
+    );
+    let scheduler = EpochMessageScheduler::new(
+        scheduler_epoch_info(&public_info),
+        BlakeRng::from_entropy(),
+        scheduler_settings(&settings.time, settings.num_blend_layers),
+    );
+    let token_collector = EpochBlendingTokenCollector::new(&reward_epoch_info(&public_info));
+    let mut backend = <TestBlendBackend as BlendBackend<_, _, _, _>>::new(
+        settings.clone(),
+        overwatch_handle.clone(),
+        backend_epoch_info(&public_info),
+        BlakeRng::from_entropy(),
+    );
+    let (sdp_relay, _sdp_relay_receiver) = sdp_relay();
+
+    let mut pending_messages = PendingLocalMessages::new();
+    pending_messages.queue_proposal(b"proposal".to_vec(), 2.try_into().unwrap());
+    pending_messages.queue_transaction(b"transaction".to_vec());
+
+    let _output = handle_epoch_event(
+        EpochEvent::NewEpoch(
+            CoreEpochInfo {
+                public: CoreEpochPublicInfo {
+                    epoch: epoch.strict_add(1.into()),
+                    ..public_info.clone()
+                },
+                core_poq_generator: Some(()),
+            }
+            .into(),
+        ),
+        &settings,
+        crypto_processor,
+        scheduler,
+        public_info,
+        ServiceState::with_epoch(
+            epoch,
+            VecDeque::new(),
+            token_collector,
+            None,
+            state_updater.clone(),
+        )
+        .unwrap(),
+        &mut backend,
+        &sdp_relay,
+        &mut None,
+        &mut pending_messages,
+    )
+    .await;
+
+    assert_eq!(
+        pending_messages.next(),
+        Some(NextLocalMessage::Transaction(b"transaction")),
+        "the proposal must not survive the rotation, and the transaction must"
+    );
+}
+
 #[test_log::test(tokio::test)]
 #[expect(clippy::too_many_lines, reason = "Test function.")]
 async fn test_handle_epoch_event() {
@@ -635,6 +725,7 @@ async fn test_handle_epoch_event() {
         &mut backend,
         &sdp_relay,
         &mut None,
+        &mut PendingLocalMessages::new(),
     )
     .await;
     let HandleEpochEventOutput::Transitioning {
@@ -681,6 +772,7 @@ async fn test_handle_epoch_event() {
         &mut backend,
         &sdp_relay,
         &mut None,
+        &mut PendingLocalMessages::new(),
     )
     .await;
     let HandleEpochEventOutput::TransitionCompleted {
@@ -729,6 +821,7 @@ async fn test_handle_epoch_event() {
         &mut backend,
         &sdp_relay,
         &mut None,
+        &mut PendingLocalMessages::new(),
     )
     .await;
     let HandleEpochEventOutput::Retiring {
@@ -820,6 +913,7 @@ async fn test_handle_epoch_event_membership_change_rewires_backend_and_generator
         &mut backend,
         &sdp_relay,
         &mut None,
+        &mut PendingLocalMessages::new(),
     )
     .await;
 
@@ -922,6 +1016,7 @@ async fn transition_to_new_epoch_with_secret(secret_epoch: Epoch) -> Vec<Epoch> 
         &mut backend,
         &sdp_relay,
         &mut Some(secret_info),
+        &mut PendingLocalMessages::new(),
     )
     .await;
     recorded_set_epoch_private_calls()
@@ -1011,6 +1106,7 @@ async fn test_handle_epoch_event_empty_epoch_retires() {
         &mut backend,
         &sdp_relay,
         &mut None,
+        &mut PendingLocalMessages::new(),
     )
     .await;
     let HandleEpochEventOutput::Retiring {
@@ -1093,6 +1189,7 @@ async fn test_handle_epoch_event_non_empty_without_local_core_path_retires() {
         &mut backend,
         &sdp_relay,
         &mut None,
+        &mut PendingLocalMessages::new(),
     )
     .await;
 

--- a/services/blend/src/edge/backends/libp2p/swarm.rs
+++ b/services/blend/src/edge/backends/libp2p/swarm.rs
@@ -16,7 +16,7 @@ use lb_blend::{
         serialize_encapsulated_message_with_verified_public_header,
     },
 };
-use lb_libp2p::{DialError, DialOpts, SwarmEvent};
+use lb_libp2p::{DialError, DialErrorExt as _, DialOpts, SwarmEvent};
 use libp2p::{
     Multiaddr, PeerId, StreamProtocol, Swarm, SwarmBuilder,
     identity::Keypair,
@@ -103,6 +103,10 @@ where
     pending_events: PendingEvents,
     protocol_name: StreamProtocol,
     replication_factor: NonZeroUsize,
+    /// Peers whose dial failed for a reason that retrying cannot fix (see
+    /// [`DialErrorExt::is_recoverable`]). They are excluded from peer selection
+    /// for the lifetime of this swarm, which spans one epoch's membership.
+    unrecoverable_peers: HashSet<PeerId>,
 }
 
 #[derive(Debug)]
@@ -157,6 +161,7 @@ where
             max_dial_attempts_per_connection: settings.max_dial_attempts_per_peer_per_message,
             protocol_name: settings.protocol_name.into_inner(),
             replication_factor,
+            unrecoverable_peers: HashSet::new(),
         }
     }
 
@@ -190,6 +195,7 @@ where
             swarm: inner_swarm,
             protocol_name,
             replication_factor,
+            unrecoverable_peers: HashSet::new(),
         }
     }
 
@@ -215,7 +221,9 @@ where
     /// A single set of `replication_factor` peers is chosen at random for the
     /// message. Each chosen peer is then retried with exponential backoff (see
     /// [`Self::schedule_retry`]); if a peer is still unreachable after all
-    /// attempts, the message is dropped for that peer.
+    /// attempts, the message is dropped for that peer. A peer that fails
+    /// unrecoverably is replaced by a different one instead of being retried
+    /// (see [`Self::abandon_peer_and_redial`]).
     fn dial_and_schedule_message(&mut self, msg: &EncapsulatedMessageWithVerifiedPublicHeader) {
         let peers = self.choose_peers();
         if peers.is_empty() {
@@ -223,27 +231,96 @@ where
             return;
         }
         for node in peers {
-            let (peer_id, address) = (node.id, node.address);
-            let opts = dial_opts(peer_id, address.clone());
-            let connection_id = opts.connection_id();
+            self.dial_peer_with_message(node.id, node.address, msg.clone());
+        }
+    }
 
-            let Entry::Vacant(empty_entry) = self.pending_dials.entry((peer_id, connection_id))
-            else {
-                panic!(
-                    "Dial attempt for peer {peer_id:?} and connection {connection_id:?} should not be present in storage."
-                );
-            };
-            empty_entry.insert(DialAttempt {
-                address,
-                attempt_number: 1.try_into().unwrap(),
-                message: msg.clone(),
-            });
+    /// Dial a single peer, recording the message to be sent once the
+    /// connection is established.
+    fn dial_peer_with_message(
+        &mut self,
+        peer_id: PeerId,
+        address: Multiaddr,
+        message: EncapsulatedMessageWithVerifiedPublicHeader,
+    ) {
+        let opts = dial_opts(peer_id, address.clone());
+        let connection_id = opts.connection_id();
 
-            if let Err(e) = self.swarm.dial(opts) {
-                error!(target: LOG_TARGET, "Failed to dial peer {peer_id:?} on connection {connection_id:?}: {e:?}");
+        let Entry::Vacant(empty_entry) = self.pending_dials.entry((peer_id, connection_id)) else {
+            panic!(
+                "Dial attempt for peer {peer_id:?} and connection {connection_id:?} should not be present in storage."
+            );
+        };
+        empty_entry.insert(DialAttempt {
+            address,
+            attempt_number: 1.try_into().unwrap(),
+            message,
+        });
+
+        if let Err(e) = self.swarm.dial(opts) {
+            error!(target: LOG_TARGET, "Failed to dial peer {peer_id:?} on connection {connection_id:?}: {e:?}");
+            // `Swarm::dial` rejects some dials synchronously (no address, our
+            // own id, a behaviour refusing it). Those carry the same
+            // recoverable/unrecoverable distinction as an asynchronous
+            // `OutgoingConnectionError` and must be classified identically.
+            if e.is_recoverable() {
                 self.schedule_retry(peer_id, connection_id);
+            } else {
+                self.abandon_peer_and_redial(peer_id, connection_id, &e);
             }
         }
+    }
+
+    /// Drop a peer that can never be dialed successfully and send its message
+    /// to a different peer instead.
+    ///
+    /// Unlike [`Self::schedule_retry`], this does not re-dial the same peer:
+    /// the failure is permanent for as long as the current membership stands,
+    /// so the peer is excluded from further selection and the message is
+    /// re-targeted immediately rather than after exhausting a backoff ladder.
+    #[expect(
+        clippy::cognitive_complexity,
+        reason = "Tracing macros add a lot of code under the hood."
+    )]
+    fn abandon_peer_and_redial(
+        &mut self,
+        peer_id: PeerId,
+        connection_id: ConnectionId,
+        error: &DialError,
+    ) {
+        self.unrecoverable_peers.insert(peer_id);
+
+        let Some(dial_attempt) = self.pending_dials.remove(&(peer_id, connection_id)) else {
+            debug!(target: LOG_TARGET, "No pending dial for peer {peer_id:?} on connection {connection_id:?}. Nothing to re-target.");
+            return;
+        };
+
+        error!(
+            target: LOG_TARGET,
+            "Unrecoverable dial failure for peer {peer_id:?} at {:?}: {error}. Not retrying; excluding it from this membership and choosing another peer.",
+            dial_attempt.address
+        );
+
+        let Some(replacement) = self.choose_replacement_peer() else {
+            warn!(target: LOG_TARGET, "No alternative peer available to send the message to. Dropping the message.");
+            return;
+        };
+        debug!(target: LOG_TARGET, "Re-targeting message from peer {peer_id:?} to {:?}", replacement.id);
+        self.dial_peer_with_message(replacement.id, replacement.address, dial_attempt.message);
+    }
+
+    /// Pick one peer that is neither known-unusable nor already being dialed.
+    fn choose_replacement_peer(&mut self) -> Option<Node<PeerId>> {
+        let exclude: HashSet<PeerId> = self
+            .unrecoverable_peers
+            .iter()
+            .chain(self.pending_dials.keys().map(|(peer_id, _)| peer_id))
+            .copied()
+            .collect();
+        self.membership
+            .filter_and_choose_remote_nodes(&mut self.rng, 1, &exclude)
+            .next()
+            .cloned()
     }
 
     /// Schedule a retry for a failed dial attempt with exponential backoff.
@@ -292,9 +369,17 @@ where
     }
 
     fn choose_peers(&mut self) -> Vec<Node<PeerId>> {
-        let peers_to_choose = self.membership.size().min(self.replication_factor.get());
+        let available = self
+            .membership
+            .size()
+            .saturating_sub(self.unrecoverable_peers.len());
+        let peers_to_choose = available.min(self.replication_factor.get());
         self.membership
-            .filter_and_choose_remote_nodes(&mut self.rng, peers_to_choose, &HashSet::new())
+            .filter_and_choose_remote_nodes(
+                &mut self.rng,
+                peers_to_choose,
+                &self.unrecoverable_peers,
+            )
             .cloned()
             .collect()
     }
@@ -384,7 +469,11 @@ where
 
         if let Err(e) = self.swarm.dial(opts) {
             error!(target: LOG_TARGET, "Failed to redial peer {peer_id:?}: {e:?}");
-            self.schedule_retry(peer_id, connection_id);
+            if e.is_recoverable() {
+                self.schedule_retry(peer_id, connection_id);
+            } else {
+                self.abandon_peer_and_redial(peer_id, connection_id, &e);
+            }
         }
     }
 
@@ -400,6 +489,11 @@ where
             debug!(target: LOG_TARGET, "No PeerId set. Ignoring: peer_id:{peer_id:?}, connection_id:{connection_id}");
             return;
         };
+
+        if !error.is_recoverable() {
+            self.abandon_peer_and_redial(peer_id, connection_id, error);
+            return;
+        }
 
         self.schedule_retry(peer_id, connection_id);
     }

--- a/services/blend/src/edge/backends/libp2p/tests/redials.rs
+++ b/services/blend/src/edge/backends/libp2p/tests/redials.rs
@@ -8,9 +8,13 @@ use lb_key_management_system_service::keys::UnsecuredEd25519Key;
 use lb_libp2p::{Protocol, SwarmEvent};
 use libp2p::{Multiaddr, PeerId};
 use test_log::test;
-use tokio::time;
+use tokio::{spawn, time};
 
 use crate::{
+    core::backends::libp2p::core_swarm_test_utils::{
+        BlendBehaviourBuilder, SwarmBuilder as CoreSwarmBuilder, SwarmExt as _,
+        TestSwarm as CoreTestSwarm, new_nodes_with_empty_address,
+    },
     edge::backends::libp2p::{
         swarm::Command,
         tests::utils::{SwarmBuilder as EdgeSwarmBuilder, TestSwarm as EdgeTestSwarm},
@@ -174,5 +178,118 @@ async fn stalled_send_does_not_block_command_processing() {
         swarm.pending_dials().len(),
         1,
         "The command should be processed even though a send is stalled"
+    );
+}
+
+/// A dial that fails because the host at the declared address presents a
+/// different identity than the membership expects (`DialError::WrongPeerId`)
+/// must not be retried: no number of attempts changes the remote's key.
+///
+/// This is the failure that took down Blend on testnet v0.2.1 — every declared
+/// locator pointed at a host holding a different key, and because the error was
+/// funnelled into the same backoff ladder as a timeout it was reported as
+/// "peer was not reachable after N attempts" rather than as a configuration
+/// fault.
+#[test(tokio::test)]
+async fn edge_does_not_retry_unrecoverable_dial_failure() {
+    // A real listening swarm, whose address we will pair with the wrong peer id.
+    let (mut identities, nodes) = new_nodes_with_empty_address(1);
+    let CoreTestSwarm {
+        swarm: mut listening_swarm,
+        ..
+    } = CoreSwarmBuilder::new(identities.next().unwrap(), &nodes)
+        .build(|id, membership| BlendBehaviourBuilder::new(id, membership).build());
+    let (listening_node, _) = listening_swarm
+        .listen_and_return_membership_entry(None)
+        .await;
+    spawn(async move { listening_swarm.run().await });
+
+    // The membership points at the right address but the wrong identity.
+    let wrong_peer_id = PeerId::random();
+    let EdgeTestSwarm { mut swarm, .. } =
+        EdgeSwarmBuilder::new(Membership::new_without_local(from_ref(&Node {
+            address: listening_node.address.clone(),
+            id: wrong_peer_id,
+            public_key: UnsecuredEd25519Key::generate_with_blake_rng().public_key(),
+        })))
+        // Generous retry budget: if the error were treated as recoverable we
+        // would see further attempts after the backoff below.
+        .with_max_dial_attempts(3)
+        .build();
+
+    swarm.send_message(&TestEncapsulatedMessage::new(b"test-payload"));
+
+    // The first (and only) dial fails with a wrong-peer-id error.
+    swarm
+        .poll_next_until(|event| {
+            let SwarmEvent::OutgoingConnectionError { peer_id, .. } = event else {
+                return false;
+            };
+            *peer_id == Some(wrong_peer_id)
+        })
+        .await;
+
+    // The first backoff would be 2^1 = 2s. Wait past it: no second attempt may
+    // be made, and the peer must be gone from the pending dials.
+    let no_second_attempt = time::timeout(
+        time::Duration::from_secs(4),
+        swarm.poll_next_until(|event| {
+            let SwarmEvent::OutgoingConnectionError { peer_id, .. } = event else {
+                return false;
+            };
+            *peer_id == Some(wrong_peer_id)
+        }),
+    )
+    .await;
+    assert!(
+        no_second_attempt.is_err(),
+        "an unrecoverable dial failure must not be retried"
+    );
+    assert!(
+        swarm.pending_dials().is_empty(),
+        "the abandoned peer must not be left pending"
+    );
+}
+
+/// A peer abandoned as unrecoverable stays excluded for the rest of the
+/// membership's life, so later messages are not spent re-dialing it.
+#[test(tokio::test)]
+async fn edge_excludes_unrecoverable_peer_from_later_sends() {
+    let (mut identities, nodes) = new_nodes_with_empty_address(1);
+    let CoreTestSwarm {
+        swarm: mut listening_swarm,
+        ..
+    } = CoreSwarmBuilder::new(identities.next().unwrap(), &nodes)
+        .build(|id, membership| BlendBehaviourBuilder::new(id, membership).build());
+    let (listening_node, _) = listening_swarm
+        .listen_and_return_membership_entry(None)
+        .await;
+    spawn(async move { listening_swarm.run().await });
+
+    let wrong_peer_id = PeerId::random();
+    let EdgeTestSwarm { mut swarm, .. } =
+        EdgeSwarmBuilder::new(Membership::new_without_local(from_ref(&Node {
+            address: listening_node.address.clone(),
+            id: wrong_peer_id,
+            public_key: UnsecuredEd25519Key::generate_with_blake_rng().public_key(),
+        })))
+        .build();
+
+    swarm.send_message(&TestEncapsulatedMessage::new(b"first"));
+    swarm
+        .poll_next_until(|event| {
+            let SwarmEvent::OutgoingConnectionError { peer_id, .. } = event else {
+                return false;
+            };
+            *peer_id == Some(wrong_peer_id)
+        })
+        .await;
+
+    // The only member is now known-unusable, so a second message finds no peer
+    // to dial at all rather than repeating the doomed dial.
+    swarm.send_message(&TestEncapsulatedMessage::new(b"second"));
+    assert!(
+        swarm.pending_dials().is_empty(),
+        "a peer abandoned as unrecoverable must not be chosen for later messages"
     );
 }

--- a/services/blend/src/edge/handlers.rs
+++ b/services/blend/src/edge/handlers.rs
@@ -1,7 +1,10 @@
 use std::{hash::Hash, marker::PhantomData, sync::Arc};
 
 use lb_blend::{
-    message::crypto::proofs::PoQVerificationInputsMinusSigningKey,
+    message::{
+        Error as MessageError, crypto::proofs::PoQVerificationInputsMinusSigningKey,
+        encap::validated::EncapsulatedMessageWithVerifiedPublicHeader,
+    },
     scheduling::{
         membership::Membership,
         message_blend::{
@@ -15,7 +18,7 @@ use lb_utils::blake_rng::BlakeRng;
 use overwatch::overwatch::OverwatchHandle;
 use rand::SeedableRng as _;
 
-use crate::edge::{LOG_TARGET, RunningSettings as Settings, backends::BlendBackend};
+use crate::edge::{RunningSettings as Settings, backends::BlendBackend};
 
 pub struct MessageHandler<Backend, NodeId, ProofsGenerator, RuntimeServiceId> {
     cryptographic_processor: EpochCryptographicProcessor<NodeId, ProofsGenerator>,
@@ -116,39 +119,48 @@ where
     Backend: BlendBackend<NodeId, RuntimeServiceId> + Sync,
     ProofsGenerator: LeaderAndPowProofsGenerator,
 {
-    /// Blend a block proposal, spending leadership quota on its layer proofs.
-    pub async fn handle_block_proposal_to_blend(&mut self, proposal: &[u8]) {
-        let Ok(message) = self
-            .cryptographic_processor
+    /// Encapsulate a block proposal, spending leadership quota on its layer
+    /// proofs.
+    ///
+    /// A failure is handed back raw for
+    /// [`resolve_encapsulation`](crate::pending::resolve_encapsulation) to
+    /// judge, since only it knows whether the message stays queued. Leadership
+    /// proofs are not simply there for the asking: they need this epoch's
+    /// secret `PoL` info, which can land after the first proposal does.
+    pub async fn encapsulate_block_proposal(
+        &mut self,
+        proposal: &[u8],
+    ) -> Result<EncapsulatedMessageWithVerifiedPublicHeader, MessageError> {
+        self.cryptographic_processor
             .encapsulate_block_proposal_payload(proposal)
             .await
-            .inspect_err(|e| {
-                tracing::error!(target: LOG_TARGET, "Failed to encapsulate block proposal: {e:?}");
-            })
-        else {
-            return;
-        };
-        self.backend.send(message).await;
     }
 
-    /// Blend a transaction, whose layer proofs are backed by a proof of work.
+    /// Encapsulate a transaction, whose layer proofs are backed by a proof of
+    /// work.
     ///
-    /// Unlike a block proposal this cannot be answered on demand: the proofs
-    /// come from a puzzle search, so the caller has to be somewhere it can
-    /// afford to wait.
-    /// Returns `None` if the transaction could not be encapsulated, so the
-    /// caller can leave it queued and try again rather than losing it.
-    pub async fn handle_transaction_to_blend(&mut self, transaction: &[u8]) -> Option<()> {
-        let message = self
-            .cryptographic_processor
+    /// Those proofs come from a puzzle search, so the caller has to be
+    /// somewhere it can afford to wait. A failure is handed back raw, as above.
+    pub async fn encapsulate_transaction(
+        &mut self,
+        transaction: &[u8],
+    ) -> Result<EncapsulatedMessageWithVerifiedPublicHeader, MessageError> {
+        self.cryptographic_processor
             .encapsulate_transaction_payload(transaction)
             .await
-            .inspect_err(|e| {
-                tracing::error!(target: LOG_TARGET, "Failed to encapsulate transaction: {e:?}");
-            })
-            .ok()?;
+    }
+
+    /// Hand a finished message to the backend.
+    ///
+    /// Kept apart from the encapsulation that produced it so the caller can put
+    /// this where cancellation cannot reach it — see
+    /// [`send_local_encapsulated_message`](super::send_local_encapsulated_message).
+    #[expect(
+        clippy::needless_pass_by_ref_mut,
+        reason = "The exclusive borrow is what keeps this future `Send` without a `Sync` bound."
+    )]
+    pub async fn send(&mut self, message: EncapsulatedMessageWithVerifiedPublicHeader) {
         self.backend.send(message).await;
-        Some(())
     }
 }
 

--- a/services/blend/src/edge/mod.rs
+++ b/services/blend/src/edge/mod.rs
@@ -47,7 +47,7 @@ use overwatch::{
 };
 use settings::StartingBlendConfig;
 use tokio::sync::oneshot;
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, warn};
 
 use crate::{
     edge::{
@@ -307,7 +307,7 @@ where
         tokio::select! {
             Some(EpochEvent::NewEpoch(new_public_epoch_info)) = remaining_public_epoch_stream.next() => {
                 current_epoch_info = new_public_epoch_info;
-                match handle_new_epoch_event(&current_epoch_info, &mut current_secret_epoch_info, &mut current_epoch_message_handler, settings.clone(), overwatch_handle.clone()) {
+                match handle_new_public_epoch_event(&current_epoch_info, &mut current_secret_epoch_info, &mut current_epoch_message_handler, &mut pending_messages, settings.clone(), overwatch_handle.clone()) {
                     Err(Error::NetworkIsTooSmall(_)) => {
                         info!(target: LOG_TARGET, "New membership does not satisfy edge node condition, edge service shutting down.");
                         return Ok(());
@@ -421,6 +421,42 @@ where
     };
 
     resolve_encapsulation(encapsulated, wrap_fn)
+}
+
+/// Handles the start of a new *public* epoch: the one this node was in has
+/// ended.
+///
+/// Split from [`handle_new_epoch_event`], which also runs when this epoch's
+/// secret `PoL` info arrives — that is not an epoch change, and a proposal
+/// queued waiting for exactly that info has to survive it. Only a real epoch
+/// change invalidates queued proposals; see [`PendingLocalMessages`] for why
+/// they cannot outlive it.
+fn handle_new_public_epoch_event<Backend, NodeId, ProofsGenerator, RuntimeServiceId>(
+    current_public_epoch_info: &BlendEpochState<NodeId>,
+    maybe_current_secret_epoch_info: &mut Option<PolEpochInfo>,
+    current_epoch_message_handler: &mut Option<
+        MessageHandler<Backend, NodeId, ProofsGenerator, RuntimeServiceId>,
+    >,
+    pending_messages: &mut PendingLocalMessages,
+    settings: RunningSettings<Backend, NodeId, RuntimeServiceId>,
+    overwatch_handle: OverwatchHandle<RuntimeServiceId>,
+) -> Result<(), Error>
+where
+    Backend: BlendBackend<NodeId, RuntimeServiceId>,
+    NodeId: Clone + Eq + Hash + Send + Sync + 'static,
+    ProofsGenerator: LeaderAndPowProofsGenerator,
+{
+    let discarded = pending_messages.discard_proposals();
+    if discarded > 0 {
+        warn!(target: LOG_TARGET, "Dropping {discarded} block proposal(s) still queued when the epoch ended.");
+    }
+    handle_new_epoch_event(
+        current_public_epoch_info,
+        maybe_current_secret_epoch_info,
+        current_epoch_message_handler,
+        settings,
+        overwatch_handle,
+    )
 }
 
 fn handle_new_epoch_event<Backend, NodeId, ProofsGenerator, RuntimeServiceId>(

--- a/services/blend/src/edge/mod.rs
+++ b/services/blend/src/edge/mod.rs
@@ -5,8 +5,8 @@ pub mod settings;
 #[cfg(test)]
 mod tests;
 
+use core::num::NonZeroU64;
 use std::{
-    collections::VecDeque,
     fmt::{Debug, Display},
     hash::Hash,
     marker::PhantomData,
@@ -16,7 +16,10 @@ use std::{
 use backends::BlendBackend;
 use futures::{Stream, StreamExt as _};
 use lb_blend::{
-    message::crypto::proofs::PoQVerificationInputsMinusSigningKey,
+    message::{
+        crypto::proofs::PoQVerificationInputsMinusSigningKey,
+        encap::validated::EncapsulatedMessageWithVerifiedPublicHeader,
+    },
     proofs::quota::inputs::prove::public::{CoreInputs, LeaderInputs, PowInputs},
     scheduling::{
         epoch::{EpochEvent, UninitializedEpochEventStream},
@@ -55,6 +58,7 @@ use crate::{
     kms::PreloadKmsService,
     membership::{self, chain::BlendEpochState, node_id},
     message::{BlendPayload, NetworkInfo, ServiceMessage},
+    pending::{LocalEncapsulation, NextLocalMessage, PendingLocalMessages, resolve_encapsulation},
 };
 
 const LOG_TARGET: &str = blend::service::EDGE;
@@ -294,7 +298,7 @@ where
 
     let mut current_secret_epoch_info: Option<PolEpochInfo> = None;
     // Transactions waiting for a `PoW` solution to back their layer proofs.
-    let mut pending_transactions: VecDeque<Vec<u8>> = VecDeque::new();
+    let mut pending_messages = PendingLocalMessages::new();
     let mut current_epoch_message_handler: Option<
         MessageHandler<Backend, NodeId, ProofsGenerator, RuntimeServiceId>,
     > = None;
@@ -332,18 +336,11 @@ where
             Some(message) = inbound_relay.next() => {
                 match message {
                     ServiceMessage::Blend(BlendPayload::Transaction(transaction)) => {
-                        pending_transactions.push_back(transaction);
+                        pending_messages.queue_transaction(transaction);
                     }
                     ServiceMessage::Blend(BlendPayload::BlockProposal(proposal)) => {
-                        // TODO: Investigate why secret PoL info at times arrives after the block proposal.
-                        let Some(handler) = current_epoch_message_handler.as_mut() else {
-                            tracing::warn!(target: LOG_TARGET, "Received a message to blend, but no active message handler is available to process it because the secret PoL info for the current epoch is not yet available. Ignoring the message.");
-                            continue;
-                        };
-                        let message_copies = settings.data_replication_factor.checked_add(1).expect("Data replication factor should not overflow when incremented.");
-                        for _ in 0..message_copies {
-                            handler.handle_block_proposal_to_blend(&proposal).await;
-                        }
+                        let proposal_copies = NonZeroU64::new(settings.data_replication_factor.checked_add(1).expect("Data replication factor should not overflow when incremented.")).expect("Number of block proposal copies cannot be zero by definition.");
+                        pending_messages.queue_proposal(proposal, proposal_copies);
                     }
                     ServiceMessage::GetNetworkInfo { reply } => {
                         drop(reply.send(Some(NetworkInfo {
@@ -352,14 +349,27 @@ where
                         })));
                     }
                     ServiceMessage::GetPendingTransactions { reply } => {
-                        drop(reply.send(pending_transactions.iter().cloned().collect()));
+                        drop(reply.send(pending_messages.transactions().cloned().collect()));
                     }
                 }
             }
             // A queued transaction leaves as soon as a `PoW` solution backs it, awaited
             // here as one branch among the others so the loop keeps turning meanwhile.
-            Some(()) = blend_next_transaction(&pending_transactions, &mut current_epoch_message_handler) => {
-                drop(pending_transactions.pop_front());
+            // Both kinds share one branch because both need the handler mutably,
+            // and `select!` builds every branch future before any of them wins.
+            Some(encapsulation_result) = encapsulate_next_local_message(&pending_messages, &mut current_epoch_message_handler) => {
+                let current_epoch_message_handler = current_epoch_message_handler.as_mut().expect("Message handler must exist for a message that was just encapsulated.");
+                match encapsulation_result {
+                    Ok(LocalEncapsulation::ProposalCopy(message)) => {
+                        current_epoch_message_handler.send(message).await;
+                        pending_messages.mark_proposal_copy_as_sent();
+                    }
+                    Ok(LocalEncapsulation::Transaction(message)) => {
+                        current_epoch_message_handler.send(message).await;
+                        drop(pending_messages.mark_transaction_as_sent());
+                    }
+                    Err(()) => drop(pending_messages.discard_head()),
+                }
             }
             else => {
                 // All input streams have terminated (e.g. disorderly shutdown).
@@ -371,34 +381,46 @@ where
     }
 }
 
-/// Blends the transaction that has been waiting longest, once a `PoW` solution
-/// backs its layer proofs.
+/// Encapsulates one locally-originated message, once a handler exists to make
+/// it and proofs back it.
 ///
-/// The transaction is only read here, never taken off the queue: `select!`
-/// drops this future whenever another branch wins the race, and one that popped
-/// before awaiting would take the transaction down with it every time that
-/// happened. It comes off the queue in the branch handler instead, which runs
-/// once the race is settled.
+/// Proposals go first: one is tied to the slot it was built for and goes stale,
+/// whereas a transaction keeps.
 ///
-/// Returns `None` when there is nothing to blend — no transaction queued, or no
-/// handler for this epoch yet — which is what leaves the `select!` branch free
-/// to wait on the others.
-async fn blend_next_transaction<Backend, NodeId, ProofsGenerator, RuntimeServiceId>(
-    pending_transactions: &VecDeque<Vec<u8>>,
+/// Neither queue is popped here either, for the same reason: one that popped
+/// before awaiting would take the message down with it every time this future
+/// was dropped. The caller updates the queues once the race is settled, which
+/// is also why only one copy of a proposal is wrapped per call.
+///
+/// Returns `None` when there is nothing to hand back — nothing queued, no
+/// handler for this epoch yet, or no proofs — which is what leaves the branch
+/// free to wait on the others.
+async fn encapsulate_next_local_message<Backend, NodeId, ProofsGenerator, RuntimeServiceId>(
+    pending_messages: &PendingLocalMessages,
     current_epoch_message_handler: &mut Option<
         MessageHandler<Backend, NodeId, ProofsGenerator, RuntimeServiceId>,
     >,
-) -> Option<()>
+) -> Option<Result<LocalEncapsulation, ()>>
 where
     Backend: BlendBackend<NodeId, RuntimeServiceId> + Sync,
     NodeId: Clone + Debug + Eq + Hash + Send + Sync + 'static,
     ProofsGenerator: LeaderAndPowProofsGenerator + Send,
 {
-    let transaction = pending_transactions.front()?;
-    current_epoch_message_handler
-        .as_mut()?
-        .handle_transaction_to_blend(transaction)
-        .await
+    type Wrap = fn(EncapsulatedMessageWithVerifiedPublicHeader) -> LocalEncapsulation;
+
+    let handler = current_epoch_message_handler.as_mut()?;
+    let (encapsulated, wrap_fn): (_, Wrap) = match pending_messages.next()? {
+        NextLocalMessage::ProposalCopy(proposal) => (
+            handler.encapsulate_block_proposal(proposal).await,
+            LocalEncapsulation::ProposalCopy,
+        ),
+        NextLocalMessage::Transaction(transaction) => (
+            handler.encapsulate_transaction(transaction).await,
+            LocalEncapsulation::Transaction,
+        ),
+    };
+
+    resolve_encapsulation(encapsulated, wrap_fn)
 }
 
 fn handle_new_epoch_event<Backend, NodeId, ProofsGenerator, RuntimeServiceId>(

--- a/services/blend/src/edge/tests/mod.rs
+++ b/services/blend/src/edge/tests/mod.rs
@@ -2,25 +2,33 @@ use core::time::Duration;
 
 use futures::stream::repeat;
 use lb_blend::{
+    message::MAX_PAYLOAD_BODY_SIZE,
     proofs::quota::inputs::prove::private::ProofOfLeadershipQuotaInputs,
     scheduling::membership::Membership,
 };
 use lb_chain_service::Epoch;
 use lb_core::crypto::ZkHash;
 use lb_groth16::{AdditiveGroup as _, Fr};
-use tokio::time::sleep;
+use tokio::{
+    sync::oneshot,
+    time::{sleep, timeout},
+};
 
 use crate::{
     edge::{
         handlers::Error,
         tests::utils::{
             MockLeaderProofsGenerator, NodeId, TestBackend, overwatch_handle, settings, spawn_run,
+            spawn_run_with_pol,
         },
     },
     epoch_info::PolEpochInfo,
     membership::chain::BlendEpochState,
-    message::BlendPayload,
-    test_utils::membership::membership,
+    message::{BlendPayload, ServiceMessage},
+    test_utils::{
+        epoch::{GatedPolStreamProvider, PolGate},
+        membership::membership,
+    },
 };
 
 pub mod utils;
@@ -354,5 +362,98 @@ async fn private_then_public_same_epoch_creates_handler() {
             .expect("Handler must be created")
             .epoch(),
         Epoch::new(1)
+    );
+}
+
+/// A block proposal that arrives before this epoch's secret `PoL` info still
+/// goes out once it lands.
+///
+/// An edge node has no message handler at all until the secret `PoL` info
+/// arrives, and that regularly happens *after* the first proposal does — most
+/// visibly at startup, when the node wins the very first slot it is asked to
+/// lead. The proposal used to be dropped with a warning in that window,
+/// silently losing a block this node had just produced.
+#[test_log::test(tokio::test)]
+async fn a_proposal_arriving_before_the_pol_info_is_still_blended() {
+    let local_node = NodeId(99);
+    let core_node = NodeId(0);
+
+    // Installed before the service exists, so the shut gate is in place from the
+    // first poll of the stream.
+    let pol_gate = PolGate::setup();
+
+    let (_join_handle, _epoch_sender, msg_sender, mut node_id_receiver) =
+        spawn_run_with_pol::<GatedPolStreamProvider>(
+            local_node,
+            1,
+            Some(membership(&[core_node], local_node)),
+        )
+        .await;
+
+    // The gate is shut, so there is no handler yet: this is the window the
+    // proposal used to die in.
+    msg_sender
+        .send(ServiceMessage::Blend(BlendPayload::BlockProposal(
+            b"proposal".to_vec(),
+        )))
+        .await
+        .unwrap();
+
+    // Answering a request proves the service went round the inbound arm again,
+    // so the proposal ahead of it has already been handled. Without this the
+    // gate could open first and the test would pass on a proposal that was
+    // never queued at all.
+    let (reply, answered) = oneshot::channel();
+    msg_sender
+        .send(ServiceMessage::GetPendingTransactions { reply })
+        .await
+        .unwrap();
+    answered.await.unwrap();
+
+    pol_gate.release();
+
+    assert_eq!(
+        timeout(Duration::from_secs(5), node_id_receiver.recv())
+            .await
+            .expect("the proposal should have been held until a handler existed"),
+        Some(core_node)
+    );
+}
+
+/// A message that can never be encapsulated is dropped rather than left
+/// blocking everything queued behind it.
+///
+/// The head of the queue is retried before anything else is looked at, so one
+/// that keeps failing — a payload too large to fit, which will not shrink by
+/// waiting — would take the whole queue down with it.
+#[test_log::test(tokio::test)]
+async fn a_message_that_can_never_be_sent_does_not_block_the_rest() {
+    let local_node = NodeId(99);
+    let core_node = NodeId(0);
+
+    let (_join_handle, _epoch_sender, msg_sender, mut node_id_receiver) =
+        spawn_run(local_node, 1, Some(membership(&[core_node], local_node))).await;
+
+    // One byte over what a payload can hold, so encapsulating it fails the same
+    // way however long it waits.
+    msg_sender
+        .send(ServiceMessage::Blend(BlendPayload::BlockProposal(vec![
+            0;
+            MAX_PAYLOAD_BODY_SIZE + 1
+        ])))
+        .await
+        .unwrap();
+    msg_sender
+        .send(ServiceMessage::Blend(BlendPayload::Transaction(
+            b"transaction".to_vec(),
+        )))
+        .await
+        .unwrap();
+
+    assert_eq!(
+        timeout(Duration::from_secs(5), node_id_receiver.recv())
+            .await
+            .expect("the transaction behind the oversized proposal should still go out"),
+        Some(core_node)
     );
 }

--- a/services/blend/src/edge/tests/mod.rs
+++ b/services/blend/src/edge/tests/mod.rs
@@ -10,7 +10,7 @@ use lb_chain_service::Epoch;
 use lb_core::crypto::ZkHash;
 use lb_groth16::{AdditiveGroup as _, Fr};
 use tokio::{
-    sync::oneshot,
+    sync::{mpsc, oneshot},
     time::{sleep, timeout},
 };
 
@@ -25,6 +25,7 @@ use crate::{
     epoch_info::PolEpochInfo,
     membership::chain::BlendEpochState,
     message::{BlendPayload, ServiceMessage},
+    pending::{NextLocalMessage, PendingLocalMessages},
     test_utils::{
         epoch::{GatedPolStreamProvider, PolGate},
         membership::membership,
@@ -171,7 +172,7 @@ fn test_pol_epoch_info(epoch: Epoch) -> PolEpochInfo {
 async fn handle_new_secret_epoch_info_recreates_handler() {
     let local_node = NodeId(99);
     let core_node = NodeId(0);
-    let (node_id_sender, _node_id_receiver) = tokio::sync::mpsc::channel(1);
+    let (node_id_sender, _node_id_receiver) = mpsc::channel(1);
 
     let settings = settings(local_node, 1, node_id_sender);
     let overwatch = overwatch_handle();
@@ -231,7 +232,7 @@ fn test_blend_epoch_state(epoch: Epoch, membership: Membership<NodeId>) -> Blend
 async fn two_publics_without_private_in_between() {
     let local_node = NodeId(99);
     let core_node = NodeId(0);
-    let (node_id_sender, _node_id_receiver) = tokio::sync::mpsc::channel(1);
+    let (node_id_sender, _node_id_receiver) = mpsc::channel(1);
 
     let settings = settings(local_node, 1, node_id_sender);
     let overwatch = overwatch_handle();
@@ -275,7 +276,7 @@ async fn two_publics_without_private_in_between() {
 async fn public_then_private_same_epoch_creates_handler() {
     let local_node = NodeId(99);
     let core_node = NodeId(0);
-    let (node_id_sender, _node_id_receiver) = tokio::sync::mpsc::channel(1);
+    let (node_id_sender, _node_id_receiver) = mpsc::channel(1);
 
     let settings = settings(local_node, 1, node_id_sender);
     let overwatch = overwatch_handle();
@@ -321,7 +322,7 @@ async fn public_then_private_same_epoch_creates_handler() {
 async fn private_then_public_same_epoch_creates_handler() {
     let local_node = NodeId(99);
     let core_node = NodeId(0);
-    let (node_id_sender, _node_id_receiver) = tokio::sync::mpsc::channel(1);
+    let (node_id_sender, _node_id_receiver) = mpsc::channel(1);
 
     let settings = settings(local_node, 1, node_id_sender);
     let overwatch = overwatch_handle();
@@ -455,5 +456,77 @@ async fn a_message_that_can_never_be_sent_does_not_block_the_rest() {
             .await
             .expect("the transaction behind the oversized proposal should still go out"),
         Some(core_node)
+    );
+}
+
+/// A proposal still queued when the public epoch rotates is dropped; a
+/// transaction is not.
+///
+/// Leadership quota is one message's worth per winning slot, so a proposal that
+/// missed its epoch would spend the quota the new epoch's own block needs.
+#[test_log::test(tokio::test)]
+async fn a_new_public_epoch_discards_queued_proposals() {
+    let local_node = NodeId(99);
+    let core_node = NodeId(0);
+    let (node_id_sender, _node_id_receiver) = mpsc::channel(1);
+    let settings = settings(local_node, 1, node_id_sender);
+
+    let mut handler_state: Option<
+        super::handlers::MessageHandler<TestBackend, NodeId, MockLeaderProofsGenerator, usize>,
+    > = None;
+    let mut pending_messages = PendingLocalMessages::new();
+    pending_messages.queue_proposal(b"proposal".to_vec(), 2.try_into().unwrap());
+    pending_messages.queue_transaction(b"transaction".to_vec());
+
+    super::handle_new_public_epoch_event(
+        &test_blend_epoch_state(Epoch::new(1), membership(&[core_node], local_node)),
+        &mut Some(test_pol_epoch_info(Epoch::new(1))),
+        &mut handler_state,
+        &mut pending_messages,
+        settings,
+        overwatch_handle(),
+    )
+    .unwrap();
+
+    assert_eq!(
+        pending_messages.next(),
+        Some(NextLocalMessage::Transaction(b"transaction")),
+        "the proposal must not survive the rotation, and the transaction must"
+    );
+}
+
+/// Secret `PoL` info arriving is not an epoch change, so it must leave queued
+/// proposals alone.
+///
+/// This is the window the queue exists for: a proposal that landed before this
+/// epoch's leadership proofs were possible is waiting for exactly this event.
+/// Discarding here would put back the bug the queue removes.
+#[test_log::test(tokio::test)]
+async fn secret_pol_info_arriving_keeps_queued_proposals() {
+    let local_node = NodeId(99);
+    let core_node = NodeId(0);
+    let (node_id_sender, _node_id_receiver) = mpsc::channel(1);
+    let settings = settings(local_node, 1, node_id_sender);
+
+    let mut handler_state: Option<
+        super::handlers::MessageHandler<TestBackend, NodeId, MockLeaderProofsGenerator, usize>,
+    > = None;
+    let mut pending_messages = PendingLocalMessages::new();
+    pending_messages.queue_proposal(b"proposal".to_vec(), 2.try_into().unwrap());
+
+    // The path the secret-`PoL` arm takes, which is not a new epoch.
+    super::handle_new_epoch_event(
+        &test_blend_epoch_state(Epoch::new(1), membership(&[core_node], local_node)),
+        &mut Some(test_pol_epoch_info(Epoch::new(1))),
+        &mut handler_state,
+        settings,
+        overwatch_handle(),
+    )
+    .unwrap();
+
+    assert_eq!(
+        pending_messages.next(),
+        Some(NextLocalMessage::ProposalCopy(b"proposal")),
+        "a proposal waiting for this epoch's leadership proofs must survive them arriving"
     );
 }

--- a/services/blend/src/edge/tests/utils.rs
+++ b/services/blend/src/edge/tests/utils.rs
@@ -30,6 +30,7 @@ use crate::{
         backends::BlendBackend, handlers::Error, run, settings::RunningBlendConfig as BlendConfig,
         tests::test_blend_epoch_state,
     },
+    epoch_info::PolInfoProvider,
     message::ServiceMessage,
     settings::TimingSettings,
     test_utils::{crypto::mock_blend_proof, epoch::OncePolStreamProvider, membership::key},
@@ -65,6 +66,30 @@ pub async fn spawn_run(
     mpsc::Sender<ServiceMessage<NodeId>>,
     mpsc::Receiver<NodeId>,
 ) {
+    spawn_run_with_pol::<OncePolStreamProvider>(
+        local_node,
+        minimal_network_size,
+        initial_membership,
+    )
+    .await
+}
+
+/// [`spawn_run`], with the source of this epoch's secret `PoL` info left to the
+/// caller — a test that needs to hold it back picks
+/// [`GatedPolStreamProvider`](crate::test_utils::epoch::GatedPolStreamProvider).
+pub async fn spawn_run_with_pol<PolProvider>(
+    local_node: NodeId,
+    minimal_network_size: u64,
+    initial_membership: Option<Membership<NodeId>>,
+) -> (
+    JoinHandle<Result<(), Error>>,
+    mpsc::Sender<Membership<NodeId>>,
+    mpsc::Sender<ServiceMessage<NodeId>>,
+    mpsc::Receiver<NodeId>,
+)
+where
+    PolProvider: PolInfoProvider<usize, Stream: Unpin + Send> + Send + 'static,
+{
     let (epoch_sender, epoch_receiver) = mpsc::channel(1);
     let (msg_sender, msg_receiver) = mpsc::channel(1);
     let (node_id_sender, node_id_receiver) = mpsc::channel(1);
@@ -85,7 +110,7 @@ pub async fn spawn_run(
             TestBackend,
             _,
             MockLeaderProofsGenerator,
-            OncePolStreamProvider,
+            PolProvider,
             _,
         >(
             UninitializedEpochEventStream::new(epoch_stream, Duration::ZERO),

--- a/services/blend/src/lib.rs
+++ b/services/blend/src/lib.rs
@@ -61,6 +61,7 @@ pub mod epoch_info;
 pub mod membership;
 pub mod message;
 pub(crate) mod metrics;
+pub mod pending;
 pub mod settings;
 
 mod instance;

--- a/services/blend/src/pending.rs
+++ b/services/blend/src/pending.rs
@@ -1,0 +1,267 @@
+//! Locally-originated messages waiting for the proofs that will back them.
+
+use core::num::NonZeroU64;
+use std::collections::VecDeque;
+
+use lb_blend::message::{
+    Error as MessageError, encap::validated::EncapsulatedMessageWithVerifiedPublicHeader,
+};
+
+use crate::LOG_TARGET;
+
+/// One locally-originated message, encapsulated and ready for the wire.
+///
+/// Which queue it came from, so the caller knows what to mark as sent once it
+/// is actually out. Both modes produce this; what differs is only the processor
+/// that made it.
+pub enum LocalEncapsulation {
+    ProposalCopy(EncapsulatedMessageWithVerifiedPublicHeader),
+    Transaction(EncapsulatedMessageWithVerifiedPublicHeader),
+}
+
+/// Turns one encapsulation attempt into what the event loop should do about it.
+///
+/// `None` means "nothing to do this time round": the branch backing this
+/// message has no proofs yet, and it stays queued to be retried. `Err(())`
+/// means the head can never be encapsulated and has to go — the head is
+/// retried before anything else is looked at, so one that keeps failing would
+/// take everything queued behind it down with it.
+///
+/// The failure is resolved here rather than handed back because a
+/// [`MessageError`] is not `Send`, and a `select!` branch output has to be.
+pub fn resolve_encapsulation<WrapFn>(
+    encapsulated: Result<EncapsulatedMessageWithVerifiedPublicHeader, MessageError>,
+    wrap: WrapFn,
+) -> Option<Result<LocalEncapsulation, ()>>
+where
+    WrapFn: FnOnce(EncapsulatedMessageWithVerifiedPublicHeader) -> LocalEncapsulation,
+{
+    match encapsulated {
+        Ok(message) => Some(Ok(wrap(message))),
+        Err(error) => match report_encapsulation_failure(&error) {
+            Verdict::Retry => None,
+            Verdict::Discard => Some(Err(())),
+        },
+    }
+}
+
+/// Whether a message that failed to encapsulate is worth keeping.
+enum Verdict {
+    /// A failure that says "not yet": leave the message queued.
+    Retry,
+    /// A failure that will repeat however long the message waits: drop it.
+    Discard,
+}
+
+/// Logs a failed encapsulation at the level it deserves, and says whether the
+/// message should stay queued.
+///
+/// Running out of proofs is the ordinary "not yet" — the branch backing this
+/// message has nothing to give until, say, the epoch's secret `PoL` info lands
+/// — and the message is retried every time the loop turns, so reporting it as
+/// an error would bury the log in noise while waiting. Everything else is a
+/// genuine failure, and a permanent one: a payload too large to fit will not
+/// shrink, so retrying it forever would block everything queued behind it.
+fn report_encapsulation_failure(error: &MessageError) -> Verdict {
+    if matches!(error, MessageError::ProofNotAvailable) {
+        tracing::trace!(target: LOG_TARGET, "No proofs available yet to encapsulate a message. Leaving it queued.");
+        Verdict::Retry
+    } else {
+        tracing::error!(target: LOG_TARGET, "Dropping a message that cannot be encapsulated: {error:?}");
+        Verdict::Discard
+    }
+}
+
+/// What [`PendingLocalMessages::next`] would have the caller work on.
+#[derive(Debug, PartialEq, Eq)]
+pub enum NextLocalMessage<'a> {
+    /// One copy of the longest-waiting block proposal.
+    ProposalCopy(&'a [u8]),
+    /// The longest-waiting transaction.
+    Transaction(&'a [u8]),
+}
+
+/// What [`PendingLocalMessages::discard_head`] dropped, handed back so a caller
+/// that persists its queue can drop it there too.
+#[derive(Debug, PartialEq, Eq)]
+pub enum Discarded {
+    Proposal(Vec<u8>),
+    Transaction(Vec<u8>),
+}
+
+/// The queue of messages this node has produced but not yet put on the wire.
+///
+/// Both modes need the same bookkeeping. A message might not be sent the moment
+/// it arrives: a transaction waits on a `PoW` solution, and a proposal waits on
+/// this epoch's secret `PoL` info, which could land *after* the first
+/// proposal does. Whatever cannot go yet stays here and is retried.
+///
+/// Nothing is removed by looking at it. The branch that does the sending is a
+/// `select!` arm, so its future is dropped whenever another branch wins the
+/// race, and a queue that popped before awaiting would lose the message every
+/// time that happened. The caller reports what actually went out instead, once
+/// the race is settled.
+#[derive(Debug)]
+pub struct PendingLocalMessages {
+    /// Each proposal with the copies it still owes. Proposals are replicated;
+    /// transactions are not.
+    proposals: VecDeque<(Vec<u8>, NonZeroU64)>,
+    transactions: VecDeque<Vec<u8>>,
+}
+
+impl PendingLocalMessages {
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            proposals: VecDeque::new(),
+            transactions: VecDeque::new(),
+        }
+    }
+
+    /// Queues a proposal to be sent `copies` times.
+    pub fn queue_proposal(&mut self, proposal: Vec<u8>, copies: NonZeroU64) {
+        self.proposals.push_back((proposal, copies));
+    }
+
+    pub fn queue_transaction(&mut self, transaction: Vec<u8>) {
+        self.transactions.push_back(transaction);
+    }
+
+    /// The next message to try, or `None` when there is nothing waiting.
+    ///
+    /// Proposals go first: one is tied to the slot it was built for and goes
+    /// stale, whereas a transaction keeps.
+    #[must_use]
+    pub fn next(&self) -> Option<NextLocalMessage<'_>> {
+        if let Some((proposal, _)) = self.proposals.front() {
+            return Some(NextLocalMessage::ProposalCopy(proposal));
+        }
+        self.transactions
+            .front()
+            .map(|transaction| NextLocalMessage::Transaction(transaction))
+    }
+
+    /// Records that one copy of the head proposal went out, dropping it once it
+    /// owes no more.
+    ///
+    /// # Panics
+    ///
+    /// If no proposal is queued, which would mean a copy was reported for a
+    /// message this queue never handed out.
+    pub fn mark_proposal_copy_as_sent(&mut self) {
+        let Some((_, remaining_copies)) = self.proposals.front_mut() else {
+            panic!("A proposal copy was reported sent, but none is queued");
+        };
+        let copies_before = *remaining_copies;
+        // If the copy sent was the last one, drop the proposal from the queue.
+        let Some(copies_after) = NonZeroU64::new(copies_before.get() - 1) else {
+            drop(self.proposals.pop_front());
+            return;
+        };
+        *remaining_copies = copies_after;
+    }
+
+    /// Records that the head transaction went out, handing it back so a caller
+    /// that persists its queue can drop it there too.
+    ///
+    /// # Panics
+    ///
+    /// If no transaction is queued.
+    pub fn mark_transaction_as_sent(&mut self) -> Vec<u8> {
+        self.transactions
+            .pop_front()
+            .expect("A transaction was reported sent, but none is queued")
+    }
+
+    /// Drops the message [`Self::next`] would hand out, for a caller that has
+    /// found it can never be sent — one too large to fit a payload, say, as
+    /// opposed to one merely waiting on proofs.
+    ///
+    /// Without this a message like that would sit at the head forever and take
+    /// everything queued behind it down with it, since the head is retried
+    /// before anything else is looked at. A proposal goes in full, outstanding
+    /// copies and all: every copy would fail the same way.
+    pub fn discard_head(&mut self) -> Option<Discarded> {
+        if let Some((proposal, _)) = self.proposals.pop_front() {
+            return Some(Discarded::Proposal(proposal));
+        }
+        self.transactions.pop_front().map(Discarded::Transaction)
+    }
+
+    /// The transactions still waiting, oldest first.
+    #[must_use]
+    pub fn transactions(&self) -> impl ExactSizeIterator<Item = &Vec<u8>> {
+        self.transactions.iter()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_proposal_goes_before_a_transaction() {
+        let mut pending = PendingLocalMessages::new();
+        pending.queue_transaction(b"tx".to_vec());
+        pending.queue_proposal(b"proposal".to_vec(), 1.try_into().unwrap());
+
+        assert_eq!(
+            pending.next(),
+            Some(NextLocalMessage::ProposalCopy(b"proposal")),
+            "a proposal is slot-bound and stales; a transaction keeps"
+        );
+    }
+
+    #[test]
+    fn a_proposal_stays_until_every_copy_is_out() {
+        let mut pending = PendingLocalMessages::new();
+        pending.queue_proposal(b"proposal".to_vec(), 3.try_into().unwrap());
+        pending.queue_transaction(b"tx".to_vec());
+
+        for _ in 0..3 {
+            assert_eq!(
+                pending.next(),
+                Some(NextLocalMessage::ProposalCopy(b"proposal"))
+            );
+            pending.mark_proposal_copy_as_sent();
+        }
+
+        assert_eq!(
+            pending.next(),
+            Some(NextLocalMessage::Transaction(b"tx")),
+            "the transaction is reached only once the proposal owes nothing"
+        );
+    }
+
+    #[test]
+    fn looking_does_not_consume() {
+        let mut pending = PendingLocalMessages::new();
+        pending.queue_transaction(b"tx".to_vec());
+
+        // However often a `select!` arm is built and dropped without sending,
+        // the message is still there.
+        for _ in 0..3 {
+            assert_eq!(pending.next(), Some(NextLocalMessage::Transaction(b"tx")));
+        }
+        assert_eq!(pending.mark_transaction_as_sent(), b"tx".to_vec());
+        assert_eq!(pending.next(), None);
+    }
+
+    #[test]
+    fn a_message_that_can_never_be_sent_does_not_block_the_rest() {
+        let mut pending = PendingLocalMessages::new();
+        pending.queue_proposal(b"proposal".to_vec(), 3.try_into().unwrap());
+        pending.queue_transaction(b"tx".to_vec());
+
+        assert_eq!(
+            pending.discard_head(),
+            Some(Discarded::Proposal(b"proposal".to_vec())),
+            "outstanding copies go with it: they would all fail the same way"
+        );
+        assert_eq!(
+            pending.next(),
+            Some(NextLocalMessage::Transaction(b"tx")),
+            "what was queued behind it must get its turn"
+        );
+    }
+}

--- a/services/blend/src/pending.rs
+++ b/services/blend/src/pending.rs
@@ -101,12 +101,26 @@ pub enum Discarded {
 /// race, and a queue that popped before awaiting would lose the message every
 /// time that happened. The caller reports what actually went out instead, once
 /// the race is settled.
+///
+/// Queued proposals do not survive an epoch change; queued transactions do.
+/// A proposal is built for one slot, and leadership quota is one message's
+/// worth per winning slot, so a proposal still waiting when the epoch turns
+/// would spend the quota that the *new* epoch's block needs. Losing the block
+/// this node is about to produce is worse than losing one it failed to send in
+/// time. A transaction is not slot-bound and its `PoW` branch is redrawn
+/// anyway, so it stays.
 #[derive(Debug)]
 pub struct PendingLocalMessages {
     /// Each proposal with the copies it still owes. Proposals are replicated;
     /// transactions are not.
     proposals: VecDeque<(Vec<u8>, NonZeroU64)>,
     transactions: VecDeque<Vec<u8>>,
+}
+
+impl Default for PendingLocalMessages {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl PendingLocalMessages {
@@ -171,6 +185,17 @@ impl PendingLocalMessages {
         self.transactions
             .pop_front()
             .expect("A transaction was reported sent, but none is queued")
+    }
+
+    /// Drops every queued proposal, returning how many went, for a caller whose
+    /// epoch has turned over. Transactions are left alone.
+    ///
+    /// See the note on this type for why proposals cannot outlive the epoch
+    /// they were queued in.
+    pub fn discard_proposals(&mut self) -> usize {
+        let discarded = self.proposals.len();
+        self.proposals.clear();
+        discarded
     }
 
     /// Drops the message [`Self::next`] would hand out, for a caller that has
@@ -262,6 +287,24 @@ mod tests {
             pending.next(),
             Some(NextLocalMessage::Transaction(b"tx")),
             "what was queued behind it must get its turn"
+        );
+    }
+
+    #[test]
+    fn an_epoch_change_takes_the_proposals_and_leaves_the_transactions() {
+        let mut pending = PendingLocalMessages::new();
+        pending.queue_proposal(b"proposal".to_vec(), 3.try_into().unwrap());
+        pending.queue_transaction(b"tx".to_vec());
+
+        assert_eq!(
+            pending.discard_proposals(),
+            1,
+            "outstanding copies go with it: they would all spend the new epoch's quota"
+        );
+        assert_eq!(
+            pending.next(),
+            Some(NextLocalMessage::Transaction(b"tx")),
+            "a transaction is not slot-bound and outlives the epoch it arrived in"
         );
     }
 }

--- a/services/blend/src/test_utils/crypto.rs
+++ b/services/blend/src/test_utils/crypto.rs
@@ -236,3 +236,45 @@ impl<CorePoQGenerator> CoreLeaderAndPowProofsGenerator<CorePoQGenerator>
         Some(mock_blend_proof())
     }
 }
+
+/// A generator whose leadership branch, like the real one, has nothing to give
+/// until this epoch's secret `PoL` info arrives.
+///
+/// `RealCoreAndLeaderProofsGenerator` holds its leader generator behind an
+/// `Option` that `set_epoch_private` fills, and returns `None` until then — so
+/// a proposal encapsulated before that point fails outright rather than
+/// waiting.
+pub struct PolAwareProofsGenerator {
+    leadership_available: bool,
+}
+
+#[async_trait]
+impl<CorePoQGenerator> CoreLeaderAndPowProofsGenerator<CorePoQGenerator>
+    for PolAwareProofsGenerator
+{
+    fn new(
+        _settings: ProofsGeneratorSettings,
+        _starting_key_index: KeyIndex,
+        _core_proof_of_quota_generator: CorePoQGenerator,
+    ) -> Self {
+        Self {
+            leadership_available: false,
+        }
+    }
+
+    fn set_epoch_private(&mut self, _: WinningPolInfoStream, _: Epoch) {
+        self.leadership_available = true;
+    }
+
+    async fn get_next_core_proof(&mut self) -> Option<BlendLayerProof> {
+        Some(mock_blend_proof())
+    }
+
+    async fn get_next_leader_proof(&mut self) -> Option<BlendLayerProof> {
+        self.leadership_available.then(mock_blend_proof)
+    }
+
+    async fn get_next_pow_proof(&mut self) -> Option<BlendLayerProof> {
+        Some(mock_blend_proof())
+    }
+}

--- a/services/blend/src/test_utils/epoch.rs
+++ b/services/blend/src/test_utils/epoch.rs
@@ -1,3 +1,5 @@
+use core::cell::RefCell;
+
 use async_trait::async_trait;
 use futures::{
     Stream,
@@ -9,6 +11,7 @@ use lb_chain_service::Epoch;
 use lb_core::crypto::ZkHash;
 use lb_groth16::AdditiveGroup as _;
 use overwatch::overwatch::OverwatchHandle;
+use tokio::sync::watch;
 
 use crate::epoch_info::{PolEpochInfo, PolInfoProvider};
 
@@ -31,6 +34,65 @@ impl<RuntimeServiceId> PolInfoProvider<RuntimeServiceId> for OncePolStreamProvid
                 aged_path_and_selectors: [(ZkHash::ZERO, false); _],
                 secret_key: ZkHash::ZERO,
             })),
+        }))))
+    }
+}
+
+thread_local! {
+    static POL_GATE: RefCell<Option<watch::Receiver<bool>>> = const { RefCell::new(None) };
+}
+
+/// Holds this epoch's secret `PoL` info back until [`Self::release`] is called,
+/// so a test can occupy the window in which a node knows its membership but
+/// cannot yet build leadership proofs — the window a block proposal used to be
+/// dropped in.
+///
+/// Level-triggered like [`crate::test_utils::crypto::PowGate`]: the stream is
+/// polled repeatedly, so an edge-triggered gate would lose the release.
+pub struct PolGate(watch::Sender<bool>);
+
+impl PolGate {
+    /// Sets up a closed gate for providers subscribed on this thread.
+    #[must_use]
+    pub fn setup() -> Self {
+        let (sender, receiver) = watch::channel(false);
+        POL_GATE.with_borrow_mut(|gate| *gate = Some(receiver));
+        Self(sender)
+    }
+
+    /// Lets the secret `PoL` info through, now and from now on.
+    pub fn release(&self) {
+        self.0.send_replace(true);
+    }
+}
+
+/// Yields the same single [`PolEpochInfo`] as [`OncePolStreamProvider`], but
+/// not until a [`PolGate`] opens.
+pub struct GatedPolStreamProvider;
+
+#[async_trait]
+impl<RuntimeServiceId> PolInfoProvider<RuntimeServiceId> for GatedPolStreamProvider {
+    type Stream = Box<dyn Stream<Item = PolEpochInfo> + Send + Unpin>;
+
+    async fn subscribe(
+        _overwatch_handle: &OverwatchHandle<RuntimeServiceId>,
+    ) -> Option<Self::Stream> {
+        let mut gate = POL_GATE.with_borrow(Clone::clone)?;
+        Some(Box::new(Box::pin(once(async move {
+            gate.wait_for(|open| *open)
+                .await
+                .expect("the gate should outlive the provider");
+            PolEpochInfo {
+                epoch: Epoch::new(0),
+                winning_pol_info_stream: Box::pin(repeat(ProofOfLeadershipQuotaInputs {
+                    slot: 1,
+                    note_value: 1,
+                    transaction_hash: ZkHash::ZERO,
+                    output_number: 1,
+                    aged_path_and_selectors: [(ZkHash::ZERO, false); _],
+                    secret_key: ZkHash::ZERO,
+                })),
+            }
         }))))
     }
 }


### PR DESCRIPTION
## 1. What does this PR implement?

There are cases where Blend receives a block to blend before the private PoL stream yields the winning slot info. We used to discard that block. We now keep it around, and also improve the tokio-friendliness of our release pipeline akin to what we did for pending transactions. This is done also for core and edge services.

Since now message encapsulation is fully async, it does not block the main tokio select loop, in the unlikely event that the node is not able to fully encapsulate an outgoing block proposal before an epoch change, we drop the block proposal since we don't want to use the new epoch's leadership quota for an old block proposal. The node self-applies the proposal anyway, so it will build a new block on top of that and other nodes will retrieve the old block via some other means.

## 2. Does the code have enough context to be clearly understood?

Yes.

## 3. Who are the specification authors and who is accountable for this PR?

@ntn-x2 @youngjoon-lee 

## 4. Is the specification accurate and complete?

Yes.

## 5. Does the implementation introduce changes in the specification?

No.