### PR TITLE
chore(node): remove inscribe subcommand and lb-tui-zone dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4877,7 +4877,6 @@ dependencies = [
  "logos-blockchain-time-service",
  "logos-blockchain-tracing",
  "logos-blockchain-tracing-service",
- "logos-blockchain-tui-zone",
  "logos-blockchain-tx-service",
  "logos-blockchain-utils",
  "logos-blockchain-wallet-service",

--- a/nodes/node/binary/Cargo.toml
+++ b/nodes/node/binary/Cargo.toml
@@ -45,7 +45,6 @@ lb-system-sig-service            = { workspace = true }
 lb-time-service                  = { features = ["ntp"], workspace = true }
 lb-tracing                       = { workspace = true }
 lb-tracing-service               = { workspace = true }
-lb-tui-zone                      = { workspace = true }
 lb-tx-service                    = { features = ["rocksdb-backend"], workspace = true }
 lb-utils                         = { features = ["time"], workspace = true }
 lb-wallet-service                = { workspace = true }

--- a/nodes/node/binary/src/cli/mod.rs
+++ b/nodes/node/binary/src/cli/mod.rs
@@ -10,7 +10,6 @@ use std::{
 
 use clap::{Parser, Subcommand};
 use color_eyre::eyre::Result;
-use lb_tui_zone::cli::NodeKeyArgs;
 use lb_utils::yaml::{OnUnknownKeys, deserialize_value_at_path};
 use libp2p::Multiaddr;
 
@@ -131,8 +130,6 @@ pub enum Command {
     AddKey(Box<AddKeyArgs>),
     /// Remove a key with title from a keystore.
     RemoveKey(Box<RemoveKeyArgs>),
-    /// Publish text inscriptions as zone blocks
-    Inscribe(NodeKeyArgs),
     /// Generate stakeholder.yaml and provider.yaml from a user config
     Participate(ParticipateArgs),
     /// Print the libp2p `PeerId` derived from the node key in a user config

--- a/nodes/node/binary/src/main.rs
+++ b/nodes/node/binary/src/main.rs
@@ -38,10 +38,6 @@ async fn main() -> Result<()> {
             Command::RemoveKey(remove_args) => {
                 return logos_blockchain_node::cli::keys::run_remove_key(*remove_args);
             }
-            Command::Inscribe(inscribe_args) => {
-                lb_tui_zone::run_commands::run_inscribe::run_inscribe(inscribe_args).await;
-                return Ok(());
-            }
             Command::Participate(participate_args) => {
                 return logos_blockchain_node::cli::participate::run(&participate_args);
             }


### PR DESCRIPTION
C-bindings had transitive dependency on zone-sdk through the `inscribe` subcommand. (which we don't want, zone-sdk is a client library, it should not be used in the node)

```
logos-blockchain-c → logos-blockchain-node → logos-blockchain-tui-zone → logos-blockchain-zone-sdk
```

After (`cargo tree -i logos-blockchain-zone-sdk`):

```
logos-blockchain-zone-sdk
├── logos-blockchain-tests
├── logos-blockchain-tui-zone
│   └── logos-blockchain-tests
└── logos-sql
```