### PR TITLE
fix(blend): handle recoverable and unrecoverable libp2p dialing errors differently

### DIFF
--- a/blend/scheduling/Cargo.toml
+++ b/blend/scheduling/Cargo.toml
@@ -34,4 +34,4 @@ lb-blend-proofs  = { features = ["unsafe-test-functions"], workspace = true }
 
 [features]
 tokio-task-names      = ["lb-utils/tokio-task-names"]
-unsafe-test-functions = []
+unsafe-test-functions = ["lb-blend-membership/unsafe-test-functions"]

--- a/libp2p/src/dial_error_ext.rs
+++ b/libp2p/src/dial_error_ext.rs
@@ -1,0 +1,35 @@
+use libp2p::{TransportError, swarm::DialError};
+
+pub trait DialErrorExt {
+    fn is_recoverable(&self) -> bool;
+}
+
+impl DialErrorExt for DialError {
+    fn is_recoverable(&self) -> bool {
+        match self {
+            // The host answering at the declared address presented a different
+            // identity than the expected one. Nothing we retry changes the key
+            // the remote holds — the declaration itself has to change.
+            Self::WrongPeerId { .. }
+            // The address handed resolves back to this node.
+            | Self::LocalPeerId { .. }
+            // There is no address to dial for this peer.
+            | Self::NoAddresses => false,
+
+            // Per-address transport failures. Permanent only when every address
+            // failed because we cannot speak its protocol at all; a timeout,
+            // refusal, or unreachable host is worth another attempt.
+            Self::Transport(errors) => {
+                errors.is_empty()
+                    || !errors
+                        .iter()
+                        .all(|(_, error)| matches!(error, TransportError::MultiaddrNotSupported(_)))
+            }
+
+            // Local, transient conditions.
+            Self::Denied { .. }
+            | Self::Aborted
+            | Self::DialPeerConditionFalse(_) => true,
+        }
+    }
+}

--- a/libp2p/src/lib.rs
+++ b/libp2p/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod behaviour;
 pub mod config;
+pub mod dial_error_ext;
 pub mod protocol_name;
 mod swarm;
 
@@ -7,6 +8,7 @@ pub use config::{
     AutonatClientSettings, ChainSyncSettings, GatewaySettings, IdentifySettings, KademliaSettings,
     NatMappingSettings, NatSettings, SwarmConfig, TraversalSettings, secret_key_serde,
 };
+pub use dial_error_ext::DialErrorExt;
 pub use lb_cryptarchia_sync::{self as cryptarchia_sync, Event};
 pub use libp2p::{
     self, PeerId, SwarmBuilder, Transport,

--- a/services/blend/src/core/backends/libp2p/swarm.rs
+++ b/services/blend/src/core/backends/libp2p/swarm.rs
@@ -28,7 +28,7 @@ use lb_blend::{
     scheduling::membership::Membership,
 };
 use lb_chain_service::Epoch;
-use lb_libp2p::{DialOpts, SwarmEvent};
+use lb_libp2p::{DialError, DialErrorExt as _, DialOpts, SwarmEvent};
 use libp2p::{Multiaddr, PeerId, Swarm, SwarmBuilder, swarm::dial_opts::PeerCondition};
 use rand::RngCore;
 use tokio::{
@@ -117,6 +117,9 @@ where
     rng: Rng,
     max_dial_attempts_per_connection: NonZeroU64,
     ongoing_dials: HashMap<PeerId, DialAttempt>,
+    /// Peers whose dial failed for a reason that retrying cannot fix. Excluded
+    /// from dialing until the next epoch rebuilds the membership.
+    unrecoverable_peers: HashSet<PeerId>,
     pending_retries: PendingRetries,
     pending_full_membership_retry: FullMembershipRetry,
     minimum_network_size: NonZeroUsize,
@@ -194,6 +197,7 @@ where
             current_epoch_info,
             rng,
             max_dial_attempts_per_connection: config.backend.max_dial_attempts_per_peer,
+            unrecoverable_peers: HashSet::new(),
             ongoing_dials: HashMap::with_capacity(
                 *config.backend.core_peering_degree.start() as usize
             ),
@@ -236,6 +240,7 @@ where
         let exclude_peers: HashSet<PeerId> = negotiated_peers
             .chain(self.swarm.behaviour().blocked_peers.blocked_peers())
             .chain(self.ongoing_dials.keys())
+            .chain(self.unrecoverable_peers.iter())
             .chain(except.iter())
             .copied()
             .collect();
@@ -258,7 +263,10 @@ where
         // schedule a single delayed retry. When `except` is empty there is
         // genuinely nobody left to dial (everyone is already negotiated,
         // in-flight, or blocked), so we stop.
-        if no_more_peers_to_dial && !except.is_empty() {
+        // Peers abandoned as unrecoverable count as "tried this cycle" too:
+        // without them a membership made entirely of undialable peers would
+        // look like "nobody left to dial" and stop silently.
+        if no_more_peers_to_dial && !(except.is_empty() && self.unrecoverable_peers.is_empty()) {
             self.schedule_full_membership_retry();
             return;
         }
@@ -288,8 +296,104 @@ where
         }));
     }
 
+    /// Drop a peer that can never be dialed successfully and immediately look
+    /// for a replacement, instead of retrying it with exponential backoff.
+    ///
+    /// The peer stays excluded for the rest of the epoch; a new epoch rebuilds
+    /// the membership and clears the set.
+    fn abandon_peer(&mut self, peer_id: PeerId, error: &DialError) {
+        let previously_failed = self
+            .ongoing_dials
+            .remove(&peer_id)
+            .map(|attempt| attempt.failed_peers)
+            .unwrap_or_default();
+        self.unrecoverable_peers.insert(peer_id);
+        tracing::debug!(
+            target: LOG_TARGET,
+            "Unrecoverable dial failure for peer {peer_id:?}: {error}. Not retrying; excluding it for this epoch and dialing another peer."
+        );
+        self.check_and_dial_new_peers_except(&previously_failed);
+    }
+
     fn check_and_dial_new_peers(&mut self) {
         self.check_and_dial_new_peers_except(&HashSet::new());
+    }
+
+    /// It tries to dial the specified peer.
+    ///
+    /// This function always tries to dial and update the counter of attempted
+    /// dials. Any checks about the maximum allowed dials must be performed in
+    /// the context of the calling function.
+    fn dial(&mut self, peer_id: PeerId, address: Multiaddr, failed_peers: HashSet<PeerId>) {
+        tracing::trace!(target: LOG_TARGET, "Dialing peer {peer_id:?} at address {address:?}.");
+        self.ongoing_dials.insert(
+            peer_id,
+            DialAttempt {
+                address: address.clone(),
+                attempt_number: 1.try_into().unwrap(),
+                failed_peers,
+            },
+        );
+
+        if let Err(e) = self.swarm.dial(
+            DialOpts::peer_id(peer_id)
+                .addresses(vec![address])
+                // We use `Always` since we want to be able to dial a peer even if we already have
+                // an established connection with it that belongs to the previous epoch.
+                .condition(PeerCondition::Always)
+                .build(),
+        ) {
+            tracing::error!(target: LOG_TARGET, "Failed to dial peer {peer_id:?}: {e:?}");
+            // `Swarm::dial` rejects some dials synchronously (our own id, no
+            // address, a behaviour refusing it). They carry the same
+            // recoverable/unrecoverable distinction as an asynchronous
+            // `OutgoingConnectionError` and must be classified identically.
+            if e.is_recoverable() {
+                self.schedule_retry(peer_id);
+            } else {
+                self.abandon_peer(peer_id, &e);
+            }
+        }
+    }
+
+    #[cfg(test)]
+    pub fn dial_peer_at_addr(&mut self, peer_id: PeerId, address: Multiaddr) {
+        self.dial(peer_id, address, HashSet::new());
+    }
+
+    /// Called when a pending retry fires. Re-checks peering degree before
+    /// actually dialing, so we don't waste a slot on a peer we no longer need.
+    fn execute_retry(&mut self, peer_id: PeerId, dial_attempt: DialAttempt) {
+        let num_new_conns_needed = self
+            .minimum_healthy_peering_degree()
+            .saturating_sub(self.num_healthy_peers());
+        if num_new_conns_needed == 0 {
+            tracing::debug!(
+                target: LOG_TARGET,
+                "Skipping retry for peer {peer_id:?}: peering degree already satisfied."
+            );
+            return;
+        }
+        tracing::debug!(
+            target: LOG_TARGET,
+            "Executing backoff retry for peer {peer_id:?} (attempt {}).",
+            dial_attempt.attempt_number
+        );
+        let address = dial_attempt.address.clone();
+        self.ongoing_dials.insert(peer_id, dial_attempt);
+        if let Err(e) = self.swarm.dial(
+            DialOpts::peer_id(peer_id)
+                .addresses(vec![address])
+                .condition(PeerCondition::Always)
+                .build(),
+        ) {
+            tracing::error!(target: LOG_TARGET, "Failed to redial peer {peer_id:?}: {e:?}");
+            if e.is_recoverable() {
+                self.schedule_retry(peer_id);
+            } else {
+                self.abandon_peer(peer_id, &e);
+            }
+        }
     }
 
     /// Dial new peers, if necessary, to maintain the peering degree.
@@ -462,6 +566,13 @@ where
                     return;
                 };
 
+                // A permanent failure is not worth a backoff ladder: drop the
+                // peer for this epoch and spend the dial budget on another one.
+                if !error.is_recoverable() {
+                    self.abandon_peer(peer_id, &error);
+                    return;
+                }
+
                 match self.schedule_retry(peer_id) {
                     EpochDialAttempt::PreviousEpoch => {
                         tracing::debug!(target: LOG_TARGET, "Received a dial error for peer {peer_id:?} that is not being tracked. This means that a new epoch has cleared the map of pending dials. No retry will be performed.");
@@ -500,6 +611,7 @@ where
                 );
                 self.ongoing_dials.clear();
                 self.pending_retries.clear();
+                self.unrecoverable_peers.clear();
                 self.pending_full_membership_retry = None;
                 self.check_and_dial_new_peers();
             }
@@ -585,38 +697,9 @@ where
         IntervalStreamProvider<IntervalStream: Unpin + Send, IntervalItem = RangeInclusive<u64>>,
     ProofsVerifier: ProofsVerifierTrait + Clone + Send + Sync + 'static,
 {
-    /// It tries to dial the specified peer.
-    ///
-    /// This function always tries to dial and update the counter of attempted
-    /// dials. Any checks about the maximum allowed dials must be performed in
-    /// the context of the calling function.
-    fn dial(&mut self, peer_id: PeerId, address: Multiaddr, failed_peers: HashSet<PeerId>) {
-        tracing::trace!(target: LOG_TARGET, "Dialing peer {peer_id:?} at address {address:?}.");
-        self.ongoing_dials.insert(
-            peer_id,
-            DialAttempt {
-                address: address.clone(),
-                attempt_number: 1.try_into().unwrap(),
-                failed_peers,
-            },
-        );
-
-        if let Err(e) = self.swarm.dial(
-            DialOpts::peer_id(peer_id)
-                .addresses(vec![address])
-                // We use `Always` since we want to be able to dial a peer even if we already have
-                // an established connection with it that belongs to the previous epoch.
-                .condition(PeerCondition::Always)
-                .build(),
-        ) {
-            tracing::error!(target: LOG_TARGET, "Failed to dial peer {peer_id:?}: {e:?}");
-            self.schedule_retry(peer_id);
-        }
-    }
-
     #[cfg(test)]
-    pub fn dial_peer_at_addr(&mut self, peer_id: PeerId, address: Multiaddr) {
-        self.dial(peer_id, address, HashSet::new());
+    pub const fn unrecoverable_peers(&self) -> &HashSet<PeerId> {
+        &self.unrecoverable_peers
     }
 
     #[cfg(test)]
@@ -691,37 +774,6 @@ where
             )
         }));
         EpochDialAttempt::OngoingEpoch(None)
-    }
-
-    /// Called when a pending retry fires. Re-checks peering degree before
-    /// actually dialing, so we don't waste a slot on a peer we no longer need.
-    fn execute_retry(&mut self, peer_id: PeerId, dial_attempt: DialAttempt) {
-        let num_new_conns_needed = self
-            .minimum_healthy_peering_degree()
-            .saturating_sub(self.num_healthy_peers());
-        if num_new_conns_needed == 0 {
-            tracing::debug!(
-                target: LOG_TARGET,
-                "Skipping retry for peer {peer_id:?}: peering degree already satisfied."
-            );
-            return;
-        }
-        tracing::debug!(
-            target: LOG_TARGET,
-            "Executing backoff retry for peer {peer_id:?} (attempt {}).",
-            dial_attempt.attempt_number
-        );
-        let address = dial_attempt.address.clone();
-        self.ongoing_dials.insert(peer_id, dial_attempt);
-        if let Err(e) = self.swarm.dial(
-            DialOpts::peer_id(peer_id)
-                .addresses(vec![address])
-                .condition(PeerCondition::Always)
-                .build(),
-        ) {
-            tracing::error!(target: LOG_TARGET, "Failed to redial peer {peer_id:?}: {e:?}");
-            self.schedule_retry(peer_id);
-        }
     }
 
     fn publish_received_edge_message(
@@ -893,6 +945,7 @@ where
             current_epoch_info,
             max_dial_attempts_per_connection,
             ongoing_dials: HashMap::new(),
+            unrecoverable_peers: HashSet::new(),
             pending_retries: FuturesUnordered::new(),
             pending_full_membership_retry: None,
             rng,

--- a/services/blend/src/core/backends/libp2p/tests/redials.rs
+++ b/services/blend/src/core/backends/libp2p/tests/redials.rs
@@ -594,3 +594,62 @@ async fn core_retry_skipped_when_peering_degree_satisfied() {
             >= 1
     );
 }
+
+#[test(tokio::test)]
+async fn core_does_not_retry_unrecoverable_dial_failure() {
+    let (mut identities, peer_ids) = new_nodes_with_empty_address(2);
+
+    // A real listening swarm whose address we pair with the wrong identity.
+    let TestSwarm {
+        swarm: mut listening_swarm,
+        ..
+    } = SwarmBuilder::new(identities.next().unwrap(), &peer_ids)
+        .build(|id, membership| BlendBehaviourBuilder::new(id, membership).build());
+    let (listening_node, _) = listening_swarm
+        .listen_and_return_membership_entry(None)
+        .await;
+    tokio::spawn(async move { listening_swarm.run().await });
+
+    let TestSwarm {
+        swarm: mut dialing_swarm,
+        ..
+    } = SwarmBuilder::new(identities.next().unwrap(), &peer_ids)
+        .build(|id, membership| BlendBehaviourBuilder::new(id, membership).build());
+
+    let wrong_peer_id = PeerId::random();
+    dialing_swarm.dial_peer_at_addr(wrong_peer_id, listening_node.address.clone());
+
+    dialing_swarm
+        .poll_next_until(|event| {
+            let SwarmEvent::OutgoingConnectionError { peer_id, .. } = event else {
+                return false;
+            };
+            *peer_id == Some(wrong_peer_id)
+        })
+        .await;
+
+    assert!(
+        dialing_swarm.unrecoverable_peers().contains(&wrong_peer_id),
+        "a wrong-peer-id failure must mark the peer unusable for this epoch"
+    );
+    assert!(
+        !dialing_swarm.ongoing_dials().contains_key(&wrong_peer_id),
+        "the abandoned peer must not be left in ongoing dials"
+    );
+
+    // The first backoff would be 2^1 = 2s; no further attempt may occur.
+    let no_second_attempt = time::timeout(
+        Duration::from_secs(4),
+        dialing_swarm.poll_next_until(|event| {
+            let SwarmEvent::OutgoingConnectionError { peer_id, .. } = event else {
+                return false;
+            };
+            *peer_id == Some(wrong_peer_id)
+        }),
+    )
+    .await;
+    assert!(
+        no_second_attempt.is_err(),
+        "an unrecoverable dial failure must not be retried"
+    );
+}

--- a/services/blend/src/edge/backends/libp2p/swarm.rs
+++ b/services/blend/src/edge/backends/libp2p/swarm.rs
@@ -16,7 +16,7 @@ use lb_blend::{
         serialize_encapsulated_message_with_verified_public_header,
     },
 };
-use lb_libp2p::{DialError, DialOpts, SwarmEvent};
+use lb_libp2p::{DialError, DialErrorExt as _, DialOpts, SwarmEvent};
 use libp2p::{
     Multiaddr, PeerId, StreamProtocol, Swarm, SwarmBuilder,
     identity::Keypair,
@@ -103,6 +103,10 @@ where
     pending_events: PendingEvents,
     protocol_name: StreamProtocol,
     replication_factor: NonZeroUsize,
+    /// Peers whose dial failed for a reason that retrying cannot fix (see
+    /// [`DialErrorExt::is_recoverable`]). They are excluded from peer selection
+    /// for the lifetime of this swarm, which spans one epoch's membership.
+    unrecoverable_peers: HashSet<PeerId>,
 }
 
 #[derive(Debug)]
@@ -157,6 +161,7 @@ where
             max_dial_attempts_per_connection: settings.max_dial_attempts_per_peer_per_message,
             protocol_name: settings.protocol_name.into_inner(),
             replication_factor,
+            unrecoverable_peers: HashSet::new(),
         }
     }
 
@@ -190,6 +195,7 @@ where
             swarm: inner_swarm,
             protocol_name,
             replication_factor,
+            unrecoverable_peers: HashSet::new(),
         }
     }
 
@@ -215,7 +221,9 @@ where
     /// A single set of `replication_factor` peers is chosen at random for the
     /// message. Each chosen peer is then retried with exponential backoff (see
     /// [`Self::schedule_retry`]); if a peer is still unreachable after all
-    /// attempts, the message is dropped for that peer.
+    /// attempts, the message is dropped for that peer. A peer that fails
+    /// unrecoverably is replaced by a different one instead of being retried
+    /// (see [`Self::abandon_peer_and_redial`]).
     fn dial_and_schedule_message(&mut self, msg: &EncapsulatedMessageWithVerifiedPublicHeader) {
         let peers = self.choose_peers();
         if peers.is_empty() {
@@ -223,27 +231,96 @@ where
             return;
         }
         for node in peers {
-            let (peer_id, address) = (node.id, node.address);
-            let opts = dial_opts(peer_id, address.clone());
-            let connection_id = opts.connection_id();
+            self.dial_peer_with_message(node.id, node.address, msg.clone());
+        }
+    }
 
-            let Entry::Vacant(empty_entry) = self.pending_dials.entry((peer_id, connection_id))
-            else {
-                panic!(
-                    "Dial attempt for peer {peer_id:?} and connection {connection_id:?} should not be present in storage."
-                );
-            };
-            empty_entry.insert(DialAttempt {
-                address,
-                attempt_number: 1.try_into().unwrap(),
-                message: msg.clone(),
-            });
+    /// Dial a single peer, recording the message to be sent once the
+    /// connection is established.
+    fn dial_peer_with_message(
+        &mut self,
+        peer_id: PeerId,
+        address: Multiaddr,
+        message: EncapsulatedMessageWithVerifiedPublicHeader,
+    ) {
+        let opts = dial_opts(peer_id, address.clone());
+        let connection_id = opts.connection_id();
 
-            if let Err(e) = self.swarm.dial(opts) {
-                error!(target: LOG_TARGET, "Failed to dial peer {peer_id:?} on connection {connection_id:?}: {e:?}");
+        let Entry::Vacant(empty_entry) = self.pending_dials.entry((peer_id, connection_id)) else {
+            panic!(
+                "Dial attempt for peer {peer_id:?} and connection {connection_id:?} should not be present in storage."
+            );
+        };
+        empty_entry.insert(DialAttempt {
+            address,
+            attempt_number: 1.try_into().unwrap(),
+            message,
+        });
+
+        if let Err(e) = self.swarm.dial(opts) {
+            error!(target: LOG_TARGET, "Failed to dial peer {peer_id:?} on connection {connection_id:?}: {e:?}");
+            // `Swarm::dial` rejects some dials synchronously (no address, our
+            // own id, a behaviour refusing it). Those carry the same
+            // recoverable/unrecoverable distinction as an asynchronous
+            // `OutgoingConnectionError` and must be classified identically.
+            if e.is_recoverable() {
                 self.schedule_retry(peer_id, connection_id);
+            } else {
+                self.abandon_peer_and_redial(peer_id, connection_id, &e);
             }
         }
+    }
+
+    /// Drop a peer that can never be dialed successfully and send its message
+    /// to a different peer instead.
+    ///
+    /// Unlike [`Self::schedule_retry`], this does not re-dial the same peer:
+    /// the failure is permanent for as long as the current membership stands,
+    /// so the peer is excluded from further selection and the message is
+    /// re-targeted immediately rather than after exhausting a backoff ladder.
+    #[expect(
+        clippy::cognitive_complexity,
+        reason = "Tracing macros add a lot of code under the hood."
+    )]
+    fn abandon_peer_and_redial(
+        &mut self,
+        peer_id: PeerId,
+        connection_id: ConnectionId,
+        error: &DialError,
+    ) {
+        self.unrecoverable_peers.insert(peer_id);
+
+        let Some(dial_attempt) = self.pending_dials.remove(&(peer_id, connection_id)) else {
+            debug!(target: LOG_TARGET, "No pending dial for peer {peer_id:?} on connection {connection_id:?}. Nothing to re-target.");
+            return;
+        };
+
+        error!(
+            target: LOG_TARGET,
+            "Unrecoverable dial failure for peer {peer_id:?} at {:?}: {error}. Not retrying; excluding it from this membership and choosing another peer.",
+            dial_attempt.address
+        );
+
+        let Some(replacement) = self.choose_replacement_peer() else {
+            warn!(target: LOG_TARGET, "No alternative peer available to send the message to. Dropping the message.");
+            return;
+        };
+        debug!(target: LOG_TARGET, "Re-targeting message from peer {peer_id:?} to {:?}", replacement.id);
+        self.dial_peer_with_message(replacement.id, replacement.address, dial_attempt.message);
+    }
+
+    /// Pick one peer that is neither known-unusable nor already being dialed.
+    fn choose_replacement_peer(&mut self) -> Option<Node<PeerId>> {
+        let exclude: HashSet<PeerId> = self
+            .unrecoverable_peers
+            .iter()
+            .chain(self.pending_dials.keys().map(|(peer_id, _)| peer_id))
+            .copied()
+            .collect();
+        self.membership
+            .filter_and_choose_remote_nodes(&mut self.rng, 1, &exclude)
+            .next()
+            .cloned()
     }
 
     /// Schedule a retry for a failed dial attempt with exponential backoff.
@@ -292,9 +369,17 @@ where
     }
 
     fn choose_peers(&mut self) -> Vec<Node<PeerId>> {
-        let peers_to_choose = self.membership.size().min(self.replication_factor.get());
+        let available = self
+            .membership
+            .size()
+            .saturating_sub(self.unrecoverable_peers.len());
+        let peers_to_choose = available.min(self.replication_factor.get());
         self.membership
-            .filter_and_choose_remote_nodes(&mut self.rng, peers_to_choose, &HashSet::new())
+            .filter_and_choose_remote_nodes(
+                &mut self.rng,
+                peers_to_choose,
+                &self.unrecoverable_peers,
+            )
             .cloned()
             .collect()
     }
@@ -384,7 +469,11 @@ where
 
         if let Err(e) = self.swarm.dial(opts) {
             error!(target: LOG_TARGET, "Failed to redial peer {peer_id:?}: {e:?}");
-            self.schedule_retry(peer_id, connection_id);
+            if e.is_recoverable() {
+                self.schedule_retry(peer_id, connection_id);
+            } else {
+                self.abandon_peer_and_redial(peer_id, connection_id, &e);
+            }
         }
     }
 
@@ -400,6 +489,11 @@ where
             debug!(target: LOG_TARGET, "No PeerId set. Ignoring: peer_id:{peer_id:?}, connection_id:{connection_id}");
             return;
         };
+
+        if !error.is_recoverable() {
+            self.abandon_peer_and_redial(peer_id, connection_id, error);
+            return;
+        }
 
         self.schedule_retry(peer_id, connection_id);
     }

--- a/services/blend/src/edge/backends/libp2p/tests/redials.rs
+++ b/services/blend/src/edge/backends/libp2p/tests/redials.rs
@@ -8,9 +8,13 @@ use lb_key_management_system_service::keys::UnsecuredEd25519Key;
 use lb_libp2p::{Protocol, SwarmEvent};
 use libp2p::{Multiaddr, PeerId};
 use test_log::test;
-use tokio::time;
+use tokio::{spawn, time};
 
 use crate::{
+    core::backends::libp2p::core_swarm_test_utils::{
+        BlendBehaviourBuilder, SwarmBuilder as CoreSwarmBuilder, SwarmExt as _,
+        TestSwarm as CoreTestSwarm, new_nodes_with_empty_address,
+    },
     edge::backends::libp2p::{
         swarm::Command,
         tests::utils::{SwarmBuilder as EdgeSwarmBuilder, TestSwarm as EdgeTestSwarm},
@@ -174,5 +178,118 @@ async fn stalled_send_does_not_block_command_processing() {
         swarm.pending_dials().len(),
         1,
         "The command should be processed even though a send is stalled"
+    );
+}
+
+/// A dial that fails because the host at the declared address presents a
+/// different identity than the membership expects (`DialError::WrongPeerId`)
+/// must not be retried: no number of attempts changes the remote's key.
+///
+/// This is the failure that took down Blend on testnet v0.2.1 — every declared
+/// locator pointed at a host holding a different key, and because the error was
+/// funnelled into the same backoff ladder as a timeout it was reported as
+/// "peer was not reachable after N attempts" rather than as a configuration
+/// fault.
+#[test(tokio::test)]
+async fn edge_does_not_retry_unrecoverable_dial_failure() {
+    // A real listening swarm, whose address we will pair with the wrong peer id.
+    let (mut identities, nodes) = new_nodes_with_empty_address(1);
+    let CoreTestSwarm {
+        swarm: mut listening_swarm,
+        ..
+    } = CoreSwarmBuilder::new(identities.next().unwrap(), &nodes)
+        .build(|id, membership| BlendBehaviourBuilder::new(id, membership).build());
+    let (listening_node, _) = listening_swarm
+        .listen_and_return_membership_entry(None)
+        .await;
+    spawn(async move { listening_swarm.run().await });
+
+    // The membership points at the right address but the wrong identity.
+    let wrong_peer_id = PeerId::random();
+    let EdgeTestSwarm { mut swarm, .. } =
+        EdgeSwarmBuilder::new(Membership::new_without_local(from_ref(&Node {
+            address: listening_node.address.clone(),
+            id: wrong_peer_id,
+            public_key: UnsecuredEd25519Key::generate_with_blake_rng().public_key(),
+        })))
+        // Generous retry budget: if the error were treated as recoverable we
+        // would see further attempts after the backoff below.
+        .with_max_dial_attempts(3)
+        .build();
+
+    swarm.send_message(&TestEncapsulatedMessage::new(b"test-payload"));
+
+    // The first (and only) dial fails with a wrong-peer-id error.
+    swarm
+        .poll_next_until(|event| {
+            let SwarmEvent::OutgoingConnectionError { peer_id, .. } = event else {
+                return false;
+            };
+            *peer_id == Some(wrong_peer_id)
+        })
+        .await;
+
+    // The first backoff would be 2^1 = 2s. Wait past it: no second attempt may
+    // be made, and the peer must be gone from the pending dials.
+    let no_second_attempt = time::timeout(
+        time::Duration::from_secs(4),
+        swarm.poll_next_until(|event| {
+            let SwarmEvent::OutgoingConnectionError { peer_id, .. } = event else {
+                return false;
+            };
+            *peer_id == Some(wrong_peer_id)
+        }),
+    )
+    .await;
+    assert!(
+        no_second_attempt.is_err(),
+        "an unrecoverable dial failure must not be retried"
+    );
+    assert!(
+        swarm.pending_dials().is_empty(),
+        "the abandoned peer must not be left pending"
+    );
+}
+
+/// A peer abandoned as unrecoverable stays excluded for the rest of the
+/// membership's life, so later messages are not spent re-dialing it.
+#[test(tokio::test)]
+async fn edge_excludes_unrecoverable_peer_from_later_sends() {
+    let (mut identities, nodes) = new_nodes_with_empty_address(1);
+    let CoreTestSwarm {
+        swarm: mut listening_swarm,
+        ..
+    } = CoreSwarmBuilder::new(identities.next().unwrap(), &nodes)
+        .build(|id, membership| BlendBehaviourBuilder::new(id, membership).build());
+    let (listening_node, _) = listening_swarm
+        .listen_and_return_membership_entry(None)
+        .await;
+    spawn(async move { listening_swarm.run().await });
+
+    let wrong_peer_id = PeerId::random();
+    let EdgeTestSwarm { mut swarm, .. } =
+        EdgeSwarmBuilder::new(Membership::new_without_local(from_ref(&Node {
+            address: listening_node.address.clone(),
+            id: wrong_peer_id,
+            public_key: UnsecuredEd25519Key::generate_with_blake_rng().public_key(),
+        })))
+        .build();
+
+    swarm.send_message(&TestEncapsulatedMessage::new(b"first"));
+    swarm
+        .poll_next_until(|event| {
+            let SwarmEvent::OutgoingConnectionError { peer_id, .. } = event else {
+                return false;
+            };
+            *peer_id == Some(wrong_peer_id)
+        })
+        .await;
+
+    // The only member is now known-unusable, so a second message finds no peer
+    // to dial at all rather than repeating the doomed dial.
+    swarm.send_message(&TestEncapsulatedMessage::new(b"second"));
+    assert!(
+        swarm.pending_dials().is_empty(),
+        "a peer abandoned as unrecoverable must not be chosen for later messages"
     );
 }


### PR DESCRIPTION
## 1. What does this PR implement?

We currently retry dialing a peer no matter what dial error we get. In this PR, we distinguish between recoverable and unrecoverable errors. The former class leads to a dial re-try up to the configured maximum per peer. The second, results in the peer being marked as unreachable until the end of the epoch. This should speed up cases like invalid SDP declarations which are not really meant to be "considered" at all, speeding up message delivery.

## 2. Does the code have enough context to be clearly understood?

Yes.

## 3. Who are the specification authors and who is accountable for this PR?

@ntn-x2 

## 4. Is the specification accurate and complete?

Yes.

## 5. Does the implementation introduce changes in the specification?

No.