### PR TITLE
fix(blend): restore unhealthy peer connection maintenance

### DIFF
--- a/blend/network/src/core/with_core/behaviour/mod.rs
+++ b/blend/network/src/core/with_core/behaviour/mod.rs
@@ -773,10 +773,6 @@ impl<ObservationWindowClockProvider, ProofsVerifier>
 
     /// Handle an unhealthy connection if it exists in the current epoch.
     /// If not, it is ignored.
-    #[expect(
-        dead_code,
-        reason = "TODO: We currently do not handle unhealthy cases."
-    )]
     fn handle_unhealthy_connection(&mut self, (peer_id, connection_id): (PeerId, ConnectionId)) {
         // Notify swarm only on first transition into unhealthy state.
         if let Some(prev_state) = self.update_state_for_negotiated_peer(
@@ -1264,14 +1260,8 @@ where
                         "Peer {peer_id:?} has been marked as spammy by its connection handler. NOT TAKING ANY ACTIONS ON THIS."
                     );
                 }
-                // TODO: Re-add logic once Blend observation window values calculation is fixed.
                 ToBehaviour::UnhealthyPeer => {
-                    // self.handle_unhealthy_connection((peer_id,
-                    // connection_id));
-                    tracing::trace!(
-                        target: LOG_TARGET,
-                        "Peer {peer_id:?} has been marked as unhealthy by its connection handler. NOT TAKING ANY ACTIONS ON THIS."
-                    );
+                    self.handle_unhealthy_connection((peer_id, connection_id));
                 }
                 ToBehaviour::HealthyPeer => {
                     self.handle_healthy_connection((peer_id, connection_id));

--- a/blend/network/src/core/with_core/behaviour/tests/connection_maintenance.rs
+++ b/blend/network/src/core/with_core/behaviour/tests/connection_maintenance.rs
@@ -84,7 +84,6 @@ async fn detect_spammy_peer() {
     }
 }
 
-#[ignore = "TODO: enable this logic after investigating epoch transition issues. Test disabled because we don't let connections turn unhealthy now until we have proper observation window values."]
 #[test(tokio::test)]
 async fn detect_unhealthy_peer() {
     let (mut identities, nodes) = new_nodes_with_empty_address(2);
@@ -145,7 +144,6 @@ async fn detect_unhealthy_peer() {
     );
 }
 
-#[ignore = "TODO: enable this logic after investigating epoch transition issues. Test disabled because we don't let connections turn unhealthy now until we have proper observation window values."]
 #[test(tokio::test)]
 async fn restore_healthy_peer() {
     let (mut identities, nodes) = new_nodes_with_empty_address(2);

--- a/services/blend/src/core/backends/libp2p/tests/network_maintenance.rs
+++ b/services/blend/src/core/backends/libp2p/tests/network_maintenance.rs
@@ -15,7 +15,6 @@ use crate::{
     test_utils::TestEncapsulatedMessage,
 };
 
-#[ignore = "TODO: enable this logic after investigating epoch transition issues. Test disabled because we don't let connections turn unhealthy because of too little messages now until we have proper observation window values."]
 #[test(tokio::test)]
 async fn on_unhealthy_peer() {
     let (mut identities, mut nodes) = new_nodes_with_empty_address(3);


### PR DESCRIPTION
## 1. What does this PR implement?

This PR restores unhealthy core-peer connection maintenance in Blend.

When a connection monitor reports `ToBehaviour::UnhealthyPeer`, the Blend
behaviour now:

- marks the negotiated peer as unhealthy;
- emits `Event::UnhealthyPeer` on the first transition into the unhealthy state;
- allows the existing Blend swarm maintenance logic to check the healthy peering
  degree and establish another connection when required.

The existing unhealthy-peer behaviour tests and service-level network-maintenance
test are re-enabled.

Spammy-peer handling remains disabled and is intentionally out of scope for this PR.

This restores functionality that was temporarily disabled in #2397 while
deployment-specific observation-window values were still being worked on.

## 2. Does the code have enough context to be clearly understood?

Specification:

Blend Protocol — Connectivity Maintenance:
https://github.com/logos-co/logos-lips/blob/master/docs/blockchain/raw/blend-protocol.md#connectivity-maintenance

The Blend connection monitor and swarm-side unhealthy-peer recovery logic were
already implemented. The behaviour layer was still suppressing
`ToBehaviour::UnhealthyPeer`, preventing that existing path from being reached.

The current observation-window provider derives its expected message range from
runtime/deployment configuration and current Blend membership information, so
this PR reconnects the existing health-monitoring path rather than introducing
new connection-maintenance semantics.

This PR does not claim to resolve or establish the root cause of any recent
testnet incident. It restores the connectivity-maintenance behaviour specified
for unhealthy Blend core connections.

### Validation

- `cargo test -p logos-blockchain-blend-network`
  - 64 passed
  - 1 unrelated spammy-peer test remains ignored
- `cargo test -p logos-blockchain-blend-service`
  - 59 passed
  - 2 existing unrelated tests remain ignored
- `cargo +nightly-2026-07-05 clippy -p logos-blockchain-blend-network -p logos-blockchain-blend-service --all-targets --all-features -- -D warnings`
  - passed
- `pre-commit run fmt --all-files`
  - passed
- `git diff --check`
  - passed

Full `pre-commit run --all-files` was also attempted locally. Unrelated
workspace/environment checks failed on:
- RocksDB C++ compilation on local macOS during full-workspace Clippy;
- an existing yanked `chacha20 0.10.0` dependency reported by `cargo-deny`;
- Taplo schema-catalog decoding.

No dependency, Cargo, or TOML files are modified by this PR.

## 3. Who are the specification authors and who is accountable for this PR?

Accountable implementation author: @bristinWild

Specification editor: Marcin Pawlowski.

Requested Blend engineering reviewers:
@youngjoon-lee @ntn-x2 @danielSanchezQ @davidrusu

## 4. Is the specification accurate and complete?

Yes for the behaviour implemented by this PR.

The PR restores the existing implementation path required for unhealthy core
connection maintenance and does not propose changes to the Blend protocol.

## 5. Does the implementation introduce changes in the specification?

No.

## Checklist

- [x] PR title follows Conventional Commits
- [x] Description added
- [x] Specification context and link added
- [x] Main implementation/specification contacts added
- [x] Implementation does not introduce specification changes
- [ ] Appropriate milestone assigned
- [x] No new or changed log statements introduced