### PR TITLE
fix(openapi): remove proc-macro-error from cargo-deny entries

### DIFF
--- a/.cargo-deny.toml
+++ b/.cargo-deny.toml
@@ -7,7 +7,6 @@ no-default-features = true
 
 [advisories]
 ignore = [
-  { id = "RUSTSEC-2024-0370", reason = "`proc-macro-error` is unmaintained; consider using an alternative. Use `cargo tree -p proc-macro-error -i > tmp.txt` to check the dependency tree." },
   { id = "RUSTSEC-2024-0388", reason = "`derivative` is unmaintained; consider using an alternative. Use `cargo tree -p derivative -i > tmp.txt` to check the dependency tree." },
   { id = "RUSTSEC-2024-0436", reason = "`paste` has a security vulnerability; consider using an alternative. Use `cargo tree -p paste -i > tmp.txt` to check the dependency tree." },
   { id = "RUSTSEC-2025-0055", reason = "`tracing-subscriber` v0.2.25 pulled in by ark-relations v0.4.0 - will be addressed before mainnet" },
@@ -15,8 +14,8 @@ ignore = [
   { id = "RUSTSEC-2026-0118", reason = "`hickory-proto` can enter an unbounded DNSSEC NSEC3 validation loop and exhaust memory; pulled in through libp2p." },
   { id = "RUSTSEC-2026-0119", reason = "`hickory-proto` DNS message compression can cause CPU exhaustion during encoding; pulled in through libp2p." },
   { id = "RUSTSEC-2026-0173", reason = "`proc-macro-error2` is unmaintained." },
-  { id = "RUSTSEC-2026-0194", reason = "`quick-xml` is used by pprof and will not parse untrusted XML." },
-  { id = "RUSTSEC-2026-0195", reason = "`quick-xml` is used by cucumber and will not parse untrusted XML." },
+  { id = "RUSTSEC-2026-0194", reason = "`quick-xml` v0.26 is pulled in by pprof (via inferno) and will not parse untrusted XML." },
+  { id = "RUSTSEC-2026-0195", reason = "`quick-xml` v0.26 is pulled in by pprof (via inferno) and will not parse untrusted XML." },
 ]
 unused-ignored-advisory = "deny"
 yanked = "deny"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4684,6 +4684,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "utoipa",
  "x25519-dalek",
  "zeroize",
 ]
@@ -5300,6 +5301,7 @@ dependencies = [
  "time",
  "tokio",
  "tracing",
+ "utoipa",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,6 +126,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
+name = "appendlist"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e149dc73cd30538307e7ffa2acd3d2221148eaeed4871f246657b1c3eaa1cbd2"
+
+[[package]]
 name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -778,6 +784,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "boon"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baa187da765010b70370368c49f08244b1ae5cae1d5d33072f76c8cb7112fe3e"
+dependencies = [
+ "ahash",
+ "appendlist",
+ "base64 0.22.1",
+ "fluent-uri",
+ "idna",
+ "once_cell",
+ "percent-encoding",
+ "regex",
+ "regex-syntax",
+ "serde",
+ "serde_json",
+ "url",
+]
+
+[[package]]
+name = "borrow-or-share"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
+
+[[package]]
 name = "bs58"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -934,9 +966,9 @@ dependencies = [
 
 [[package]]
 name = "chacha20"
-version = "0.10.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
@@ -1372,9 +1404,9 @@ dependencies = [
 
 [[package]]
 name = "cucumber"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18c09939b8de21501b829a3839fa8a01ef6cc226e6bc1f5f163f7104bd5e847d"
+checksum = "96a87e18d925b19ebe0fd47ea45316abd216d81ec0879c2448c3f9a0e9da62be"
 dependencies = [
  "anyhow",
  "clap",
@@ -1400,9 +1432,9 @@ dependencies = [
 
 [[package]]
 name = "cucumber-codegen"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f5afe541b5147a7b986816153ccfd502622bb37789420cfff412685f27c0a95"
+checksum = "ed2fc8a8bbb73af3230db699e8690c5c786655f75eb89e5f18d76055fa1a9a4d"
 dependencies = [
  "cucumber-expressions",
  "inflections",
@@ -1638,13 +1670,13 @@ dependencies = [
 
 [[package]]
 name = "derive-getters"
-version = "0.3.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2c35ab6e03642397cdda1dd58abbc05d418aef8e36297f336d5aba060fe8df"
+checksum = "74ef43543e701c01ad77d3a5922755c6a1d71b22d942cb8042be4994b380caff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1949,7 +1981,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2076,6 +2108,16 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "fluent-uri"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1918b65d96df47d3591bed19c5cca17e3fa5d0707318e4b5ef2eae01764df7e5"
+dependencies = [
+ "borrow-or-share",
+ "ref-cast",
 ]
 
 [[package]]
@@ -2324,9 +2366,9 @@ dependencies = [
 
 [[package]]
 name = "gherkin"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70197ce7751bfe8bc828e3a855502d3a869a1e9416b58b10c4bde5cf8a0a3cb3"
+checksum = "9e2c0d8c632f8a251ce9a8198079b1022adc586ff4e3d33e18debd40eb463b31"
 dependencies = [
  "heck",
  "peg",
@@ -3054,7 +3096,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3204,13 +3246,12 @@ dependencies = [
 
 [[package]]
 name = "junit-report"
-version = "0.8.3"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06c3a3342e6720a82d7d179f380e9841b73a1dd49344e33959fdfe571ce56b55"
+checksum = "cb201fc2964416320139f702d888df6a39685e648f68e3c910a77cfda99ce44d"
 dependencies = [
  "derive-getters",
- "quick-xml 0.31.0",
- "strip-ansi-escapes",
+ "quick-xml 0.41.0",
  "time",
 ]
 
@@ -3960,6 +4001,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
+ "utoipa",
 ]
 
 [[package]]
@@ -4476,6 +4518,7 @@ dependencies = [
  "ark-ff",
  "bincode",
  "blake2",
+ "boon",
  "bytes",
  "divan",
  "hasher",
@@ -4504,6 +4547,7 @@ dependencies = [
  "time",
  "tokio",
  "tracing",
+ "utoipa",
 ]
 
 [[package]]
@@ -4520,6 +4564,7 @@ dependencies = [
  "time",
  "tokio",
  "tracing",
+ "utoipa",
 ]
 
 [[package]]
@@ -4821,6 +4866,7 @@ version = "0.0.0"
 dependencies = [
  "async-trait",
  "axum 0.7.9",
+ "boon",
  "bytes",
  "clap",
  "color-eyre",
@@ -5912,7 +5958,6 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -6518,39 +6563,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-crate"
-version = "3.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
-dependencies = [
- "toml_edit",
-]
-
-[[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
-
-[[package]]
 name = "proc-macro-error-attr2"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6804,9 +6816,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.31.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1004a344b30a54e2ee58d66a71b32d2db2feb0a31f9a2d302bf0536f15de2a33"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]
@@ -7110,7 +7122,6 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64 0.22.1",
  "bytes",
- "futures-channel",
  "futures-core",
  "futures-util",
  "h2",
@@ -7395,7 +7406,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7937,15 +7948,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f446288b699d66d0fd2e30d1cfe7869194312524b3b9252594868ed26ef056a"
 
 [[package]]
-name = "strip-ansi-escapes"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a8f8038e7e7969abb3f1b7c2a811225e9296da208539e0f79c5251d6cac0025"
-dependencies = [
- "vte",
-]
-
-[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8154,7 +8156,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8613,7 +8615,7 @@ dependencies = [
  "indexmap",
  "serde_core",
  "serde_spanned",
- "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_datetime",
  "toml_parser",
  "toml_writer",
  "winnow 0.7.15",
@@ -8626,27 +8628,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
 dependencies = [
  "serde_core",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "1.1.1+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
-dependencies = [
- "serde_core",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.25.12+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
-dependencies = [
- "indexmap",
- "toml_datetime 1.1.1+spec-1.1.0",
- "toml_parser",
- "winnow 1.0.3",
 ]
 
 [[package]]
@@ -9132,9 +9113,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "utoipa"
-version = "4.2.3"
+version = "5.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5afb1a60e207dca502682537fefcfd9921e71d0b83e9576060f09abc6efab23"
+checksum = "8bde15df68e80b16c7d16b9616e80770ad158988daa56a27dccd1e55558b0160"
 dependencies = [
  "indexmap",
  "serde",
@@ -9144,11 +9125,10 @@ dependencies = [
 
 [[package]]
 name = "utoipa-gen"
-version = "4.3.1"
+version = "5.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20c24e8ab68ff9ee746aad22d39b5535601e6416d1b0feeabf78be986a5c4392"
+checksum = "6ba0b99ee52df3028635d93840c797102da61f8a7bb3cf751032455895b52ef8"
 dependencies = [
- "proc-macro-error",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -9156,14 +9136,13 @@ dependencies = [
 
 [[package]]
 name = "utoipa-swagger-ui"
-version = "7.1.0"
+version = "8.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "943e0ff606c6d57d410fd5663a4d7c074ab2c5f14ab903b9514565e59fa1189e"
+checksum = "a5c80b4dd79ea382e8374d67dcce22b5c6663fa13a82ad3886441d1bbede5e35"
 dependencies = [
  "axum 0.7.9",
  "mime_guess",
  "regex",
- "reqwest 0.12.28",
  "rust-embed",
  "serde",
  "serde_json",
@@ -9236,15 +9215,6 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "vte"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "231fdcd7ef3037e8330d8e17e61011a2c244126acc0a982f4040ac3f9f0bc077"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "walkdir"
@@ -9417,7 +9387,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9738,9 +9708,6 @@ name = "winnow"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "wit-bindgen"
@@ -9967,9 +9934,9 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "1.1.4"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cc23c04387f4da0374be4533ad1208cbb091d5c11d070dfef13676ad6497164"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
 dependencies = [
  "arbitrary",
  "crc32fast",
@@ -9977,8 +9944,9 @@ dependencies = [
  "displaydoc",
  "flate2",
  "indexmap",
- "num_enum",
- "thiserror 1.0.69",
+ "memchr",
+ "thiserror 2.0.18",
+ "zopfli",
 ]
 
 [[package]]
@@ -9986,3 +9954,15 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -192,6 +192,7 @@ axum                               = { default-features = false, version = "0.7.
 backon                             = { default-features = false, version = "1.3.0" }
 bincode                            = { default-features = false, version = "1.3" }
 blake2                             = { default-features = false, version = "0.10" }
+boon                               = { default-features = false, version = "0.6" }
 bytes                              = { default-features = false, version = "1.3" }
 cbindgen                           = { default-features = false, version = "0.29" }
 chrono                             = { default-features = false, version = "0.4" }
@@ -200,7 +201,7 @@ clap                               = { default-features = false, version = "4" }
 color-eyre                         = { default-features = false, version = "0.6.0" }
 console-subscriber                 = { default-features = false, version = "0.5" }
 const-hex                          = { default-features = false, version = "1" }
-cucumber                           = { default-features = false, version = "=0.22.0" }
+cucumber                           = { default-features = false, version = "=0.23.0" }
 derivative                         = { default-features = false, version = "2" }
 dhat                               = { default-features = false, version = "0.3.3" }
 divan                              = { default-features = false, version = "0.1" }
@@ -294,8 +295,8 @@ tracing-loki          = { default-features = false, version = "0.2.5" }
 tracing-opentelemetry = { default-features = false, version = "0.33.0" }
 tracing-subscriber    = { default-features = false, version = "0.3" }
 url                   = { default-features = false, version = "2" }
-utoipa                = { default-features = false, version = "4.0" }
-utoipa-swagger-ui     = { default-features = false, version = "7.0" }
+utoipa                = { default-features = false, version = "5.0" }
+utoipa-swagger-ui     = { default-features = false, version = "8.0" }
 uuid                  = { default-features = false, version = "1" }
 validator             = { default-features = false, version = "0.20.0" }
 x25519-dalek          = { default-features = false, version = "2" }

--- a/consensus/cryptarchia-engine/Cargo.toml
+++ b/consensus/cryptarchia-engine/Cargo.toml
@@ -27,6 +27,8 @@ thiserror  = { workspace = true }
 time       = { workspace = true }
 tokio      = { features = ["time"], optional = true, workspace = true }
 tracing    = { workspace = true }
+utoipa     = { features = ["macros"], optional = true, workspace = true }
 
 [features]
-tokio = ["dep:tokio"]
+openapi = ["dep:utoipa"]
+tokio   = ["dep:tokio"]

--- a/consensus/cryptarchia-engine/src/lib.rs
+++ b/consensus/cryptarchia-engine/src/lib.rs
@@ -21,6 +21,7 @@ pub(crate) const LOG_TARGET: &str = "cryptarchia::engine";
 pub type UncleSlots = UpperBoundedVec<Slot, MAX_UNCLES>;
 
 #[derive(Clone, Debug, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub enum State {
     Bootstrapping,
     Online,

--- a/consensus/cryptarchia-engine/src/time.rs
+++ b/consensus/cryptarchia-engine/src/time.rs
@@ -209,6 +209,16 @@ impl TryFrom<u64> for Epoch {
     }
 }
 
+#[cfg(feature = "openapi")]
+impl utoipa::PartialSchema for Slot {
+    fn schema() -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
+        u64::schema()
+    }
+}
+
+#[cfg(feature = "openapi")]
+impl utoipa::ToSchema for Slot {}
+
 impl From<u64> for Slot {
     fn from(slot: u64) -> Self {
         Self(slot)

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -56,5 +56,5 @@ name    = "mantle_tx_components"
 
 [features]
 default               = []
-openapi               = ["dep:utoipa"]
+openapi               = ["dep:utoipa", "lb-utils/openapi"]
 unsafe-test-functions = []

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -40,8 +40,10 @@ strum                         = { features = ["derive"], workspace = true }
 thiserror                     = { workspace = true }
 time                          = { workspace = true }
 tracing                       = { workspace = true }
+utoipa                        = { features = ["macros"], optional = true, workspace = true }
 
 [dev-dependencies]
+boon       = { workspace = true }
 divan      = { workspace = true }
 hasher     = { workspace = true }
 rand       = { workspace = true }
@@ -54,4 +56,5 @@ name    = "mantle_tx_components"
 
 [features]
 default               = []
+openapi               = ["dep:utoipa"]
 unsafe-test-functions = []

--- a/core/src/mantle/ledger.rs
+++ b/core/src/mantle/ledger.rs
@@ -465,7 +465,7 @@ pub struct NoteId(#[serde(with = "serde_fr")] pub Fr);
 #[cfg(feature = "openapi")]
 impl utoipa::PartialSchema for NoteId {
     fn schema() -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
-        crate::utils::hex_bytes_schema(size_of::<lb_groth16::FrBytes>())
+        lb_utils::openapi::hex_bytes_schema(size_of::<lb_groth16::FrBytes>())
     }
 }
 

--- a/core/src/mantle/ledger.rs
+++ b/core/src/mantle/ledger.rs
@@ -462,6 +462,16 @@ impl<'input> IntoIterator for &'input Inputs {
 #[serde(transparent)]
 pub struct NoteId(#[serde(with = "serde_fr")] pub Fr);
 
+#[cfg(feature = "openapi")]
+impl utoipa::PartialSchema for NoteId {
+    fn schema() -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
+        crate::utils::hex_bytes_schema(size_of::<lb_groth16::FrBytes>())
+    }
+}
+
+#[cfg(feature = "openapi")]
+impl utoipa::ToSchema for NoteId {}
+
 impl NoteId {
     #[must_use]
     pub const fn as_fr(&self) -> &Fr {

--- a/core/src/sdp/mod.rs
+++ b/core/src/sdp/mod.rs
@@ -113,6 +113,24 @@ type BoundedMultiaddr = lb_utils::bounded::multiaddr::BoundedMultiaddr<0, MAX_LO
 #[serde(try_from = "Multiaddr")]
 pub struct Locator(BoundedMultiaddr);
 
+#[cfg(feature = "openapi")]
+impl utoipa::PartialSchema for Locator {
+    fn schema() -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
+        utoipa::openapi::schema::ObjectBuilder::new()
+            .schema_type(utoipa::openapi::schema::Type::String)
+            .max_length(Some(MAX_LOCATOR_BYTE_SIZE))
+            .description(Some(
+                "Multiaddress, e.g. `/ip4/127.0.0.1/tcp/3000`.".to_owned(),
+            ))
+            .examples(["/ip4/127.0.0.1/tcp/3000"])
+            .build()
+            .into()
+    }
+}
+
+#[cfg(feature = "openapi")]
+impl utoipa::ToSchema for Locator {}
+
 impl Locator {
     #[must_use]
     pub const fn new_unchecked(addr: Multiaddr) -> Self {

--- a/core/src/utils/mod.rs
+++ b/core/src/utils/mod.rs
@@ -37,7 +37,7 @@ macro_rules! serde_bytes_newtype {
         #[cfg(feature = "openapi")]
         impl utoipa::PartialSchema for $newtype {
             fn schema() -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
-                $crate::utils::hex_bytes_schema($len)
+                lb_utils::openapi::hex_bytes_schema($len)
             }
         }
 
@@ -48,27 +48,6 @@ macro_rules! serde_bytes_newtype {
 
 pub(crate) use display_hex_bytes_newtype;
 pub(crate) use serde_bytes_newtype;
-
-/// The documented schema for a fixed-size byte value encoded by
-/// [`lb_utils::serde::serialize_bytes_array`].
-///
-/// Human-readable formats encode as unprefixed lowercase hex; the
-/// deserializer additionally tolerates a `0x` prefix and uppercase, which the
-/// pattern reflects.
-#[cfg(feature = "openapi")]
-pub(crate) fn hex_bytes_schema(
-    bytes: usize,
-) -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
-    let hex_len = bytes * 2;
-    utoipa::openapi::schema::ObjectBuilder::new()
-        .schema_type(utoipa::openapi::schema::Type::String)
-        .pattern(Some(format!("^(0x)?[0-9a-fA-F]{{{hex_len}}}$")))
-        .min_length(Some(hex_len))
-        .max_length(Some(hex_len + 2))
-        .description(Some(format!("{bytes}-byte value, hex encoded.")))
-        .build()
-        .into()
-}
 
 #[cfg(all(test, feature = "openapi"))]
 mod schema_conformance_tests {

--- a/core/src/utils/mod.rs
+++ b/core/src/utils/mod.rs
@@ -33,8 +33,135 @@ macro_rules! serde_bytes_newtype {
                 lb_utils::serde::deserialize_bytes_array::<$len, D>(deserializer).map(Self)
             }
         }
+
+        #[cfg(feature = "openapi")]
+        impl utoipa::PartialSchema for $newtype {
+            fn schema() -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
+                $crate::utils::hex_bytes_schema($len)
+            }
+        }
+
+        #[cfg(feature = "openapi")]
+        impl utoipa::ToSchema for $newtype {}
     };
 }
 
 pub(crate) use display_hex_bytes_newtype;
 pub(crate) use serde_bytes_newtype;
+
+/// The documented schema for a fixed-size byte value encoded by
+/// [`lb_utils::serde::serialize_bytes_array`].
+///
+/// Human-readable formats encode as unprefixed lowercase hex; the
+/// deserializer additionally tolerates a `0x` prefix and uppercase, which the
+/// pattern reflects.
+#[cfg(feature = "openapi")]
+pub(crate) fn hex_bytes_schema(
+    bytes: usize,
+) -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
+    let hex_len = bytes * 2;
+    utoipa::openapi::schema::ObjectBuilder::new()
+        .schema_type(utoipa::openapi::schema::Type::String)
+        .pattern(Some(format!("^(0x)?[0-9a-fA-F]{{{hex_len}}}$")))
+        .min_length(Some(hex_len))
+        .max_length(Some(hex_len + 2))
+        .description(Some(format!("{bytes}-byte value, hex encoded.")))
+        .build()
+        .into()
+}
+
+#[cfg(all(test, feature = "openapi"))]
+mod schema_conformance_tests {
+    use boon::{Compiler, Schemas};
+    use serde::{Deserialize, Serialize};
+    use utoipa::PartialSchema;
+
+    // Newtypes declared with the macro under test, one per length that
+    // `serialize_bytes_array` treats differently.
+    //
+    // Every real call site is this same macro with a different `$len`: the
+    // documented schema is derived from `$len` and the encoding from
+    // `serialize_bytes_array`, both parameterised identically. Covering the
+    // length parameter therefore covers every instantiation, so adding a
+    // newtype elsewhere in the crate needs no change here.
+    //
+    // 33 and 64 matter specifically: `serialize_bytes_array` switches to an
+    // explicit tuple above 32 elements, because `serde` only implements
+    // `Serialize` for arrays up to that size.
+    struct Bytes1([u8; 1]);
+    struct Bytes16([u8; 16]);
+    struct Bytes32([u8; 32]);
+    struct Bytes33([u8; 33]);
+    struct Bytes64([u8; 64]);
+
+    serde_bytes_newtype!(Bytes1, 1);
+    serde_bytes_newtype!(Bytes16, 16);
+    serde_bytes_newtype!(Bytes32, 32);
+    serde_bytes_newtype!(Bytes33, 33);
+    serde_bytes_newtype!(Bytes64, 64);
+
+    /// Asserts that what `serde` emits for `T` validates against the schema
+    /// [`serde_bytes_newtype`] documents for it.
+    ///
+    /// The byte length itself is already tied at compile time — the macro's
+    /// `deserialize_bytes_array::<$len, _>(..).map(Self)` will not compile if
+    /// `$len` disagrees with the newtype. What this catches is a change to
+    /// `lb_utils::serde::serialize_bytes_array`, which lives in another crate
+    /// and is not tied to the macro: a different encoding, a different case, or
+    /// a `0x` prefix appearing on output would all silently invalidate the
+    /// published schema.
+    fn assert_serde_output_matches_schema<T>(bytes: usize)
+    where
+        T: Serialize + for<'de> Deserialize<'de> + PartialSchema,
+    {
+        let raw: Vec<u8> = (0..bytes)
+            .map(|byte| u8::try_from(byte % 256).expect("byte fits in u8"))
+            .collect();
+        let hex = hex::encode(&raw);
+        let as_json = serde_json::Value::String(hex.clone());
+
+        let value: T = serde_json::from_value(as_json.clone()).expect("hex string deserializes");
+        let emitted = serde_json::to_value(&value).expect("value serializes");
+        assert_eq!(
+            emitted,
+            as_json,
+            "round trip changed the encoding for {}",
+            std::any::type_name::<T>()
+        );
+
+        let schema = serde_json::to_value(T::schema()).expect("schema serializes");
+        let mut schemas = Schemas::new();
+        let mut compiler = Compiler::new();
+        compiler
+            .add_resource("schema.json", schema.clone())
+            .expect("schema is a valid resource");
+        let index = compiler
+            .compile("schema.json", &mut schemas)
+            .expect("schema compiles");
+
+        assert!(
+            schemas.validate(&emitted, index).is_ok(),
+            "{} emits {emitted} which does not satisfy its documented schema {schema}",
+            std::any::type_name::<T>(),
+        );
+
+        // The documented pattern allows an optional `0x` prefix. Hold the
+        // deserializer to that, so the schema is not more permissive than the
+        // API actually is.
+        let prefixed: T = serde_json::from_value(serde_json::Value::String(format!("0x{hex}")))
+            .expect("0x-prefixed hex deserializes");
+        assert_eq!(
+            serde_json::to_value(&prefixed).expect("value serializes"),
+            emitted
+        );
+    }
+
+    #[test]
+    fn generated_schemas_match_the_generated_encoding() {
+        assert_serde_output_matches_schema::<Bytes1>(1);
+        assert_serde_output_matches_schema::<Bytes16>(16);
+        assert_serde_output_matches_schema::<Bytes32>(32);
+        assert_serde_output_matches_schema::<Bytes33>(33);
+        assert_serde_output_matches_schema::<Bytes64>(64);
+    }
+}

--- a/kms/keys/Cargo.toml
+++ b/kms/keys/Cargo.toml
@@ -32,6 +32,7 @@ subtle                          = { workspace = true }
 thiserror                       = { workspace = true }
 tokio                           = { features = ["rt"], workspace = true }
 tracing                         = { workspace = true }
+utoipa                          = { features = ["macros"], optional = true, workspace = true }
 x25519-dalek                    = { features = ["serde", "static_secrets", "zeroize"], workspace = true }
 zeroize                         = { workspace = true }
 
@@ -41,4 +42,5 @@ serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 
 [features]
-unsafe = []
+openapi = ["dep:utoipa", "lb-utils/openapi"]
+unsafe  = []

--- a/kms/keys/src/keys/zk/public.rs
+++ b/kms/keys/src/keys/zk/public.rs
@@ -17,6 +17,18 @@ pub const MAX_ZK_SIGNING_KEYS: usize = 32;
 pub struct PublicKey(#[serde(with = "lb_groth16::serde::serde_fr")] Fr);
 
 pub type PublicKeys = UpperBoundedVec<PublicKey, MAX_ZK_SIGNING_KEYS>;
+// Encoded through `serde_fr`, which routes to
+// `lb_utils::serde::serialize_bytes_array`, so the key documents itself with
+// that encoding's schema rather than restating it at each use site.
+#[cfg(feature = "openapi")]
+impl utoipa::PartialSchema for PublicKey {
+    fn schema() -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
+        lb_utils::openapi::hex_bytes_schema(size_of::<lb_groth16::FrBytes>())
+    }
+}
+
+#[cfg(feature = "openapi")]
+impl utoipa::ToSchema for PublicKey {}
 
 impl PublicKey {
     #[must_use]

--- a/nodes/api-common/Cargo.toml
+++ b/nodes/api-common/Cargo.toml
@@ -14,7 +14,7 @@ workspace = true
 
 [dependencies]
 axum                          = { features = ["http1", "http2", "json", "matched-path", "query", "tokio"], workspace = true }
-lb-core                       = { workspace = true }
+lb-core                       = { features = ["openapi"], workspace = true }
 lb-key-management-system-keys = { workspace = true }
 lb-log-targets                = { workspace = true }
 lb-tracing                    = { workspace = true }
@@ -26,7 +26,7 @@ time                          = { workspace = true }
 tokio                         = { features = ["time"], optional = true, workspace = true }
 tracing                       = { workspace = true }
 url                           = { workspace = true }
-utoipa                        = { workspace = true }
+utoipa                        = { features = ["macros"], workspace = true }
 validator                     = { features = ["derive"], workspace = true }
 
 [target.'cfg(not(windows))'.dependencies]

--- a/nodes/api-common/src/bodies/blend.rs
+++ b/nodes/api-common/src/bodies/blend.rs
@@ -1,7 +1,8 @@
 use lb_core::{mantle::NoteId, sdp::Locator};
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, ToSchema)]
 pub struct JoinBlendRequestBody {
     pub locator: Locator,
     pub service_note_id: NoteId,

--- a/nodes/api-common/src/queries.rs
+++ b/nodes/api-common/src/queries.rs
@@ -2,7 +2,7 @@ use std::num::NonZero;
 
 use serde::{Deserialize, Serialize};
 use url::Url;
-use utoipa::IntoParams;
+use utoipa::{IntoParams, ToSchema};
 use validator::Validate;
 
 use crate::{MAX_BLOCKS_STREAM_BLOCKS, MAX_BLOCKS_STREAM_CHUNK_SIZE};
@@ -36,13 +36,13 @@ pub struct BlocksStreamQuery {
     /// - otherwise defaults to `100`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[validate(custom(function = "validate_blocks_limit"))]
-    #[param(minimum = 1, maximum = 630_720_000, default = 100, example = 100)]
+    #[param(value_type = usize, minimum = 1, maximum = 630_720_000, default = 100, example = 100)]
     pub blocks_limit: Option<NonZero<usize>>,
     /// Server chunk size hint for streamed delivery. Defaults to `100` ,
     /// maximum `1000`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[validate(custom(function = "validate_server_batch_size"))]
-    #[param(minimum = 1, maximum = 1_000, default = 100, example = 100)]
+    #[param(value_type = usize, minimum = 1, maximum = 1_000, default = 100, example = 100)]
     pub server_batch_size: Option<NonZero<usize>>,
     /// When true, include only immutable blocks.
     /// If `slot_to` is omitted, the default anchor is LIB slot.
@@ -116,7 +116,7 @@ impl BlocksStreamQuery {
 }
 
 /// Sort order for blocks in the `get_blocks_range_stream` method.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum BlockSortOrder {
     /// Ascending order (oldest to newest).
@@ -126,7 +126,7 @@ pub enum BlockSortOrder {
 }
 
 /// Filter for block types in the `get_blocks_range_stream` method.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum BlockFilter {
     /// Includes only immutable blocks.

--- a/nodes/node/binary/Cargo.toml
+++ b/nodes/node/binary/Cargo.toml
@@ -26,9 +26,9 @@ lb-blend-service                 = { workspace = true }
 lb-chain-broadcast-service       = { workspace = true }
 lb-chain-leader-service          = { workspace = true }
 lb-chain-network-service         = { workspace = true }
-lb-chain-service                 = { workspace = true }
-lb-core                          = { workspace = true }
-lb-cryptarchia-engine            = { workspace = true }
+lb-chain-service                 = { features = ["openapi"], workspace = true }
+lb-core                          = { features = ["openapi"], workspace = true }
+lb-cryptarchia-engine            = { features = ["openapi"], workspace = true }
 lb-groth16                       = { workspace = true }
 lb-http-api-common               = { workspace = true }
 lb-key-management-system-service = { features = ["unsafe"], workspace = true }
@@ -64,7 +64,7 @@ tracing                          = { workspace = true }
 url                              = { workspace = true }
 
 # openapi related dependencies
-utoipa = { workspace = true }
+utoipa = { features = ["macros"], workspace = true }
 # XCompiling from Unix has issues downloading assets. Also, building with Nix can't download assets.
 utoipa-swagger-ui = { features = ["axum", "vendored"], workspace = true }
 
@@ -80,6 +80,7 @@ validator  = { features = ["derive"], workspace = true }
 tikv-jemallocator = { optional = true, workspace = true }
 
 [dev-dependencies]
+boon             = { workspace = true }
 bytes            = { workspace = true }
 rand             = { workspace = true }
 serde_urlencoded = { workspace = true }

--- a/nodes/node/binary/src/api/backend.rs
+++ b/nodes/node/binary/src/api/backend.rs
@@ -22,8 +22,8 @@ use lb_core::{
     header::HeaderId,
     mantle::{SignedMantleTx, traits::Hashable, transactions::states::Preverified},
 };
+use lb_http_api_common::metrics::http_metrics_middleware;
 pub use lb_http_api_common::settings::AxumBackendSettings;
-use lb_http_api_common::{metrics::http_metrics_middleware, paths};
 use lb_sdp_service::{
     mempool::SdpMempoolAdapter, state::SdpStateStorage as SdpStateStorageTrait,
     wallet::SdpWalletAdapter,
@@ -60,9 +60,21 @@ use crate::{
             pow_stop_mining,
         },
         openapi::ApiDoc,
+        routes::api_routes,
         tracing::reload_tracing_filter,
     },
 };
+
+/// Builds the axum router from the shared route table.
+///
+/// Only the `$handler` half of each row is used; the `OpenAPI` half is matched
+/// and discarded. Expanded inside `AxumBackend::serve`, where the handler type
+/// parameters are in scope.
+macro_rules! build_router {
+    ($( $method:ident $path:expr => $doc:path, $handler:expr ; )*) => {
+        Router::new()$(.route($path, routing::$method($handler)))*
+    };
+}
 
 pub(crate) type BlockStorageBackend = RocksBackend;
 type BlockStorageService<RuntimeServiceId> = StorageService<BlockStorageBackend, RuntimeServiceId>;
@@ -196,7 +208,6 @@ where
         })
     }
 
-    #[expect(clippy::too_many_lines, reason = "TODO: Address this at some point.")]
     async fn serve(self, handle: OverwatchHandle<RuntimeServiceId>) -> Result<(), Self::Error> {
         let mut builder = CorsLayer::new();
         if self.settings.cors_origins.is_empty() {
@@ -212,228 +223,8 @@ where
             );
         }
 
-        let app = Router::new()
-            .merge(SwaggerUi::new("/swagger-ui").url("/api-docs/openapi.json", ApiDoc::openapi()))
-            .route(paths::NODE_VERSION, routing::get(version))
-            .route(
-                paths::MANTLE_METRICS,
-                routing::get(mantle_metrics::<MempoolStorageAdapter, RuntimeServiceId>),
-            )
-            .route(
-                paths::MANTLE_STATUS,
-                routing::post(mantle_status::<MempoolStorageAdapter, RuntimeServiceId>),
-            )
-            .route(
-                paths::CRYPTARCHIA_INFO,
-                routing::get(cryptarchia_info::<RuntimeServiceId>),
-            )
-            .route(
-                paths::TIME_INFO,
-                routing::get(time_info::<RuntimeServiceId>),
-            )
-            .route(
-                paths::CRYPTARCHIA_HEADERS,
-                routing::get(cryptarchia_headers::<RuntimeServiceId>),
-            )
-            .route(
-                paths::CRYPTARCHIA_LIB_STREAM,
-                routing::get(cryptarchia_lib_stream::<RuntimeServiceId>),
-            )
-            .route(
-                paths::NETWORK_INFO,
-                routing::get(libp2p_info::<RuntimeServiceId>),
-            )
-            .route(
-                paths::DIAL_PEER,
-                routing::post(dial_peer::<RuntimeServiceId>),
-            )
-            .route(
-                paths::BLEND_NETWORK_INFO,
-                routing::get(blend_info::<BlendService, RuntimeServiceId>),
-            )
-            .route(
-                paths::BLEND_JOIN_NETWORK,
-                routing::post(blend_join_network::<BlendService, RuntimeServiceId>),
-            )
-            .route(
-                paths::BLEND_PENDING_TRANSACTIONS,
-                routing::get(blend_pending_transactions::<BlendService, RuntimeServiceId>),
-            )
-            .route(
-                paths::MEMPOOL_ADD_TX,
-                routing::post(add_tx::<MempoolStorageAdapter, RuntimeServiceId>),
-            )
-            .route(
-                paths::BLEND_DISPERSE_TRANSACTION,
-                routing::post(blend_tx::<BlendService, RuntimeServiceId>),
-            )
-            .route(
-                paths::MEMPOOL_VIEW,
-                routing::get(mempool_view::<MempoolStorageAdapter, RuntimeServiceId>),
-            )
-            .route(paths::CHANNEL, routing::get(channel::<RuntimeServiceId>))
-            .route(
-                paths::CHANNEL_DEPOSIT,
-                routing::post(
-                    channel_deposit::<WalletService, MempoolStorageAdapter, RuntimeServiceId>,
-                ),
-            )
-            .route(
-                paths::SDP_POST_DECLARATION,
-                routing::post(
-                    post_declaration::<
-                        SdpMempool,
-                        SdpWallet,
-                        Cryptarchia<RuntimeServiceId>,
-                        SdpStateStorage,
-                        RuntimeServiceId,
-                    >,
-                ),
-            )
-            .route(
-                paths::SDP_POST_ACTIVITY,
-                routing::post(
-                    post_activity::<
-                        SdpMempool,
-                        SdpWallet,
-                        Cryptarchia<RuntimeServiceId>,
-                        SdpStateStorage,
-                        RuntimeServiceId,
-                    >,
-                ),
-            )
-            .route(
-                paths::SDP_POST_WITHDRAWAL,
-                routing::post(
-                    post_withdrawal::<
-                        SdpMempool,
-                        SdpWallet,
-                        Cryptarchia<RuntimeServiceId>,
-                        SdpStateStorage,
-                        RuntimeServiceId,
-                    >,
-                ),
-            )
-            .route(
-                paths::SDP_POST_SET_DECLARATION_ID,
-                routing::post(
-                    post_set_declaration_id::<
-                        SdpMempool,
-                        SdpWallet,
-                        Cryptarchia<RuntimeServiceId>,
-                        SdpStateStorage,
-                        RuntimeServiceId,
-                    >,
-                ),
-            )
-            .route(
-                paths::MANTLE_SDP_DECLARATIONS,
-                routing::get(get_sdp_declarations::<RuntimeServiceId>),
-            )
-            .route(
-                paths::MANTLE_SDP_SNAPSHOT,
-                routing::get(get_sdp_snapshot::<RuntimeServiceId>),
-            )
-            .route(
-                paths::LEADER_CLAIM,
-                routing::post(leader_claim::<ChainLeader, RuntimeServiceId>),
-            )
-            .route(
-                paths::POW_START_MINING,
-                routing::put(pow_start_mining::<PoWService, RuntimeServiceId>),
-            )
-            .route(
-                paths::POW_STOP_MINING,
-                routing::put(pow_stop_mining::<PoWService, RuntimeServiceId>),
-            )
-            .route(
-                paths::POW_START_AUTO_CLAIM,
-                routing::put(pow_start_auto_claim::<PoWService, RuntimeServiceId>),
-            )
-            .route(
-                paths::POW_STOP_AUTO_CLAIM,
-                routing::put(pow_stop_auto_claim::<PoWService, RuntimeServiceId>),
-            )
-            .route(
-                paths::POW_CLAIM,
-                routing::post(pow_claim::<PoWService, RuntimeServiceId>),
-            )
-            .route(
-                paths::POW_CLAIMABLE_REWARDS,
-                routing::get(pow_claimable_rewards::<PoWService, RuntimeServiceId>),
-            )
-            .route(
-                paths::LEADER_CLAIM_VOUCHERS,
-                routing::get(wallet::get_claimable_vouchers::<WalletService, _>),
-            )
-            .route(
-                paths::wallet::BALANCE,
-                routing::get(wallet::get_balance::<WalletService, _>),
-            )
-            .route(
-                paths::MANTLE_GAS_PRICES,
-                routing::get(get_gas_prices::<RuntimeServiceId>),
-            )
-            .route(
-                paths::wallet::TRANSACTIONS_TRANSFER_FUNDS,
-                routing::post(
-                    wallet::post_transactions_transfer_funds::<
-                        WalletService,
-                        MempoolStorageAdapter,
-                        _,
-                    >,
-                ),
-            )
-            .route(
-                paths::wallet::SIGN_TX_ED25519,
-                routing::post(wallet::sign_tx_ed25519::<WalletService, MempoolStorageAdapter, _>),
-            )
-            .route(
-                paths::wallet::SIGN_TX_ZK,
-                routing::post(wallet::sign_tx_zk::<WalletService, MempoolStorageAdapter, _>),
-            )
-            .route(
-                paths::wallet::FUND,
-                routing::post(wallet::fund::<WalletService, MempoolStorageAdapter, _>),
-            )
-            .route(
-                paths::admin::TRACING_FILTER,
-                routing::put(reload_tracing_filter::<RuntimeServiceId>),
-            );
-
-        let app = app.route(
-            paths::BLOCKS_STREAM,
-            routing::get(
-                blocks_stream::<
-                    BlockStorageBackend,
-                    CryptarchiaConsensus<_, _, _, _>,
-                    RuntimeServiceId,
-                >,
-            ),
-        );
-
-        let app = app.route(
-            paths::BLOCKS_RANGE_STREAM,
-            routing::get(blocks_range_stream::<BlockStorageBackend, RuntimeServiceId>),
-        );
-
-        let app = app
-            .route(
-                paths::BLOCKS,
-                routing::get(immutable_blocks::<BlockStorageBackend, RuntimeServiceId>),
-            )
-            .route(
-                paths::BLOCKS_DETAIL,
-                routing::get(block::<StorageAdapter, RuntimeServiceId>),
-            )
-            .route(
-                paths::BLOCK_EVENTS,
-                routing::get(block_events::<RuntimeServiceId>),
-            )
-            .route(
-                paths::TRANSACTION,
-                routing::get(transaction::<StorageAdapter, RuntimeServiceId>),
-            );
+        let app = api_routes!(build_router)
+            .merge(SwaggerUi::new("/swagger-ui").url("/api-docs/openapi.json", ApiDoc::openapi()));
 
         let app = app
             .with_state(handle.clone())

--- a/nodes/node/binary/src/api/handlers.rs
+++ b/nodes/node/binary/src/api/handlers.rs
@@ -13,14 +13,14 @@ use axum::{
 use futures::FutureExt as _;
 use lb_api_service::http::{
     DynError, blend,
-    consensus::{self, Cryptarchia},
+    consensus::{self, Cryptarchia, leader::LeaderClaimResponseBody},
     libp2p, mantle, mempool, pow,
     storage::StorageAdapter,
 };
 use lb_blend_service::message::ProxyServiceMessage;
 use lb_chain_broadcast_service::BlockBroadcastService;
 use lb_chain_leader_service::api::ChainLeaderServiceData;
-use lb_chain_service::{ConsensusMsg, Slot, api::CryptarchiaServiceApi};
+use lb_chain_service::{ChainServiceInfo, ConsensusMsg, Slot, api::CryptarchiaServiceApi};
 use lb_core::{
     block::Block,
     events::Events,
@@ -77,11 +77,12 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::oneshot;
 use tokio_stream::StreamExt as _;
 use tracing::debug;
+use utoipa::ToSchema;
 
 use crate::{
     TimeService,
     api::{
-        errors::{ApiError, BlocksStreamHandlerError, BlocksStreamWindowError},
+        errors::{ApiError, BlocksStreamHandlerError, BlocksStreamWindowError, ErrorBody},
         openapi::schema,
         queries::{BlockRangeQuery, BlocksStreamRequest},
         responses::{self, overwatch::get_relay},
@@ -106,8 +107,10 @@ fn validate_max_tx_fee(
     Ok(())
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct DialPeerRequestBody {
+    /// Multiaddress of the peer to dial.
+    #[schema(value_type = String)]
     pub addr: Multiaddr,
 }
 
@@ -425,7 +428,7 @@ where
     post,
     path = paths::MANTLE_STATUS,
     responses(
-        (status = 200, description = "Query the mempool status of the cl service", body = Vec<<T as Transaction>::Hash>),
+        (status = 200, description = "Query the mempool status of the cl service", body = Vec<TxHash>),
         (status = 500, description = "Internal server error", body = ErrorBody),
     )
 )]
@@ -496,7 +499,7 @@ pub struct CryptarchiaInfoQuery {
     get,
     path = paths::CRYPTARCHIA_INFO,
     responses(
-        (status = 200, description = "Query consensus information", body = lb_consensus::CryptarchiaInfo),
+        (status = 200, description = "Query consensus information", body = ChainServiceInfo),
         (status = 500, description = "Internal server error", body = ErrorBody),
     )
 )]
@@ -619,7 +622,7 @@ where
     path = paths::DIAL_PEER,
     request_body = DialPeerRequestBody,
     responses(
-        (status = 200, description = "Dial a network peer", body = PeerId),
+        (status = 200, description = "Dial a network peer", body = String),
         (status = 500, description = "Internal server error", body = ErrorBody),
     )
 )]
@@ -645,7 +648,7 @@ where
     get,
     path = paths::BLEND_NETWORK_INFO,
     responses(
-        (status = 200, description = "Query the blend network information", body = Option<lb_blend_service::message::NetworkInfo<PeerId>>),
+        (status = 200, description = "Query the blend network information", body = Option<Object>),
         (status = 500, description = "Internal server error", body = ErrorBody),
     )
 )]
@@ -664,7 +667,7 @@ where
 #[utoipa::path(
     post,
     path = paths::BLEND_JOIN_NETWORK,
-    request_body = BlendJoinNetworkRequestBody,
+    request_body = JoinBlendRequestBody,
     responses(
         (status = 200, description = "Join the blend network", body = Option<lb_core::sdp::DeclarationId>),
         (status = 500, description = "Internal server error", body = ErrorBody),
@@ -1297,7 +1300,7 @@ where
     get,
     path = paths::MANTLE_SDP_DECLARATIONS,
     responses(
-        (status = 200, description = "Get current SDP declarations keyed by declaration id", body = std::collections::HashMap<lb_core::sdp::DeclarationId, lb_core::sdp::Declaration>),
+        (status = 200, description = "Get current SDP declarations keyed by declaration id", body = std::collections::HashMap<lb_core::sdp::DeclarationId, Object>),
         (status = 500, description = "Internal server error", body = ErrorBody),
     )
 )]
@@ -1315,7 +1318,7 @@ where
     get,
     path = paths::MANTLE_SDP_SNAPSHOT,
     responses(
-        (status = 200, description = "Get the SDP snapshot for the current epoch keyed by declaration id", body = std::collections::HashMap<lb_core::sdp::DeclarationId, lb_core::sdp::Declaration>),
+        (status = 200, description = "Get the SDP snapshot for the current epoch keyed by declaration id", body = std::collections::HashMap<lb_core::sdp::DeclarationId, Object>),
         (status = 500, description = "Internal server error", body = ErrorBody),
     )
 )]
@@ -1333,7 +1336,7 @@ where
     post,
     path = paths::LEADER_CLAIM,
     responses(
-        (status = 200, description = "Leader claim transaction submitted", body = lb_api_service::http::consensus::leader::LeaderClaimResponseBody),
+        (status = 200, description = "Leader claim transaction submitted", body = LeaderClaimResponseBody),
         (status = 500, description = "Internal server error", body = ErrorBody),
     )
 )]
@@ -1348,7 +1351,7 @@ where
 }
 
 #[utoipa::path(
-    post,
+    put,
     path = paths::POW_START_MINING,
     responses(
         (status = 200, description = "PoW mining started"),
@@ -1366,7 +1369,7 @@ where
 }
 
 #[utoipa::path(
-    post,
+    put,
     path = paths::POW_STOP_MINING,
     responses(
         (status = 200, description = "PoW mining stopped"),
@@ -1422,9 +1425,9 @@ where
 #[utoipa::path(
     post,
     path = paths::POW_CLAIM,
-    request_body = Option<lb_api_service::http::pow::PoWClaimRequestBody>,
+    request_body = Option<pow::PoWClaimRequestBody>,
     responses(
-        (status = 200, description = "PoW reward-claim transactions submitted", body = lb_api_service::http::pow::PoWClaimResponseBody),
+        (status = 200, description = "PoW reward-claim transactions submitted", body = pow::PoWClaimResponseBody),
         (status = 500, description = "Internal server error", body = ErrorBody),
     )
 )]
@@ -1534,7 +1537,7 @@ where
     get,
     path = paths::BLOCK_EVENTS,
     responses(
-        (status = 200, description = "Block events", body = Events),
+        (status = 200, description = "Block events", body = Object),
         (status = 404, description = "Block not found", body = ErrorBody),
         (status = 500, description = "Internal server error", body = ErrorBody),
     )

--- a/nodes/node/binary/src/api/mod.rs
+++ b/nodes/node/binary/src/api/mod.rs
@@ -4,5 +4,6 @@ pub mod handlers;
 mod openapi;
 mod queries;
 mod responses;
+mod routes;
 pub mod serializers;
 mod tracing;

--- a/nodes/node/binary/src/api/openapi.rs
+++ b/nodes/node/binary/src/api/openapi.rs
@@ -1,53 +1,38 @@
 #![allow(clippy::needless_for_each, reason = "Utoipa implementation")]
 
-use utoipa::OpenApi;
+use crate::api::routes::api_routes;
 
-#[derive(OpenApi)]
-#[openapi(
-    paths(
-        crate::api::handlers::version,
-        crate::api::handlers::mantle_metrics,
-        crate::api::handlers::mantle_status,
-        crate::api::handlers::cryptarchia_info,
-        crate::api::handlers::time_info,
-        crate::api::handlers::cryptarchia_headers,
-        crate::api::handlers::cryptarchia_lib_stream,
-        crate::api::handlers::libp2p_info,
-        crate::api::handlers::dial_peer,
-        crate::api::handlers::add_tx,
-        crate::api::handlers::blend_tx,
-        crate::api::handlers::blend_pending_transactions,
-        crate::api::handlers::mempool_view,
-        crate::api::handlers::channel,
-        crate::api::handlers::channel_deposit,
-        crate::api::handlers::post_declaration,
-        crate::api::handlers::post_activity,
-        crate::api::handlers::post_withdrawal,
-        crate::api::handlers::get_sdp_declarations,
-        crate::api::handlers::get_sdp_snapshot,
-        crate::api::handlers::leader_claim,
-        crate::api::handlers::pow_start_mining,
-        crate::api::handlers::pow_stop_mining,
-        crate::api::handlers::pow_start_auto_claim,
-        crate::api::handlers::pow_stop_auto_claim,
-        crate::api::handlers::pow_claim,
-        crate::api::handlers::pow_claimable_rewards,
-        crate::api::handlers::immutable_blocks,
-        crate::api::handlers::block,
-        crate::api::handlers::block_events,
-        crate::api::handlers::blocks_stream,
-        crate::api::handlers::transaction,
-        crate::api::handlers::wallet::get_balance,
-        crate::api::handlers::wallet::get_claimable_vouchers,
-        crate::api::handlers::get_gas_prices,
-        crate::api::handlers::wallet::post_transactions_transfer_funds,
-        crate::api::handlers::wallet::fund,
-        crate::api::tracing::reload_tracing_filter,
-    ),
-    components(schemas(schema::Status, schema::MempoolMetrics, crate::api::errors::ErrorBody)),
-    tags()
-)]
-pub struct ApiDoc;
+/// Builds [`ApiDoc`] from the shared route table.
+///
+/// Only the `$doc` half of each row is used; the router half is matched and
+/// discarded, so the handler type parameters it names are never resolved here.
+macro_rules! declare_api_doc {
+    ($( $method:ident $path:expr => $doc:path, $handler:expr ; )*) => {
+        #[derive(utoipa::OpenApi)]
+        #[openapi(
+            paths($($doc),*),
+            components(schemas(
+                schema::Status,
+                schema::MempoolMetrics,
+                crate::api::errors::ErrorBody,
+                // Referenced by `BlocksStreamQuery`'s `IntoParams` derive.
+                // utoipa collects schemas reached through request and response
+                // bodies automatically, but not through query parameters.
+                lb_http_api_common::queries::BlockFilter,
+                lb_http_api_common::queries::BlockSortOrder
+            )),
+            tags()
+        )]
+        pub struct ApiDoc;
+
+        /// The `(method, path)` pairs the router serves, as declared by the
+        /// table. Compared against the generated document in the tests below.
+        #[cfg(test)]
+        const ROUTE_TABLE: &[(&str, &str)] = &[$((stringify!($method), $path)),*];
+    };
+}
+
+api_routes!(declare_api_doc);
 
 pub mod schema {
     use lb_tx_service::{MempoolMetrics as DomainMempoolMetrics, backend::Status as DomainStatus};
@@ -61,4 +46,229 @@ pub mod schema {
     #[derive(ToSchema, Serialize)]
     #[serde(transparent)]
     pub struct Status(pub DomainStatus);
+}
+
+#[cfg(test)]
+fn document() -> serde_json::Value {
+    use utoipa::OpenApi as _;
+    serde_json::from_str(&ApiDoc::openapi().to_json().expect("serialize document"))
+        .expect("document is valid JSON")
+}
+
+/// Compiles the named component of the generated document, resolving any
+/// `$ref` it contains against the document itself.
+#[cfg(test)]
+fn compile_component(component: &str) -> (boon::Schemas, boon::SchemaIndex) {
+    let mut schemas = boon::Schemas::new();
+    let mut compiler = boon::Compiler::new();
+    compiler
+        .add_resource("openapi.json", document())
+        .expect("document is a valid resource");
+    let index = compiler
+        .compile(
+            &format!("openapi.json#/components/schemas/{component}"),
+            &mut schemas,
+        )
+        .unwrap_or_else(|error| panic!("component {component} is not a valid schema: {error}"));
+    (schemas, index)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+
+    use super::{ROUTE_TABLE, document};
+
+    /// `(METHOD, path)` pairs the generated document actually advertises.
+    ///
+    /// Read off the serialized document rather than
+    /// [`utoipa::openapi::PathItem`], which exposes one field per method
+    /// rather than a map.
+    fn documented_operations() -> BTreeSet<(String, String)> {
+        document()["paths"]
+            .as_object()
+            .expect("document has paths")
+            .iter()
+            .flat_map(|(path, item)| {
+                item.as_object()
+                    .expect("path item is an object")
+                    .keys()
+                    .map(|method| (method.to_uppercase(), path.clone()))
+                    .collect::<Vec<_>>()
+            })
+            .collect()
+    }
+
+    /// The route table drives both the router and `paths(..)`, so an endpoint
+    /// cannot be served without being documented. The HTTP method, however,
+    /// still comes from the handler's own `#[utoipa::path]` attribute, so a
+    /// row routed as `PUT` can be documented as `POST`. This pins them
+    /// together.
+    #[test]
+    fn documented_methods_match_the_routed_methods() {
+        let routed: BTreeSet<(String, String)> = ROUTE_TABLE
+            .iter()
+            .map(|(method, path)| ((*method).to_uppercase(), (*path).to_owned()))
+            .collect();
+        let documented = documented_operations();
+
+        assert_eq!(
+            routed,
+            documented,
+            "route table and OpenAPI document disagree.\nrouted but not documented: {:?}\ndocumented but not routed: {:?}",
+            routed.difference(&documented).collect::<Vec<_>>(),
+            documented.difference(&routed).collect::<Vec<_>>(),
+        );
+    }
+
+    /// Every `$ref` must resolve to a registered component. utoipa collects
+    /// schemas reached through request and response bodies automatically, but
+    /// not those reached only through `IntoParams` query parameters.
+    #[test]
+    fn document_has_no_dangling_schema_references() {
+        fn collect_refs(value: &serde_json::Value, out: &mut BTreeSet<String>) {
+            match value {
+                serde_json::Value::Object(map) => {
+                    if let Some(serde_json::Value::String(reference)) = map.get("$ref")
+                        && let Some(name) = reference.strip_prefix("#/components/schemas/")
+                    {
+                        out.insert(name.to_owned());
+                    }
+                    for nested in map.values() {
+                        collect_refs(nested, out);
+                    }
+                }
+                serde_json::Value::Array(items) => {
+                    for nested in items {
+                        collect_refs(nested, out);
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        let doc = document();
+        let registered: BTreeSet<String> = doc["components"]["schemas"]
+            .as_object()
+            .map(|schemas| schemas.keys().cloned().collect())
+            .unwrap_or_default();
+
+        let mut referenced = BTreeSet::new();
+        collect_refs(&doc, &mut referenced);
+
+        let dangling: Vec<_> = referenced.difference(&registered).collect();
+        assert!(dangling.is_empty(), "dangling $refs: {dangling:?}");
+    }
+
+    /// A component whose schema is malformed would otherwise only surface in a
+    /// client generator.
+    #[test]
+    fn every_component_compiles_as_a_schema() {
+        let doc = document();
+        let components = doc["components"]["schemas"]
+            .as_object()
+            .expect("document registers components");
+        assert!(!components.is_empty());
+        for name in components.keys() {
+            drop(super::compile_component(name));
+        }
+    }
+}
+
+/// Serialized-shape conformance for the hand-written
+/// `schema(value_type = ..)` annotations.
+///
+/// Types whose schema is generated alongside their `serde` impl — the
+/// `serde_bytes_newtype!` family — are covered by `lb-core`'s own tests. What
+/// remains here are the foreign types whose schema is a hand-written claim the
+/// compiler cannot check: `Slot`, `State`, `PeerId`, `Multiaddr`, `Locator`
+/// and `NoteId`.
+///
+/// Each case starts from a representative JSON instance, so the test asserts
+/// both that the documented shape deserializes into the Rust type and that
+/// re-serializing it satisfies the published schema.
+#[cfg(test)]
+mod schema_conformance_tests {
+    use serde::{Serialize, de::DeserializeOwned};
+
+    use super::compile_component;
+
+    fn assert_round_trip_matches_component<T>(component: &str, instance: serde_json::Value)
+    where
+        T: Serialize + DeserializeOwned,
+    {
+        let value: T = serde_json::from_value(instance).unwrap_or_else(|error| {
+            panic!("sample instance for {component} does not deserialize: {error}")
+        });
+        let serialized = serde_json::to_value(&value).expect("value serializes");
+
+        let (schemas, index) = compile_component(component);
+        assert!(
+            schemas.validate(&serialized, index).is_ok(),
+            "{component} is documented in a way its own serialized form does not satisfy: \
+             {serialized}",
+        );
+    }
+
+    const HASH: &str = "0000000000000000000000000000000000000000000000000000000000000007";
+
+    /// Covers `Slot` (documented as `u64`), `State` and `PhaseTag`.
+    #[test]
+    fn chain_service_info_matches_its_schema() {
+        assert_round_trip_matches_component::<lb_chain_service::ChainServiceInfo>(
+            "ChainServiceInfo",
+            serde_json::json!({
+                "cryptarchia_info": {
+                    "lib": HASH,
+                    "lib_slot": 11,
+                    "tip": HASH,
+                    "slot": 42,
+                    "height": 42,
+                    "state": "Online",
+                },
+                "phase": "Following",
+            }),
+        );
+    }
+
+    /// Covers `PeerId` and `Multiaddr`, both documented as `String`.
+    #[test]
+    fn libp2p_info_matches_its_schema() {
+        assert_round_trip_matches_component::<lb_network_service::backends::libp2p::Libp2pInfo>(
+            "Libp2pInfo",
+            serde_json::json!({
+                "listen_addresses": ["/ip4/127.0.0.1/tcp/3000"],
+                "peer_id": "12D3KooWPjceQrSwdWXPyLLeABRXmuqt69Rg3sBYbU1Nft9HyQ6X",
+                "connected_peers": ["12D3KooWH3uVF6wv47WnArKHk5p6cvgCJEb74UTmxztmQDc298L3"],
+                "n_peers": 1,
+                "n_connections": 1,
+                "n_pending_connections": 0,
+                "discovered_peers": [],
+                "n_discovered_peers": 0,
+            }),
+        );
+    }
+
+    /// Covers `Locator` and `NoteId`, both documented as `String`.
+    #[test]
+    fn join_blend_request_body_matches_its_schema() {
+        assert_round_trip_matches_component::<
+            lb_http_api_common::bodies::blend::JoinBlendRequestBody,
+        >(
+            "JoinBlendRequestBody",
+            serde_json::json!({
+                "locator": "/ip4/127.0.0.1/tcp/3000",
+                "service_note_id": HASH,
+            }),
+        );
+    }
+
+    /// Covers `Multiaddr` in a request body.
+    #[test]
+    fn dial_peer_request_body_matches_its_schema() {
+        assert_round_trip_matches_component::<crate::api::handlers::DialPeerRequestBody>(
+            "DialPeerRequestBody",
+            serde_json::json!({ "addr": "/ip4/127.0.0.1/tcp/3000" }),
+        );
+    }
 }

--- a/nodes/node/binary/src/api/routes.rs
+++ b/nodes/node/binary/src/api/routes.rs
@@ -1,0 +1,76 @@
+//! The node's HTTP API surface, declared once.
+//!
+//! Every documented endpoint appears exactly once in [`api_routes`]. The table
+//! drives both the axum router ([`crate::api::backend`]) and the `OpenAPI` path
+//! registration ([`crate::api::openapi`]), so an endpoint cannot be routed
+//! without also being documented, nor documented without being routed.
+//!
+//! Each row is `METHOD PATH => DOC_FN, HANDLER;` where `PATH` is the shared
+//! constant the handler's own `#[utoipa::path]` attribute also names, `DOC_FN`
+//! is the bare handler path utoipa registers, and `HANDLER` is the fully
+//! instantiated function axum routes to. `HANDLER` mentions type parameters
+//! that only exist inside `AxumBackend::serve`, so that half of each row is
+//! only ever expanded there.
+//!
+//! To add an endpoint: annotate the handler with `#[utoipa::path]` and add one
+//! row here. Nothing else needs touching.
+//!
+//! The row's method and the `#[utoipa::path]` method are still written
+//! separately — utoipa reads the latter off the handler itself. They are
+//! cross-checked by `crate::api::openapi` tests.
+
+/// Expands `$consumer!` with the full route table.
+///
+/// See the module documentation for the row format.
+macro_rules! api_routes {
+    ($consumer:ident) => {
+        $consumer! {
+            get lb_http_api_common::paths::NODE_VERSION => crate::api::handlers::version, version;
+            get lb_http_api_common::paths::MANTLE_METRICS => crate::api::handlers::mantle_metrics, mantle_metrics::<MempoolStorageAdapter, RuntimeServiceId>;
+            post lb_http_api_common::paths::MANTLE_STATUS => crate::api::handlers::mantle_status, mantle_status::<MempoolStorageAdapter, RuntimeServiceId>;
+            get lb_http_api_common::paths::CRYPTARCHIA_INFO => crate::api::handlers::cryptarchia_info, cryptarchia_info::<RuntimeServiceId>;
+            get lb_http_api_common::paths::TIME_INFO => crate::api::handlers::time_info, time_info::<RuntimeServiceId>;
+            get lb_http_api_common::paths::CRYPTARCHIA_HEADERS => crate::api::handlers::cryptarchia_headers, cryptarchia_headers::<RuntimeServiceId>;
+            get lb_http_api_common::paths::CRYPTARCHIA_LIB_STREAM => crate::api::handlers::cryptarchia_lib_stream, cryptarchia_lib_stream::<RuntimeServiceId>;
+            get lb_http_api_common::paths::NETWORK_INFO => crate::api::handlers::libp2p_info, libp2p_info::<RuntimeServiceId>;
+            post lb_http_api_common::paths::DIAL_PEER => crate::api::handlers::dial_peer, dial_peer::<RuntimeServiceId>;
+            get lb_http_api_common::paths::BLEND_NETWORK_INFO => crate::api::handlers::blend_info, blend_info::<BlendService, RuntimeServiceId>;
+            post lb_http_api_common::paths::BLEND_JOIN_NETWORK => crate::api::handlers::blend_join_network, blend_join_network::<BlendService, RuntimeServiceId>;
+            get lb_http_api_common::paths::BLEND_PENDING_TRANSACTIONS => crate::api::handlers::blend_pending_transactions, blend_pending_transactions::<BlendService, RuntimeServiceId>;
+            post lb_http_api_common::paths::MEMPOOL_ADD_TX => crate::api::handlers::add_tx, add_tx::<MempoolStorageAdapter, RuntimeServiceId>;
+            post lb_http_api_common::paths::BLEND_DISPERSE_TRANSACTION => crate::api::handlers::blend_tx, blend_tx::<BlendService, RuntimeServiceId>;
+            get lb_http_api_common::paths::MEMPOOL_VIEW => crate::api::handlers::mempool_view, mempool_view::<MempoolStorageAdapter, RuntimeServiceId>;
+            get lb_http_api_common::paths::CHANNEL => crate::api::handlers::channel, channel::<RuntimeServiceId>;
+            post lb_http_api_common::paths::CHANNEL_DEPOSIT => crate::api::handlers::channel_deposit, channel_deposit::<WalletService, MempoolStorageAdapter, RuntimeServiceId>;
+            post lb_http_api_common::paths::SDP_POST_DECLARATION => crate::api::handlers::post_declaration, post_declaration::<SdpMempool, SdpWallet, Cryptarchia<RuntimeServiceId>, SdpStateStorage, RuntimeServiceId>;
+            post lb_http_api_common::paths::SDP_POST_ACTIVITY => crate::api::handlers::post_activity, post_activity::<SdpMempool, SdpWallet, Cryptarchia<RuntimeServiceId>, SdpStateStorage, RuntimeServiceId>;
+            post lb_http_api_common::paths::SDP_POST_WITHDRAWAL => crate::api::handlers::post_withdrawal, post_withdrawal::<SdpMempool, SdpWallet, Cryptarchia<RuntimeServiceId>, SdpStateStorage, RuntimeServiceId>;
+            post lb_http_api_common::paths::SDP_POST_SET_DECLARATION_ID => crate::api::handlers::post_set_declaration_id, post_set_declaration_id::<SdpMempool, SdpWallet, Cryptarchia<RuntimeServiceId>, SdpStateStorage, RuntimeServiceId>;
+            get lb_http_api_common::paths::MANTLE_SDP_DECLARATIONS => crate::api::handlers::get_sdp_declarations, get_sdp_declarations::<RuntimeServiceId>;
+            get lb_http_api_common::paths::MANTLE_SDP_SNAPSHOT => crate::api::handlers::get_sdp_snapshot, get_sdp_snapshot::<RuntimeServiceId>;
+            post lb_http_api_common::paths::LEADER_CLAIM => crate::api::handlers::leader_claim, leader_claim::<ChainLeader, RuntimeServiceId>;
+            put lb_http_api_common::paths::POW_START_MINING => crate::api::handlers::pow_start_mining, pow_start_mining::<PoWService, RuntimeServiceId>;
+            put lb_http_api_common::paths::POW_STOP_MINING => crate::api::handlers::pow_stop_mining, pow_stop_mining::<PoWService, RuntimeServiceId>;
+            put lb_http_api_common::paths::POW_START_AUTO_CLAIM => crate::api::handlers::pow_start_auto_claim, pow_start_auto_claim::<PoWService, RuntimeServiceId>;
+            put lb_http_api_common::paths::POW_STOP_AUTO_CLAIM => crate::api::handlers::pow_stop_auto_claim, pow_stop_auto_claim::<PoWService, RuntimeServiceId>;
+            post lb_http_api_common::paths::POW_CLAIM => crate::api::handlers::pow_claim, pow_claim::<PoWService, RuntimeServiceId>;
+            get lb_http_api_common::paths::POW_CLAIMABLE_REWARDS => crate::api::handlers::pow_claimable_rewards, pow_claimable_rewards::<PoWService, RuntimeServiceId>;
+            get lb_http_api_common::paths::LEADER_CLAIM_VOUCHERS => crate::api::handlers::wallet::get_claimable_vouchers, wallet::get_claimable_vouchers::<WalletService, _>;
+            get lb_http_api_common::paths::wallet::BALANCE => crate::api::handlers::wallet::get_balance, wallet::get_balance::<WalletService, _>;
+            get lb_http_api_common::paths::MANTLE_GAS_PRICES => crate::api::handlers::get_gas_prices, get_gas_prices::<RuntimeServiceId>;
+            post lb_http_api_common::paths::wallet::TRANSACTIONS_TRANSFER_FUNDS => crate::api::handlers::wallet::post_transactions_transfer_funds, wallet::post_transactions_transfer_funds::<WalletService, MempoolStorageAdapter, _>;
+            post lb_http_api_common::paths::wallet::SIGN_TX_ED25519 => crate::api::handlers::wallet::sign_tx_ed25519, wallet::sign_tx_ed25519::<WalletService, MempoolStorageAdapter, _>;
+            post lb_http_api_common::paths::wallet::SIGN_TX_ZK => crate::api::handlers::wallet::sign_tx_zk, wallet::sign_tx_zk::<WalletService, MempoolStorageAdapter, _>;
+            post lb_http_api_common::paths::wallet::FUND => crate::api::handlers::wallet::fund, wallet::fund::<WalletService, MempoolStorageAdapter, _>;
+            put lb_http_api_common::paths::admin::TRACING_FILTER => crate::api::tracing::reload_tracing_filter, reload_tracing_filter::<RuntimeServiceId>;
+            get lb_http_api_common::paths::BLOCKS_STREAM => crate::api::handlers::blocks_stream, blocks_stream::<BlockStorageBackend, CryptarchiaConsensus<_, _, _, _>, RuntimeServiceId>;
+            get lb_http_api_common::paths::BLOCKS_RANGE_STREAM => crate::api::handlers::blocks_range_stream, blocks_range_stream::<BlockStorageBackend, RuntimeServiceId>;
+            get lb_http_api_common::paths::BLOCKS => crate::api::handlers::immutable_blocks, immutable_blocks::<BlockStorageBackend, RuntimeServiceId>;
+            get lb_http_api_common::paths::BLOCKS_DETAIL => crate::api::handlers::block, block::<StorageAdapter, RuntimeServiceId>;
+            get lb_http_api_common::paths::BLOCK_EVENTS => crate::api::handlers::block_events, block_events::<RuntimeServiceId>;
+            get lb_http_api_common::paths::TRANSACTION => crate::api::handlers::transaction, transaction::<StorageAdapter, RuntimeServiceId>;
+        }
+    };
+}
+
+pub(crate) use api_routes;

--- a/services/api/Cargo.toml
+++ b/services/api/Cargo.toml
@@ -21,7 +21,7 @@ lb-chain-broadcast-service    = { workspace = true }
 lb-chain-leader-service       = { workspace = true }
 lb-chain-service              = { features = ["openapi"], workspace = true }
 lb-core                       = { features = ["openapi"], workspace = true }
-lb-key-management-system-keys = { workspace = true }
+lb-key-management-system-keys = { features = ["openapi"], workspace = true }
 lb-ledger                     = { workspace = true }
 lb-libp2p                     = { workspace = true }
 lb-log-targets                = { workspace = true }

--- a/services/api/Cargo.toml
+++ b/services/api/Cargo.toml
@@ -20,7 +20,7 @@ lb-blend-service              = { workspace = true }
 lb-chain-broadcast-service    = { workspace = true }
 lb-chain-leader-service       = { workspace = true }
 lb-chain-service              = { features = ["openapi"], workspace = true }
-lb-core                       = { workspace = true }
+lb-core                       = { features = ["openapi"], workspace = true }
 lb-key-management-system-keys = { workspace = true }
 lb-ledger                     = { workspace = true }
 lb-libp2p                     = { workspace = true }
@@ -38,6 +38,7 @@ thiserror                     = { workspace = true }
 tokio                         = { features = ["net"], workspace = true }
 tokio-stream                  = { workspace = true }
 tracing                       = { workspace = true }
+utoipa                        = { features = ["macros"], workspace = true }
 
 [dev-dependencies]
 serde   = { workspace = true }

--- a/services/api/src/http/consensus/leader.rs
+++ b/services/api/src/http/consensus/leader.rs
@@ -4,6 +4,7 @@ use lb_chain_leader_service::api::{ChainLeaderSerivceApi, ChainLeaderServiceData
 use lb_core::mantle::transactions::hash::TxHash;
 use overwatch::{overwatch::OverwatchHandle, services::AsServiceId};
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
 use crate::http::DynError;
 
@@ -21,7 +22,7 @@ where
     Ok(LeaderClaimResponseBody { tx_hash })
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, ToSchema)]
 pub struct LeaderClaimResponseBody {
     pub tx_hash: TxHash,
 }

--- a/services/api/src/http/pow.rs
+++ b/services/api/src/http/pow.rs
@@ -103,11 +103,7 @@ where
 /// "use the node's auto-claim target".
 #[derive(Serialize, Deserialize, Default, ToSchema)]
 pub struct PoWClaimRequestBody {
-    // `ZkPublicKey` encodes through `serde_fr` as a 32-byte hex string, but it
-    // lives in `lb-key-management-system-keys`, which sits below `lb-core` in
-    // the dependency graph and so cannot reach `lb_core::utils::hex_bytes_schema`.
     #[serde(default)]
-    #[schema(value_type = Option<String>)]
     pub claim_address: Option<ZkPublicKey>,
 }
 

--- a/services/api/src/http/pow.rs
+++ b/services/api/src/http/pow.rs
@@ -8,6 +8,7 @@ use lb_pow_service::{
 };
 use overwatch::{overwatch::OverwatchHandle, services::AsServiceId};
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
 use crate::http::DynError;
 
@@ -100,15 +101,19 @@ where
 ///
 /// The whole body is optional, and so is the key inside it: both omitted mean
 /// "use the node's auto-claim target".
-#[derive(Serialize, Deserialize, Default)]
+#[derive(Serialize, Deserialize, Default, ToSchema)]
 pub struct PoWClaimRequestBody {
+    // `ZkPublicKey` encodes through `serde_fr` as a 32-byte hex string, but it
+    // lives in `lb-key-management-system-keys`, which sits below `lb-core` in
+    // the dependency graph and so cannot reach `lb_core::utils::hex_bytes_schema`.
     #[serde(default)]
+    #[schema(value_type = Option<String>)]
     pub claim_address: Option<ZkPublicKey>,
 }
 
 /// The id of the reward-claim transaction submitted by a claim request, or
 /// `null` when there were no rewards to claim.
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, ToSchema)]
 pub struct PoWClaimResponseBody {
     pub tx_hash: Option<TxHash>,
 }

--- a/services/chain/chain-service/Cargo.toml
+++ b/services/chain/chain-service/Cargo.toml
@@ -37,7 +37,7 @@ time                       = { workspace = true }
 tokio                      = { workspace = true }
 tracing                    = { workspace = true }
 tracing-futures            = { features = ["std-future"], workspace = true }
-utoipa                     = { optional = true, workspace = true }
+utoipa                     = { features = ["macros"], optional = true, workspace = true }
 
 [dev-dependencies]
 lb-core                       = { workspace = true }
@@ -50,4 +50,4 @@ tempfile                      = { workspace = true }
 
 [features]
 default = []
-openapi = ["dep:utoipa"]
+openapi = ["dep:utoipa", "lb-core/openapi", "lb-cryptarchia-engine/openapi"]

--- a/services/chain/chain-service/src/service/phases/mod.rs
+++ b/services/chain/chain-service/src/service/phases/mod.rs
@@ -19,6 +19,7 @@ pub trait Phase: Send + Sync + Debug {
 
 /// Phase tags
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub enum PhaseTag {
     /// The genesis time is in the future. Only read-only queries are served.
     AwaitingGenesisTime,

--- a/services/network/Cargo.toml
+++ b/services/network/Cargo.toml
@@ -28,7 +28,7 @@ serde               = { features = ["derive"], workspace = true }
 tokio               = { features = ["macros", "sync"], workspace = true }
 tokio-stream        = { workspace = true }
 tracing             = { workspace = true }
-utoipa              = { optional = true, workspace = true }
+utoipa              = { features = ["macros"], optional = true, workspace = true }
 
 [dev-dependencies]
 chrono             = { features = ["now"], workspace = true }

--- a/services/network/src/backends/libp2p/command.rs
+++ b/services/network/src/backends/libp2p/command.rs
@@ -37,14 +37,18 @@ pub struct Dial {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct Libp2pInfo {
+    #[cfg_attr(feature = "openapi", schema(value_type = Vec<String>))]
     pub listen_addresses: Vec<Multiaddr>,
+    #[cfg_attr(feature = "openapi", schema(value_type = String))]
     pub peer_id: PeerId,
     #[serde(default)]
+    #[cfg_attr(feature = "openapi", schema(value_type = Vec<String>))]
     pub connected_peers: Vec<PeerId>,
     pub n_peers: usize,
     pub n_connections: u32,
     pub n_pending_connections: u32,
     #[serde(default)]
+    #[cfg_attr(feature = "openapi", schema(value_type = Vec<String>))]
     pub discovered_peers: Vec<PeerId>,
     #[serde(default)]
     pub n_discovered_peers: usize,

--- a/services/tx-service/Cargo.toml
+++ b/services/tx-service/Cargo.toml
@@ -37,7 +37,7 @@ thiserror          = { workspace = true }
 tokio              = { workspace = true }
 tokio-stream       = { workspace = true }
 tracing            = { workspace = true }
-utoipa             = { optional = true, workspace = true }
+utoipa             = { features = ["macros"], optional = true, workspace = true }
 
 [dev-dependencies]
 lb-tracing-service = { workspace = true }

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -28,8 +28,10 @@ thiserror      = { workspace = true }
 time           = { features = ["serde-human-readable"], optional = true, workspace = true }
 tokio          = { optional = true, workspace = true }
 tracing        = { workspace = true }
+utoipa         = { features = ["macros"], optional = true, workspace = true }
 
 [features]
+openapi          = ["dep:utoipa"]
 serde            = ["const-hex/alloc", "serde/alloc"]
 time             = ["dep:humantime", "dep:serde_with", "dep:time"]
 tokio            = ["dep:futures", "dep:tokio"]

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -8,6 +8,9 @@ pub mod yaml;
 #[cfg(feature = "time")]
 pub mod bounded_duration;
 
+#[cfg(feature = "openapi")]
+pub mod openapi;
+
 #[cfg(feature = "tokio")]
 pub mod tokio;
 

--- a/utils/src/openapi.rs
+++ b/utils/src/openapi.rs
@@ -1,0 +1,24 @@
+//! `OpenAPI` schema helpers for the wire encodings defined in this crate.
+
+/// The schema for a value encoded by
+/// [`serialize_bytes_array`](crate::serde::serialize_bytes_array).
+///
+/// The single description of that encoding: every type whose `serde` impl
+/// routes through `serialize_bytes_array` documents itself with this, so they
+/// cannot describe the same wire format differently.
+///
+/// Human-readable formats encode as unprefixed lowercase hex; the deserializer
+/// additionally tolerates a `0x` prefix and uppercase, which the pattern
+/// reflects.
+#[must_use]
+pub fn hex_bytes_schema(bytes: usize) -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
+    let hex_len = bytes * 2;
+    utoipa::openapi::schema::ObjectBuilder::new()
+        .schema_type(utoipa::openapi::schema::Type::String)
+        .pattern(Some(format!("^(0x)?[0-9a-fA-F]{{{hex_len}}}$")))
+        .min_length(Some(hex_len))
+        .max_length(Some(hex_len + 2))
+        .description(Some(format!("{bytes}-byte value, hex encoded.")))
+        .build()
+        .into()
+}


### PR DESCRIPTION
## 1. What does this PR implement?

Remove `proc-macro-error` (RUSTSEC-2024-0370) from `cargo-deny` by upgrading `utoipa` 4 -> 5, then close the OpenAPI correctness gaps that upgrade exposed. `utoipa` 4 accepted any `body = X` and emitted a
`$ref` to a component it never registered, so much of the published document was silently
wrong; `utoipa` 5 resolves body types as real paths and requires `ToSchema`.

### Bugs fixed

- **`POW_START_MINING`/`POW_STOP_MINING` routed `PUT`, documented `POST`** — anyone
  driving them off the spec got a 405. The router is what works, so the docs were wrong.
- **Six routed endpoints missing from the document** — they had `#[utoipa::path]` but were
  never listed in `paths(...)`, which is inert on its own.
- **`BlockFilter`/`BlockSortOrder` referenced but unregistered** — utoipa auto-collects
  schemas from bodies, but not from `IntoParams` query parameters.
- **Three annotations named non-existent things** — a renamed crate, a type not in scope,
  and a request body that doesn't exist. utoipa 4 never resolved them.

### Enforcement

- **One route table** (`api/routes.rs`) drives both the axum router and `paths(...)` — an
  endpoint can no longer be served without being documented. Side effect: `serve` lost 231
  lines and its `too_many_lines` exemption.
- **Schemas emitted beside the serde impls** — `serde_bytes_newtype!` generates
  `ToSchema` from the same `$len` as the encoder, so the two can't drift.
- **Direct impls for `NoteId`, `Locator`, `Slot`, `State`** — one definition per type
  instead of restating `value_type` at each use site. `State` now documents its real
  variants. Hand-written claims: 13 → 3, and those three are foreign types the orphan
  rule blocks.
- **`boon` conformance tests** for what neither can catch. The `lb-core` one is
  parameterised over encoding length, not over a list of types, so adding a newtype needs
  no test change. Both suites mutation-checked to confirm they fail when the schema lies.

Co-authored with Claude, checked manually before opening the PR.

## 2. Does the code have enough context to be clearly understood?

Description above should be sufficient to guide the review.

## 3. Who are the specification authors and who is accountable for this PR?

@ntn-x2 

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

No.