### PR TITLE
fix(flake): Include hex files from blend fixtures in flake.nix build

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -98,17 +98,17 @@
         ]
       },
       "locked": {
-        "lastModified": 1785302874,
-        "narHash": "sha256-fpKEww3TJoo1ANHO2q918ei+ayOrp0YEQAO1DuBLOB4=",
+        "lastModified": 1787281715,
+        "narHash": "sha256-5yIL5XL31hCZBPWDdUOvUy4cYAl27XZrke7JELhHlnI=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "b99d48435bc3e34309d2c7ae6f7d45e77a156c38",
+        "rev": "89abdfd661ea493cde2f73d7b1332cb34150aa43",
         "type": "github"
       },
       "original": {
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "b99d48435bc3e34309d2c7ae6f7d45e77a156c38",
+        "rev": "89abdfd661ea493cde2f73d7b1332cb34150aa43",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -57,10 +57,18 @@
           pkgs = mkPkgs system;
           rustToolchain = pkgs.rust-bin.stable.${rustVersion}.default;
           craneLib = (crane.mkLib pkgs).overrideToolchain rustToolchain;
+          # `craneLib.filterCargoSources` keeps only *.rs, *.toml, Cargo.lock and
+          # .cargo/config, so any non-Rust file pulled in with include_str!/
+          # include_bytes! has to be allowed through explicitly or the build
+          # fails with "couldn't read ...: No such file or directory".
+          assetSuffixes = [
+            ".hex"
+            "nodes/node/binary/src/config/deployment/settings.yaml"
+          ];
           src = pkgs.lib.cleanSourceWith {
             src = craneLib.path ./.;
             filter = path: type:
-              (pkgs.lib.hasSuffix "nodes/node/binary/src/config/deployment/settings.yaml" path) ||
+              (pkgs.lib.any (suffix: pkgs.lib.hasSuffix suffix path) assetSuffixes) ||
               (craneLib.filterCargoSources path type);
           };
           crateName = craneLib.crateNameFromCargoToml { inherit src; };
@@ -87,12 +95,12 @@
             RUSTFLAGS = "-L ${pkgs.libiconv}/lib";
           };
 
-          logosBlockchainDependencies = craneLib.buildDepsOnly (commonArgs);
+          logosBlockchainDependencies = craneLib.buildDepsOnly commonArgs;
 
           logosBlockChainC = craneLib.buildPackage (
             commonArgs
             // {
-              inherit logosBlockchainDependencies;
+              cargoArtifacts = logosBlockchainDependencies;
 
               postInstall = ''
                 mkdir -p $out/include


### PR DESCRIPTION
## 1. What does this PR implement?

Nix build was broken because of some blend fixture files. Nix do not include some kind of files by default so they need to be added manually. All hex files should be included in the nix package now.

## 2. Does the code have enough context to be clearly understood?

Yes


## 3. Who are the specification authors and who is accountable for this PR?

@danielSanchezQ @ntn-x2 

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

N/A

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
