### PR TITLE
chore(blend): group components related to old epoch on core service shutdown

### DIFF
--- a/services/blend/src/core/epoch_stages/mod.rs
+++ b/services/blend/src/core/epoch_stages/mod.rs
@@ -3,6 +3,7 @@ use lb_blend::provers::crypto::EncapsulatedMessageWithVerifiedPublicHeader;
 use crate::message::ProcessedMessage;
 
 pub mod retiring;
+pub mod running;
 pub mod transitioning;
 
 type OldEpochScheduler<Rng> = lb_blend::scheduling::message_scheduler::OldEpochMessageScheduler<

--- a/services/blend/src/core/epoch_stages/mod.rs
+++ b/services/blend/src/core/epoch_stages/mod.rs
@@ -1,0 +1,12 @@
+use lb_blend::provers::crypto::EncapsulatedMessageWithVerifiedPublicHeader;
+
+use crate::message::ProcessedMessage;
+
+pub mod retiring;
+pub mod transitioning;
+
+type OldEpochScheduler<Rng> = lb_blend::scheduling::message_scheduler::OldEpochMessageScheduler<
+    Rng,
+    ProcessedMessage,
+    EncapsulatedMessageWithVerifiedPublicHeader,
+>;

--- a/services/blend/src/core/epoch_stages/retiring.rs
+++ b/services/blend/src/core/epoch_stages/retiring.rs
@@ -1,0 +1,61 @@
+use lb_blend::message::reward::OldEpochBlendingTokenCollector;
+use lb_chain_service::Epoch;
+
+use crate::core::{
+    OldEpochCryptographicProcessor as Processor,
+    epoch_stages::{OldEpochScheduler, transitioning::TransitioningEpoch},
+};
+
+/// Everything a node leaving core mode still has to finish: the epoch it is
+/// draining, and the blending tokens that epoch is owed for.
+///
+/// The two travel together because retirement is where they stop having
+/// separate owners. While the service keeps running the tokens live in the
+/// recovery state, so [`TransitioningEpoch`] alone is what the event loop
+/// carries.
+pub struct RetiringEpoch<Rng, ProofsVerifier> {
+    transitioning: TransitioningEpoch<Rng, ProofsVerifier>,
+    tokens: OldEpochBlendingTokenCollector,
+}
+
+impl<Rng, ProofsVerifier> RetiringEpoch<Rng, ProofsVerifier> {
+    pub const fn new(
+        transitioning: TransitioningEpoch<Rng, ProofsVerifier>,
+        tokens: OldEpochBlendingTokenCollector,
+    ) -> Self {
+        Self {
+            transitioning,
+            tokens,
+        }
+    }
+
+    /// The epoch being drained, which every message it releases is published
+    /// under.
+    pub const fn epoch(&self) -> Epoch {
+        self.transitioning.epoch()
+    }
+
+    pub const fn scheduler_mut(&mut self) -> &mut OldEpochScheduler<Rng> {
+        self.transitioning.scheduler_mut()
+    }
+
+    /// All three at once, which the incoming-message path needs: it reads the
+    /// old processor to decapsulate, and writes both the old scheduler and the
+    /// token collector with what comes out.
+    pub const fn split_mut(
+        &mut self,
+    ) -> (
+        &Processor<ProofsVerifier>,
+        &mut OldEpochScheduler<Rng>,
+        &mut OldEpochBlendingTokenCollector,
+    ) {
+        let (crypto, scheduler) = self.transitioning.split_mut();
+        (crypto, scheduler, &mut self.tokens)
+    }
+
+    /// The tokens, once there is nothing left to drain and they are worth an
+    /// activity proof.
+    pub fn into_tokens(self) -> OldEpochBlendingTokenCollector {
+        self.tokens
+    }
+}

--- a/services/blend/src/core/epoch_stages/running.rs
+++ b/services/blend/src/core/epoch_stages/running.rs
@@ -1,0 +1,271 @@
+use core::hash::Hash;
+
+use futures::StreamExt as _;
+use lb_blend::{
+    provers::crypto::EncapsulatedMessageWithVerifiedPublicHeader,
+    scheduling::{EpochMessageScheduler, message_scheduler::round_info::RoundInfo},
+};
+use lb_chain_service::Epoch;
+
+use crate::{
+    core::{
+        CoreEpochPublicInfo, CoreLeaderAndPowProofsGenerator,
+        CurrentEpochCryptographicProcessor as CryptoProcessor, OldEpochCryptographicProcessor,
+        encapsulate_next_local_message,
+        epoch_stages::{OldEpochScheduler, transitioning::TransitioningEpoch},
+    },
+    message::ProcessedMessage,
+    pending::{EncapsulationResult, PendingProposals, PendingTransactions},
+};
+
+type MessageScheduler<Rng> =
+    EpochMessageScheduler<Rng, ProcessedMessage, EncapsulatedMessageWithVerifiedPublicHeader>;
+
+/// What scheduling a locally-encapsulated message borrows: see
+/// [`CurrentEpoch::scheduling_borrows`].
+type SchedulingBorrows<'a, NodeId, CorePoQGenerator, ProofsGenerator, ProofsVerifier, Rng> = (
+    &'a mut PendingProposals,
+    &'a CryptoProcessor<NodeId, CorePoQGenerator, ProofsGenerator, ProofsVerifier>,
+    &'a mut MessageScheduler<Rng>,
+);
+
+/// What decapsulating an incoming message borrows while an epoch is
+/// transitioning: see [`CurrentEpochDuringTransition::decapsulation_borrows`].
+type DecapsulationBorrows<'a, NodeId, CorePoQGenerator, ProofsGenerator, ProofsVerifier, Rng> = (
+    &'a mut MessageScheduler<Rng>,
+    &'a mut OldEpochScheduler<Rng>,
+    &'a CryptoProcessor<NodeId, CorePoQGenerator, ProofsGenerator, ProofsVerifier>,
+    &'a OldEpochCryptographicProcessor<ProofsVerifier>,
+);
+
+/// What a rotation consumes: see [`CurrentEpoch::into_components`].
+pub type Components<NodeId, CorePoQGenerator, ProofsGenerator, ProofsVerifier, Rng> = (
+    CryptoProcessor<NodeId, CorePoQGenerator, ProofsGenerator, ProofsVerifier>,
+    MessageScheduler<Rng>,
+    CoreEpochPublicInfo<NodeId>,
+);
+type Round = RoundInfo<ProcessedMessage, EncapsulatedMessageWithVerifiedPublicHeader>;
+
+/// The epoch the node is blending under: what it needs to encapsulate, release
+/// and account for messages minted right now.
+pub struct CurrentEpoch<NodeId, CorePoQGenerator, ProofsGenerator, ProofsVerifier, Rng> {
+    crypto: CryptoProcessor<NodeId, CorePoQGenerator, ProofsGenerator, ProofsVerifier>,
+    scheduler: MessageScheduler<Rng>,
+    epoch_info: CoreEpochPublicInfo<NodeId>,
+    proposals: PendingProposals,
+}
+
+impl<NodeId, CorePoQGenerator, ProofsGenerator, ProofsVerifier, Rng>
+    CurrentEpoch<NodeId, CorePoQGenerator, ProofsGenerator, ProofsVerifier, Rng>
+{
+    pub const fn new(
+        crypto: CryptoProcessor<NodeId, CorePoQGenerator, ProofsGenerator, ProofsVerifier>,
+        scheduler: MessageScheduler<Rng>,
+        epoch_info: CoreEpochPublicInfo<NodeId>,
+    ) -> Self {
+        let proposals = PendingProposals::new(epoch_info.epoch);
+        Self {
+            crypto,
+            scheduler,
+            epoch_info,
+            proposals,
+        }
+    }
+
+    pub const fn proposals_mut(&mut self) -> &mut PendingProposals {
+        &mut self.proposals
+    }
+
+    pub const fn crypto_processor_mut(
+        &mut self,
+    ) -> &mut CryptoProcessor<NodeId, CorePoQGenerator, ProofsGenerator, ProofsVerifier> {
+        &mut self.crypto
+    }
+
+    pub const fn epoch_info(&self) -> &CoreEpochPublicInfo<NodeId> {
+        &self.epoch_info
+    }
+
+    /// The two parts the paths that schedule a locally-encapsulated message
+    /// need at once: they read the processor for its epoch and write the
+    /// message into the scheduler. Borrowing them through one method keeps them
+    /// disjoint.
+    pub const fn scheduling_borrows(
+        &mut self,
+    ) -> SchedulingBorrows<'_, NodeId, CorePoQGenerator, ProofsGenerator, ProofsVerifier, Rng> {
+        (&mut self.proposals, &self.crypto, &mut self.scheduler)
+    }
+
+    /// The two parts decapsulating an incoming message minted under *this*
+    /// epoch needs. Borrowing them through one method keeps them disjoint.
+    pub const fn decapsulation_borrows(
+        &mut self,
+    ) -> (
+        &mut MessageScheduler<Rng>,
+        &CryptoProcessor<NodeId, CorePoQGenerator, ProofsGenerator, ProofsVerifier>,
+    ) {
+        (&mut self.scheduler, &self.crypto)
+    }
+
+    pub fn into_components(
+        self,
+    ) -> Components<NodeId, CorePoQGenerator, ProofsGenerator, ProofsVerifier, Rng> {
+        (self.crypto, self.scheduler, self.epoch_info)
+    }
+}
+
+/// Something the current epoch produced on its own, as opposed to something
+/// that arrived from outside it.
+pub enum CurrentEpochEvent {
+    /// A queued message now has proofs behind it, or never will.
+    ///
+    /// Never [`EncapsulationResult::Retry`]: that one means "nothing to act
+    /// on", and
+    /// is what disables the branch below rather than a value to report.
+    Encapsulated(EncapsulationResult),
+    /// This epoch's scheduler says it is time to release.
+    ReleaseRound(Round),
+}
+
+impl<NodeId, CorePoQGenerator, ProofsGenerator, ProofsVerifier, Rng>
+    CurrentEpoch<NodeId, CorePoQGenerator, ProofsGenerator, ProofsVerifier, Rng>
+where
+    NodeId: Eq + Hash + 'static,
+    ProofsGenerator: CoreLeaderAndPowProofsGenerator<CorePoQGenerator>,
+    Rng: rand::Rng + Clone + Unpin,
+{
+    /// Races this epoch's own two sources and reports whichever is ready first.
+    ///
+    /// Borrows rather than consumes, so the caller's `select!` may drop this
+    /// future — which it does whenever an outside event wins the race. That is
+    /// safe for the same reason it was safe when these were separate branches,
+    /// and for the same reasons: nothing here commits before its await. The
+    /// queue is only read, a partial proof draw is left on the encapsulator
+    /// rather than in this frame, and the scheduler keeps its timers.
+    pub async fn next_event(&mut self, transactions: &PendingTransactions) -> CurrentEpochEvent {
+        let proposals = &self.proposals;
+        let crypto = &mut self.crypto;
+        let scheduler = &mut self.scheduler;
+
+        tokio::select! {
+            Some(encapsulation) = encapsulate_next_local_message(proposals, transactions, crypto) => {
+                CurrentEpochEvent::Encapsulated(encapsulation)
+            }
+            Some(round_info) = scheduler.next() => CurrentEpochEvent::ReleaseRound(round_info),
+        }
+    }
+}
+
+/// The current epoch, while the epoch before it is still being drained.
+///
+/// A previous epoch is live for exactly one window — its transition period —
+/// and outside that window there is none at all. Holding it as an `Option`
+/// made every use restate that: the release branch had to be a
+/// `match`-in-an-`async`-block yielding `None` to disable itself, and the
+/// decapsulation path handed back two `Option`s that were always both `Some`
+/// or both `None`. Here the window *is* the type, so the branch that drains the
+/// previous epoch exists only where there is something to drain — and the stage
+/// without one, [`CurrentEpoch`], has no way to name it at all.
+///
+/// The current epoch is a field rather than repeated, so the two stages cannot
+/// drift apart.
+pub struct CurrentEpochDuringTransition<
+    NodeId,
+    CorePoQGenerator,
+    ProofsGenerator,
+    ProofsVerifier,
+    Rng,
+> {
+    current: CurrentEpoch<NodeId, CorePoQGenerator, ProofsGenerator, ProofsVerifier, Rng>,
+    previous: TransitioningEpoch<Rng, ProofsVerifier>,
+}
+
+impl<NodeId, CorePoQGenerator, ProofsGenerator, ProofsVerifier, Rng>
+    CurrentEpochDuringTransition<NodeId, CorePoQGenerator, ProofsGenerator, ProofsVerifier, Rng>
+{
+    pub const fn new(
+        current: CurrentEpoch<NodeId, CorePoQGenerator, ProofsGenerator, ProofsVerifier, Rng>,
+        previous: TransitioningEpoch<Rng, ProofsVerifier>,
+    ) -> Self {
+        Self { current, previous }
+    }
+
+    pub const fn current_mut(
+        &mut self,
+    ) -> &mut CurrentEpoch<NodeId, CorePoQGenerator, ProofsGenerator, ProofsVerifier, Rng> {
+        &mut self.current
+    }
+
+    /// The four halves the incoming-message path needs at once: a message names
+    /// the epoch it was minted under, and only one of the two epochs can
+    /// decapsulate it. Borrowing them through one method keeps them disjoint.
+    pub const fn decapsulation_borrows(
+        &mut self,
+    ) -> DecapsulationBorrows<'_, NodeId, CorePoQGenerator, ProofsGenerator, ProofsVerifier, Rng>
+    {
+        let (previous_crypto, previous_scheduler) = self.previous.split_mut();
+        (
+            &mut self.current.scheduler,
+            previous_scheduler,
+            &self.current.crypto,
+            previous_crypto,
+        )
+    }
+
+    /// Gives up the epoch being drained, leaving the current one whole —
+    /// proposals included, because a transition period ending is not an epoch
+    /// change. What the drained epoch still held is dropped: past its
+    /// transition period no peer would accept what it releases, having rotated
+    /// its verifier on.
+    pub fn end_transition(
+        self,
+    ) -> CurrentEpoch<NodeId, CorePoQGenerator, ProofsGenerator, ProofsVerifier, Rng> {
+        self.current
+    }
+
+    /// Splits into the parts a rotation consumes. The epoch being drained goes
+    /// with them: a rotation replaces it with the epoch that has just ended,
+    /// and one older than that has no peers left that would accept it.
+    pub fn into_components(
+        self,
+    ) -> Components<NodeId, CorePoQGenerator, ProofsGenerator, ProofsVerifier, Rng> {
+        self.current.into_components()
+    }
+}
+
+/// The same, plus what the epoch being drained produced.
+pub enum DuringTransitionEvent {
+    Current(CurrentEpochEvent),
+    /// The transitioning epoch's scheduler says it is time to release, for the
+    /// epoch it names — every message it releases is published under that one,
+    /// so it reaches the peers still negotiated for it.
+    PreviousEpochReleaseRound(Round, Epoch),
+}
+
+impl<NodeId, CorePoQGenerator, ProofsGenerator, ProofsVerifier, Rng>
+    CurrentEpochDuringTransition<NodeId, CorePoQGenerator, ProofsGenerator, ProofsVerifier, Rng>
+where
+    NodeId: Eq + Hash + 'static,
+    ProofsGenerator: CoreLeaderAndPowProofsGenerator<CorePoQGenerator>,
+    Rng: rand::Rng + Clone + Unpin,
+{
+    /// Races both epochs' own sources and reports whichever is ready first.
+    ///
+    /// Cancel-safe on the same terms as [`CurrentEpoch::next_event`], which it
+    /// wraps.
+    pub async fn next_event(
+        &mut self,
+        transactions: &PendingTransactions,
+    ) -> DuringTransitionEvent {
+        let previous_epoch = self.previous.epoch();
+        let current = &mut self.current;
+        let previous = &mut self.previous;
+
+        tokio::select! {
+            event = current.next_event(transactions) => DuringTransitionEvent::Current(event),
+            Some(round_info) = previous.scheduler_mut().next() => {
+                DuringTransitionEvent::PreviousEpochReleaseRound(round_info, previous_epoch)
+            }
+        }
+    }
+}

--- a/services/blend/src/core/epoch_stages/transitioning.rs
+++ b/services/blend/src/core/epoch_stages/transitioning.rs
@@ -1,15 +1,6 @@
-//! The previous epoch's pipeline, kept alive while the transition period runs.
-
-use lb_blend::{
-    message::encap::validated::EncapsulatedMessageWithVerifiedPublicHeader,
-    scheduling::message_scheduler::OldEpochMessageScheduler,
-};
 use lb_chain_service::Epoch;
 
-use crate::{core::OldEpochCryptographicProcessor as Processor, message::ProcessedMessage};
-
-type Scheduler<Rng> =
-    OldEpochMessageScheduler<Rng, ProcessedMessage, EncapsulatedMessageWithVerifiedPublicHeader>;
+use crate::core::{OldEpochCryptographicProcessor as Processor, epoch_stages::OldEpochScheduler};
 
 /// An epoch that has ended but is not finished with.
 ///
@@ -20,26 +11,27 @@ type Scheduler<Rng> =
 /// had to keep in step; pairing them makes "an old epoch is transitioning" a
 /// single fact rather than an invariant held by hand.
 ///
-/// The blending tokens the old epoch is still earning are deliberately *not*
-/// here: while the service is running they are collected into the persisted
-/// recovery state, and only a node on its way out of core keeps them
-/// separately, because by then there is no recovery state left to hold them.
+/// The blending tokens the old epoch is still earning are *not* here, because
+/// while the service is running the persisted recovery state owns them — which
+/// is what carries them across a restart. A node on its way out of core has
+/// consumed that state, so it pairs this with the tokens itself: see
+/// [`RetiringEpoch`].
 pub struct TransitioningEpoch<Rng, ProofsVerifier> {
     crypto: Processor<ProofsVerifier>,
-    scheduler: Scheduler<Rng>,
+    scheduler: OldEpochScheduler<Rng>,
 }
 
 impl<Rng, ProofsVerifier> TransitioningEpoch<Rng, ProofsVerifier> {
-    pub const fn new(crypto: Processor<ProofsVerifier>, scheduler: Scheduler<Rng>) -> Self {
+    pub const fn new(crypto: Processor<ProofsVerifier>, scheduler: OldEpochScheduler<Rng>) -> Self {
         Self { crypto, scheduler }
     }
 
     #[cfg(test)]
-    pub const fn scheduler(&self) -> &Scheduler<Rng> {
+    pub const fn scheduler(&self) -> &OldEpochScheduler<Rng> {
         &self.scheduler
     }
 
-    pub const fn scheduler_mut(&mut self) -> &mut Scheduler<Rng> {
+    pub const fn scheduler_mut(&mut self) -> &mut OldEpochScheduler<Rng> {
         &mut self.scheduler
     }
 
@@ -52,12 +44,7 @@ impl<Rng, ProofsVerifier> TransitioningEpoch<Rng, ProofsVerifier> {
     /// Both halves at once, which the incoming-message path needs: it reads the
     /// old processor to decapsulate and writes the old scheduler to queue the
     /// result. Borrowing them through one method keeps that disjoint.
-    pub const fn split_mut(&mut self) -> (&Processor<ProofsVerifier>, &mut Scheduler<Rng>) {
+    pub const fn split_mut(&mut self) -> (&Processor<ProofsVerifier>, &mut OldEpochScheduler<Rng>) {
         (&self.crypto, &mut self.scheduler)
-    }
-
-    /// Splits into the halves a retiring node drives directly.
-    pub fn into_components(self) -> (Processor<ProofsVerifier>, Scheduler<Rng>) {
-        (self.crypto, self.scheduler)
     }
 }

--- a/services/blend/src/core/mod.rs
+++ b/services/blend/src/core/mod.rs
@@ -83,7 +83,14 @@ use tracing::{debug, error, info};
 use crate::{
     core::{
         backends::BackendEpochInfo,
-        epoch_stages::{retiring::RetiringEpoch, transitioning::TransitioningEpoch},
+        epoch_stages::{
+            retiring::RetiringEpoch,
+            running::{
+                Components, CurrentEpoch, CurrentEpochDuringTransition, CurrentEpochEvent,
+                DuringTransitionEvent,
+            },
+            transitioning::TransitioningEpoch,
+        },
         kms::{KmsPoQAdapter, PreloadKMSBackendCorePoQGenerator},
         processor::{
             CoreCryptographicProcessor as CurrentEpochCryptographicProcessor, Error,
@@ -99,8 +106,8 @@ use crate::{
     membership::{self, ZkInfo, chain::BlendEpochState},
     message::{BlendPayload, ProcessedMessage, ServiceMessage},
     pending::{
-        Discarded, LocalEncapsulation, NextLocalMessage, PendingLocalMessages,
-        resolve_encapsulation,
+        EncapsulationResult, LocalEncapsulation, MessageKind, NextLocalMessage, PendingProposals,
+        PendingTransactions, next_local_message, resolve_encapsulation,
     },
 };
 
@@ -397,7 +404,7 @@ where
             current_public_info,
             crypto_processor,
             current_recovery_checkpoint,
-            pending_messages,
+            pending_transactions,
             message_scheduler,
             mut backend,
             mut rng,
@@ -417,6 +424,7 @@ where
             &sdp_relay,
             last_saved_state,
             state_updater,
+            BlakeRng::from_entropy(),
         )
         .await;
 
@@ -445,11 +453,13 @@ where
             &mut backend,
             &payload_dispatcher,
             &sdp_relay,
-            message_scheduler.into(),
             &mut rng,
-            pending_messages,
-            crypto_processor,
-            current_public_info,
+            CurrentEpoch::new(
+                crypto_processor,
+                message_scheduler.into(),
+                current_public_info,
+            ),
+            pending_transactions,
             current_recovery_checkpoint,
         )
         .await;
@@ -481,6 +491,7 @@ where
     clippy::cognitive_complexity,
     reason = "TODO: address this in a dedicated refactor"
 )]
+#[expect(clippy::too_many_arguments, reason = "categorize args")]
 async fn initialize<
     NodeId,
     Backend,
@@ -499,6 +510,7 @@ async fn initialize<
     state_updater: StateUpdater<
         Option<RecoveryServiceState<Backend::Settings, Dispatcher::Settings>>,
     >,
+    release_delay_rng: BlakeRng,
 ) -> (
     impl Stream<Item = EpochEvent<MaybeEmptyCoreEpochInfo<NodeId, KmsAdapter::CorePoQGenerator>>>
     + Unpin
@@ -512,7 +524,7 @@ async fn initialize<
         ProofsVerifier,
     >,
     ServiceState<Backend::Settings, Dispatcher::Settings>,
-    PendingLocalMessages,
+    PendingTransactions,
     SchedulerWrapper<BlakeRng, ProcessedMessage, EncapsulatedMessageWithVerifiedPublicHeader>,
     Backend,
     BlakeRng,
@@ -723,7 +735,7 @@ where
             core_quota: epoch_core_quota.saturating_sub(spent_core_quota),
             epoch: current_epoch_public_info.epoch,
         },
-        BlakeRng::from_entropy(),
+        release_delay_rng,
         blend_config.scheduler_settings(),
         // We don't consume the map because we will remove the items one by one once they
         // will be scheduled for release.
@@ -755,9 +767,9 @@ where
 
     // The transactions a previous run had queued, back in the shared queue that
     // also holds proposals.
-    let mut pending_messages = PendingLocalMessages::new();
+    let mut pending_transactions = PendingTransactions::new();
     for transaction in current_recovery_checkpoint.pending_transactions() {
-        pending_messages.queue_transaction(transaction.clone());
+        pending_transactions.queue(transaction.clone());
     }
 
     (
@@ -765,7 +777,7 @@ where
         current_epoch_public_info,
         crypto_processor,
         current_recovery_checkpoint,
-        pending_messages,
+        pending_transactions,
         message_scheduler,
         backend,
         rng,
@@ -827,20 +839,9 @@ async fn run_event_loop<
     backend: &mut Backend,
     payload_dispatcher: &Dispatcher,
     sdp_relay: &OutboundRelay<SdpMessage>,
-    mut message_scheduler: EpochMessageScheduler<
-        Rng,
-        ProcessedMessage,
-        EncapsulatedMessageWithVerifiedPublicHeader,
-    >,
     rng: &mut Rng,
-    mut pending_messages: PendingLocalMessages,
-    mut crypto_processor: CurrentEpochCryptographicProcessor<
-        NodeId,
-        CorePoQGenerator,
-        ProofsGenerator,
-        ProofsVerifier,
-    >,
-    mut current_epoch_info: CoreEpochPublicInfo<NodeId>,
+    current_epoch: CurrentEpoch<NodeId, CorePoQGenerator, ProofsGenerator, ProofsVerifier, Rng>,
+    mut pending_transactions: PendingTransactions,
     mut recovery_checkpoint: ServiceState<Backend::Settings, Dispatcher::Settings>,
 ) -> RetiringEpoch<Rng, ProofsVerifier>
 where
@@ -853,109 +854,539 @@ where
     ProofsVerifier: ProofsVerifierTrait + Send + Sync,
     RuntimeServiceId: Sync + Send,
 {
-    // The previous epoch's pipeline, present only while its transition period
-    // runs.
-    let mut old_epoch_components: Option<TransitioningEpoch<Rng, ProofsVerifier>> = None;
     let mut latest_secret_pol_info: Option<PolEpochInfo> = None;
-
+    let mut current_epoch_stage = current_epoch.into();
     loop {
-        let old_epoch = old_epoch_components.as_ref().map(TransitioningEpoch::epoch);
+        let epoch_outcome = match current_epoch_stage {
+            Stage::Current(current) => {
+                run_current_epoch(
+                    &mut inbound_relay,
+                    blend_messages,
+                    &mut secret_pol_info_stream,
+                    remaining_epoch_stream,
+                    blend_config,
+                    backend,
+                    payload_dispatcher,
+                    sdp_relay,
+                    rng,
+                    *current,
+                    &mut pending_transactions,
+                    &mut latest_secret_pol_info,
+                    recovery_checkpoint,
+                )
+                .await
+            }
+            Stage::DuringTransition(during_transition) => {
+                run_during_transition(
+                    &mut inbound_relay,
+                    blend_messages,
+                    &mut secret_pol_info_stream,
+                    remaining_epoch_stream,
+                    blend_config,
+                    backend,
+                    payload_dispatcher,
+                    sdp_relay,
+                    rng,
+                    *during_transition,
+                    &mut pending_transactions,
+                    &mut latest_secret_pol_info,
+                    recovery_checkpoint,
+                )
+                .await
+            }
+        };
+        match epoch_outcome {
+            StageOutcome::NewEpoch {
+                next,
+                recovery_checkpoint: checkpoint,
+            } => {
+                current_epoch_stage = next;
+                recovery_checkpoint = *checkpoint;
+            }
+            StageOutcome::Retiring(retiring_epoch) => {
+                tracing::info!(target: LOG_TARGET, "Exiting from the main event loop");
+                return *retiring_epoch;
+            }
+        }
+    }
+}
+
+/// Which stage of its life the node's blending is in.
+enum Stage<NodeId, CorePoQGenerator, ProofsGenerator, ProofsVerifier, Rng> {
+    Current(Box<CurrentEpoch<NodeId, CorePoQGenerator, ProofsGenerator, ProofsVerifier, Rng>>),
+    DuringTransition(
+        Box<
+            CurrentEpochDuringTransition<
+                NodeId,
+                CorePoQGenerator,
+                ProofsGenerator,
+                ProofsVerifier,
+                Rng,
+            >,
+        >,
+    ),
+}
+
+impl<NodeId, CorePoQGenerator, ProofsGenerator, ProofsVerifier, Rng>
+    From<CurrentEpoch<NodeId, CorePoQGenerator, ProofsGenerator, ProofsVerifier, Rng>>
+    for Stage<NodeId, CorePoQGenerator, ProofsGenerator, ProofsVerifier, Rng>
+{
+    fn from(
+        value: CurrentEpoch<NodeId, CorePoQGenerator, ProofsGenerator, ProofsVerifier, Rng>,
+    ) -> Self {
+        Self::Current(Box::new(value))
+    }
+}
+
+impl<NodeId, CorePoQGenerator, ProofsGenerator, ProofsVerifier, Rng>
+    From<
+        CurrentEpochDuringTransition<
+            NodeId,
+            CorePoQGenerator,
+            ProofsGenerator,
+            ProofsVerifier,
+            Rng,
+        >,
+    > for Stage<NodeId, CorePoQGenerator, ProofsGenerator, ProofsVerifier, Rng>
+{
+    fn from(
+        value: CurrentEpochDuringTransition<
+            NodeId,
+            CorePoQGenerator,
+            ProofsGenerator,
+            ProofsVerifier,
+            Rng,
+        >,
+    ) -> Self {
+        Self::DuringTransition(Box::new(value))
+    }
+}
+
+/// How a stage ended.
+enum StageOutcome<
+    NodeId,
+    CorePoQGenerator,
+    ProofsGenerator,
+    ProofsVerifier,
+    Rng,
+    BackendSettings,
+    NetworkSettings,
+> {
+    /// An epoch event moved the node to another stage.
+    NewEpoch {
+        next: Stage<NodeId, CorePoQGenerator, ProofsGenerator, ProofsVerifier, Rng>,
+        recovery_checkpoint: Box<ServiceState<BackendSettings, NetworkSettings>>,
+    },
+    /// The node is no longer a core node, or Blend is disabled.
+    Retiring(Box<RetiringEpoch<Rng, ProofsVerifier>>),
+}
+
+/// The stage with no previous epoch left to drain.
+#[expect(clippy::too_many_arguments, reason = "categorize args")]
+async fn run_current_epoch<
+    NodeId,
+    Backend,
+    Rng,
+    Dispatcher,
+    ProofsGenerator,
+    ProofsVerifier,
+    CorePoQGenerator,
+    RuntimeServiceId,
+>(
+    inbound_relay: &mut (impl Stream<Item = ServiceMessage<NodeId>> + Send + Unpin),
+    blend_messages: &mut (
+             impl Stream<Item = (EncapsulatedMessageWithVerifiedPublicHeader, Epoch)>
+             + Send
+             + Unpin
+             + 'static
+         ),
+    secret_pol_info_stream: &mut (impl Stream<Item = PolEpochInfo> + Send + Unpin),
+    remaining_epoch_stream: &mut (
+             impl Stream<Item = EpochEvent<MaybeEmptyCoreEpochInfo<NodeId, CorePoQGenerator>>>
+             + Unpin
+             + Send
+         ),
+    blend_config: &RunningBlendConfig<Backend::Settings>,
+    backend: &mut Backend,
+    payload_dispatcher: &Dispatcher,
+    sdp_relay: &OutboundRelay<SdpMessage>,
+    rng: &mut Rng,
+    mut current_epoch: CurrentEpoch<NodeId, CorePoQGenerator, ProofsGenerator, ProofsVerifier, Rng>,
+    pending_transactions: &mut PendingTransactions,
+    latest_secret_pol_info: &mut Option<PolEpochInfo>,
+    mut recovery_checkpoint: ServiceState<Backend::Settings, Dispatcher::Settings>,
+) -> StageOutcome<
+    NodeId,
+    CorePoQGenerator,
+    ProofsGenerator,
+    ProofsVerifier,
+    Rng,
+    Backend::Settings,
+    Dispatcher::Settings,
+>
+where
+    NodeId: Clone + Eq + Hash + Send + Sync + 'static,
+    Rng: rand::Rng + Clone + Send + Unpin,
+    Backend: BlendBackend<NodeId, BlakeRng, ProofsVerifier, RuntimeServiceId> + Sync + Send,
+    Dispatcher: PayloadDispatcher<RuntimeServiceId> + Sync,
+    ProofsGenerator: CoreLeaderAndPowProofsGenerator<CorePoQGenerator> + Send,
+    CorePoQGenerator: Send + Sync,
+    ProofsVerifier: ProofsVerifierTrait + Send + Sync,
+    RuntimeServiceId: Sync + Send,
+{
+    loop {
         tokio::select! {
             Some(msg) = inbound_relay.next() => {
-                match msg {
-                    ServiceMessage::Blend(BlendPayload::Transaction(transaction)) => {
-                        recovery_checkpoint = queue_transaction_for_encapsulation(transaction, &mut pending_messages, recovery_checkpoint);
-                    }
-                    ServiceMessage::Blend(BlendPayload::BlockProposal(proposal)) => {
-                        let copies = NonZeroU64::new(blend_config.data_replication_factor.strict_add(1)).unwrap();
-                        pending_messages.queue_proposal(proposal, copies);
-                    }
-                    ServiceMessage::GetNetworkInfo { reply } => {
-                        let info = backend.network_info().await;
-                        drop(reply.send(info));
-                    }
-                    ServiceMessage::GetPendingTransactions { reply } => {
-                        drop(reply.send(pending_messages.transactions().cloned().collect()));
-                    }
-                }
-            }
-            // A queued message leaves as soon as proofs back it — a `PoW` solution
-            // for a transaction, this epoch's secret `PoL` info for a proposal. Both
-            // are awaited here so the rest of the loop keeps turning meanwhile, and
-            // both share one branch because both need the processor mutably and
-            // `select!` builds every branch future before any of them wins.
-            Some(encapsulation) = encapsulate_next_local_message(&pending_messages, &mut crypto_processor) => {
-                match encapsulation {
-                    Ok(LocalEncapsulation::ProposalCopy(message)) => {
-                        recovery_checkpoint = schedule_local_encapsulated_message(&message, &crypto_processor, &mut message_scheduler, recovery_checkpoint);
-                        pending_messages.mark_proposal_copy_as_sent();
-                    }
-                    Ok(LocalEncapsulation::Transaction(message)) => {
-                        recovery_checkpoint = handle_local_transaction(&message, &mut pending_messages, &crypto_processor, &mut message_scheduler, recovery_checkpoint);
-                    }
-                    Err(()) => {
-                        recovery_checkpoint = discard_unencapsulatable_message(&mut pending_messages, recovery_checkpoint);
-                    }
-                }
+                recovery_checkpoint = handle_service_message(msg, current_epoch.proposals_mut(), pending_transactions, blend_config, backend, recovery_checkpoint).await;
             }
             Some(incoming_message) = blend_messages.next() => {
-                let (old_cryptographic_processor, old_scheduler) = old_epoch_components
-                    .as_mut()
-                    .map_or((None, None), |transitioning| {
-                        let (crypto, scheduler) = transitioning.split_mut();
-                        (Some(crypto), Some(scheduler))
-                    });
-                recovery_checkpoint = handle_incoming_blend_message(incoming_message, &mut message_scheduler, old_scheduler, crypto_processor.receiver(), old_cryptographic_processor,  recovery_checkpoint);
+                let (scheduler, crypto) = current_epoch.decapsulation_borrows();
+                recovery_checkpoint = handle_incoming_blend_message(incoming_message, scheduler, None, crypto.receiver(), None, recovery_checkpoint);
             }
-            Some(round_info) = message_scheduler.next() => {
-                recovery_checkpoint = handle_release_round(round_info, &mut crypto_processor, rng, backend, payload_dispatcher, recovery_checkpoint).await;
-            }
-            Some((Some(round_info), previous_epoch)) = async {
-                match (&mut old_epoch_components, old_epoch) {
-                    (Some(old_epoch_components), Some(old_epoch)) => {
-                        Some((old_epoch_components.scheduler_mut().next().await, old_epoch))
-                    },
-                    _ => None
-                }
-            } => {
-                handle_release_round_for_old_epoch(round_info, rng, backend, payload_dispatcher, previous_epoch).await;
+            event = current_epoch.next_event(pending_transactions) => {
+                recovery_checkpoint = handle_current_epoch_event(event, &mut current_epoch, pending_transactions, rng, backend, payload_dispatcher, recovery_checkpoint).await;
             }
             Some(pol_secret_info) = secret_pol_info_stream.next() => {
-                if current_epoch_info.epoch == pol_secret_info.epoch {
-                    // Apply now: move the winning-slot stream into the current processor.
-                    crypto_processor.set_epoch_private(pol_secret_info.winning_pol_info_stream, pol_secret_info.epoch);
-                    latest_secret_pol_info = None;
-                } else {
-                    // Belongs to an upcoming epoch: keep it to seed that epoch's
-                    // processor when the rotation happens.
-                    latest_secret_pol_info = Some(pol_secret_info);
-                }
+                apply_or_hold_secret_pol_info(pol_secret_info, &mut current_epoch, latest_secret_pol_info);
             }
             Some(epoch_event) = remaining_epoch_stream.next() => {
-                match handle_epoch_event(epoch_event, blend_config, crypto_processor, message_scheduler, current_epoch_info, recovery_checkpoint, backend, sdp_relay, &mut latest_secret_pol_info, &mut pending_messages).await {
-                    // Current epoch info updated to new one
-                    HandleEpochEventOutput::Transitioning { new_crypto_processor, new_scheduler, new_epoch_info, new_recovery_checkpoint, old_epoch_components: transitioning_epoch } => {
-                        crypto_processor = new_crypto_processor;
-                        message_scheduler = new_scheduler;
-                        current_epoch_info = new_epoch_info;
-                        recovery_checkpoint = new_recovery_checkpoint;
-                        old_epoch_components = Some(*transitioning_epoch);
-                    },
-                    // Current epoch info unchanged
-                    HandleEpochEventOutput::TransitionCompleted { current_crypto_processor, current_scheduler, new_recovery_checkpoint, current_epoch_info: same_epoch_info } => {
-                        crypto_processor = current_crypto_processor;
-                        message_scheduler = current_scheduler;
-                        current_epoch_info = same_epoch_info;
-                        recovery_checkpoint = new_recovery_checkpoint;
-                        old_epoch_components = None;
-                    },
-                    // Current epoch info consumed, not usable anymore
-                    HandleEpochEventOutput::Retiring { retiring_epoch } => {
-                        tracing::info!(target: LOG_TARGET, "Exiting from the main event loop");
-                        return *retiring_epoch;
-                    },
+                match epoch_event {
+                    // Not an epoch change, so this stage keeps everything it
+                    // has — queued proposals included. There is nothing to
+                    // drain here, but the expiry still has to be acknowledged.
+                    EpochEvent::TransitionPeriodExpired => {
+                        recovery_checkpoint = complete_transition_period(backend, sdp_relay, recovery_checkpoint).await;
+                    }
+                    EpochEvent::NewEpoch(new_epoch_info) => {
+                        return rotate::<_, _, _, Dispatcher, _, _, _, RuntimeServiceId>(new_epoch_info, current_epoch.into_components(), latest_secret_pol_info, blend_config, backend, recovery_checkpoint).await;
+                    }
                 }
             }
+        }
+    }
+}
+
+/// The stage in which the epoch before this one is still within its transition
+/// period, so both are live.
+#[expect(clippy::too_many_arguments, reason = "categorize args")]
+async fn run_during_transition<
+    NodeId,
+    Backend,
+    Rng,
+    Dispatcher,
+    ProofsGenerator,
+    ProofsVerifier,
+    CorePoQGenerator,
+    RuntimeServiceId,
+>(
+    inbound_relay: &mut (impl Stream<Item = ServiceMessage<NodeId>> + Send + Unpin),
+    blend_messages: &mut (
+             impl Stream<Item = (EncapsulatedMessageWithVerifiedPublicHeader, Epoch)>
+             + Send
+             + Unpin
+             + 'static
+         ),
+    secret_pol_info_stream: &mut (impl Stream<Item = PolEpochInfo> + Send + Unpin),
+    remaining_epoch_stream: &mut (
+             impl Stream<Item = EpochEvent<MaybeEmptyCoreEpochInfo<NodeId, CorePoQGenerator>>>
+             + Unpin
+             + Send
+         ),
+    blend_config: &RunningBlendConfig<Backend::Settings>,
+    backend: &mut Backend,
+    payload_dispatcher: &Dispatcher,
+    sdp_relay: &OutboundRelay<SdpMessage>,
+    rng: &mut Rng,
+    mut during_transition: CurrentEpochDuringTransition<
+        NodeId,
+        CorePoQGenerator,
+        ProofsGenerator,
+        ProofsVerifier,
+        Rng,
+    >,
+    pending_transactions: &mut PendingTransactions,
+    latest_secret_pol_info: &mut Option<PolEpochInfo>,
+    mut recovery_checkpoint: ServiceState<Backend::Settings, Dispatcher::Settings>,
+) -> StageOutcome<
+    NodeId,
+    CorePoQGenerator,
+    ProofsGenerator,
+    ProofsVerifier,
+    Rng,
+    Backend::Settings,
+    Dispatcher::Settings,
+>
+where
+    NodeId: Clone + Eq + Hash + Send + Sync + 'static,
+    Rng: rand::Rng + Clone + Send + Unpin,
+    Backend: BlendBackend<NodeId, BlakeRng, ProofsVerifier, RuntimeServiceId> + Sync + Send,
+    Dispatcher: PayloadDispatcher<RuntimeServiceId> + Sync,
+    ProofsGenerator: CoreLeaderAndPowProofsGenerator<CorePoQGenerator> + Send,
+    CorePoQGenerator: Send + Sync,
+    ProofsVerifier: ProofsVerifierTrait + Send + Sync,
+    RuntimeServiceId: Sync + Send,
+{
+    loop {
+        tokio::select! {
+            Some(msg) = inbound_relay.next() => {
+                recovery_checkpoint = handle_service_message(msg, during_transition.current_mut().proposals_mut(), pending_transactions, blend_config, backend, recovery_checkpoint).await;
+            }
+            Some(incoming_message) = blend_messages.next() => {
+                let (scheduler, previous_scheduler, crypto, previous_crypto) = during_transition.decapsulation_borrows();
+                recovery_checkpoint = handle_incoming_blend_message(incoming_message, scheduler, Some(previous_scheduler), crypto.receiver(), Some(previous_crypto), recovery_checkpoint);
+            }
+            event = during_transition.next_event(pending_transactions) => {
+                match event {
+                    DuringTransitionEvent::Current(event) => {
+                        recovery_checkpoint = handle_current_epoch_event(event, during_transition.current_mut(), pending_transactions, rng, backend, payload_dispatcher, recovery_checkpoint).await;
+                    }
+                    DuringTransitionEvent::PreviousEpochReleaseRound(round_info, previous_epoch) => {
+                        handle_release_round_for_old_epoch(round_info, rng, backend, payload_dispatcher, previous_epoch).await;
+                    }
+                }
+            }
+            Some(pol_secret_info) = secret_pol_info_stream.next() => {
+                apply_or_hold_secret_pol_info(pol_secret_info, during_transition.current_mut(), latest_secret_pol_info);
+            }
+            Some(epoch_event) = remaining_epoch_stream.next() => {
+                match epoch_event {
+                    // The epoch being drained is finished with, but this one is
+                    // not: `end_transition` keeps it whole, proposals and all.
+                    EpochEvent::TransitionPeriodExpired => {
+                        return StageOutcome::NewEpoch {
+                            next: during_transition.end_transition().into(),
+                            recovery_checkpoint: Box::new(complete_transition_period(backend, sdp_relay, recovery_checkpoint).await),
+                        };
+                    }
+                    EpochEvent::NewEpoch(new_epoch_info) => {
+                        return rotate::<_, _, _, Dispatcher, _, _, _, RuntimeServiceId>(new_epoch_info, during_transition.into_components(), latest_secret_pol_info, blend_config, backend, recovery_checkpoint).await;
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Answers a message from another service, which both stages do the same way.
+async fn handle_service_message<
+    NodeId,
+    Backend,
+    ProofsVerifier,
+    NetworkSettings,
+    RuntimeServiceId,
+>(
+    message: ServiceMessage<NodeId>,
+    pending_proposals: &mut PendingProposals,
+    pending_transactions: &mut PendingTransactions,
+    blend_config: &RunningBlendConfig<Backend::Settings>,
+    backend: &Backend,
+    recovery_checkpoint: ServiceState<Backend::Settings, NetworkSettings>,
+) -> ServiceState<Backend::Settings, NetworkSettings>
+where
+    Backend: BlendBackend<NodeId, BlakeRng, ProofsVerifier, RuntimeServiceId> + Sync,
+    NetworkSettings: Clone,
+{
+    match message {
+        ServiceMessage::Blend(BlendPayload::Transaction(transaction)) => {
+            queue_transaction_for_encapsulation(
+                transaction,
+                pending_transactions,
+                recovery_checkpoint,
+            )
+        }
+        ServiceMessage::Blend(BlendPayload::BlockProposal(proposal)) => {
+            let copies = NonZeroU64::new(blend_config.data_replication_factor.strict_add(1))
+                .expect("A block proposal is always sent at least once.");
+            pending_proposals.queue(proposal, copies);
+            recovery_checkpoint
+        }
+        ServiceMessage::GetNetworkInfo { reply } => {
+            let info = backend.network_info().await;
+            drop(reply.send(info));
+            recovery_checkpoint
+        }
+        ServiceMessage::GetPendingTransactions { reply } => {
+            drop(reply.send(pending_transactions.iter().cloned().collect()));
+            recovery_checkpoint
+        }
+    }
+}
+
+/// Acts on something the current epoch produced, which both stages do the same
+/// way.
+async fn handle_current_epoch_event<
+    NodeId,
+    Backend,
+    Rng,
+    Dispatcher,
+    ProofsGenerator,
+    ProofsVerifier,
+    CorePoQGenerator,
+    RuntimeServiceId,
+>(
+    event: CurrentEpochEvent,
+    current_epoch: &mut CurrentEpoch<
+        NodeId,
+        CorePoQGenerator,
+        ProofsGenerator,
+        ProofsVerifier,
+        Rng,
+    >,
+    pending_transactions: &mut PendingTransactions,
+    rng: &mut Rng,
+    backend: &Backend,
+    payload_dispatcher: &Dispatcher,
+    recovery_checkpoint: ServiceState<Backend::Settings, Dispatcher::Settings>,
+) -> ServiceState<Backend::Settings, Dispatcher::Settings>
+where
+    NodeId: Eq + Hash + Send + Sync + 'static,
+    Rng: rand::Rng + Clone + Send + Unpin,
+    Backend: BlendBackend<NodeId, BlakeRng, ProofsVerifier, RuntimeServiceId> + Sync,
+    Dispatcher: PayloadDispatcher<RuntimeServiceId> + Sync,
+    ProofsGenerator: CoreLeaderAndPowProofsGenerator<CorePoQGenerator>,
+    ProofsVerifier: ProofsVerifierTrait,
+{
+    match event {
+        CurrentEpochEvent::Encapsulated(encapsulation_result) => match encapsulation_result {
+            EncapsulationResult::Complete(encapsulation) => {
+                let LocalEncapsulation { message, kind } = *encapsulation;
+                let (proposals, crypto_processor, scheduler) = current_epoch.scheduling_borrows();
+                match kind {
+                    MessageKind::Proposal => {
+                        let checkpoint = schedule_local_encapsulated_message(
+                            &message,
+                            crypto_processor,
+                            scheduler,
+                            recovery_checkpoint,
+                        );
+                        proposals.mark_copy_as_sent();
+                        checkpoint
+                    }
+                    MessageKind::Transaction => handle_local_transaction(
+                        &message,
+                        pending_transactions,
+                        crypto_processor,
+                        scheduler,
+                        recovery_checkpoint,
+                    ),
+                }
+            }
+            // The head of whichever queue it came from can never be
+            // encapsulated, so it goes rather than blocking everything behind
+            // it.
+            EncapsulationResult::Discard(MessageKind::Proposal) => {
+                current_epoch.proposals_mut().discard_head();
+                recovery_checkpoint
+            }
+            EncapsulationResult::Discard(MessageKind::Transaction) => {
+                discard_unencapsulatable_transaction(pending_transactions, recovery_checkpoint)
+            }
+            EncapsulationResult::Retry => unreachable!(
+                "`encapsulate_next_local_message` turns the encapsulation result into the `None` that disables its branch, so that the loop waits rather than spinning on a branch with nothing to do."
+            ),
+        },
+        CurrentEpochEvent::ReleaseRound(round_info) => {
+            handle_release_round(
+                round_info,
+                current_epoch.crypto_processor_mut(),
+                rng,
+                backend,
+                payload_dispatcher,
+                recovery_checkpoint,
+            )
+            .await
+        }
+    }
+}
+
+/// Applies this epoch's secret `PoL` info, or holds it for the epoch it names,
+/// which both stages do the same way.
+fn apply_or_hold_secret_pol_info<NodeId, CorePoQGenerator, ProofsGenerator, ProofsVerifier, Rng>(
+    pol_secret_info: PolEpochInfo,
+    current_epoch: &mut CurrentEpoch<
+        NodeId,
+        CorePoQGenerator,
+        ProofsGenerator,
+        ProofsVerifier,
+        Rng,
+    >,
+    latest_secret_pol_info: &mut Option<PolEpochInfo>,
+) where
+    ProofsGenerator: CoreLeaderAndPowProofsGenerator<CorePoQGenerator>,
+{
+    if current_epoch.epoch_info().epoch == pol_secret_info.epoch {
+        // Apply now: move the winning-slot stream into the current processor.
+        current_epoch.crypto_processor_mut().set_epoch_private(
+            pol_secret_info.winning_pol_info_stream,
+            pol_secret_info.epoch,
+        );
+        *latest_secret_pol_info = None;
+    } else {
+        // Belongs to an upcoming epoch: keep it to seed that epoch's processor
+        // when the rotation happens.
+        *latest_secret_pol_info = Some(pol_secret_info);
+    }
+}
+
+/// Turns an epoch event into the stage that follows, which is the only thing
+/// either stage ends on.
+async fn rotate<
+    NodeId,
+    Backend,
+    Rng,
+    Dispatcher,
+    ProofsGenerator,
+    ProofsVerifier,
+    CorePoQGenerator,
+    RuntimeServiceId,
+>(
+    new_epoch_info: MaybeEmptyCoreEpochInfo<NodeId, CorePoQGenerator>,
+    components: Components<NodeId, CorePoQGenerator, ProofsGenerator, ProofsVerifier, Rng>,
+    latest_secret_pol_info: &mut Option<PolEpochInfo>,
+    blend_config: &RunningBlendConfig<Backend::Settings>,
+    backend: &mut Backend,
+    recovery_checkpoint: ServiceState<Backend::Settings, Dispatcher::Settings>,
+) -> StageOutcome<
+    NodeId,
+    CorePoQGenerator,
+    ProofsGenerator,
+    ProofsVerifier,
+    Rng,
+    Backend::Settings,
+    Dispatcher::Settings,
+>
+where
+    NodeId: Clone + Eq + Hash + Send,
+    Rng: rand::Rng + Clone + Unpin,
+    Backend: BlendBackend<NodeId, BlakeRng, ProofsVerifier, RuntimeServiceId>,
+    Dispatcher: PayloadDispatcher<RuntimeServiceId>,
+    ProofsGenerator: CoreLeaderAndPowProofsGenerator<CorePoQGenerator>,
+    ProofsVerifier: ProofsVerifierTrait,
+{
+    // The epoch's own components go in; whatever it also held — its queued
+    // proposals — is dropped here, which is the whole reason they live on it.
+    let (crypto_processor, message_scheduler, _) = components;
+    match handle_epoch_event(
+        new_epoch_info,
+        blend_config,
+        crypto_processor,
+        message_scheduler,
+        recovery_checkpoint,
+        backend,
+        latest_secret_pol_info,
+    )
+    .await
+    {
+        HandleEpochEventOutput::Transitioning {
+            current_epoch,
+            new_recovery_checkpoint,
+            old_epoch_components,
+        } => StageOutcome::NewEpoch {
+            next: CurrentEpochDuringTransition::new(*current_epoch, *old_epoch_components).into(),
+            recovery_checkpoint: new_recovery_checkpoint,
+        },
+        HandleEpochEventOutput::Retiring { retiring_epoch } => {
+            StageOutcome::Retiring(retiring_epoch)
         }
     }
 }
@@ -964,13 +1395,13 @@ where
 /// proofs.
 fn queue_transaction_for_encapsulation<BackendSettings, NetworkSettings>(
     transaction: Vec<u8>,
-    pending_messages: &mut PendingLocalMessages,
+    pending_transactions: &mut PendingTransactions,
     current_recovery_checkpoint: ServiceState<BackendSettings, NetworkSettings>,
 ) -> ServiceState<BackendSettings, NetworkSettings>
 where
     BackendSettings: Clone,
 {
-    pending_messages.queue_transaction(transaction.clone());
+    pending_transactions.queue(transaction.clone());
     let mut state_updater = current_recovery_checkpoint.start_updating();
     state_updater.queue_unencapsulated_transaction(transaction);
     state_updater.commit_changes()
@@ -994,75 +1425,62 @@ where
 /// anything else is looked at, so one that keeps failing would take everything
 /// queued behind it down with it.
 async fn encapsulate_next_local_message<NodeId, ProofsGenerator, ProofsVerifier, CorePoQGenerator>(
-    pending_messages: &PendingLocalMessages,
+    pending_proposals: &PendingProposals,
+    pending_transactions: &PendingTransactions,
     cryptographic_processor: &mut CurrentEpochCryptographicProcessor<
         NodeId,
         CorePoQGenerator,
         ProofsGenerator,
         ProofsVerifier,
     >,
-) -> Option<Result<LocalEncapsulation, ()>>
+) -> Option<EncapsulationResult>
 where
     NodeId: Eq + Hash + 'static,
     ProofsGenerator: CoreLeaderAndPowProofsGenerator<CorePoQGenerator>,
 {
-    type Wrap = fn(EncapsulatedMessageWithVerifiedPublicHeader) -> LocalEncapsulation;
-
-    let (encapsulated, wrap_fn): (_, Wrap) = match pending_messages.next()? {
+    let (kind, encapsulated) = match next_local_message(pending_proposals, pending_transactions)? {
         NextLocalMessage::ProposalCopy(proposal) => (
+            MessageKind::Proposal,
             cryptographic_processor
                 .encapsulate_block_proposal_payload(proposal)
                 .await,
-            LocalEncapsulation::ProposalCopy,
         ),
         NextLocalMessage::Transaction(transaction) => (
+            MessageKind::Transaction,
             cryptographic_processor
                 .encapsulate_transaction_payload(transaction)
                 .await,
-            LocalEncapsulation::Transaction,
         ),
     };
 
-    resolve_encapsulation(encapsulated, wrap_fn)
-}
-
-/// Drops proposals left over from the epoch that just ended, saying so if there
-/// were any.
-fn discard_stale_proposals(pending_messages: &mut PendingLocalMessages) {
-    let discarded_proposals = pending_messages.discard_proposals();
-    if discarded_proposals > 0 {
-        tracing::warn!(
-            target: LOG_TARGET,
-            "Dropping {discarded_proposals} block proposal(s) still queued when the epoch ended."
-        );
+    match resolve_encapsulation(encapsulated, kind) {
+        // Not something the caller acts on, and handing it back would be worse
+        // than useless: the branch this feeds would then complete immediately
+        // every time round with nothing to do, which is a busy loop rather than
+        // a wait. `None` fails the branch's pattern and disables it instead.
+        EncapsulationResult::Retry => None,
+        processed => Some(processed),
     }
 }
 
 /// Drops the queued message that cannot be encapsulated, taking it out of the
 /// recovery state too so a restart does not bring it back to fail again.
-fn discard_unencapsulatable_message<BackendSettings, NetworkSettings>(
-    pending_messages: &mut PendingLocalMessages,
+fn discard_unencapsulatable_transaction<BackendSettings, NetworkSettings>(
+    pending_transactions: &mut PendingTransactions,
     current_recovery_checkpoint: ServiceState<BackendSettings, NetworkSettings>,
 ) -> ServiceState<BackendSettings, NetworkSettings>
 where
     BackendSettings: Clone,
 {
-    match pending_messages.discard_head() {
-        // Proposals are not persisted, so there is nothing else to undo.
-        Some(Discarded::Proposal(_)) | None => current_recovery_checkpoint,
-        Some(Discarded::Transaction(transaction)) => {
-            let mut state_updater = current_recovery_checkpoint.start_updating();
-            state_updater.dequeue_unencapsulated_transaction(&transaction);
-            state_updater.commit_changes()
-        }
-    }
+    let Some(transaction) = pending_transactions.discard_head() else {
+        return current_recovery_checkpoint;
+    };
+    let mut state_updater = current_recovery_checkpoint.start_updating();
+    state_updater.dequeue_unencapsulated_transaction(&transaction);
+    state_updater.commit_changes()
 }
 
 /// Processes a transaction whose wait for a `PoW` solution is over.
-///
-/// The counterpart to [`handle_local_block_proposal`], split in two because a
-/// transaction cannot be dealt with where it arrives: leadership proofs are
-/// ready on demand, whereas a transaction's have to be mined for.
 fn handle_local_transaction<
     NodeId,
     Rng,
@@ -1073,7 +1491,7 @@ fn handle_local_transaction<
     CorePoQGenerator,
 >(
     encapsulation: &EncapsulatedMessageWithVerifiedPublicHeader,
-    pending_messages: &mut PendingLocalMessages,
+    pending_transactions: &mut PendingTransactions,
     cryptographic_processor: &CurrentEpochCryptographicProcessor<
         NodeId,
         CorePoQGenerator,
@@ -1100,7 +1518,7 @@ where
         current_recovery_checkpoint,
     );
 
-    let transaction = pending_messages.mark_transaction_as_sent();
+    let transaction = pending_transactions.mark_as_sent();
     let mut state_updater = recovery_checkpoint.start_updating();
     state_updater.dequeue_unencapsulated_transaction(&transaction);
     state_updater.commit_changes()
@@ -1168,9 +1586,7 @@ async fn retire<
 /// available, leadership-proof generation is enabled on the new processor right
 /// away. It ignores the transition period expiration event and returns the
 /// previous cryptographic processor as is.
-#[expect(clippy::too_many_arguments, reason = "necessary for epoch handling")]
 #[expect(clippy::too_many_lines, reason = "necessary for epoch handling")]
-#[expect(clippy::cognitive_complexity, reason = "necessary for epoch handling")]
 async fn handle_epoch_event<
     NodeId,
     ProofsGenerator,
@@ -1181,7 +1597,7 @@ async fn handle_epoch_event<
     CorePoQGenerator,
     RuntimeServiceId,
 >(
-    event: EpochEvent<MaybeEmptyCoreEpochInfo<NodeId, CorePoQGenerator>>,
+    new_epoch_info: MaybeEmptyCoreEpochInfo<NodeId, CorePoQGenerator>,
     settings: &RunningBlendConfig<Backend::Settings>,
     current_cryptographic_processor: CurrentEpochCryptographicProcessor<
         NodeId,
@@ -1194,12 +1610,9 @@ async fn handle_epoch_event<
         ProcessedMessage,
         EncapsulatedMessageWithVerifiedPublicHeader,
     >,
-    current_epoch_info: CoreEpochPublicInfo<NodeId>,
     current_recovery_checkpoint: ServiceState<Backend::Settings, NetworkSettings>,
     backend: &mut Backend,
-    sdp_relay: &OutboundRelay<SdpMessage>,
     current_secret_info: &mut Option<PolEpochInfo>,
-    pending_messages: &mut PendingLocalMessages,
 ) -> HandleEpochEventOutput<
     NodeId,
     Rng,
@@ -1216,8 +1629,8 @@ where
     ProofsVerifier: ProofsVerifierTrait,
     Backend: BlendBackend<NodeId, BlakeRng, ProofsVerifier, RuntimeServiceId>,
 {
-    match event {
-        EpochEvent::NewEpoch(MaybeEmptyCoreEpochInfo::NonEmpty(core_epoch_info)) => {
+    match new_epoch_info {
+        MaybeEmptyCoreEpochInfo::NonEmpty(core_epoch_info) => {
             let CoreEpochInfo {
                 core_poq_generator: new_core_poq_generator,
                 public: new_epoch_info,
@@ -1229,11 +1642,6 @@ where
             // Queued proposals go with it, and for the same reason: the rotation
             // is what makes them unsendable. Anything not yet encapsulated would
             // now draw on the new epoch's leadership quota — one message's worth
-            // per winning slot — spending it on a block the chain has moved past
-            // instead of on the one this node is about to produce. What was
-            // already encapsulated is not here; it is in the old scheduler, which
-            // goes on releasing it for the transition period.
-            discard_stale_proposals(pending_messages);
             let (
                 _,
                 _,
@@ -1345,26 +1753,28 @@ where
 
             let (new_scheduler, old_scheduler) = current_scheduler
                 .rotate_epoch(new_scheduler_epoch_info, settings.scheduler_settings());
+            let new_recovery_checkpoint = ServiceState::with_epoch(
+                new_epoch_info.epoch,
+                pending_transactions,
+                new_epoch_blending_token_collector,
+                Some(old_epoch_blending_token_collector),
+                state_updater,
+            )
+            .expect("service state should be created successfully");
             HandleEpochEventOutput::Transitioning {
-                new_crypto_processor: new_processor,
-                new_scheduler,
+                current_epoch: Box::new(CurrentEpoch::new(
+                    new_processor,
+                    new_scheduler,
+                    new_epoch_info,
+                )),
                 old_epoch_components: Box::new(TransitioningEpoch::new(
                     old_cryptographic_processor,
                     old_scheduler,
                 )),
-                new_recovery_checkpoint: ServiceState::with_epoch(
-                    new_epoch_info.epoch,
-                    pending_transactions,
-                    new_epoch_blending_token_collector,
-                    Some(old_epoch_blending_token_collector),
-                    state_updater,
-                )
-                .expect("service state should be created successfully"),
-                new_epoch_info,
+                new_recovery_checkpoint: Box::new(new_recovery_checkpoint),
             }
         }
-        EpochEvent::NewEpoch(MaybeEmptyCoreEpochInfo::Empty { epoch, epoch_nonce }) => {
-            discard_stale_proposals(pending_messages);
+        MaybeEmptyCoreEpochInfo::Empty { epoch, epoch_nonce } => {
             tracing::info!(target: LOG_TARGET, "New epoch event received, but no epoch info is available due to empty membership set.");
             let old_cryptographic_processor = current_cryptographic_processor.rotate_epoch();
             let (_, _, _, _, _, current_epoch_blending_token_collector, _, _) =
@@ -1389,21 +1799,37 @@ where
                 )),
             }
         }
-        EpochEvent::TransitionPeriodExpired => {
-            let mut state_updater = current_recovery_checkpoint.start_updating();
-
-            if let Some(old_token_collector) = state_updater.clear_old_epoch_token_collector() {
-                handle_epoch_transition_expired(backend, old_token_collector, sdp_relay).await;
-            }
-
-            HandleEpochEventOutput::TransitionCompleted {
-                current_crypto_processor: current_cryptographic_processor,
-                current_scheduler,
-                current_epoch_info,
-                new_recovery_checkpoint: state_updater.commit_changes(),
-            }
-        }
     }
+}
+
+/// Handles [`EpochEvent::TransitionPeriodExpired`]: the epoch that was being
+/// drained is finished with, and what it earned is submitted.
+///
+/// Takes nothing belonging to the current epoch, because the transition period
+/// ending is not an epoch change — which is what lets the caller keep that
+/// epoch whole rather than taking it apart and putting it back together.
+async fn complete_transition_period<
+    Backend,
+    NodeId,
+    Rng,
+    ProofsVerifier,
+    NetworkSettings,
+    RuntimeServiceId,
+>(
+    backend: &mut Backend,
+    sdp_relay: &OutboundRelay<SdpMessage>,
+    current_recovery_checkpoint: ServiceState<Backend::Settings, NetworkSettings>,
+) -> ServiceState<Backend::Settings, NetworkSettings>
+where
+    Backend: BlendBackend<NodeId, Rng, ProofsVerifier, RuntimeServiceId>,
+    NodeId: Clone + Eq + Hash + Send,
+    NetworkSettings: Clone,
+{
+    let mut state_updater = current_recovery_checkpoint.start_updating();
+    if let Some(old_token_collector) = state_updater.clear_old_epoch_token_collector() {
+        handle_epoch_transition_expired(backend, old_token_collector, sdp_relay).await;
+    }
+    state_updater.commit_changes()
 }
 
 /// Handles [`EpochEvent::TransitionPeriodExpired`].
@@ -1442,35 +1868,10 @@ enum HandleEpochEventOutput<
     CorePoQGenerator,
 > {
     Transitioning {
-        new_crypto_processor: CurrentEpochCryptographicProcessor<
-            NodeId,
-            CorePoQGenerator,
-            ProofsGenerator,
-            ProofsVerifier,
-        >,
-        new_scheduler: EpochMessageScheduler<
-            Rng,
-            ProcessedMessage,
-            EncapsulatedMessageWithVerifiedPublicHeader,
-        >,
-        new_epoch_info: CoreEpochPublicInfo<NodeId>,
-        new_recovery_checkpoint: ServiceState<BackendSettings, NetworkSettings>,
+        current_epoch:
+            Box<CurrentEpoch<NodeId, CorePoQGenerator, ProofsGenerator, ProofsVerifier, Rng>>,
+        new_recovery_checkpoint: Box<ServiceState<BackendSettings, NetworkSettings>>,
         old_epoch_components: Box<TransitioningEpoch<Rng, ProofsVerifier>>,
-    },
-    TransitionCompleted {
-        current_crypto_processor: CurrentEpochCryptographicProcessor<
-            NodeId,
-            CorePoQGenerator,
-            ProofsGenerator,
-            ProofsVerifier,
-        >,
-        current_scheduler: EpochMessageScheduler<
-            Rng,
-            ProcessedMessage,
-            EncapsulatedMessageWithVerifiedPublicHeader,
-        >,
-        current_epoch_info: CoreEpochPublicInfo<NodeId>,
-        new_recovery_checkpoint: ServiceState<BackendSettings, NetworkSettings>,
     },
     Retiring {
         retiring_epoch: Box<RetiringEpoch<Rng, ProofsVerifier>>,

--- a/services/blend/src/core/mod.rs
+++ b/services/blend/src/core/mod.rs
@@ -83,6 +83,7 @@ use tracing::{debug, error, info};
 use crate::{
     core::{
         backends::BackendEpochInfo,
+        epoch_stages::{retiring::RetiringEpoch, transitioning::TransitioningEpoch},
         kms::{KmsPoQAdapter, PreloadKMSBackendCorePoQGenerator},
         processor::{
             CoreCryptographicProcessor as CurrentEpochCryptographicProcessor, Error,
@@ -91,7 +92,6 @@ use crate::{
         scheduler::SchedulerWrapper,
         settings::{RunningBlendConfig, StartingBlendConfig},
         state::{RecoveryServiceState, ServiceState, StateUpdater as ServiceStateUpdater},
-        transitioning::TransitioningEpoch,
     },
     epoch::{CoreEpochInfo, CoreEpochPublicInfo, MaybeEmptyCoreEpochInfo},
     epoch_info::{PolEpochInfo, PolInfoProvider as PolInfoProviderTrait},
@@ -111,12 +111,12 @@ pub mod settings;
 
 pub(super) mod service_components;
 
+mod epoch_stages;
 mod processor;
 mod scheduler;
 mod state;
 #[cfg(test)]
 mod tests;
-mod transitioning;
 pub use state::RecoveryServiceState as CoreServiceState;
 
 const LOG_TARGET: &str = blend::service::CORE;
@@ -436,7 +436,7 @@ where
         // Run the main event loop while the node is a core node across multiple
         // epochs. When the node becomes a non-core node in a new epoch, the
         // epoch it is leaving behind is handed over for the retirement phase.
-        let (old_epoch_components, old_epoch_blending_token_collector) = run_event_loop(
+        let retiring_epoch = run_event_loop(
             inbound_relay,
             &mut blend_messages,
             secret_pol_info_stream,
@@ -467,8 +467,7 @@ where
             payload_dispatcher,
             sdp_relay,
             rng,
-            old_epoch_blending_token_collector,
-            old_epoch_components,
+            retiring_epoch,
         )
         .await;
 
@@ -843,10 +842,7 @@ async fn run_event_loop<
     >,
     mut current_epoch_info: CoreEpochPublicInfo<NodeId>,
     mut recovery_checkpoint: ServiceState<Backend::Settings, Dispatcher::Settings>,
-) -> (
-    TransitioningEpoch<Rng, ProofsVerifier>,
-    OldEpochBlendingTokenCollector,
-)
+) -> RetiringEpoch<Rng, ProofsVerifier>
 where
     NodeId: Clone + Eq + Hash + Send + Sync + 'static,
     Rng: rand::Rng + Clone + Send + Unpin,
@@ -954,9 +950,9 @@ where
                         old_epoch_components = None;
                     },
                     // Current epoch info consumed, not usable anymore
-                    HandleEpochEventOutput::Retiring { old_epoch_components, old_token_collector } => {
+                    HandleEpochEventOutput::Retiring { retiring_epoch } => {
                         tracing::info!(target: LOG_TARGET, "Exiting from the main event loop");
-                        return (*old_epoch_components, old_token_collector);
+                        return *retiring_epoch;
                     },
                 }
             }
@@ -1112,7 +1108,6 @@ where
 
 /// Processes the old epoch during the epoch transition period
 /// before retiring the core service.
-#[expect(clippy::too_many_arguments, reason = "categorize args")]
 async fn retire<
     NodeId,
     Backend,
@@ -1134,8 +1129,7 @@ async fn retire<
     payload_dispatcher: Dispatcher,
     sdp_relay: OutboundRelay<SdpMessage>,
     mut rng: Rng,
-    mut blending_token_collector: OldEpochBlendingTokenCollector,
-    old_epoch_components: TransitioningEpoch<Rng, ProofsVerifier>,
+    mut retiring_epoch: RetiringEpoch<Rng, ProofsVerifier>,
 ) where
     NodeId: Clone + Eq + Hash + Send + Sync + 'static,
     Rng: rand::Rng + Clone + Send + Unpin,
@@ -1145,17 +1139,18 @@ async fn retire<
     ProofsVerifier: ProofsVerifierTrait + Send + Sync,
     RuntimeServiceId: Send + Sync,
 {
-    let (crypto_processor, mut message_scheduler) = old_epoch_components.into_components();
     loop {
+        let epoch = retiring_epoch.epoch();
         tokio::select! {
             Some(incoming_message) = blend_messages.next() => {
-                handle_incoming_blend_message_from_old_epoch(incoming_message, &mut message_scheduler, &crypto_processor, &mut blending_token_collector);
+                let (crypto_processor, message_scheduler, blending_token_collector) = retiring_epoch.split_mut();
+                handle_incoming_blend_message_from_old_epoch(incoming_message, message_scheduler, crypto_processor, blending_token_collector);
             }
-            Some(round_info) = message_scheduler.next() => {
-                handle_release_round_for_old_epoch(round_info, &mut rng, &backend, &payload_dispatcher, crypto_processor.epoch()).await;
+            Some(round_info) = retiring_epoch.scheduler_mut().next() => {
+                handle_release_round_for_old_epoch(round_info, &mut rng, &backend, &payload_dispatcher, epoch).await;
             }
             Some(EpochEvent::TransitionPeriodExpired) = remaining_epoch_stream.next() => {
-                handle_epoch_transition_expired(&mut backend, blending_token_collector, &sdp_relay).await;
+                handle_epoch_transition_expired(&mut backend, retiring_epoch.into_tokens(), &sdp_relay).await;
                 // Now the core service is no longer needed for the current (new) epoch,
                 // and the remaining epoch transition has been completed,
                 // so finishing the retirement process.
@@ -1282,13 +1277,18 @@ where
             let Some(core_poq_generator) = new_core_poq_generator else {
                 tracing::info!(target: LOG_TARGET, "Local node is not part of new membership. Retiring from core.");
                 return HandleEpochEventOutput::Retiring {
-                    old_epoch_components: Box::new(TransitioningEpoch::new(
-                        old_cryptographic_processor,
-                        current_scheduler
-                            .rotate_epoch(new_scheduler_epoch_info, settings.scheduler_settings())
-                            .1,
+                    retiring_epoch: Box::new(RetiringEpoch::new(
+                        TransitioningEpoch::new(
+                            old_cryptographic_processor,
+                            current_scheduler
+                                .rotate_epoch(
+                                    new_scheduler_epoch_info,
+                                    settings.scheduler_settings(),
+                                )
+                                .1,
+                        ),
+                        old_epoch_blending_token_collector,
                     )),
-                    old_token_collector: old_epoch_blending_token_collector,
                 };
             };
 
@@ -1327,16 +1327,18 @@ where
                     Err(e @ (Error::LocalIsNotCoreNode | Error::NetworkIsTooSmall(_))) => {
                         tracing::info!(target: LOG_TARGET, "New membership does not satisfy the core node condition: {e:?}");
                         return HandleEpochEventOutput::Retiring {
-                            old_epoch_components: Box::new(TransitioningEpoch::new(
-                                old_cryptographic_processor,
-                                current_scheduler
-                                    .rotate_epoch(
-                                        new_scheduler_epoch_info,
-                                        settings.scheduler_settings(),
-                                    )
-                                    .1,
+                            retiring_epoch: Box::new(RetiringEpoch::new(
+                                TransitioningEpoch::new(
+                                    old_cryptographic_processor,
+                                    current_scheduler
+                                        .rotate_epoch(
+                                            new_scheduler_epoch_info,
+                                            settings.scheduler_settings(),
+                                        )
+                                        .1,
+                                ),
+                                old_epoch_blending_token_collector,
                             )),
-                            old_token_collector: old_epoch_blending_token_collector,
                         };
                     }
                 };
@@ -1378,11 +1380,13 @@ where
             let (_, old_epoch_blending_token_collector) =
                 current_epoch_blending_token_collector.rotate_epoch(&new_reward_epoch_info);
             HandleEpochEventOutput::Retiring {
-                old_epoch_components: Box::new(TransitioningEpoch::new(
-                    old_cryptographic_processor,
-                    current_scheduler.consume(),
+                retiring_epoch: Box::new(RetiringEpoch::new(
+                    TransitioningEpoch::new(
+                        old_cryptographic_processor,
+                        current_scheduler.consume(),
+                    ),
+                    old_epoch_blending_token_collector,
                 )),
-                old_token_collector: old_epoch_blending_token_collector,
             }
         }
         EpochEvent::TransitionPeriodExpired => {
@@ -1469,11 +1473,7 @@ enum HandleEpochEventOutput<
         new_recovery_checkpoint: ServiceState<BackendSettings, NetworkSettings>,
     },
     Retiring {
-        old_epoch_components: Box<TransitioningEpoch<Rng, ProofsVerifier>>,
-        /// Held apart from `old_epoch_components` because the recovery state
-        /// that would otherwise carry these is consumed on the way out
-        /// of core.
-        old_token_collector: OldEpochBlendingTokenCollector,
+        retiring_epoch: Box<RetiringEpoch<Rng, ProofsVerifier>>,
     },
 }
 

--- a/services/blend/src/core/tests/mod.rs
+++ b/services/blend/src/core/tests/mod.rs
@@ -824,14 +824,10 @@ async fn test_handle_epoch_event() {
         &mut PendingLocalMessages::new(),
     )
     .await;
-    let HandleEpochEventOutput::Retiring {
-        old_epoch_components,
-        ..
-    } = output
-    else {
+    let HandleEpochEventOutput::Retiring { retiring_epoch } = output else {
         panic!("expected Retiring output");
     };
-    assert_eq!(old_epoch_components.epoch(), epoch.strict_add(1.into()));
+    assert_eq!(retiring_epoch.epoch(), epoch.strict_add(1.into()));
 }
 
 /// On an epoch change where the membership actually changes (and the local node
@@ -1109,16 +1105,12 @@ async fn test_handle_epoch_event_empty_epoch_retires() {
         &mut PendingLocalMessages::new(),
     )
     .await;
-    let HandleEpochEventOutput::Retiring {
-        old_epoch_components,
-        ..
-    } = output
-    else {
+    let HandleEpochEventOutput::Retiring { retiring_epoch } = output else {
         panic!("expected Retiring output for Empty epoch");
     };
     // The old processor/info should be from the epoch we were on before
     // the empty epoch arrived.
-    assert_eq!(old_epoch_components.epoch(), epoch);
+    assert_eq!(retiring_epoch.epoch(), epoch);
 }
 
 /// Handle a `NewEpoch(NonEmpty)` event where membership exists but the local
@@ -1193,15 +1185,11 @@ async fn test_handle_epoch_event_non_empty_without_local_core_path_retires() {
     )
     .await;
 
-    let HandleEpochEventOutput::Retiring {
-        old_epoch_components,
-        ..
-    } = output
-    else {
+    let HandleEpochEventOutput::Retiring { retiring_epoch } = output else {
         panic!("expected Retiring output for NonEmpty epoch without local core path");
     };
 
-    assert_eq!(old_epoch_components.epoch(), epoch);
+    assert_eq!(retiring_epoch.epoch(), epoch);
 }
 
 /// Check if the service keeps running after it receives a new epoch where
@@ -1283,7 +1271,7 @@ async fn complete_old_epoch_after_main_loop_done() {
         let secret_pol_info_stream =
             post_initialize::<OncePolStreamProvider, RuntimeServiceId>(&overwatch_handle).await;
 
-        let (old_epoch_components, old_epoch_blending_token_collector) = run_event_loop(
+        let retiring_epoch = run_event_loop(
             inbound_relay,
             &mut blend_message_stream,
             secret_pol_info_stream,
@@ -1308,8 +1296,7 @@ async fn complete_old_epoch_after_main_loop_done() {
             TestPayloadDispatcher,
             sdp_relay,
             rng,
-            old_epoch_blending_token_collector,
-            old_epoch_components,
+            retiring_epoch,
         )
         .await;
     });
@@ -1427,7 +1414,7 @@ async fn stop_on_empty_epoch() {
         let secret_pol_info_stream =
             post_initialize::<OncePolStreamProvider, RuntimeServiceId>(&overwatch_handle).await;
 
-        let (old_epoch_components, old_epoch_blending_token_collector) = run_event_loop(
+        let retiring_epoch = run_event_loop(
             inbound_relay,
             &mut blend_message_stream,
             secret_pol_info_stream,
@@ -1452,8 +1439,7 @@ async fn stop_on_empty_epoch() {
             TestPayloadDispatcher,
             sdp_relay,
             rng,
-            old_epoch_blending_token_collector,
-            old_epoch_components,
+            retiring_epoch,
         )
         .await;
     });
@@ -1560,7 +1546,7 @@ async fn stop_on_non_empty_epoch_without_local_core_path() {
         let secret_pol_info_stream =
             post_initialize::<OncePolStreamProvider, RuntimeServiceId>(&overwatch_handle).await;
 
-        let (old_epoch_components, old_epoch_blending_token_collector) = run_event_loop(
+        let retiring_epoch = run_event_loop(
             inbound_relay,
             &mut blend_message_stream,
             secret_pol_info_stream,
@@ -1585,8 +1571,7 @@ async fn stop_on_non_empty_epoch_without_local_core_path() {
             TestPayloadDispatcher,
             sdp_relay,
             rng,
-            old_epoch_blending_token_collector,
-            old_epoch_components,
+            retiring_epoch,
         )
         .await;
     });

--- a/services/blend/src/core/tests/mod.rs
+++ b/services/blend/src/core/tests/mod.rs
@@ -9,8 +9,7 @@ use lb_blend::{
     },
     proofs::{quota::VerifiedProofOfQuota, selection::VerifiedProofOfSelection},
     scheduling::{
-        EpochMessageScheduler, epoch::EpochEvent,
-        message_blend::crypto::EpochCryptographicProcessorSettings,
+        EpochMessageScheduler, message_blend::crypto::EpochCryptographicProcessorSettings,
     },
 };
 use lb_chain_service::Epoch;
@@ -27,6 +26,11 @@ use crate::{
     core::{
         HandleEpochEventOutput,
         backends::BlendBackend,
+        complete_transition_period,
+        epoch_stages::{
+            running::{CurrentEpoch, CurrentEpochDuringTransition},
+            transitioning::TransitioningEpoch,
+        },
         handle_epoch_event, handle_epoch_transition_expired, handle_incoming_blend_message,
         initialize, post_initialize, retire, run_event_loop,
         state::ServiceState,
@@ -34,16 +38,17 @@ use crate::{
             MockKmsAdapter, MockProofsVerifier, NodeId, TestBlendBackend, TestBlendBackendEvent,
             TestPayloadDispatcher, backend_epoch_info, dummy_overwatch_resources,
             dummy_pol_private_inputs, new_crypto_processor, new_epoch_info, new_membership,
-            new_stream, outgoing_messages_recorder, recorded_set_epoch_private_calls,
-            reset_set_epoch_private_calls, reward_epoch_info, scheduler_epoch_info,
-            scheduler_settings, sdp_relay, settings, timing_settings, wait_for_blend_backend_event,
+            new_stream, outgoing_messages_recorder, published_epochs_recorder,
+            recorded_set_epoch_private_calls, reset_set_epoch_private_calls, reward_epoch_info,
+            scheduler_epoch_info, scheduler_settings, sdp_relay, seeded_release_delay_rng,
+            settings, timing_settings, wait_for_blend_backend_event,
         },
     },
     epoch::{CoreEpochInfo, CoreEpochPublicInfo},
     epoch_info::PolEpochInfo,
     membership::{MembershipInfo, ZkInfo, chain::BlendEpochState},
     message::{BlendPayload, ServiceMessage},
-    pending::{NextLocalMessage, PendingLocalMessages},
+    pending::{NextLocalMessage, PendingTransactions, next_local_message},
     test_utils::{
         crypto::{
             GatedPowProofsGenerator, MockCoreAndLeaderProofsGenerator, PolAwareProofsGenerator,
@@ -577,7 +582,7 @@ async fn test_handle_epoch_transition_expired() {
 /// the transition period, when peers still hold that epoch's verifier.
 #[test_log::test(tokio::test)]
 async fn test_handle_epoch_event_discards_queued_proposals() {
-    let (overwatch_handle, _overwatch_cmd_receiver, state_updater, _state_receiver) =
+    let (overwatch_handle, _overwatch_cmd_receiver, _state_updater, _state_receiver) =
         dummy_overwatch_resources::<(), (), RuntimeServiceId>();
 
     // Prepare components for epoch event handling.
@@ -585,12 +590,12 @@ async fn test_handle_epoch_event_discards_queued_proposals() {
     let minimal_network_size = 2;
     let (membership, local_private_key) = new_membership(minimal_network_size);
     let settings = settings(
-        local_private_key.clone(),
+        local_private_key,
         u64::from(minimal_network_size).try_into().unwrap(),
         (),
         0,
     );
-    let public_info = new_epoch_info(epoch, membership.clone(), &settings);
+    let public_info = new_epoch_info(epoch, membership, &settings);
     let crypto_processor = new_crypto_processor(
         EpochCryptographicProcessorSettings {
             non_ephemeral_encryption_key: settings.non_ephemeral_signing_key.derive_x25519(),
@@ -607,52 +612,57 @@ async fn test_handle_epoch_event_discards_queued_proposals() {
         scheduler_settings(&settings.time, settings.num_blend_layers),
     );
     let token_collector = EpochBlendingTokenCollector::new(&reward_epoch_info(&public_info));
-    let mut backend = <TestBlendBackend as BlendBackend<_, _, _, _>>::new(
+    let backend = <TestBlendBackend as BlendBackend<_, _, _, _>>::new(
         settings.clone(),
-        overwatch_handle.clone(),
+        overwatch_handle,
         backend_epoch_info(&public_info),
         BlakeRng::from_entropy(),
     );
-    let (sdp_relay, _sdp_relay_receiver) = sdp_relay();
-
-    let mut pending_messages = PendingLocalMessages::new();
-    pending_messages.queue_proposal(b"proposal".to_vec(), 2.try_into().unwrap());
-    pending_messages.queue_transaction(b"transaction".to_vec());
-
-    let _output = handle_epoch_event(
-        EpochEvent::NewEpoch(
-            CoreEpochInfo {
-                public: CoreEpochPublicInfo {
-                    epoch: epoch.strict_add(1.into()),
-                    ..public_info.clone()
-                },
-                core_poq_generator: Some(()),
-            }
-            .into(),
-        ),
-        &settings,
-        crypto_processor,
-        scheduler,
-        public_info,
-        ServiceState::with_epoch(
-            epoch,
-            VecDeque::new(),
-            token_collector,
-            None,
-            state_updater.clone(),
+    drop(backend);
+    let (old_crypto_processor, old_scheduler) = (
+        new_crypto_processor(
+            EpochCryptographicProcessorSettings {
+                non_ephemeral_encryption_key: settings.non_ephemeral_signing_key.derive_x25519(),
+                num_blend_layers: settings.num_blend_layers,
+                pow_mining_pool: Arc::new(ThreadPoolBuilder::new().build().unwrap()),
+                spent_core_quota: Quota::ZERO,
+            },
+            &public_info,
+            (),
         )
-        .unwrap(),
-        &mut backend,
-        &sdp_relay,
-        &mut None,
-        &mut pending_messages,
-    )
-    .await;
+        .rotate_epoch(),
+        EpochMessageScheduler::new(
+            scheduler_epoch_info(&public_info),
+            BlakeRng::from_entropy(),
+            scheduler_settings(&settings.time, settings.num_blend_layers),
+        )
+        .rotate_epoch(
+            scheduler_epoch_info(&public_info),
+            scheduler_settings(&settings.time, settings.num_blend_layers),
+        )
+        .1,
+    );
+    drop(token_collector);
 
+    let mut current_epoch = CurrentEpoch::new(crypto_processor, scheduler, public_info);
+    current_epoch
+        .proposals_mut()
+        .queue(b"proposal".to_vec(), 2.try_into().unwrap());
+
+    let during_transition = CurrentEpochDuringTransition::new(
+        current_epoch,
+        TransitioningEpoch::new(old_crypto_processor, old_scheduler),
+    );
+
+    // The transition period ending is not an epoch change, so the epoch it
+    // leaves behind keeps everything it had. Were this routed through the
+    // rotation path instead, the proposal would go with it.
+    let mut kept = during_transition.end_transition();
+    let transactions = PendingTransactions::new();
     assert_eq!(
-        pending_messages.next(),
-        Some(NextLocalMessage::Transaction(b"transaction")),
-        "the proposal must not survive the rotation, and the transaction must"
+        next_local_message(kept.proposals_mut(), &transactions),
+        Some(NextLocalMessage::ProposalCopy(b"proposal")),
+        "a proposal must outlive the end of a transition period, which is not an epoch change"
     );
 }
 
@@ -700,20 +710,17 @@ async fn test_handle_epoch_event() {
 
     // Handle a NewEpoch event, expecting Transitioning output.
     let output = handle_epoch_event(
-        EpochEvent::NewEpoch(
-            CoreEpochInfo {
-                public: CoreEpochPublicInfo {
-                    epoch: epoch.strict_add(1.into()),
-                    ..public_info.clone()
-                },
-                core_poq_generator: Some(()),
-            }
-            .into(),
-        ),
+        CoreEpochInfo {
+            public: CoreEpochPublicInfo {
+                epoch: epoch.strict_add(1.into()),
+                ..public_info.clone()
+            },
+            core_poq_generator: Some(()),
+        }
+        .into(),
         &settings,
         crypto_processor,
         scheduler,
-        public_info,
         ServiceState::with_epoch(
             epoch,
             VecDeque::new(),
@@ -723,21 +730,18 @@ async fn test_handle_epoch_event() {
         )
         .unwrap(),
         &mut backend,
-        &sdp_relay,
         &mut None,
-        &mut PendingLocalMessages::new(),
     )
     .await;
     let HandleEpochEventOutput::Transitioning {
-        new_crypto_processor,
-        new_scheduler,
-        new_epoch_info,
+        current_epoch: new_current_epoch,
         new_recovery_checkpoint,
         old_epoch_components,
     } = output
     else {
         panic!("expected Transitioning output");
     };
+    let (new_crypto_processor, new_scheduler, new_epoch_info) = new_current_epoch.into_components();
     assert_eq!(new_crypto_processor.epoch(), epoch.strict_add(1.into()));
     assert_eq!(old_epoch_components.epoch(), epoch);
     assert_eq!(
@@ -761,31 +765,19 @@ async fn test_handle_epoch_event() {
             .is_some()
     );
 
-    // Handle a TransitionExpired event, expecting TransitionCompleted output.
-    let output = handle_epoch_event(
-        EpochEvent::TransitionPeriodExpired,
-        &settings,
-        new_crypto_processor,
-        new_scheduler,
-        new_epoch_info,
-        new_recovery_checkpoint,
-        &mut backend,
-        &sdp_relay,
-        &mut None,
-        &mut PendingLocalMessages::new(),
-    )
-    .await;
-    let HandleEpochEventOutput::TransitionCompleted {
-        current_crypto_processor,
-        current_scheduler,
-        current_epoch_info,
-        new_recovery_checkpoint,
-    } = output
-    else {
-        panic!("expected TransitionCompleted output");
-    };
+    // The end of the transition period is handled apart from a rotation, and
+    // takes nothing belonging to the current epoch — which is what lets that
+    // epoch, and the proposals it owns, survive it untouched.
+    let new_recovery_checkpoint =
+        complete_transition_period::<_, NodeId, BlakeRng, MockProofsVerifier, _, RuntimeServiceId>(
+            &mut backend,
+            &sdp_relay,
+            *new_recovery_checkpoint,
+        )
+        .await;
+    let (current_crypto_processor, current_scheduler) = (new_crypto_processor, new_scheduler);
     assert_eq!(current_crypto_processor.epoch(), epoch.strict_add(1.into()));
-    assert_eq!(current_epoch_info.epoch, epoch.strict_add(1.into()));
+    assert_eq!(new_epoch_info.epoch, epoch.strict_add(1.into()));
     assert!(
         new_recovery_checkpoint
             .clone()
@@ -802,26 +794,21 @@ async fn test_handle_epoch_event() {
     // Handle a NewEpoch event with a new too small membership,
     // expecting Retiring output.
     let output = handle_epoch_event(
-        EpochEvent::NewEpoch(
-            CoreEpochInfo {
-                public: CoreEpochPublicInfo {
-                    membership: new_membership(minimal_network_size - 1).0,
-                    epoch: epoch.strict_add(2.into()),
-                    ..current_epoch_info.clone()
-                },
-                core_poq_generator: Some(()),
-            }
-            .into(),
-        ),
+        CoreEpochInfo {
+            public: CoreEpochPublicInfo {
+                membership: new_membership(minimal_network_size - 1).0,
+                epoch: epoch.strict_add(2.into()),
+                ..new_epoch_info.clone()
+            },
+            core_poq_generator: Some(()),
+        }
+        .into(),
         &settings,
         current_crypto_processor,
         current_scheduler,
-        current_epoch_info,
         new_recovery_checkpoint,
         &mut backend,
-        &sdp_relay,
         &mut None,
-        &mut PendingLocalMessages::new(),
     )
     .await;
     let HandleEpochEventOutput::Retiring { retiring_epoch } = output else {
@@ -873,7 +860,7 @@ async fn test_handle_epoch_event_membership_change_rewires_backend_and_generator
         BlakeRng::from_entropy(),
     );
     let mut backend_event_receiver = backend.subscribe_to_events();
-    let (sdp_relay, _sdp_relay_receiver) = sdp_relay();
+    let (_sdp_relay, _sdp_relay_receiver) = sdp_relay();
 
     // The new epoch has a *different* (larger) membership; `new_membership`
     // always includes the local node, so the node stays part of the core.
@@ -887,17 +874,14 @@ async fn test_handle_epoch_event_membership_change_rewires_backend_and_generator
     let new_public_info = new_epoch_info(new_epoch, new_membership.clone(), &settings);
 
     let output = handle_epoch_event(
-        EpochEvent::NewEpoch(
-            CoreEpochInfo {
-                public: new_public_info.clone(),
-                core_poq_generator: Some(()),
-            }
-            .into(),
-        ),
+        CoreEpochInfo {
+            public: new_public_info.clone(),
+            core_poq_generator: Some(()),
+        }
+        .into(),
         &settings,
         crypto_processor,
         scheduler,
-        public_info,
         ServiceState::with_epoch(
             epoch,
             VecDeque::new(),
@@ -907,21 +891,19 @@ async fn test_handle_epoch_event_membership_change_rewires_backend_and_generator
         )
         .unwrap(),
         &mut backend,
-        &sdp_relay,
         &mut None,
-        &mut PendingLocalMessages::new(),
     )
     .await;
 
     let HandleEpochEventOutput::Transitioning {
-        new_crypto_processor,
+        current_epoch: new_current_epoch,
         old_epoch_components,
-        new_epoch_info: returned_epoch_info,
         ..
     } = output
     else {
         panic!("expected Transitioning output");
     };
+    let (new_crypto_processor, _, returned_epoch_info) = new_current_epoch.into_components();
 
     // A fresh generator is built for the new epoch, and the previous one is
     // retained for the old epoch.
@@ -977,7 +959,7 @@ async fn transition_to_new_epoch_with_secret(secret_epoch: Epoch) -> Vec<Epoch> 
         backend_epoch_info(&public_info),
         BlakeRng::from_entropy(),
     );
-    let (sdp_relay, _sdp_relay_receiver) = sdp_relay();
+    let (_sdp_relay, _sdp_relay_receiver) = sdp_relay();
 
     let secret_info = PolEpochInfo {
         epoch: secret_epoch,
@@ -987,20 +969,17 @@ async fn transition_to_new_epoch_with_secret(secret_epoch: Epoch) -> Vec<Epoch> 
     // Isolate the `set_epoch_private` calls made by `handle_epoch_event`.
     reset_set_epoch_private_calls();
     let _output = handle_epoch_event(
-        EpochEvent::NewEpoch(
-            CoreEpochInfo {
-                public: CoreEpochPublicInfo {
-                    epoch: epoch.strict_add(1.into()),
-                    ..public_info.clone()
-                },
-                core_poq_generator: Some(()),
-            }
-            .into(),
-        ),
+        CoreEpochInfo {
+            public: CoreEpochPublicInfo {
+                epoch: epoch.strict_add(1.into()),
+                ..public_info.clone()
+            },
+            core_poq_generator: Some(()),
+        }
+        .into(),
         &settings,
         crypto_processor,
         scheduler,
-        public_info,
         ServiceState::with_epoch(
             epoch,
             VecDeque::new(),
@@ -1010,9 +989,7 @@ async fn transition_to_new_epoch_with_secret(secret_epoch: Epoch) -> Vec<Epoch> 
         )
         .unwrap(),
         &mut backend,
-        &sdp_relay,
         &mut Some(secret_info),
-        &mut PendingLocalMessages::new(),
     )
     .await;
     recorded_set_epoch_private_calls()
@@ -1081,16 +1058,15 @@ async fn test_handle_epoch_event_empty_epoch_retires() {
         backend_epoch_info(&public_info),
         BlakeRng::from_entropy(),
     );
-    let (sdp_relay, _sdp_relay_receiver) = sdp_relay();
+    let (_sdp_relay, _sdp_relay_receiver) = sdp_relay();
 
     // Handle a NewEpoch(Empty) event - empty membership triggers Retiring.
     let empty_epoch = epoch.strict_add(1.into());
     let output = handle_epoch_event(
-        EpochEvent::NewEpoch((empty_epoch, ZkHash::from(1)).into()),
+        (empty_epoch, ZkHash::from(1)).into(),
         &settings,
         crypto_processor,
         scheduler,
-        public_info.clone(),
         ServiceState::with_epoch(
             epoch,
             VecDeque::new(),
@@ -1100,9 +1076,7 @@ async fn test_handle_epoch_event_empty_epoch_retires() {
         )
         .unwrap(),
         &mut backend,
-        &sdp_relay,
         &mut None,
-        &mut PendingLocalMessages::new(),
     )
     .await;
     let HandleEpochEventOutput::Retiring { retiring_epoch } = output else {
@@ -1153,23 +1127,20 @@ async fn test_handle_epoch_event_non_empty_without_local_core_path_retires() {
         backend_epoch_info(&public_info),
         BlakeRng::from_entropy(),
     );
-    let (sdp_relay, _sdp_relay_receiver) = sdp_relay();
+    let (_sdp_relay, _sdp_relay_receiver) = sdp_relay();
 
     let output = handle_epoch_event(
-        EpochEvent::NewEpoch(
-            CoreEpochInfo {
-                public: CoreEpochPublicInfo {
-                    epoch: epoch.strict_add(1.into()),
-                    ..public_info.clone()
-                },
-                core_poq_generator: None,
-            }
-            .into(),
-        ),
+        CoreEpochInfo {
+            public: CoreEpochPublicInfo {
+                epoch: epoch.strict_add(1.into()),
+                ..public_info.clone()
+            },
+            core_poq_generator: None,
+        }
+        .into(),
         &settings,
         crypto_processor,
         scheduler,
-        public_info.clone(),
         ServiceState::with_epoch(
             epoch,
             VecDeque::new(),
@@ -1179,9 +1150,7 @@ async fn test_handle_epoch_event_non_empty_without_local_core_path_retires() {
         )
         .unwrap(),
         &mut backend,
-        &sdp_relay,
         &mut None,
-        &mut PendingLocalMessages::new(),
     )
     .await;
 
@@ -1261,6 +1230,7 @@ async fn complete_old_epoch_after_main_loop_done() {
         &sdp_relay,
         None,
         state_updater,
+        seeded_release_delay_rng(),
     )
     .await;
     let mut backend_event_receiver = backend.subscribe_to_events();
@@ -1280,11 +1250,13 @@ async fn complete_old_epoch_after_main_loop_done() {
             &mut backend,
             &TestPayloadDispatcher,
             &sdp_relay,
-            message_scheduler.into(),
             &mut rng,
+            CurrentEpoch::new(
+                crypto_processor,
+                message_scheduler.into(),
+                current_public_info,
+            ),
             pending_transactions,
-            crypto_processor,
-            current_public_info,
             current_recovery_checkpoint,
         )
         .await;
@@ -1404,6 +1376,7 @@ async fn stop_on_empty_epoch() {
         &sdp_relay,
         None,
         state_updater,
+        seeded_release_delay_rng(),
     )
     .await;
 
@@ -1423,11 +1396,13 @@ async fn stop_on_empty_epoch() {
             &mut backend,
             &TestPayloadDispatcher,
             &sdp_relay,
-            message_scheduler.into(),
             &mut rng,
+            CurrentEpoch::new(
+                crypto_processor,
+                message_scheduler.into(),
+                current_public_info,
+            ),
             pending_transactions,
-            crypto_processor,
-            current_public_info,
             current_recovery_checkpoint,
         )
         .await;
@@ -1536,6 +1511,7 @@ async fn stop_on_non_empty_epoch_without_local_core_path() {
         &sdp_relay,
         None,
         state_updater,
+        seeded_release_delay_rng(),
     )
     .await;
 
@@ -1555,11 +1531,13 @@ async fn stop_on_non_empty_epoch_without_local_core_path() {
             &mut backend,
             &TestPayloadDispatcher,
             &sdp_relay,
-            message_scheduler.into(),
             &mut rng,
+            CurrentEpoch::new(
+                crypto_processor,
+                message_scheduler.into(),
+                current_public_info,
+            ),
             pending_transactions,
-            crypto_processor,
-            current_public_info,
             current_recovery_checkpoint,
         )
         .await;
@@ -1841,6 +1819,7 @@ async fn test_initialize_recovers_matching_saved_state() {
         &sdp_relay_1,
         Some(saved_state),
         state_updater,
+        seeded_release_delay_rng(),
     )
     .await;
 
@@ -1930,6 +1909,7 @@ async fn test_initialize_recovers_matching_saved_state() {
         &sdp_relay2,
         Some(stale_state),
         state_updater2,
+        seeded_release_delay_rng(),
     )
     .await;
 
@@ -1952,7 +1932,7 @@ async fn test_initialize_recovers_matching_saved_state() {
         "Mismatched epoch: a queued transaction should outlive the state that carried it"
     );
     assert_eq!(
-        pending_messages2.transactions().next(),
+        pending_messages2.iter().next(),
         Some(&b"stale epoch transaction".to_vec()),
         "Mismatched epoch: the queue handed to the event loop should carry it too"
     );
@@ -2037,6 +2017,7 @@ async fn test_initialize_submits_activity_proof_for_the_previous_epoch() {
         &sdp_relay,
         Some(saved_state),
         state_updater,
+        seeded_release_delay_rng(),
     )
     .await;
 
@@ -2125,6 +2106,7 @@ async fn test_initialize_drops_activity_proof_older_than_one_epoch() {
         &sdp_relay,
         Some(stale_state),
         state_updater,
+        seeded_release_delay_rng(),
     )
     .await;
 
@@ -2206,6 +2188,7 @@ async fn a_proposal_arriving_before_the_pol_info_is_still_sent() {
         &sdp_relay,
         None,
         state_updater,
+        seeded_release_delay_rng(),
     )
     .await;
 
@@ -2221,11 +2204,13 @@ async fn a_proposal_arriving_before_the_pol_info_is_still_sent() {
             &mut backend,
             &TestPayloadDispatcher,
             &sdp_relay,
-            message_scheduler.into(),
             &mut rng,
+            CurrentEpoch::new(
+                crypto_processor,
+                message_scheduler.into(),
+                current_public_info,
+            ),
             pending_transactions,
-            crypto_processor,
-            current_public_info,
             current_recovery_checkpoint,
         )
         .await;
@@ -2258,6 +2243,159 @@ async fn a_proposal_arriving_before_the_pol_info_is_still_sent() {
         "the proposal should have been held until leadership proofs were possible",
     )
     .await;
+}
+
+/// A message queued before an epoch rotation still goes out afterwards, under
+/// the epoch it was minted for.
+///
+/// The previous epoch keeps releasing through its own scheduler for the length
+/// of its transition period, and each message it releases is published under
+/// that epoch so it reaches the peers still negotiated for it. Publishing it
+/// under the new epoch would fail their `PoQ` check and earn this node a
+/// `SpamReason::InvalidProofOfQuota`.
+///
+/// What is pinned here is that the message survives the rotation and is
+/// published under the epoch it was minted for. *Which* scheduler releases it
+/// is not: both the current epoch before the rotation and the previous epoch
+/// after it publish under epoch 0, and which one gets there first depends on
+/// how the round clock falls against an epoch arriving over a channel. Seeding
+/// the delayer fixes the round but not that race — measured at roughly three
+/// runs in eight exercising the previous-epoch path.
+///
+/// Pinning it needs a test that does not go through the loop at all, on
+/// [`CurrentEpochDuringTransition::next_event`] directly.
+#[test_log::test(tokio::test)]
+#[expect(clippy::too_many_lines, reason = "Test function.")]
+async fn the_previous_epoch_keeps_releasing_under_its_own_epoch() {
+    let minimal_network_size = 2;
+    let (membership, local_private_key) = new_membership(minimal_network_size);
+    let mut settings = settings(
+        local_private_key.clone(),
+        u64::from(minimal_network_size).try_into().unwrap(),
+        (),
+        0,
+    );
+    // No cover traffic, so the only message that can come out is the queued
+    // transaction. See the `PoW` liveness test for why this quota silences it.
+    settings.num_blend_layers = NonZeroU64::try_from(2).unwrap();
+    settings.scheduler.cover.message_frequency_per_round = 0.05.try_into().unwrap();
+    let (inbound_relay, inbound_message_sender) = new_stream();
+    let (mut blend_message_stream, _blend_message_sender) = new_stream();
+    let (membership_stream, membership_sender) = new_stream();
+
+    let membership_info = MembershipInfo {
+        membership,
+        zk: Some(ZkInfo {
+            root: ZkHash::ZERO,
+            core_and_path_selectors: Some([(ZkHash::ZERO, false); CORE_MERKLE_TREE_HEIGHT]),
+        }),
+    };
+    membership_sender
+        .send(test_blend_epoch_state(0, membership_info.clone()))
+        .await
+        .unwrap();
+
+    let (sdp_relay, _sdp_relay_receiver) = sdp_relay();
+    let (overwatch_handle, _overwatch_cmd_receiver, state_updater, _state_receiver) =
+        dummy_overwatch_resources();
+
+    // Both installed before the service exists, so nothing is missed.
+    let mut published_epochs = published_epochs_recorder();
+
+    let (
+        mut remaining_epoch_stream,
+        current_public_info,
+        crypto_processor,
+        current_recovery_checkpoint,
+        pending_transactions,
+        message_scheduler,
+        mut backend,
+        mut rng,
+    ) = initialize::<
+        NodeId,
+        TestBlendBackend,
+        TestPayloadDispatcher,
+        MockCoreAndLeaderProofsGenerator,
+        MockProofsVerifier,
+        MockKmsAdapter,
+        RuntimeServiceId,
+    >(
+        settings.clone(),
+        membership_stream,
+        overwatch_handle.clone(),
+        MockKmsAdapter,
+        &sdp_relay,
+        None,
+        state_updater,
+        seeded_release_delay_rng(),
+    )
+    .await;
+
+    tokio::spawn(async move {
+        let secret_pol_info_stream =
+            post_initialize::<OncePolStreamProvider, RuntimeServiceId>(&overwatch_handle).await;
+        run_event_loop(
+            inbound_relay,
+            &mut blend_message_stream,
+            secret_pol_info_stream,
+            &mut remaining_epoch_stream,
+            &settings,
+            &mut backend,
+            &TestPayloadDispatcher,
+            &sdp_relay,
+            &mut rng,
+            CurrentEpoch::new(
+                crypto_processor,
+                message_scheduler.into(),
+                current_public_info,
+            ),
+            pending_transactions,
+            current_recovery_checkpoint,
+        )
+        .await;
+    });
+
+    // Queued under epoch 0, and released on a round that has not come yet.
+    inbound_message_sender
+        .send(ServiceMessage::Blend(BlendPayload::Transaction(
+            b"transaction".to_vec(),
+        )))
+        .await
+        .unwrap();
+
+    // Answering a request proves the service went round the inbound arm again,
+    // so the transaction ahead of it is already queued when the epoch turns.
+    let (reply, answered) = oneshot::channel();
+    inbound_message_sender
+        .send(ServiceMessage::GetPendingTransactions { reply })
+        .await
+        .unwrap();
+    answered.await.unwrap();
+
+    membership_sender
+        .send(test_blend_epoch_state(1, membership_info))
+        .await
+        .unwrap();
+
+    // The rotation has to be observed before anything is asserted: a release
+    // that happened while epoch 0 was still current is also published under
+    // epoch 0, and would satisfy the assertion without the previous epoch
+    // having released anything at all.
+    // The first message out is the one the previous epoch still had queued: the
+    // rotation lands before it (measured at ~440µs against ~580µs), and nothing
+    // else is due, since this test's quota leaves no room for cover traffic.
+    //
+    // Generous next to the release round the message has to wait for, and only
+    // ever reached when the assertion has already failed.
+    let published_under = tokio::time::timeout(Duration::from_secs(10), published_epochs.recv())
+        .await
+        .expect("timed out: the previous epoch should still release what it had queued")
+        .expect("service stopped publishing");
+    assert_eq!(
+        published_under,
+        Epoch::from(0),
+        "a message minted under the previous epoch must be published under it, not the new one"
+    );
 }
 
 /// A block proposal that arrives before this epoch's secret `PoL` info still
@@ -2331,6 +2469,7 @@ async fn a_message_that_can_never_be_sent_does_not_block_the_rest() {
         &sdp_relay,
         None,
         state_updater,
+        seeded_release_delay_rng(),
     )
     .await;
 
@@ -2346,11 +2485,13 @@ async fn a_message_that_can_never_be_sent_does_not_block_the_rest() {
             &mut backend,
             &TestPayloadDispatcher,
             &sdp_relay,
-            message_scheduler.into(),
             &mut rng,
+            CurrentEpoch::new(
+                crypto_processor,
+                message_scheduler.into(),
+                current_public_info,
+            ),
             pending_transactions,
-            crypto_processor,
-            current_public_info,
             current_recovery_checkpoint,
         )
         .await;
@@ -2388,6 +2529,7 @@ async fn a_message_that_can_never_be_sent_does_not_block_the_rest() {
 /// and this test pins that down by getting a block proposal all the way out
 /// while the transaction is still waiting for its solution.
 #[test_log::test(tokio::test)]
+#[expect(clippy::too_many_lines, reason = "Test function.")]
 async fn a_transaction_awaiting_a_pow_solution_does_not_stall_the_event_loop() {
     let minimal_network_size = 2;
     let (membership, local_private_key) = new_membership(minimal_network_size);
@@ -2456,6 +2598,7 @@ async fn a_transaction_awaiting_a_pow_solution_does_not_stall_the_event_loop() {
         &sdp_relay,
         None,
         state_updater,
+        seeded_release_delay_rng(),
     )
     .await;
 
@@ -2471,11 +2614,13 @@ async fn a_transaction_awaiting_a_pow_solution_does_not_stall_the_event_loop() {
             &mut backend,
             &TestPayloadDispatcher,
             &sdp_relay,
-            message_scheduler.into(),
             &mut rng,
+            CurrentEpoch::new(
+                crypto_processor,
+                message_scheduler.into(),
+                current_public_info,
+            ),
             pending_transactions,
-            crypto_processor,
-            current_public_info,
             current_recovery_checkpoint,
         )
         .await;

--- a/services/blend/src/core/tests/utils.rs
+++ b/services/blend/src/core/tests/utils.rs
@@ -38,10 +38,12 @@ use lb_key_management_system_service::keys::{Ed25519PublicKey, UnsecuredEd25519K
 use lb_network_service::{NetworkService, backends::NetworkBackend};
 use lb_poq::{CorePathAndSelectors, KeyIndex};
 use lb_sdp_service::SdpMessage;
+use lb_utils::blake_rng::BlakeRng;
 use overwatch::{
     overwatch::{OverwatchHandle, commands::OverwatchCommand},
     services::{ServiceData, relay::OutboundRelay, state::StateUpdater},
 };
+use rand::SeedableRng as _;
 use rayon::ThreadPoolBuilder;
 use tokio::sync::{
     broadcast::{self},
@@ -113,6 +115,22 @@ pub fn settings<BackendSettings>(
     }
 }
 
+/// The seed every test's release delayer is built from.
+const RELEASE_DELAY_SEED: u64 = 1;
+
+/// A release delayer that draws the same delays on every run.
+///
+/// `initialize` takes this rather than drawing from entropy so that how many
+/// rounds a message waits is a fixed property of a test rather than a fresh
+/// draw each time. Note what this does *not* buy: the delay is in whole rounds
+/// (`release_delayer` picks from `[1, max]`, never zero), so it fixes which
+/// round a message goes out on, not how that round falls against events driven
+/// from elsewhere — an epoch rotation arriving over a channel, say. A test that
+/// depends on such an ordering needs more than this.
+pub fn seeded_release_delay_rng() -> BlakeRng {
+    BlakeRng::seed_from_u64(RELEASE_DELAY_SEED)
+}
+
 pub fn timing_settings() -> TimingSettings {
     TimingSettings {
         rounds_per_epoch: 10.try_into().unwrap(),
@@ -169,9 +187,10 @@ where
     async fn publish(
         &self,
         _msg: EncapsulatedMessageWithVerifiedPublicHeader,
-        _intended_epoch: Epoch,
+        intended_epoch: Epoch,
     ) {
         note_outgoing_message();
+        note_published_epoch(intended_epoch);
     }
 
     async fn rotate_epoch(&mut self, new_epoch_info: BackendEpochInfo<NodeId, ProofsVerifier>) {
@@ -248,6 +267,10 @@ thread_local! {
     /// Installed by [`record_outgoing_messages`] for the duration of a test.
     static OUTGOING_MESSAGES: RefCell<Option<mpsc::UnboundedSender<()>>> =
         const { RefCell::new(None) };
+
+    /// Installed by [`published_epochs_recorder`] for the duration of a test.
+    static PUBLISHED_EPOCHS: RefCell<Option<mpsc::UnboundedSender<Epoch>>> =
+        const { RefCell::new(None) };
 }
 
 /// Starts recording every message the service sends onwards, whether it goes
@@ -263,6 +286,24 @@ fn note_outgoing_message() {
     OUTGOING_MESSAGES.with_borrow(|recorder| {
         if let Some(sender) = recorder.as_ref() {
             let _ = sender.send(());
+        }
+    });
+}
+
+/// Records the epoch each message is published under, which is what tells a
+/// transitioning epoch's release apart from the current one's. Separate from
+/// [`outgoing_messages_recorder`], which also counts payloads handed to the
+/// local dispatcher and so has no epoch to report.
+pub fn published_epochs_recorder() -> mpsc::UnboundedReceiver<Epoch> {
+    let (sender, receiver) = mpsc::unbounded_channel();
+    PUBLISHED_EPOCHS.with_borrow_mut(|recorder| *recorder = Some(sender));
+    receiver
+}
+
+fn note_published_epoch(intended_epoch: Epoch) {
+    PUBLISHED_EPOCHS.with_borrow(|recorder| {
+        if let Some(sender) = recorder.as_ref() {
+            let _ = sender.send(intended_epoch);
         }
     });
 }

--- a/services/blend/src/edge/current_epoch.rs
+++ b/services/blend/src/edge/current_epoch.rs
@@ -1,0 +1,366 @@
+//! The epoch this node is blending under, and what belongs to it alone.
+
+use core::{hash::Hash, num::NonZeroU64};
+
+use lb_blend::{
+    membership::Membership,
+    message::{
+        crypto::proofs::PoQVerificationInputsMinusSigningKey,
+        encap::validated::EncapsulatedMessageWithVerifiedPublicHeader,
+    },
+    proofs::quota::{
+        inputs::prove::public::{CoreInputs, LeaderInputs, PowInputs},
+        pow::PowTarget,
+    },
+    scheduling::message_blend::provers::leader_and_pow::LeaderAndPowProofsGenerator,
+};
+use lb_chain_service::Epoch;
+use lb_groth16::Fr;
+use overwatch::overwatch::OverwatchHandle;
+use tracing::debug;
+
+use crate::{
+    edge::{
+        LOG_TARGET, RunningSettings,
+        backends::BlendBackend,
+        handlers::{Error, MessageHandler},
+    },
+    epoch_info::PolEpochInfo,
+    membership::{MembershipInfo, ZkInfo, chain::BlendEpochState},
+    pending::{
+        EncapsulationResult, MessageKind, NextLocalMessage, PendingProposals, PendingTransactions,
+        next_local_message, resolve_encapsulation,
+    },
+};
+
+/// Which of the two this node is in for the epoch it is on.
+pub enum CurrentEpoch<Backend, NodeId, ProofsGenerator, RuntimeServiceId> {
+    AwaitingSecretInfo(AwaitingSecretInfo<NodeId>),
+    Blending(Blending<Backend, NodeId, ProofsGenerator, RuntimeServiceId>),
+}
+
+/// The epoch this node is blending under, before its secret `PoL` info has
+/// arrived.
+///
+/// It can take proposals but not mint anything: leadership proofs need that
+/// info, and this is the window a queued proposal waits out. Everything here is
+/// replaced when the epoch turns and nothing here outlives it, which is what
+/// decides membership — queued proposals belong because one is built for a slot
+/// in this epoch, so a rotation makes it worthless. Transactions are not
+/// slot-bound and are held outside, by whatever outlives epochs.
+pub struct AwaitingSecretInfo<NodeId> {
+    info: ValidBlendEpochState<NodeId>,
+    proposals: PendingProposals,
+}
+
+/// Epoch state for a valid Blend session (i.e., membership above the minimum
+/// network size).
+#[derive(Clone, Debug)]
+pub struct ValidBlendEpochState<NodeId> {
+    pub epoch: Epoch,
+    pub nonce: Fr,
+    pub aged: Fr,
+    pub lottery_0: Fr,
+    pub lottery_1: Fr,
+    pub pow_difficulty: PowTarget,
+    pub membership_info: ValidMembershipInfo<NodeId>,
+}
+
+#[derive(Clone, Debug)]
+pub struct ValidMembershipInfo<NodeId> {
+    pub membership: Membership<NodeId>,
+    pub zk: ZkInfo,
+}
+
+/// The same epoch, once both halves are in and a handler exists to mint for it.
+///
+/// The handler is a field rather than an `Option` on one type, so the methods
+/// that need one — encapsulating and sending — exist only where there is one.
+pub struct Blending<Backend, NodeId, ProofsGenerator, RuntimeServiceId> {
+    awaiting: AwaitingSecretInfo<NodeId>,
+    handler: MessageHandler<Backend, NodeId, ProofsGenerator, RuntimeServiceId>,
+}
+
+impl<Backend, NodeId, ProofsGenerator, RuntimeServiceId>
+    CurrentEpoch<Backend, NodeId, ProofsGenerator, RuntimeServiceId>
+{
+    const fn awaiting_mut(&mut self) -> &mut AwaitingSecretInfo<NodeId> {
+        match self {
+            Self::AwaitingSecretInfo(awaiting) | Self::Blending(Blending { awaiting, .. }) => {
+                awaiting
+            }
+        }
+    }
+
+    /// Queues a proposal to be sent `copies` times, to go out under this epoch
+    /// or not at all.
+    pub fn queue_proposal(&mut self, proposal: Vec<u8>, copies: NonZeroU64) {
+        self.awaiting_mut().proposals.queue(proposal, copies);
+    }
+
+    pub const fn proposals_mut(&mut self) -> &mut PendingProposals {
+        &mut self.awaiting_mut().proposals
+    }
+
+    const fn awaiting(&self) -> &AwaitingSecretInfo<NodeId> {
+        match self {
+            Self::AwaitingSecretInfo(awaiting) | Self::Blending(Blending { awaiting, .. }) => {
+                awaiting
+            }
+        }
+    }
+
+    const fn awaiting_epoch(&self) -> Epoch {
+        self.awaiting().info.epoch
+    }
+
+    #[cfg(test)]
+    pub const fn info(&self) -> &ValidBlendEpochState<NodeId> {
+        &self.awaiting().info
+    }
+
+    #[cfg(test)]
+    pub const fn has_handler(&self) -> bool {
+        matches!(self, Self::Blending(_))
+    }
+}
+
+impl<Backend, NodeId, ProofsGenerator, RuntimeServiceId>
+    CurrentEpoch<Backend, NodeId, ProofsGenerator, RuntimeServiceId>
+where
+    Backend: BlendBackend<NodeId, RuntimeServiceId>,
+    NodeId: Clone + Send + Eq + Hash + 'static,
+    ProofsGenerator: LeaderAndPowProofsGenerator,
+{
+    /// A new epoch, which by definition has no handler yet: one needs secret
+    /// `PoL` info that has not been matched to it.
+    ///
+    /// Fails when the membership says this node has no business being an edge
+    /// node of this epoch, which shuts the service down. Doing it here is what
+    /// makes the rest of this type unconditional: a `CurrentEpoch` that exists
+    /// is one whose membership was accepted, so nothing downstream has to ask
+    /// again — and the handler, which used to re-check the same two conditions,
+    /// no longer does.
+    pub fn try_new(
+        BlendEpochState {
+            aged,
+            epoch,
+            lottery_0,
+            lottery_1,
+            membership_info: MembershipInfo { membership, zk },
+            nonce,
+            pow_difficulty,
+        }: BlendEpochState<NodeId>,
+        settings: &RunningSettings<Backend, NodeId, RuntimeServiceId>,
+    ) -> Result<Self, Error> {
+        let Some(zk_info) = zk else {
+            return Err(Error::NetworkIsTooSmall(0));
+        };
+
+        let membership_size = membership.size();
+        if membership_size < settings.minimum_network_size.get() as usize {
+            return Err(Error::NetworkIsTooSmall(membership_size));
+        }
+        if membership.contains_local() {
+            return Err(Error::LocalIsCoreNode);
+        }
+
+        Ok(Self::AwaitingSecretInfo(AwaitingSecretInfo {
+            info: ValidBlendEpochState {
+                epoch,
+                nonce,
+                aged,
+                lottery_0,
+                lottery_1,
+                pow_difficulty,
+                membership_info: ValidMembershipInfo {
+                    membership,
+                    zk: zk_info,
+                },
+            },
+            proposals: PendingProposals::new(epoch),
+        }))
+    }
+
+    /// This epoch with the handler it can have, given what secret `PoL` info is
+    /// to hand.
+    ///
+    /// The stash outlives epochs — info can arrive for one this node has not
+    /// reached — so it is only drawn from when it names *this* epoch, and left
+    /// alone otherwise.
+    pub fn with_available_secret_info(
+        self,
+        stashed_secret_info: &mut Option<PolEpochInfo>,
+        settings: RunningSettings<Backend, NodeId, RuntimeServiceId>,
+        overwatch_handle: OverwatchHandle<RuntimeServiceId>,
+    ) -> Self {
+        let epoch = self.awaiting_epoch();
+        if let Some(secret_epoch_info) =
+            stashed_secret_info.take_if(|stashed| stashed.epoch == epoch)
+        {
+            return self.with_secret_info(secret_epoch_info, settings, overwatch_handle);
+        }
+
+        // Nothing to do, and nothing to undo: an epoch this node has not
+        // reached having secret info stashed for it says nothing about the one
+        // it is on, which keeps whatever handler it had.
+        debug!(target: LOG_TARGET, "No secret PoL info for epoch {epoch:?} yet, leaving this epoch as it is.");
+        self
+    }
+
+    /// This epoch with the handler its secret `PoL` info makes possible.
+    ///
+    /// The info must be *this* epoch's; matching it against the epoch is the
+    /// caller's job, since the caller is what holds one that has not found its
+    /// epoch yet. Infallible: the only thing that could have gone wrong was the
+    /// membership, and a `CurrentEpoch` cannot exist unless that was accepted.
+    ///
+    /// Any handler this epoch already had goes with it. That is the point of
+    /// consuming `self`: a fresh secret means a fresh winning-`PoL` stream, so
+    /// the old handler is no longer the right one. Everything else travels —
+    /// its queued proposals above all — because secret info arriving is not an
+    /// epoch change.
+    pub fn with_secret_info(
+        self,
+        secret_epoch_info: PolEpochInfo,
+        settings: RunningSettings<Backend, NodeId, RuntimeServiceId>,
+        overwatch_handle: OverwatchHandle<RuntimeServiceId>,
+    ) -> Self {
+        let awaiting = match self {
+            Self::AwaitingSecretInfo(awaiting) | Self::Blending(Blending { awaiting, .. }) => {
+                awaiting
+            }
+        };
+        debug_assert_eq!(
+            secret_epoch_info.epoch, awaiting.info.epoch,
+            "Secret `PoL` info must belong to the epoch it is being attached to."
+        );
+
+        let new_public_inputs = PoQVerificationInputsMinusSigningKey {
+            core: CoreInputs {
+                quota: settings.cover.epoch_core_quota(
+                    settings.num_blend_layers,
+                    &settings.time,
+                    awaiting.info.membership_info.membership.size(),
+                ),
+                zk_root: awaiting.info.membership_info.zk.root,
+            },
+            leader: LeaderInputs {
+                lottery_0: awaiting.info.lottery_0,
+                lottery_1: awaiting.info.lottery_1,
+                pol_epoch_nonce: awaiting.info.nonce,
+                pol_ledger_aged: awaiting.info.aged,
+                message_quota: settings.epoch_leadership_quota(),
+            },
+            pow: PowInputs {
+                pow_blend_difficulty: awaiting.info.pow_difficulty,
+                pow_quota: settings.epoch_pow_quota(),
+            },
+        };
+
+        debug!(target: LOG_TARGET, "Creating new handler for epoch {:?}", awaiting.info.epoch);
+        let handler = MessageHandler::new(
+            settings,
+            awaiting.info.membership_info.membership.clone(),
+            new_public_inputs,
+            secret_epoch_info.winning_pol_info_stream,
+            overwatch_handle,
+            awaiting.info.epoch,
+        );
+
+        Self::Blending(Blending { awaiting, handler })
+    }
+}
+
+impl<Backend, NodeId, ProofsGenerator, RuntimeServiceId>
+    Blending<Backend, NodeId, ProofsGenerator, RuntimeServiceId>
+where
+    Backend: BlendBackend<NodeId, RuntimeServiceId> + Sync,
+    NodeId: Clone + core::fmt::Debug + Eq + Hash + Send + Sync + 'static,
+    ProofsGenerator: LeaderAndPowProofsGenerator + Send,
+{
+    /// Encapsulates one locally-originated message, once proofs back it.
+    ///
+    /// Proposals go first; see [`next_local_message`]. Neither queue is popped
+    /// here: `select!` drops this future whenever another branch wins the race,
+    /// and one that popped before awaiting would take the message down with it
+    /// every time that happened. The caller updates the queues once the race is
+    /// settled, which is also why only one copy of a proposal is wrapped per
+    /// call.
+    async fn encapsulate_next_local_message(
+        &mut self,
+        transactions: &PendingTransactions,
+    ) -> Option<EncapsulationResult> {
+        let (kind, encapsulated) = match next_local_message(&self.awaiting.proposals, transactions)?
+        {
+            NextLocalMessage::ProposalCopy(proposal) => (
+                MessageKind::Proposal,
+                self.handler.encapsulate_block_proposal(proposal).await,
+            ),
+            NextLocalMessage::Transaction(transaction) => (
+                MessageKind::Transaction,
+                self.handler.encapsulate_transaction(transaction).await,
+            ),
+        };
+
+        match resolve_encapsulation(encapsulated, kind) {
+            // Not something the caller acts on, and handing it back would be
+            // worse than useless: the branch this feeds would then complete
+            // immediately every time round with nothing to do, which is a busy
+            // loop rather than a wait. `None` fails the branch's pattern and
+            // disables it instead.
+            EncapsulationResult::Retry => None,
+            acted_on => Some(acted_on),
+        }
+    }
+
+    /// Hands a finished message to the backend.
+    ///
+    /// Apart from the encapsulation that produced it because this is where the
+    /// message leaves the node, and `select!` drops the losing branch futures:
+    /// a send cancelled midway would bin the proofs backing that
+    /// encapsulation while the payload stayed queued. Handler bodies are
+    /// never cancelled.
+    async fn send(&mut self, message: EncapsulatedMessageWithVerifiedPublicHeader) {
+        self.handler.send(message).await;
+    }
+}
+
+impl<Backend, NodeId, ProofsGenerator, RuntimeServiceId>
+    CurrentEpoch<Backend, NodeId, ProofsGenerator, RuntimeServiceId>
+where
+    Backend: BlendBackend<NodeId, RuntimeServiceId> + Sync,
+    NodeId: Clone + core::fmt::Debug + Eq + Hash + Send + Sync + 'static,
+    ProofsGenerator: LeaderAndPowProofsGenerator + Send,
+{
+    /// Encapsulates one locally-originated message, if this epoch can mint at
+    /// all yet.
+    ///
+    /// `None` when it cannot — no handler, nothing queued, or no proofs — which
+    /// is what leaves the `select!` branch free to wait on the others.
+    pub async fn encapsulate_next_local_message(
+        &mut self,
+        transactions: &PendingTransactions,
+    ) -> Option<EncapsulationResult> {
+        match self {
+            Self::AwaitingSecretInfo(_) => None,
+            Self::Blending(blending) => blending.encapsulate_next_local_message(transactions).await,
+        }
+    }
+
+    /// Hands a finished message to the backend.
+    ///
+    /// # Panics
+    ///
+    /// If this epoch has no handler, which cannot happen: a message only exists
+    /// because that handler encapsulated it a moment ago, and nothing runs in
+    /// between that could take it away.
+    pub async fn send(&mut self, message: EncapsulatedMessageWithVerifiedPublicHeader) {
+        match self {
+            Self::Blending(blending) => blending.send(message).await,
+            Self::AwaitingSecretInfo(_) => {
+                unreachable!("A message can only have been encapsulated by this epoch's handler.")
+            }
+        }
+    }
+}

--- a/services/blend/src/edge/handlers.rs
+++ b/services/blend/src/edge/handlers.rs
@@ -33,10 +33,6 @@ where
     NodeId: Clone,
     ProofsGenerator: LeaderAndPowProofsGenerator,
 {
-    #[cfg(test)]
-    pub const fn epoch(&self) -> Epoch {
-        self.cryptographic_processor.epoch()
-    }
 }
 
 impl<Backend, NodeId, ProofsGenerator, RuntimeServiceId>
@@ -52,35 +48,7 @@ where
     /// edge node condition:
     /// 1. The membership size is at least `settings.minimum_network_size`.
     /// 2. The local node is not a core node.
-    pub fn try_new_with_edge_condition_check(
-        settings: Settings<Backend, NodeId, RuntimeServiceId>,
-        membership: Membership<NodeId>,
-        public_info: PoQVerificationInputsMinusSigningKey,
-        winning_pol_info_stream: WinningPolInfoStream,
-        overwatch_handle: OverwatchHandle<RuntimeServiceId>,
-        epoch: Epoch,
-    ) -> Result<Self, Error>
-    where
-        NodeId: Eq + Hash,
-    {
-        let membership_size = membership.size();
-        if membership_size < settings.minimum_network_size.get() as usize {
-            Err(Error::NetworkIsTooSmall(membership_size))
-        } else if membership.contains_local() {
-            Err(Error::LocalIsCoreNode)
-        } else {
-            Ok(Self::new(
-                settings,
-                membership,
-                public_info,
-                winning_pol_info_stream,
-                overwatch_handle,
-                epoch,
-            ))
-        }
-    }
-
-    fn new(
+    pub(super) fn new(
         settings: Settings<Backend, NodeId, RuntimeServiceId>,
         membership: Membership<NodeId>,
         public_info: PoQVerificationInputsMinusSigningKey,

--- a/services/blend/src/edge/mod.rs
+++ b/services/blend/src/edge/mod.rs
@@ -1,4 +1,5 @@
 pub mod backends;
+mod current_epoch;
 mod handlers;
 pub(crate) mod service_components;
 pub mod settings;
@@ -15,18 +16,9 @@ use std::{
 
 use backends::BlendBackend;
 use futures::{Stream, StreamExt as _};
-use lb_blend::{
-    message::{
-        crypto::proofs::PoQVerificationInputsMinusSigningKey,
-        encap::validated::EncapsulatedMessageWithVerifiedPublicHeader,
-    },
-    proofs::quota::inputs::prove::public::{CoreInputs, LeaderInputs, PowInputs},
-    scheduling::{
-        epoch::{EpochEvent, UninitializedEpochEventStream},
-        message_blend::provers::{
-            leader_and_pow::LeaderAndPowProofsGenerator, pow::new_mining_pool,
-        },
-    },
+use lb_blend::scheduling::{
+    epoch::{EpochEvent, UninitializedEpochEventStream},
+    message_blend::provers::{leader_and_pow::LeaderAndPowProofsGenerator, pow::new_mining_pool},
 };
 use lb_chain_service::api::CryptarchiaServiceData;
 use lb_key_management_system_service::{
@@ -47,18 +39,15 @@ use overwatch::{
 };
 use settings::StartingBlendConfig;
 use tokio::sync::oneshot;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, error, info};
 
 use crate::{
-    edge::{
-        handlers::{Error, MessageHandler},
-        settings::RunningBlendConfig,
-    },
+    edge::{current_epoch::CurrentEpoch, handlers::Error, settings::RunningBlendConfig},
     epoch_info::{PolEpochInfo, PolInfoProvider as PolInfoProviderTrait},
     kms::PreloadKmsService,
     membership::{self, chain::BlendEpochState, node_id},
     message::{BlendPayload, NetworkInfo, ServiceMessage},
-    pending::{LocalEncapsulation, NextLocalMessage, PendingLocalMessages, resolve_encapsulation},
+    pending::{EncapsulationResult, LocalEncapsulation, MessageKind, PendingTransactions},
 };
 
 const LOG_TARGET: &str = blend::service::EDGE;
@@ -274,7 +263,7 @@ where
     PolInfoProvider: PolInfoProviderTrait<RuntimeServiceId, Stream: Unpin>,
     RuntimeServiceId: Clone + Send + Sync,
 {
-    let (mut current_epoch_info, mut remaining_public_epoch_stream) = public_epoch_stream
+    let (current_epoch_info, mut remaining_public_epoch_stream) = public_epoch_stream
         .await_first_ready()
         .await
         .expect("The current epoch info must be available.");
@@ -297,17 +286,26 @@ where
         .expect("Should not fail to subscribe to secret PoL info stream.");
 
     let mut current_secret_epoch_info: Option<PolEpochInfo> = None;
-    // Transactions waiting for a `PoW` solution to back their layer proofs.
-    let mut pending_messages = PendingLocalMessages::new();
-    let mut current_epoch_message_handler: Option<
-        MessageHandler<Backend, NodeId, ProofsGenerator, RuntimeServiceId>,
-    > = None;
+    // The epoch owns its proposals, so a new one takes them with it; a
+    // transaction is not slot-bound and outlives every epoch it waits through.
+    let mut current_epoch: CurrentEpoch<Backend, NodeId, ProofsGenerator, RuntimeServiceId> =
+        match CurrentEpoch::try_new(current_epoch_info, &settings) {
+            Err(Error::NetworkIsTooSmall(_)) => {
+                info!(target: LOG_TARGET, "Initial membership does not satisfy edge node condition, edge service shutting down.");
+                return Ok(());
+            }
+            Err(e) => {
+                error!(target: LOG_TARGET, "Error with the initial epoch: {e:?}, edge service shutting down.");
+                return Err(e);
+            }
+            Ok(epoch) => epoch,
+        };
+    let mut pending_transactions = PendingTransactions::new();
 
     loop {
         tokio::select! {
             Some(EpochEvent::NewEpoch(new_public_epoch_info)) = remaining_public_epoch_stream.next() => {
-                current_epoch_info = new_public_epoch_info;
-                match handle_new_public_epoch_event(&current_epoch_info, &mut current_secret_epoch_info, &mut current_epoch_message_handler, &mut pending_messages, settings.clone(), overwatch_handle.clone()) {
+                match CurrentEpoch::try_new(new_public_epoch_info, &settings) {
                     Err(Error::NetworkIsTooSmall(_)) => {
                         info!(target: LOG_TARGET, "New membership does not satisfy edge node condition, edge service shutting down.");
                         return Ok(());
@@ -316,31 +314,25 @@ where
                         error!(target: LOG_TARGET, "Error when handling new public epoch: {e:?}, edge service shutting down.");
                         return Err(e);
                     }
-                    Ok(()) => {}
+                    // The epoch this replaces takes its queued proposals with
+                    // it: they were built for slots it owned, and blending them
+                    // under the new one would spend the quota its own block
+                    // needs.
+                    Ok(next) => current_epoch = next.with_available_secret_info(&mut current_secret_epoch_info, settings.clone(), overwatch_handle.clone()),
                 }
             }
             Some(new_secret_pol_info) = secret_pol_info_stream.next() => {
                 current_secret_epoch_info = Some(new_secret_pol_info);
-                match handle_new_epoch_event(&current_epoch_info, &mut current_secret_epoch_info, &mut current_epoch_message_handler, settings.clone(), overwatch_handle.clone()) {
-                    Err(Error::NetworkIsTooSmall(_)) => {
-                        info!(target: LOG_TARGET, "New membership does not satisfy edge node condition, edge service shutting down.");
-                        return Ok(());
-                    }
-                    Err(e) => {
-                        error!(target: LOG_TARGET, "Error when handling new secret epoch: {e:?}, edge service shutting down.");
-                        return Err(e);
-                    }
-                    Ok(()) => {}
-                }
+                current_epoch = current_epoch.with_available_secret_info(&mut current_secret_epoch_info, settings.clone(), overwatch_handle.clone());
             }
             Some(message) = inbound_relay.next() => {
                 match message {
                     ServiceMessage::Blend(BlendPayload::Transaction(transaction)) => {
-                        pending_messages.queue_transaction(transaction);
+                        pending_transactions.queue(transaction);
                     }
                     ServiceMessage::Blend(BlendPayload::BlockProposal(proposal)) => {
                         let proposal_copies = NonZeroU64::new(settings.data_replication_factor.checked_add(1).expect("Data replication factor should not overflow when incremented.")).expect("Number of block proposal copies cannot be zero by definition.");
-                        pending_messages.queue_proposal(proposal, proposal_copies);
+                        current_epoch.queue_proposal(proposal, proposal_copies);
                     }
                     ServiceMessage::GetNetworkInfo { reply } => {
                         drop(reply.send(Some(NetworkInfo {
@@ -349,7 +341,7 @@ where
                         })));
                     }
                     ServiceMessage::GetPendingTransactions { reply } => {
-                        drop(reply.send(pending_messages.transactions().cloned().collect()));
+                        drop(reply.send(pending_transactions.iter().cloned().collect()));
                     }
                 }
             }
@@ -357,18 +349,21 @@ where
             // here as one branch among the others so the loop keeps turning meanwhile.
             // Both kinds share one branch because both need the handler mutably,
             // and `select!` builds every branch future before any of them wins.
-            Some(encapsulation_result) = encapsulate_next_local_message(&pending_messages, &mut current_epoch_message_handler) => {
-                let current_epoch_message_handler = current_epoch_message_handler.as_mut().expect("Message handler must exist for a message that was just encapsulated.");
+            Some(encapsulation_result) = current_epoch.encapsulate_next_local_message(&pending_transactions) => {
                 match encapsulation_result {
-                    Ok(LocalEncapsulation::ProposalCopy(message)) => {
-                        current_epoch_message_handler.send(message).await;
-                        pending_messages.mark_proposal_copy_as_sent();
+                    EncapsulationResult::Complete(encapsulation) => {
+                        let LocalEncapsulation { message, kind } = *encapsulation;
+                        current_epoch.send(message).await;
+                        match kind {
+                            MessageKind::Proposal => current_epoch.proposals_mut().mark_copy_as_sent(),
+                            MessageKind::Transaction => drop(pending_transactions.mark_as_sent()),
+                        }
                     }
-                    Ok(LocalEncapsulation::Transaction(message)) => {
-                        current_epoch_message_handler.send(message).await;
-                        drop(pending_messages.mark_transaction_as_sent());
-                    }
-                    Err(()) => drop(pending_messages.discard_head()),
+                    // The head of whichever queue it came from can never be
+                    // encapsulated, so it goes rather than blocking the rest.
+                    EncapsulationResult::Discard(MessageKind::Proposal) => current_epoch.proposals_mut().discard_head(),
+                    EncapsulationResult::Discard(MessageKind::Transaction) => drop(pending_transactions.discard_head()),
+                    EncapsulationResult::Retry => unreachable!("`Retry` is never returned by `encapsulate_next_local_message`"),
                 }
             }
             else => {
@@ -379,174 +374,4 @@ where
             }
         }
     }
-}
-
-/// Encapsulates one locally-originated message, once a handler exists to make
-/// it and proofs back it.
-///
-/// Proposals go first: one is tied to the slot it was built for and goes stale,
-/// whereas a transaction keeps.
-///
-/// Neither queue is popped here either, for the same reason: one that popped
-/// before awaiting would take the message down with it every time this future
-/// was dropped. The caller updates the queues once the race is settled, which
-/// is also why only one copy of a proposal is wrapped per call.
-///
-/// Returns `None` when there is nothing to hand back — nothing queued, no
-/// handler for this epoch yet, or no proofs — which is what leaves the branch
-/// free to wait on the others.
-async fn encapsulate_next_local_message<Backend, NodeId, ProofsGenerator, RuntimeServiceId>(
-    pending_messages: &PendingLocalMessages,
-    current_epoch_message_handler: &mut Option<
-        MessageHandler<Backend, NodeId, ProofsGenerator, RuntimeServiceId>,
-    >,
-) -> Option<Result<LocalEncapsulation, ()>>
-where
-    Backend: BlendBackend<NodeId, RuntimeServiceId> + Sync,
-    NodeId: Clone + Debug + Eq + Hash + Send + Sync + 'static,
-    ProofsGenerator: LeaderAndPowProofsGenerator + Send,
-{
-    type Wrap = fn(EncapsulatedMessageWithVerifiedPublicHeader) -> LocalEncapsulation;
-
-    let handler = current_epoch_message_handler.as_mut()?;
-    let (encapsulated, wrap_fn): (_, Wrap) = match pending_messages.next()? {
-        NextLocalMessage::ProposalCopy(proposal) => (
-            handler.encapsulate_block_proposal(proposal).await,
-            LocalEncapsulation::ProposalCopy,
-        ),
-        NextLocalMessage::Transaction(transaction) => (
-            handler.encapsulate_transaction(transaction).await,
-            LocalEncapsulation::Transaction,
-        ),
-    };
-
-    resolve_encapsulation(encapsulated, wrap_fn)
-}
-
-/// Handles the start of a new *public* epoch: the one this node was in has
-/// ended.
-///
-/// Split from [`handle_new_epoch_event`], which also runs when this epoch's
-/// secret `PoL` info arrives — that is not an epoch change, and a proposal
-/// queued waiting for exactly that info has to survive it. Only a real epoch
-/// change invalidates queued proposals; see [`PendingLocalMessages`] for why
-/// they cannot outlive it.
-fn handle_new_public_epoch_event<Backend, NodeId, ProofsGenerator, RuntimeServiceId>(
-    current_public_epoch_info: &BlendEpochState<NodeId>,
-    maybe_current_secret_epoch_info: &mut Option<PolEpochInfo>,
-    current_epoch_message_handler: &mut Option<
-        MessageHandler<Backend, NodeId, ProofsGenerator, RuntimeServiceId>,
-    >,
-    pending_messages: &mut PendingLocalMessages,
-    settings: RunningSettings<Backend, NodeId, RuntimeServiceId>,
-    overwatch_handle: OverwatchHandle<RuntimeServiceId>,
-) -> Result<(), Error>
-where
-    Backend: BlendBackend<NodeId, RuntimeServiceId>,
-    NodeId: Clone + Eq + Hash + Send + Sync + 'static,
-    ProofsGenerator: LeaderAndPowProofsGenerator,
-{
-    let discarded = pending_messages.discard_proposals();
-    if discarded > 0 {
-        warn!(target: LOG_TARGET, "Dropping {discarded} block proposal(s) still queued when the epoch ended.");
-    }
-    handle_new_epoch_event(
-        current_public_epoch_info,
-        maybe_current_secret_epoch_info,
-        current_epoch_message_handler,
-        settings,
-        overwatch_handle,
-    )
-}
-
-fn handle_new_epoch_event<Backend, NodeId, ProofsGenerator, RuntimeServiceId>(
-    current_public_epoch_info: &BlendEpochState<NodeId>,
-    maybe_current_secret_epoch_info: &mut Option<PolEpochInfo>,
-    current_epoch_message_handler: &mut Option<
-        MessageHandler<Backend, NodeId, ProofsGenerator, RuntimeServiceId>,
-    >,
-    settings: RunningSettings<Backend, NodeId, RuntimeServiceId>,
-    overwatch_handle: OverwatchHandle<RuntimeServiceId>,
-) -> Result<(), Error>
-where
-    Backend: BlendBackend<NodeId, RuntimeServiceId>,
-    NodeId: Clone + Send + Eq + Hash + 'static,
-    ProofsGenerator: LeaderAndPowProofsGenerator,
-{
-    // Whatever happens on a new epoch, we shut down the previous handler.
-    // It will be rebuilt below if the current public and secret info line up
-    // on the same epoch.
-    drop(current_epoch_message_handler.take());
-
-    let Some(zk_info) = &current_public_epoch_info.membership_info.zk else {
-        return Err(Error::NetworkIsTooSmall(0));
-    };
-
-    // Validate the edge node condition up front so the service shuts down on
-    // an invalid membership regardless of whether secret PoL info is available
-    // yet for the current epoch.
-    let membership_size = current_public_epoch_info.membership_info.membership.size();
-    if membership_size < settings.minimum_network_size.get() as usize {
-        return Err(Error::NetworkIsTooSmall(membership_size));
-    }
-    if current_public_epoch_info
-        .membership_info
-        .membership
-        .contains_local()
-    {
-        return Err(Error::LocalIsCoreNode);
-    }
-
-    let Some(current_secret_epoch_info) = maybe_current_secret_epoch_info.take() else {
-        assert!(
-            current_epoch_message_handler.is_none(),
-            "If there is no secret PoL info, there should not be an active message handler."
-        );
-        debug!(target: LOG_TARGET, "No secret PoL info available for the new epoch, cannot create message handler until it arrives.");
-        return Ok(());
-    };
-
-    if current_secret_epoch_info.epoch != current_public_epoch_info.epoch {
-        debug!(target: LOG_TARGET, "Secret PoL info is for epoch {:?} which does not match the current public epoch {:?}, cannot create message handler until they line up.", current_secret_epoch_info.epoch, current_public_epoch_info.epoch);
-        // Re-instate the stream since we need it for when the new public epoch info
-        // will arrive. We chose this over not calling `.take()` here and use
-        // `.take().unwrap()` below instead.
-        *maybe_current_secret_epoch_info = Some(current_secret_epoch_info);
-        return Ok(());
-    }
-
-    let new_public_inputs = PoQVerificationInputsMinusSigningKey {
-        core: CoreInputs {
-            quota: settings.cover.epoch_core_quota(
-                settings.num_blend_layers,
-                &settings.time,
-                current_public_epoch_info.membership_info.membership.size(),
-            ),
-            zk_root: zk_info.root,
-        },
-        leader: LeaderInputs {
-            lottery_0: current_public_epoch_info.lottery_0,
-            lottery_1: current_public_epoch_info.lottery_1,
-            pol_epoch_nonce: current_public_epoch_info.nonce,
-            pol_ledger_aged: current_public_epoch_info.aged,
-            message_quota: settings.epoch_leadership_quota(),
-        },
-        pow: PowInputs {
-            pow_blend_difficulty: current_public_epoch_info.pow_difficulty,
-            pow_quota: settings.epoch_pow_quota(),
-        },
-    };
-
-    debug!(target: LOG_TARGET, "Creating new handler for epoch {:?}", current_public_epoch_info.epoch);
-    let new_handler = MessageHandler::try_new_with_edge_condition_check(
-        settings,
-        current_public_epoch_info.membership_info.membership.clone(),
-        new_public_inputs,
-        current_secret_epoch_info.winning_pol_info_stream,
-        overwatch_handle,
-        current_public_epoch_info.epoch,
-    )?;
-
-    *current_epoch_message_handler = Some(new_handler);
-    Ok(())
 }

--- a/services/blend/src/edge/tests/mod.rs
+++ b/services/blend/src/edge/tests/mod.rs
@@ -16,6 +16,7 @@ use tokio::{
 
 use crate::{
     edge::{
+        current_epoch::CurrentEpoch,
         handlers::Error,
         tests::utils::{
             MockLeaderProofsGenerator, NodeId, TestBackend, overwatch_handle, settings, spawn_run,
@@ -25,7 +26,7 @@ use crate::{
     epoch_info::PolEpochInfo,
     membership::chain::BlendEpochState,
     message::{BlendPayload, ServiceMessage},
-    pending::{NextLocalMessage, PendingLocalMessages},
+    pending::{NextLocalMessage, PendingTransactions, next_local_message},
     test_utils::{
         epoch::{GatedPolStreamProvider, PolGate},
         membership::membership,
@@ -177,40 +178,28 @@ async fn handle_new_secret_epoch_info_recreates_handler() {
     let settings = settings(local_node, 1, node_id_sender);
     let overwatch = overwatch_handle();
 
-    let mut handler_state: Option<
-        super::handlers::MessageHandler<TestBackend, NodeId, MockLeaderProofsGenerator, usize>,
-    > = None;
-
     // Public + secret for epoch 2 -> handler is created.
     let public_2 = test_blend_epoch_state(Epoch::new(2), membership(&[core_node], local_node));
     let secret_2 = test_pol_epoch_info(Epoch::new(2));
-    super::handle_new_epoch_event(
-        &public_2,
-        &mut Some(secret_2),
-        &mut handler_state,
-        settings.clone(),
-        overwatch.clone(),
-    )
-    .unwrap();
+    let current_epoch: CurrentEpoch<TestBackend, NodeId, MockLeaderProofsGenerator, usize> =
+        CurrentEpoch::try_new(public_2, &settings)
+            .unwrap()
+            .with_secret_info(secret_2, settings.clone(), overwatch.clone());
     assert!(
-        handler_state.is_some(),
+        current_epoch.has_handler(),
         "Handler should be created when public and secret info for the same epoch are present"
     );
-    assert_eq!(handler_state.as_ref().unwrap().epoch(), Epoch::new(2));
+    assert_eq!(current_epoch.info().epoch, Epoch::new(2));
 
     // Public + secret for epoch 3 -> handler is replaced.
     let public_3 = test_blend_epoch_state(Epoch::new(3), membership(&[core_node], local_node));
     let secret_3 = test_pol_epoch_info(Epoch::new(3));
-    super::handle_new_epoch_event(
-        &public_3,
-        &mut Some(secret_3),
-        &mut handler_state,
-        settings,
-        overwatch,
-    )
-    .unwrap();
-    assert!(handler_state.is_some());
-    assert_eq!(handler_state.as_ref().unwrap().epoch(), Epoch::new(3));
+    let current_epoch: CurrentEpoch<TestBackend, NodeId, MockLeaderProofsGenerator, usize> =
+        CurrentEpoch::try_new(public_3, &settings)
+            .unwrap()
+            .with_secret_info(secret_3, settings, overwatch);
+    assert!(current_epoch.has_handler());
+    assert_eq!(current_epoch.info().epoch, Epoch::new(3));
 }
 
 fn test_blend_epoch_state(epoch: Epoch, membership: Membership<NodeId>) -> BlendEpochState<NodeId> {
@@ -235,37 +224,29 @@ async fn two_publics_without_private_in_between() {
     let (node_id_sender, _node_id_receiver) = mpsc::channel(1);
 
     let settings = settings(local_node, 1, node_id_sender);
-    let overwatch = overwatch_handle();
-
-    let mut handler_state: Option<
-        super::handlers::MessageHandler<TestBackend, NodeId, MockLeaderProofsGenerator, usize>,
-    > = None;
+    let _overwatch = overwatch_handle();
 
     // First public, no secret yet -> handler must stay down.
-    super::handle_new_epoch_event(
-        &test_blend_epoch_state(Epoch::new(1), membership(&[core_node], local_node)),
-        &mut None,
-        &mut handler_state,
-        settings.clone(),
-        overwatch.clone(),
-    )
-    .unwrap();
+    let current_epoch: CurrentEpoch<TestBackend, NodeId, MockLeaderProofsGenerator, usize> =
+        CurrentEpoch::try_new(
+            test_blend_epoch_state(Epoch::new(1), membership(&[core_node], local_node)),
+            &settings,
+        )
+        .unwrap();
     assert!(
-        handler_state.is_none(),
+        !current_epoch.has_handler(),
         "Handler must not be created without the private info"
     );
 
     // Second public for a later epoch, still no secret -> handler stays down.
-    super::handle_new_epoch_event(
-        &test_blend_epoch_state(Epoch::new(2), membership(&[core_node], local_node)),
-        &mut None,
-        &mut handler_state,
-        settings,
-        overwatch,
-    )
-    .unwrap();
+    let current_epoch: CurrentEpoch<TestBackend, NodeId, MockLeaderProofsGenerator, usize> =
+        CurrentEpoch::try_new(
+            test_blend_epoch_state(Epoch::new(2), membership(&[core_node], local_node)),
+            &settings,
+        )
+        .unwrap();
     assert!(
-        handler_state.is_none(),
+        !current_epoch.has_handler(),
         "Handler must remain down: no private info has been received"
     );
 }
@@ -281,39 +262,21 @@ async fn public_then_private_same_epoch_creates_handler() {
     let settings = settings(local_node, 1, node_id_sender);
     let overwatch = overwatch_handle();
 
-    let mut handler_state: Option<
-        super::handlers::MessageHandler<TestBackend, NodeId, MockLeaderProofsGenerator, usize>,
-    > = None;
-
     let public_1 = test_blend_epoch_state(Epoch::new(1), membership(&[core_node], local_node));
 
     // Public for epoch 1, no secret yet -> no handler.
-    super::handle_new_epoch_event(
-        &public_1,
-        &mut None,
-        &mut handler_state,
-        settings.clone(),
-        overwatch.clone(),
-    )
-    .unwrap();
-    assert!(handler_state.is_none());
+    let current_epoch: CurrentEpoch<TestBackend, NodeId, MockLeaderProofsGenerator, usize> =
+        CurrentEpoch::try_new(public_1, &settings).unwrap();
+    assert!(!current_epoch.has_handler());
 
-    // Secret for epoch 1 arrives, same public -> handler is created.
-    super::handle_new_epoch_event(
-        &public_1,
-        &mut Some(test_pol_epoch_info(Epoch::new(1))),
-        &mut handler_state,
-        settings,
-        overwatch,
-    )
-    .unwrap();
-    assert_eq!(
-        handler_state
-            .as_ref()
-            .expect("Handler must be created")
-            .epoch(),
-        Epoch::new(1)
+    // Secret for epoch 1 arrives on the *same* epoch value -> handler is built.
+    let current_epoch =
+        current_epoch.with_secret_info(test_pol_epoch_info(Epoch::new(1)), settings, overwatch);
+    assert!(
+        current_epoch.has_handler(),
+        "Handler must be created once public and secret line up"
     );
+    assert_eq!(current_epoch.info().epoch, Epoch::new(1));
 }
 
 /// Secret arrives for an epoch ahead of the current public (mismatch), then
@@ -327,43 +290,35 @@ async fn private_then_public_same_epoch_creates_handler() {
     let settings = settings(local_node, 1, node_id_sender);
     let overwatch = overwatch_handle();
 
-    let mut handler_state: Option<
-        super::handlers::MessageHandler<TestBackend, NodeId, MockLeaderProofsGenerator, usize>,
-    > = None;
-
     // Secret for epoch 1 while public is still on epoch 0 -> epochs mismatch,
     // no handler. The secret must be retained for when the public catches up.
     let mut secret_1 = Some(test_pol_epoch_info(Epoch::new(1)));
-    super::handle_new_epoch_event(
-        &test_blend_epoch_state(Epoch::new(0), membership(&[core_node], local_node)),
-        &mut secret_1,
-        &mut handler_state,
-        settings.clone(),
-        overwatch.clone(),
-    )
-    .unwrap();
-    assert!(handler_state.is_none());
+    let current_epoch: CurrentEpoch<TestBackend, NodeId, MockLeaderProofsGenerator, usize> =
+        CurrentEpoch::try_new(
+            test_blend_epoch_state(Epoch::new(0), membership(&[core_node], local_node)),
+            &settings,
+        )
+        .unwrap()
+        .with_available_secret_info(&mut secret_1, settings.clone(), overwatch.clone());
+    assert!(!current_epoch.has_handler());
     assert!(
         secret_1.is_some(),
         "Secret PoL info for a future epoch must be retained on mismatch."
     );
 
     // Public catches up to epoch 1 -> handler is created.
-    super::handle_new_epoch_event(
-        &test_blend_epoch_state(Epoch::new(1), membership(&[core_node], local_node)),
-        &mut secret_1,
-        &mut handler_state,
-        settings,
-        overwatch,
-    )
-    .unwrap();
-    assert_eq!(
-        handler_state
-            .as_ref()
-            .expect("Handler must be created")
-            .epoch(),
-        Epoch::new(1)
+    let current_epoch: CurrentEpoch<TestBackend, NodeId, MockLeaderProofsGenerator, usize> =
+        CurrentEpoch::try_new(
+            test_blend_epoch_state(Epoch::new(1), membership(&[core_node], local_node)),
+            &settings,
+        )
+        .unwrap()
+        .with_available_secret_info(&mut secret_1, settings, overwatch);
+    assert!(
+        current_epoch.has_handler(),
+        "Handler must be created once public and secret line up"
     );
+    assert_eq!(current_epoch.info().epoch, Epoch::new(1));
 }
 
 /// A block proposal that arrives before this epoch's secret `PoL` info still
@@ -459,42 +414,6 @@ async fn a_message_that_can_never_be_sent_does_not_block_the_rest() {
     );
 }
 
-/// A proposal still queued when the public epoch rotates is dropped; a
-/// transaction is not.
-///
-/// Leadership quota is one message's worth per winning slot, so a proposal that
-/// missed its epoch would spend the quota the new epoch's own block needs.
-#[test_log::test(tokio::test)]
-async fn a_new_public_epoch_discards_queued_proposals() {
-    let local_node = NodeId(99);
-    let core_node = NodeId(0);
-    let (node_id_sender, _node_id_receiver) = mpsc::channel(1);
-    let settings = settings(local_node, 1, node_id_sender);
-
-    let mut handler_state: Option<
-        super::handlers::MessageHandler<TestBackend, NodeId, MockLeaderProofsGenerator, usize>,
-    > = None;
-    let mut pending_messages = PendingLocalMessages::new();
-    pending_messages.queue_proposal(b"proposal".to_vec(), 2.try_into().unwrap());
-    pending_messages.queue_transaction(b"transaction".to_vec());
-
-    super::handle_new_public_epoch_event(
-        &test_blend_epoch_state(Epoch::new(1), membership(&[core_node], local_node)),
-        &mut Some(test_pol_epoch_info(Epoch::new(1))),
-        &mut handler_state,
-        &mut pending_messages,
-        settings,
-        overwatch_handle(),
-    )
-    .unwrap();
-
-    assert_eq!(
-        pending_messages.next(),
-        Some(NextLocalMessage::Transaction(b"transaction")),
-        "the proposal must not survive the rotation, and the transaction must"
-    );
-}
-
 /// Secret `PoL` info arriving is not an epoch change, so it must leave queued
 /// proposals alone.
 ///
@@ -508,25 +427,68 @@ async fn secret_pol_info_arriving_keeps_queued_proposals() {
     let (node_id_sender, _node_id_receiver) = mpsc::channel(1);
     let settings = settings(local_node, 1, node_id_sender);
 
-    let mut handler_state: Option<
-        super::handlers::MessageHandler<TestBackend, NodeId, MockLeaderProofsGenerator, usize>,
-    > = None;
-    let mut pending_messages = PendingLocalMessages::new();
-    pending_messages.queue_proposal(b"proposal".to_vec(), 2.try_into().unwrap());
+    let mut current_epoch: CurrentEpoch<TestBackend, NodeId, MockLeaderProofsGenerator, usize> =
+        CurrentEpoch::try_new(
+            test_blend_epoch_state(Epoch::new(1), membership(&[core_node], local_node)),
+            &settings,
+        )
+        .unwrap();
+    current_epoch.queue_proposal(b"proposal".to_vec(), 2.try_into().unwrap());
 
-    // The path the secret-`PoL` arm takes, which is not a new epoch.
-    super::handle_new_epoch_event(
-        &test_blend_epoch_state(Epoch::new(1), membership(&[core_node], local_node)),
-        &mut Some(test_pol_epoch_info(Epoch::new(1))),
-        &mut handler_state,
+    // The path the secret-`PoL` arm takes, which is not an epoch change: it
+    // rebuilds the handler and must leave everything else this epoch owns.
+    let mut current_epoch = current_epoch.with_secret_info(
+        test_pol_epoch_info(Epoch::new(1)),
         settings,
         overwatch_handle(),
-    )
-    .unwrap();
+    );
 
     assert_eq!(
-        pending_messages.next(),
+        next_local_message(current_epoch.proposals_mut(), &PendingTransactions::new()),
         Some(NextLocalMessage::ProposalCopy(b"proposal")),
         "a proposal waiting for this epoch's leadership proofs must survive them arriving"
+    );
+}
+
+/// Secret `PoL` info for an epoch this node has not reached leaves the epoch it
+/// is on alone.
+///
+/// It used to cost the node its handler: the old code dropped that before
+/// looking at which epoch the info named, so learning about the next epoch
+/// early stopped this node blending for the current one until the public info
+/// caught up. Nothing about a future epoch says anything about this one.
+#[test_log::test(tokio::test)]
+async fn secret_pol_info_for_another_epoch_leaves_this_one_alone() {
+    let local_node = NodeId(99);
+    let core_node = NodeId(0);
+    let (node_id_sender, _node_id_receiver) = mpsc::channel(1);
+    let settings = settings(local_node, 1, node_id_sender);
+    let overwatch = overwatch_handle();
+
+    let current_epoch: CurrentEpoch<TestBackend, NodeId, MockLeaderProofsGenerator, usize> =
+        CurrentEpoch::try_new(
+            test_blend_epoch_state(Epoch::new(1), membership(&[core_node], local_node)),
+            &settings,
+        )
+        .unwrap()
+        .with_secret_info(
+            test_pol_epoch_info(Epoch::new(1)),
+            settings.clone(),
+            overwatch.clone(),
+        );
+    assert!(current_epoch.has_handler());
+
+    // Info for an epoch this node has not reached yet.
+    let mut stashed_secret_info = Some(test_pol_epoch_info(Epoch::new(2)));
+    let current_epoch =
+        current_epoch.with_available_secret_info(&mut stashed_secret_info, settings, overwatch);
+
+    assert!(
+        current_epoch.has_handler(),
+        "a secret for a future epoch must not cost this node the handler it is blending with"
+    );
+    assert!(
+        stashed_secret_info.is_some(),
+        "and it must stay stashed for the epoch it does name"
     );
 }

--- a/services/blend/src/lib.rs
+++ b/services/blend/src/lib.rs
@@ -61,12 +61,12 @@ pub mod epoch_info;
 pub mod membership;
 pub mod message;
 pub(crate) mod metrics;
-pub mod pending;
 pub mod settings;
 
 mod instance;
 mod kms;
 mod modes;
+mod pending;
 mod service_components;
 pub use self::service_components::ServiceComponents;
 

--- a/services/blend/src/pending.rs
+++ b/services/blend/src/pending.rs
@@ -6,73 +6,65 @@ use std::collections::VecDeque;
 use lb_blend::message::{
     Error as MessageError, encap::validated::EncapsulatedMessageWithVerifiedPublicHeader,
 };
+use lb_chain_service::Epoch;
 
 use crate::LOG_TARGET;
 
-/// One locally-originated message, encapsulated and ready for the wire.
-///
-/// Which queue it came from, so the caller knows what to mark as sent once it
-/// is actually out. Both modes produce this; what differs is only the processor
-/// that made it.
-pub enum LocalEncapsulation {
-    ProposalCopy(EncapsulatedMessageWithVerifiedPublicHeader),
-    Transaction(EncapsulatedMessageWithVerifiedPublicHeader),
-}
-
 /// Turns one encapsulation attempt into what the event loop should do about it.
-///
-/// `None` means "nothing to do this time round": the branch backing this
-/// message has no proofs yet, and it stays queued to be retried. `Err(())`
-/// means the head can never be encapsulated and has to go — the head is
-/// retried before anything else is looked at, so one that keeps failing would
-/// take everything queued behind it down with it.
 ///
 /// The failure is resolved here rather than handed back because a
 /// [`MessageError`] is not `Send`, and a `select!` branch output has to be.
-pub fn resolve_encapsulation<WrapFn>(
+#[must_use]
+pub fn resolve_encapsulation(
     encapsulated: Result<EncapsulatedMessageWithVerifiedPublicHeader, MessageError>,
-    wrap: WrapFn,
-) -> Option<Result<LocalEncapsulation, ()>>
-where
-    WrapFn: FnOnce(EncapsulatedMessageWithVerifiedPublicHeader) -> LocalEncapsulation,
-{
+    kind: MessageKind,
+) -> EncapsulationResult {
     match encapsulated {
-        Ok(message) => Some(Ok(wrap(message))),
-        Err(error) => match report_encapsulation_failure(&error) {
-            Verdict::Retry => None,
-            Verdict::Discard => Some(Err(())),
-        },
+        Ok(message) => {
+            EncapsulationResult::Complete(Box::new(LocalEncapsulation { message, kind }))
+        }
+        Err(MessageError::ProofNotAvailable) => {
+            tracing::trace!(target: LOG_TARGET, "No proofs available yet to encapsulate a message. Leaving it queued.");
+            EncapsulationResult::Retry
+        }
+        Err(error) => {
+            tracing::error!(target: LOG_TARGET, "Dropping a message that cannot be encapsulated: {error:?}");
+            EncapsulationResult::Discard(kind)
+        }
     }
 }
 
-/// Whether a message that failed to encapsulate is worth keeping.
-enum Verdict {
-    /// A failure that says "not yet": leave the message queued.
+/// What the event loop should do about one encapsulation attempt.
+pub enum EncapsulationResult {
+    /// It worked, and this is ready for the wire.
+    Complete(Box<LocalEncapsulation>),
+    /// Not this time: the branch backing this message has no proofs yet, so it
+    /// stays queued and is tried again next time.
     Retry,
-    /// A failure that will repeat however long the message waits: drop it.
-    Discard,
+    /// Never: the head of this queue can never be encapsulated, so it goes. The
+    /// head is retried before anything else is looked at, so one that keeps
+    /// failing would take everything queued behind it down with it.
+    Discard(MessageKind),
 }
 
-/// Logs a failed encapsulation at the level it deserves, and says whether the
-/// message should stay queued.
+/// An encapsulated message of a specific kind.
+pub struct LocalEncapsulation {
+    pub message: EncapsulatedMessageWithVerifiedPublicHeader,
+    pub kind: MessageKind,
+}
+
+/// Which of the two kinds a locally-originated message is.
 ///
-/// Running out of proofs is the ordinary "not yet" — the branch backing this
-/// message has nothing to give until, say, the epoch's secret `PoL` info lands
-/// — and the message is retried every time the loop turns, so reporting it as
-/// an error would bury the log in noise while waiting. Everything else is a
-/// genuine failure, and a permanent one: a payload too large to fit will not
-/// shrink, so retrying it forever would block everything queued behind it.
-fn report_encapsulation_failure(error: &MessageError) -> Verdict {
-    if matches!(error, MessageError::ProofNotAvailable) {
-        tracing::trace!(target: LOG_TARGET, "No proofs available yet to encapsulate a message. Leaving it queued.");
-        Verdict::Retry
-    } else {
-        tracing::error!(target: LOG_TARGET, "Dropping a message that cannot be encapsulated: {error:?}");
-        Verdict::Discard
-    }
+/// The two are queued apart, because only one of them is bound to the epoch it
+/// arrived in, so anything that acts on "whichever was next" has to say which
+/// queue it means.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MessageKind {
+    Proposal,
+    Transaction,
 }
 
-/// What [`PendingLocalMessages::next`] would have the caller work on.
+/// What [`next_local_message`] would have the caller work on.
 #[derive(Debug, PartialEq, Eq)]
 pub enum NextLocalMessage<'a> {
     /// One copy of the longest-waiting block proposal.
@@ -81,142 +73,147 @@ pub enum NextLocalMessage<'a> {
     Transaction(&'a [u8]),
 }
 
-/// What [`PendingLocalMessages::discard_head`] dropped, handed back so a caller
-/// that persists its queue can drop it there too.
-#[derive(Debug, PartialEq, Eq)]
-pub enum Discarded {
-    Proposal(Vec<u8>),
-    Transaction(Vec<u8>),
-}
-
-/// The queue of messages this node has produced but not yet put on the wire.
+/// The next locally-originated message to try, or `None` when nothing is
+/// waiting.
 ///
-/// Both modes need the same bookkeeping. A message might not be sent the moment
-/// it arrives: a transaction waits on a `PoW` solution, and a proposal waits on
-/// this epoch's secret `PoL` info, which could land *after* the first
-/// proposal does. Whatever cannot go yet stays here and is retried.
+/// The one statement of the rule that proposals go first: one is tied to the
+/// slot it was built for and goes stale, whereas a transaction keeps. The two
+/// queues are owned separately — a proposal by the epoch it belongs to, a
+/// transaction by whatever outlives epochs — so the rule that spans them lives
+/// here rather than in either.
 ///
-/// Nothing is removed by looking at it. The branch that does the sending is a
+/// Nothing is removed by looking. The branch that does the sending is a
 /// `select!` arm, so its future is dropped whenever another branch wins the
 /// race, and a queue that popped before awaiting would lose the message every
 /// time that happened. The caller reports what actually went out instead, once
 /// the race is settled.
+#[must_use]
+pub fn next_local_message<'a>(
+    proposals: &'a PendingProposals,
+    transactions: &'a PendingTransactions,
+) -> Option<NextLocalMessage<'a>> {
+    proposals.head().map_or_else(
+        || transactions.head().map(NextLocalMessage::Transaction),
+        |proposal| Some(NextLocalMessage::ProposalCopy(proposal)),
+    )
+}
+
+/// Block proposals this node has produced but not yet put on the wire, each
+/// with the copies it still owes.
 ///
-/// Queued proposals do not survive an epoch change; queued transactions do.
-/// A proposal is built for one slot, and leadership quota is one message's
-/// worth per winning slot, so a proposal still waiting when the epoch turns
-/// would spend the quota that the *new* epoch's block needs. Losing the block
-/// this node is about to produce is worse than losing one it failed to send in
-/// time. A transaction is not slot-bound and its `PoW` branch is redrawn
-/// anyway, so it stays.
+/// **Bound to the epoch it was queued in.** A proposal is built for one slot,
+/// and leadership quota is one message's worth per winning slot, so a proposal
+/// still waiting when the epoch turns would spend the quota that the *new*
+/// epoch's block needs.
 #[derive(Debug)]
-pub struct PendingLocalMessages {
-    /// Each proposal with the copies it still owes. Proposals are replicated;
-    /// transactions are not.
-    proposals: VecDeque<(Vec<u8>, NonZeroU64)>,
-    transactions: VecDeque<Vec<u8>>,
+pub struct PendingProposals {
+    epoch: Epoch,
+    queued: VecDeque<(Vec<u8>, NonZeroU64)>,
 }
 
-impl Default for PendingLocalMessages {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl PendingLocalMessages {
+impl PendingProposals {
     #[must_use]
-    pub const fn new() -> Self {
+    pub const fn new(epoch: Epoch) -> Self {
         Self {
-            proposals: VecDeque::new(),
-            transactions: VecDeque::new(),
+            epoch,
+            queued: VecDeque::new(),
         }
     }
 
     /// Queues a proposal to be sent `copies` times.
-    pub fn queue_proposal(&mut self, proposal: Vec<u8>, copies: NonZeroU64) {
-        self.proposals.push_back((proposal, copies));
+    pub fn queue(&mut self, proposal: Vec<u8>, copies: NonZeroU64) {
+        self.queued.push_back((proposal, copies));
     }
 
-    pub fn queue_transaction(&mut self, transaction: Vec<u8>) {
-        self.transactions.push_back(transaction);
+    fn head(&self) -> Option<&[u8]> {
+        self.queued.front().map(|(proposal, _)| proposal.as_slice())
     }
 
-    /// The next message to try, or `None` when there is nothing waiting.
-    ///
-    /// Proposals go first: one is tied to the slot it was built for and goes
-    /// stale, whereas a transaction keeps.
-    #[must_use]
-    pub fn next(&self) -> Option<NextLocalMessage<'_>> {
-        if let Some((proposal, _)) = self.proposals.front() {
-            return Some(NextLocalMessage::ProposalCopy(proposal));
-        }
-        self.transactions
-            .front()
-            .map(|transaction| NextLocalMessage::Transaction(transaction))
-    }
-
-    /// Records that one copy of the head proposal went out, dropping it once it
-    /// owes no more.
+    /// Records that one copy of the head went out, dropping it once it owes no
+    /// more.
     ///
     /// # Panics
     ///
-    /// If no proposal is queued, which would mean a copy was reported for a
-    /// message this queue never handed out.
-    pub fn mark_proposal_copy_as_sent(&mut self) {
-        let Some((_, remaining_copies)) = self.proposals.front_mut() else {
+    /// If none is queued, which would mean a copy was reported for a message
+    /// this queue never handed out.
+    pub fn mark_copy_as_sent(&mut self) {
+        let Some((_, remaining_copies)) = self.queued.front_mut() else {
             panic!("A proposal copy was reported sent, but none is queued");
         };
-        let copies_before = *remaining_copies;
-        // If the copy sent was the last one, drop the proposal from the queue.
-        let Some(copies_after) = NonZeroU64::new(copies_before.get() - 1) else {
-            drop(self.proposals.pop_front());
-            return;
-        };
-        *remaining_copies = copies_after;
+        match NonZeroU64::new(remaining_copies.get() - 1) {
+            // The copy sent was the last one it owed.
+            None => drop(self.queued.pop_front()),
+            Some(left) => *remaining_copies = left,
+        }
     }
 
-    /// Records that the head transaction went out, handing it back so a caller
-    /// that persists its queue can drop it there too.
+    /// Drops the head, for a caller that has found it can never be sent — one
+    /// too large to fit a payload, say, as opposed to one merely waiting on
+    /// proofs.
+    pub fn discard_head(&mut self) {
+        drop(self.queued.pop_front());
+    }
+}
+
+impl Drop for PendingProposals {
+    fn drop(&mut self) {
+        let dropping = self.queued.len();
+        if dropping > 0 {
+            tracing::warn!(
+                target: LOG_TARGET,
+                "Dropping {dropping} block proposal(s) queued under epoch {:?} without sending them.",
+                self.epoch
+            );
+        }
+    }
+}
+
+/// Transactions this node has accepted but not yet put on the wire.
+///
+/// **Not bound to any epoch.** A transaction stays valid however long it waits,
+/// its `PoW` branch is redrawn under whichever epoch is current when it finally
+/// goes, and it is persisted so it survives a restart. So it is owned by
+/// something that outlives epochs, not by one of them.
+#[derive(Debug, Default)]
+pub struct PendingTransactions(VecDeque<Vec<u8>>);
+
+impl PendingTransactions {
+    #[must_use]
+    pub const fn new() -> Self {
+        Self(VecDeque::new())
+    }
+
+    pub fn queue(&mut self, transaction: Vec<u8>) {
+        self.0.push_back(transaction);
+    }
+
+    fn head(&self) -> Option<&[u8]> {
+        self.0.front().map(Vec::as_slice)
+    }
+
+    /// Records that the head went out, handing it back so a caller that
+    /// persists this queue can drop it there too.
     ///
     /// # Panics
     ///
-    /// If no transaction is queued.
-    pub fn mark_transaction_as_sent(&mut self) -> Vec<u8> {
-        self.transactions
+    /// If none is queued.
+    pub fn mark_as_sent(&mut self) -> Vec<u8> {
+        self.0
             .pop_front()
             .expect("A transaction was reported sent, but none is queued")
     }
 
-    /// Drops every queued proposal, returning how many went, for a caller whose
-    /// epoch has turned over. Transactions are left alone.
-    ///
-    /// See the note on this type for why proposals cannot outlive the epoch
-    /// they were queued in.
-    pub fn discard_proposals(&mut self) -> usize {
-        let discarded = self.proposals.len();
-        self.proposals.clear();
-        discarded
+    /// Drops the head, for a caller that has found it can never be sent, and
+    /// hands it back so the caller can drop it from the recovery state too. See
+    /// [`PendingProposals::discard_head`] for why the head cannot simply stay.
+    pub fn discard_head(&mut self) -> Option<Vec<u8>> {
+        self.0.pop_front()
     }
 
-    /// Drops the message [`Self::next`] would hand out, for a caller that has
-    /// found it can never be sent — one too large to fit a payload, say, as
-    /// opposed to one merely waiting on proofs.
-    ///
-    /// Without this a message like that would sit at the head forever and take
-    /// everything queued behind it down with it, since the head is retried
-    /// before anything else is looked at. A proposal goes in full, outstanding
-    /// copies and all: every copy would fail the same way.
-    pub fn discard_head(&mut self) -> Option<Discarded> {
-        if let Some((proposal, _)) = self.proposals.pop_front() {
-            return Some(Discarded::Proposal(proposal));
-        }
-        self.transactions.pop_front().map(Discarded::Transaction)
-    }
-
-    /// The transactions still waiting, oldest first.
+    /// Those still waiting, oldest first.
     #[must_use]
-    pub fn transactions(&self) -> impl ExactSizeIterator<Item = &Vec<u8>> {
-        self.transactions.iter()
+    pub fn iter(&self) -> impl ExactSizeIterator<Item = &Vec<u8>> {
+        self.0.iter()
     }
 }
 
@@ -224,14 +221,22 @@ impl PendingLocalMessages {
 mod tests {
     use super::*;
 
+    fn proposal(copies: u64) -> PendingProposals {
+        let mut proposals = PendingProposals::new(Epoch::new(1));
+        proposals.queue(b"proposal".to_vec(), copies.try_into().unwrap());
+        proposals
+    }
+
+    fn transaction() -> PendingTransactions {
+        let mut transactions = PendingTransactions::new();
+        transactions.queue(b"tx".to_vec());
+        transactions
+    }
+
     #[test]
     fn a_proposal_goes_before_a_transaction() {
-        let mut pending = PendingLocalMessages::new();
-        pending.queue_transaction(b"tx".to_vec());
-        pending.queue_proposal(b"proposal".to_vec(), 1.try_into().unwrap());
-
         assert_eq!(
-            pending.next(),
+            next_local_message(&proposal(1), &transaction()),
             Some(NextLocalMessage::ProposalCopy(b"proposal")),
             "a proposal is slot-bound and stales; a transaction keeps"
         );
@@ -239,72 +244,43 @@ mod tests {
 
     #[test]
     fn a_proposal_stays_until_every_copy_is_out() {
-        let mut pending = PendingLocalMessages::new();
-        pending.queue_proposal(b"proposal".to_vec(), 3.try_into().unwrap());
-        pending.queue_transaction(b"tx".to_vec());
-
+        let mut proposals = proposal(3);
+        let transactions = transaction();
         for _ in 0..3 {
             assert_eq!(
-                pending.next(),
+                next_local_message(&proposals, &transactions),
                 Some(NextLocalMessage::ProposalCopy(b"proposal"))
             );
-            pending.mark_proposal_copy_as_sent();
+            proposals.mark_copy_as_sent();
         }
-
         assert_eq!(
-            pending.next(),
+            next_local_message(&proposals, &transactions),
             Some(NextLocalMessage::Transaction(b"tx")),
-            "the transaction is reached only once the proposal owes nothing"
+            "once it owes no more copies the transaction behind it gets its turn"
         );
     }
 
     #[test]
     fn looking_does_not_consume() {
-        let mut pending = PendingLocalMessages::new();
-        pending.queue_transaction(b"tx".to_vec());
-
-        // However often a `select!` arm is built and dropped without sending,
-        // the message is still there.
-        for _ in 0..3 {
-            assert_eq!(pending.next(), Some(NextLocalMessage::Transaction(b"tx")));
-        }
-        assert_eq!(pending.mark_transaction_as_sent(), b"tx".to_vec());
-        assert_eq!(pending.next(), None);
+        let proposals = proposal(1);
+        let transactions = transaction();
+        assert_eq!(
+            next_local_message(&proposals, &transactions),
+            next_local_message(&proposals, &transactions),
+            "the sending branch is dropped and rebuilt, so looking must not pop"
+        );
     }
 
     #[test]
     fn a_message_that_can_never_be_sent_does_not_block_the_rest() {
-        let mut pending = PendingLocalMessages::new();
-        pending.queue_proposal(b"proposal".to_vec(), 3.try_into().unwrap());
-        pending.queue_transaction(b"tx".to_vec());
+        let mut proposals = proposal(3);
+        let transactions = transaction();
 
+        proposals.discard_head();
         assert_eq!(
-            pending.discard_head(),
-            Some(Discarded::Proposal(b"proposal".to_vec())),
-            "outstanding copies go with it: they would all fail the same way"
-        );
-        assert_eq!(
-            pending.next(),
+            next_local_message(&proposals, &transactions),
             Some(NextLocalMessage::Transaction(b"tx")),
-            "what was queued behind it must get its turn"
-        );
-    }
-
-    #[test]
-    fn an_epoch_change_takes_the_proposals_and_leaves_the_transactions() {
-        let mut pending = PendingLocalMessages::new();
-        pending.queue_proposal(b"proposal".to_vec(), 3.try_into().unwrap());
-        pending.queue_transaction(b"tx".to_vec());
-
-        assert_eq!(
-            pending.discard_proposals(),
-            1,
-            "outstanding copies go with it: they would all spend the new epoch's quota"
-        );
-        assert_eq!(
-            pending.next(),
-            Some(NextLocalMessage::Transaction(b"tx")),
-            "a transaction is not slot-bound and outlives the epoch it arrived in"
+            "outstanding copies go with it, and what was queued behind gets its turn"
         );
     }
 }


### PR DESCRIPTION
## 1. What does this PR implement?

Similar to https://github.com/logos-blockchain/logos-blockchain/pull/3417, but we group all components for the old epoch when the core service is shutting down. Small QoL PR, preparing the ground for the larger service refactoring landing in the follow-up PRs.

## 2. Does the code have enough context to be clearly understood?

Yes.

## 3. Who are the specification authors and who is accountable for this PR?

@ntn-x2 @youngjoon-lee 

## 4. Is the specification accurate and complete?

Yes.

## 5. Does the implementation introduce changes in the specification?

No.