### PR TITLE
test(wallet): repro LIB-update panic for a block the wallet never applied

### DIFF
--- a/services/wallet/src/states.rs
+++ b/services/wallet/src/states.rs
@@ -471,4 +471,137 @@ mod tests {
 
         assert!(pending_notes.note_ids().is_empty());
     }
+
+    fn ledger_config() -> lb_ledger::Config {
+        use std::{
+            num::{NonZero, NonZeroU64},
+            sync::Arc,
+        };
+
+        use lb_core::sdp::{MinStake, ServiceParameters, ServiceType};
+        use lb_cryptarchia_engine::EpochConfig;
+        use lb_ledger::{
+            config::{BlendPoWConfig, ModulusShift, PoWConfig, RewardPoWConfig},
+            mantle::sdp::{ServiceRewardsParameters, rewards},
+        };
+        use lb_utils::math::{NonNegativeRatio, PositiveF64};
+
+        let epoch_config = EpochConfig {
+            epoch_stake_distribution_stabilization: NonZero::new(1).unwrap(),
+            epoch_period_nonce_buffer: NonZero::new(1).unwrap(),
+            epoch_period_nonce_stabilization: NonZero::new(1).unwrap(),
+        };
+        let consensus_config = lb_cryptarchia_engine::Config::new(
+            NonZero::new(1).unwrap(),
+            NonNegativeRatio::new(1, 10.try_into().unwrap()),
+            1f64.try_into().expect("1 > 0"),
+            NonZero::new(12).unwrap(),
+        );
+        let epoch_length = epoch_config.epoch_length(consensus_config.base_period_length());
+
+        lb_ledger::Config {
+            epoch_config,
+            consensus_config,
+            sdp_config: lb_ledger::mantle::sdp::Config {
+                service_params: Arc::new(
+                    [(
+                        ServiceType::BlendNetwork,
+                        ServiceParameters {
+                            inactivity_period: 20.try_into().unwrap(),
+                            epoch: 0.into(),
+                        },
+                    )]
+                    .into(),
+                ),
+                service_rewards_params: ServiceRewardsParameters {
+                    blend: rewards::blend::RewardsParameters {
+                        rounds_per_epoch: epoch_length.try_into().unwrap(),
+                        message_frequency_per_round: PositiveF64::try_from(1.0).unwrap(),
+                        num_blend_layers: NonZeroU64::new(3).unwrap(),
+                        minimum_network_size: NonZeroU64::new(1).unwrap(),
+                        data_replication_factor: 0,
+                        activity_threshold_sensitivity: 1,
+                    },
+                },
+                min_stake: MinStake {
+                    threshold: 1,
+                    timestamp: 0,
+                },
+            },
+            faucet_pk: None,
+            pow_config: PoWConfig {
+                blend: BlendPoWConfig {
+                    base_difficulty: ModulusShift::new::<19>(),
+                    damping_den_offset: 0,
+                    damping_num: 1.try_into().unwrap(),
+                    max_step: 1.try_into().unwrap(),
+                    target_transactions_per_block: 1.try_into().unwrap(),
+                },
+                reward: RewardPoWConfig {
+                    reward_pool_genesis: 1_000_000_000,
+                    epoch_reward_genesis: 1_000_000,
+                    initial_difficulty_seed: 1_000,
+                    ema_smoothing_factor: 9,
+                    ema_smoothing_precision: NonZeroU64::new(10).unwrap(),
+                    target_claims_per_block: 100,
+                    rate_num: 0,
+                    rate_den: NonZeroU64::MIN,
+                    target_claim_per_block: NonZeroU64::MIN,
+                    expected_blocks_per_epoch: NonZeroU64::MIN,
+                    slot_window: NonZeroU64::new(100).unwrap(),
+                },
+            },
+        }
+    }
+
+    /// Reproduces the wallet-service crash seen the first time a bootstrapping
+    /// node switches to Online:
+    ///
+    /// During bootstrap the engine never advances the LIB, so no `LibUpdate`
+    /// is broadcast and the wallet's `state.lib` stays at its starting point.
+    /// `switch_to_online()` then jumps the chain LIB to the tip's k-th
+    /// ancestor without broadcasting a `LibUpdate`. The first block processed
+    /// afterwards broadcasts a `LibUpdate` whose `new_lib` can be a block the
+    /// wallet has not applied yet (its frontier lags during IBD), and
+    /// `handle_lib_update` has no backfill path, so the wallet service dies:
+    /// "`WalletState` at LIB must exist: `UnknownBlock(...)`".
+    #[test]
+    #[should_panic(expected = "WalletState at LIB must exist")]
+    fn lib_update_for_unapplied_block_panics() {
+        use std::sync::Arc;
+
+        use lb_services_utils::overwatch::RecoveryData;
+
+        let settings = WalletServiceSettings {
+            known_keys: HashMap::new(),
+            voucher_master_key_id: "voucher-master".into(),
+            recovery_data: RecoveryData::default(),
+            pending_note_expiry_blocks: 10,
+        };
+
+        // Fresh wallet: initialized from the LIB ledger state at genesis.
+        let recovery = RecoveryState {
+            next_new_voucher_index: 0,
+            vouchers: Vouchers::default(),
+            lib_wallet_state: None,
+            pending_claims: PendingClaims::default(),
+        };
+
+        let genesis = HeaderId::from([0; 32]);
+        let ledger = LedgerState::from_utxos([], &ledger_config());
+        let (sender, _receiver) = tokio::sync::watch::channel(None);
+        let updater = StateUpdater::new(Arc::new(sender));
+
+        let mut state = ServiceState::new(recovery, &settings, genesis, &ledger, &updater, 5);
+
+        // The first post-online LibUpdate delivers a new_lib the wallet never
+        // applied (the silent bootstrap->online LIB jump outran the wallet).
+        let unseen_lib = HeaderId::from([42; 32]);
+        state.advance_lib(
+            unseen_lib,
+            Vec::<HeaderId>::new(),
+            1,
+            Vec::<VoucherNullifier>::new(),
+        );
+    }
 }


### PR DESCRIPTION
Reproduces the wallet-service crash seen the first time a node switches from Bootstrapping to Online: during bootstrap the LIB never advances (no `LibUpdate` is ever broadcast), `switch_to_online()` jumps the LIB **without** broadcasting a `LibUpdate`, and the first post-online `LibUpdate` can then reference a block the wallet never applied. `handle_lib_update` has no backfill path, so the wallet service dies with `WalletState at LIB must exist: UnknownBlock(...)` (`services/wallet/src/states.rs`). Afterwards all wallet RPCs fail and the chain service logs `No LIB-update subscribers to notify` on every LIB advance.

The test is `#[should_panic]`, documenting the current behaviour; a fix should flip it.

```sh
cargo test -p logos-blockchain-wallet-service --lib lib_update_for_unapplied_block_panics
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)