### PR TITLE
fix(test): make port block reservations race-free

### DIFF
--- a/tests/cucumber_tests/cucumber.rs
+++ b/tests/cucumber_tests/cucumber.rs
@@ -27,9 +27,9 @@ use cucumber::{
     writer::Verbosity,
 };
 use lb_testing_framework::{
-    hash_str, is_truthy_env, reap_all_stale_port_blocks, record_system_monitor_event,
-    register_system_monitor_output_file, release_reserved_port_block,
-    resolve_automatic_genesis_time, unregister_system_monitor_output_file,
+    hash_str, is_truthy_env, record_system_monitor_event, register_system_monitor_output_file,
+    release_reserved_port_block, resolve_automatic_genesis_time,
+    unregister_system_monitor_output_file,
 };
 use logos_blockchain_tests::cucumber::{
     defaults::{
@@ -71,7 +71,6 @@ fn increment_attempts(
 
 #[tokio::main]
 async fn main() {
-    reap_all_stale_port_blocks();
     println!("args: {:?}", std::env::args());
 
     let deployer = selected_deployer();
@@ -187,7 +186,7 @@ async fn main() {
         .run(get_feature_path_for_deployer(deployer))
         .await;
 
-    // Clean up manually reserved handshake port block files for this process
+    // Release this process's reserved port block before exiting.
     release_reserved_port_block();
 
     if failed.execution_has_failed() {

--- a/tests/testing_framework/src/lib.rs
+++ b/tests/testing_framework/src/lib.rs
@@ -19,7 +19,7 @@ mod unique_persistent;
 pub mod workloads;
 pub use unique_persistent::{
     get_reserved_available_tcp_port, get_reserved_available_udp_port, hash_str,
-    reap_all_stale_port_blocks, release_reserved_port_block, unique_test_context,
+    release_reserved_port_block, unique_test_context,
 };
 
 pub static IS_DEBUG_TRACING: LazyLock<bool> = LazyLock::new(env::debug_tracing);

--- a/tests/testing_framework/src/unique_persistent.rs
+++ b/tests/testing_framework/src/unique_persistent.rs
@@ -1,33 +1,16 @@
 use std::{
-    fs,
-    fs::OpenOptions,
     hash::{Hash as _, Hasher as _},
-    io::Write as _,
-    net::{TcpListener, UdpSocket},
-    path::{Path, PathBuf},
-    process::Command,
     sync::{Mutex, OnceLock},
     time::{SystemTime, UNIX_EPOCH},
 };
 
-use lb_utils::net::{get_available_tcp_port, get_available_udp_port};
-
-/// Total size of one reserved block per test process.
-///
-/// Half is used for TCP, half for UDP.
-const PORT_BLOCK_SIZE: u16 = 256;
-
-/// Inclusive start of the overall test port range.
-const PORT_RANGE_START: u16 = 20_000;
-
-/// Inclusive end of the overall test port range.
-const PORT_RANGE_END: u16 = 55_000;
+use lb_utils::net::ReservedPortBlock;
 
 /// One allocator slot per process.
 ///
-/// Cross-process coordination is done via lock files in the temp directory.
+/// Cross-process coordination is done by a kernel-owned socket lease.
 /// We keep the allocator inside an Option so it can be explicitly released.
-static TEST_PORT_ALLOCATOR: OnceLock<Mutex<Option<TestPortAllocator>>> = OnceLock::new();
+static TEST_PORT_ALLOCATOR: OnceLock<Mutex<Option<ReservedPortBlock>>> = OnceLock::new();
 
 static PROCESS_START_NONCE: OnceLock<String> = OnceLock::new();
 
@@ -69,243 +52,36 @@ pub fn unique_test_context(test_context: Option<&str>) -> String {
     )
 }
 
-#[derive(Debug)]
-struct TestPortAllocator {
-    // The lock file that proves this process owns its port block.
-    claim_file: PathBuf,
-    // Next TCP port candidate in this process's reserved block.
-    tcp_next: u16,
-    // Final TCP port in this process's reserved block.
-    tcp_end: u16,
-    // Next UDP port candidate in this process's reserved block.
-    udp_next: u16,
-    // Final UDP port in this process's reserved block.
-    udp_end: u16,
-}
-
-impl TestPortAllocator {
-    fn new() -> Option<Self> {
-        fs::create_dir_all(handshake_dir()).ok()?;
-
-        let owner = format!("process_start_nonce={}", process_start_nonce());
-
-        // Example block starts for PORT_BLOCK_SIZE=256:
-        // 20000, 20256, 20512, ...
-        let max_block_start = PORT_RANGE_END.checked_sub(PORT_BLOCK_SIZE - 1)?;
-
-        for block_start in (PORT_RANGE_START..=max_block_start).step_by(PORT_BLOCK_SIZE as usize) {
-            let block_end = block_start + PORT_BLOCK_SIZE - 1;
-            let claim_file = handshake_dir().join(format!("{block_start}.lock"));
-
-            // First try to reap an obviously stale lock from a dead pid.
-            if claim_file.exists() {
-                try_reap_stale_port_claim_file(&claim_file);
-            }
-
-            // The existence of this file is the reservation.
-            match OpenOptions::new()
-                .write(true)
-                .create_new(true)
-                .open(&claim_file)
-            {
-                Ok(mut file) => {
-                    write_port_claim_metadata(&mut file, &owner, block_start, block_end).ok()?;
-
-                    let tcp_next = block_start;
-                    let tcp_end = block_start + (PORT_BLOCK_SIZE / 2) - 1;
-
-                    let udp_next = tcp_end + 1;
-                    let udp_end = block_end;
-
-                    return Some(Self {
-                        claim_file,
-                        tcp_next,
-                        tcp_end,
-                        udp_next,
-                        udp_end,
-                    });
-                }
-                Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
-                    // This block is currently claimed by another live process,
-                    // or a race occurred while reaping/claiming. Try the next
-                    // block.
-                }
-                Err(_) => {
-                    return None;
-                }
-            }
-        }
-
-        None
-    }
-
-    /// Returns an available TCP port from this allocator's reserved block.
-    fn next_tcp_port(&mut self) -> Option<u16> {
-        while self.tcp_next <= self.tcp_end {
-            let port = self.tcp_next;
-            self.tcp_next += 1;
-
-            if TcpListener::bind(("127.0.0.1", port)).is_ok() {
-                return Some(port);
-            }
-        }
-        // The persistent blocks may be exhausted, try global allocation (failsafe)
-        get_available_tcp_port()
-    }
-
-    /// Returns an available UDP port from this allocator's reserved block.
-    fn next_udp_port(&mut self) -> Option<u16> {
-        while self.udp_next <= self.udp_end {
-            let port = self.udp_next;
-            self.udp_next += 1;
-
-            if UdpSocket::bind(("127.0.0.1", port)).is_ok() {
-                return Some(port);
-            }
-        }
-        // The persistent blocks may be exhausted, try global allocation (failsafe)
-        get_available_udp_port()
-    }
-}
-
-impl Drop for TestPortAllocator {
-    fn drop(&mut self) {
-        drop(fs::remove_file(&self.claim_file));
-    }
-}
-
-fn test_port_allocator_slot() -> &'static Mutex<Option<TestPortAllocator>> {
+fn test_port_allocator_slot() -> &'static Mutex<Option<ReservedPortBlock>> {
     TEST_PORT_ALLOCATOR.get_or_init(|| Mutex::new(None))
 }
 
-fn with_test_port_allocator<T>(f: impl FnOnce(&mut TestPortAllocator) -> Option<T>) -> Option<T> {
+fn with_test_port_allocator<T>(f: impl FnOnce(&mut ReservedPortBlock) -> Option<T>) -> Option<T> {
     let slot = test_port_allocator_slot();
     let mut guard = slot.lock().ok()?;
 
     if guard.is_none() {
-        *guard = Some(TestPortAllocator::new()?);
+        *guard = Some(ReservedPortBlock::try_new()?);
     }
 
     f(guard.as_mut().expect("allocator just initialized"))
 }
-
-fn write_port_claim_metadata(
-    file: &mut fs::File,
-    owner: &str,
-    block_start: u16,
-    block_end: u16,
-) -> std::io::Result<()> {
-    let tcp_start = block_start;
-    let tcp_end = block_start + (PORT_BLOCK_SIZE / 2) - 1;
-    let udp_start = tcp_end + 1;
-    let udp_end = block_end;
-
-    writeln!(file, "owner={owner}")?;
-    writeln!(file, "pid={}", std::process::id())?;
-    writeln!(file, "block_start={block_start}")?;
-    writeln!(file, "block_end={block_end}")?;
-    writeln!(file, "tcp_range={tcp_start}-{tcp_end}")?;
-    writeln!(file, "udp_range={udp_start}-{udp_end}")?;
-    Ok(())
-}
-
-fn read_pid_from_claim_file(path: &Path) -> Option<u32> {
-    let contents = fs::read_to_string(path).ok()?;
-
-    for line in contents.lines() {
-        if let Some(pid) = line.strip_prefix("pid=") {
-            return pid.trim().parse::<u32>().ok();
-        }
-    }
-
-    None
-}
-
-fn is_pid_alive(pid: u32) -> bool {
-    if pid == 0 {
-        return true;
-    }
-
-    #[cfg(unix)]
-    {
-        // `ps -p <pid> -o pid=` prints an empty line when the process is absent.
-        // Be conservative: if probing fails, treat PID as alive to avoid deleting a
-        // live claim.
-        let output = Command::new("ps")
-            .arg("-p")
-            .arg(pid.to_string())
-            .arg("-o")
-            .arg("pid=")
-            .output();
-
-        match output {
-            // process exists
-            Ok(out) if out.status.success() => {
-                !String::from_utf8_lossy(&out.stdout).trim().is_empty()
-            }
-            // process absent
-            Ok(out) if out.status.code() == Some(1) => false,
-            // probe failed -> conservative
-            _ => true,
-        }
-    }
-
-    #[cfg(windows)]
-    {
-        // PowerShell exits 0 when the PID exists and 1 when it does not.
-        // Be conservative on probe errors to avoid deleting a live claim.
-        let status = Command::new("powershell")
-            .arg("-NoProfile")
-            .arg("-NonInteractive")
-            .arg("-Command")
-            .arg(format!(
-                "if (Get-Process -Id {pid} -ErrorAction SilentlyContinue) {{ exit 0 }} else {{ exit 1 }}"
-            ))
-            .status();
-
-        match status {
-            // process exists
-            Ok(s) if s.code() == Some(0) => true,
-            // process absent
-            Ok(s) if s.code() == Some(1) => false,
-            // probe failed -> conservative
-            _ => true,
-        }
-    }
-
-    #[cfg(not(any(unix, windows)))]
-    {
-        // Unknown platform: fail closed and avoid stale-lock reaping.
-        true
-    }
-}
-
-fn try_reap_stale_port_claim_file(path: &Path) {
-    let Some(pid) = read_pid_from_claim_file(path) else {
-        return;
-    };
-
-    if !is_pid_alive(pid) {
-        drop(fs::remove_file(path));
-    }
-}
-
 /// Returns an available TCP port from this process's reserved port block.
 #[must_use]
 pub fn get_reserved_available_tcp_port() -> Option<u16> {
-    with_test_port_allocator(TestPortAllocator::next_tcp_port)
+    with_test_port_allocator(ReservedPortBlock::next_tcp_port)
 }
 
 /// Returns an available UDP port from this process's reserved port block.
 #[must_use]
 pub fn get_reserved_available_udp_port() -> Option<u16> {
-    with_test_port_allocator(TestPortAllocator::next_udp_port)
+    with_test_port_allocator(ReservedPortBlock::next_udp_port)
 }
 
 /// Explicitly releases this process's reserved port block.
 ///
-/// Call this near the end of the test process or harness teardown so that
-/// normal exits do not leave lock files behind.
+/// Call this near the end of the test process or harness teardown to release
+/// the block's kernel-owned socket lease immediately.
 pub fn release_reserved_port_block() {
     let slot = test_port_allocator_slot();
 
@@ -313,23 +89,8 @@ pub fn release_reserved_port_block() {
         return;
     };
 
-    // Taking the allocator out of the slot drops it here, which removes the
-    // claim file via Drop.
+    // Taking the allocator out of the slot drops the socket lease here.
     drop(guard.take());
-}
-
-fn handshake_dir() -> PathBuf {
-    std::env::temp_dir().join("logos-e2e-port-blocks")
-}
-
-/// Reaps all stale lock files in the port-blocks directory that belong to
-/// dead processes. Call this once at process startup.
-pub fn reap_all_stale_port_blocks() {
-    if let Ok(entries) = fs::read_dir(handshake_dir()) {
-        for entry in entries.flatten() {
-            try_reap_stale_port_claim_file(&entry.path());
-        }
-    }
 }
 
 /// Create a short 8-byte hash from string

--- a/tools/config/src/unique.rs
+++ b/tools/config/src/unique.rs
@@ -1,24 +1,13 @@
 use std::{
-    fs,
-    fs::OpenOptions,
     hash::{Hash as _, Hasher as _},
-    io::Write as _,
-    net::{TcpListener, UdpSocket},
-    path::{Path, PathBuf},
-    process::Command,
     sync::{Mutex, OnceLock},
-    time::{Duration, SystemTime, UNIX_EPOCH},
+    time::{SystemTime, UNIX_EPOCH},
 };
 
 use lb_core::mantle::transactions::genesis_tx::ChainId;
-use lb_utils::net::{get_available_tcp_port, get_available_udp_port};
+use lb_utils::net::ReservedPortBlock;
 
-const PORT_BLOCK_SIZE: u16 = 256;
-const PORT_RANGE_START: u16 = 20_000;
-const PORT_RANGE_END: u16 = 55_000;
-const MALFORMED_CLAIM_FILE_REAP_GRACE: Duration = Duration::from_mins(1);
-
-static TEST_PORT_ALLOCATOR: OnceLock<Mutex<Option<TestPortAllocator>>> = OnceLock::new();
+static TEST_PORT_ALLOCATOR: OnceLock<Mutex<Option<ReservedPortBlock>>> = OnceLock::new();
 static PROCESS_START_NONCE: OnceLock<String> = OnceLock::new();
 
 fn process_start_nonce() -> &'static str {
@@ -59,188 +48,25 @@ pub fn unique_test_context(test_context: Option<&str>) -> ChainId {
 
 #[must_use]
 pub fn get_reserved_available_tcp_port() -> Option<u16> {
-    with_test_port_allocator(TestPortAllocator::next_tcp_port)
+    with_test_port_allocator(ReservedPortBlock::next_tcp_port)
 }
 
 #[must_use]
 pub fn get_reserved_available_udp_port() -> Option<u16> {
-    with_test_port_allocator(TestPortAllocator::next_udp_port)
+    with_test_port_allocator(ReservedPortBlock::next_udp_port)
 }
 
-fn test_port_allocator_slot() -> &'static Mutex<Option<TestPortAllocator>> {
-    TEST_PORT_ALLOCATOR.get_or_init(|| Mutex::new(TestPortAllocator::new()))
+fn test_port_allocator_slot() -> &'static Mutex<Option<ReservedPortBlock>> {
+    TEST_PORT_ALLOCATOR.get_or_init(|| Mutex::new(ReservedPortBlock::try_new()))
 }
 
-fn with_test_port_allocator(f: impl FnOnce(&mut TestPortAllocator) -> Option<u16>) -> Option<u16> {
+fn with_test_port_allocator(f: impl FnOnce(&mut ReservedPortBlock) -> Option<u16>) -> Option<u16> {
     let slot = test_port_allocator_slot();
     let Ok(mut guard) = slot.lock() else {
         return None;
     };
     let allocator = guard.as_mut()?;
     f(allocator)
-}
-
-#[derive(Debug)]
-struct TestPortAllocator {
-    claim_file: PathBuf,
-    tcp_next: u16,
-    tcp_end: u16,
-    udp_next: u16,
-    udp_end: u16,
-}
-
-impl TestPortAllocator {
-    fn new() -> Option<Self> {
-        fs::create_dir_all(handshake_dir()).ok()?;
-
-        let owner = format!("process_start_nonce={}", process_start_nonce());
-        let max_block_start = PORT_RANGE_END.checked_sub(PORT_BLOCK_SIZE - 1)?;
-
-        for block_start in (PORT_RANGE_START..=max_block_start).step_by(PORT_BLOCK_SIZE as usize) {
-            let block_end = block_start + PORT_BLOCK_SIZE - 1;
-            let claim_file = handshake_dir().join(format!("{block_start}.lock"));
-
-            if claim_file.exists() {
-                try_reap_stale_port_claim_file(&claim_file);
-            }
-
-            if let Ok(mut file) = OpenOptions::new()
-                .write(true)
-                .create_new(true)
-                .open(&claim_file)
-            {
-                write_port_claim_metadata(&mut file, &owner, block_start, block_end).ok()?;
-
-                let tcp_next = block_start;
-                let tcp_end = block_start + (PORT_BLOCK_SIZE / 2) - 1;
-                let udp_next = tcp_end + 1;
-                let udp_end = block_end;
-
-                return Some(Self {
-                    claim_file,
-                    tcp_next,
-                    tcp_end,
-                    udp_next,
-                    udp_end,
-                });
-            }
-        }
-
-        None
-    }
-
-    fn next_tcp_port(&mut self) -> Option<u16> {
-        while self.tcp_next <= self.tcp_end {
-            let candidate = self.tcp_next;
-            self.tcp_next = self.tcp_next.saturating_add(1);
-
-            if is_tcp_port_available(candidate) {
-                return Some(candidate);
-            }
-        }
-
-        get_available_tcp_port()
-    }
-
-    fn next_udp_port(&mut self) -> Option<u16> {
-        while self.udp_next <= self.udp_end {
-            let candidate = self.udp_next;
-            self.udp_next = self.udp_next.saturating_add(1);
-
-            if is_udp_port_available(candidate) {
-                return Some(candidate);
-            }
-        }
-
-        get_available_udp_port()
-    }
-}
-
-impl Drop for TestPortAllocator {
-    fn drop(&mut self) {
-        drop(fs::remove_file(&self.claim_file));
-    }
-}
-
-fn handshake_dir() -> PathBuf {
-    std::env::temp_dir().join("logos-e2e-port-blocks")
-}
-
-fn write_port_claim_metadata(
-    file: &mut fs::File,
-    owner: &str,
-    block_start: u16,
-    block_end: u16,
-) -> std::io::Result<()> {
-    let pid = std::process::id();
-    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
-    writeln!(
-        file,
-        "pid={pid}\nowner={owner}\nblock_start={block_start}\nblock_end={block_end}\ncwd={}",
-        cwd.display()
-    )
-}
-
-fn try_reap_stale_port_claim_file(claim_file: &Path) {
-    let Ok(contents) = fs::read_to_string(claim_file) else {
-        try_reap_malformed_claim_file(claim_file);
-        return;
-    };
-
-    let pid = contents
-        .lines()
-        .find_map(|line| line.strip_prefix("pid="))
-        .and_then(|pid| pid.parse::<u32>().ok());
-
-    let Some(pid) = pid else {
-        try_reap_malformed_claim_file(claim_file);
-        return;
-    };
-
-    if !process_exists(pid) {
-        drop(fs::remove_file(claim_file));
-    }
-}
-
-fn try_reap_malformed_claim_file(claim_file: &Path) {
-    // A claim file is visible before its metadata is fully written. Give fresh
-    // malformed files time to become valid instead of deleting a live claim.
-    if claim_file_age(claim_file).is_some_and(|age| age >= MALFORMED_CLAIM_FILE_REAP_GRACE) {
-        drop(fs::remove_file(claim_file));
-    }
-}
-
-fn claim_file_age(claim_file: &Path) -> Option<Duration> {
-    fs::metadata(claim_file)
-        .ok()?
-        .modified()
-        .ok()?
-        .elapsed()
-        .ok()
-}
-
-fn process_exists(pid: u32) -> bool {
-    #[cfg(unix)]
-    {
-        Command::new("kill")
-            .args(["-0", &pid.to_string()])
-            .status()
-            .is_ok_and(|status| status.success())
-    }
-
-    #[cfg(not(unix))]
-    {
-        let _ = pid;
-        true
-    }
-}
-
-fn is_tcp_port_available(port: u16) -> bool {
-    TcpListener::bind(("127.0.0.1", port)).is_ok()
-}
-
-fn is_udp_port_available(port: u16) -> bool {
-    UdpSocket::bind(("127.0.0.1", port)).is_ok()
 }
 
 fn hash_str(s: &str) -> String {

--- a/utils/src/net.rs
+++ b/utils/src/net.rs
@@ -192,11 +192,12 @@ mod tests {
 
     #[test]
     fn reservations_are_unique_across_processes() {
+        const CHILD_COUNT: usize = 4;
+        const TIMEOUT: Duration = Duration::from_secs(20);
+
         let _guard = RESERVATION_TEST_LOCK
             .lock()
             .expect("reservation test lock should be available");
-        const CHILD_COUNT: usize = 4;
-        const TIMEOUT: Duration = Duration::from_secs(20);
 
         let temp_dir = tempfile::tempdir().expect("temporary directory should be created");
         let release_path = temp_dir.path().join("release");

--- a/utils/src/net.rs
+++ b/utils/src/net.rs
@@ -173,8 +173,10 @@ mod tests {
     use std::{
         collections::HashSet,
         env, fs,
+        net::{TcpListener, UdpSocket},
         path::{Path, PathBuf},
         process::{Command, Stdio},
+        sync::Mutex,
         thread,
         time::{Duration, Instant},
     };
@@ -186,9 +188,13 @@ mod tests {
 
     const CHILD_MARKER_ENV: &str = "LOGOS_PORT_BLOCK_TEST_MARKER";
     const CHILD_RELEASE_ENV: &str = "LOGOS_PORT_BLOCK_TEST_RELEASE";
+    static RESERVATION_TEST_LOCK: Mutex<()> = Mutex::new(());
 
     #[test]
     fn reservations_are_unique_across_processes() {
+        let _guard = RESERVATION_TEST_LOCK
+            .lock()
+            .expect("reservation test lock should be available");
         const CHILD_COUNT: usize = 4;
         const TIMEOUT: Duration = Duration::from_secs(20);
 
@@ -254,6 +260,9 @@ mod tests {
 
     #[test]
     fn reservation_preserves_full_tcp_and_udp_halves() {
+        let _guard = RESERVATION_TEST_LOCK
+            .lock()
+            .expect("reservation test lock should be available");
         let mut allocator = ReservedPortBlock::try_new().expect("a test port block should exist");
         let block_start = allocator.block_start();
         let half_block_size = TEST_PORT_BLOCK_SIZE / 2;
@@ -298,6 +307,28 @@ mod tests {
             claim_port <= claim_range_end,
             "the lease must map into the candidate block's claim range"
         );
+    }
+
+    #[test]
+    fn reservation_skips_a_block_with_orphaned_data_ports() {
+        let _guard = RESERVATION_TEST_LOCK
+            .lock()
+            .expect("reservation test lock should be available");
+        let tcp_port = TEST_PORT_RANGE_START;
+        let udp_port = TEST_PORT_RANGE_START + TEST_PORT_BLOCK_SIZE / 2;
+        let tcp_socket = TcpListener::bind(("127.0.0.1", tcp_port))
+            .expect("the first block's TCP probe port should be available");
+        let udp_socket = UdpSocket::bind(("127.0.0.1", udp_port))
+            .expect("the first block's UDP probe port should be available");
+
+        let allocator = ReservedPortBlock::try_new().expect("a later test port block should exist");
+
+        assert_ne!(
+            allocator.block_start(),
+            TEST_PORT_RANGE_START,
+            "an occupied data port must make the allocator skip the entire block"
+        );
+        drop((tcp_socket, udp_socket));
     }
 
     #[test]

--- a/utils/src/net.rs
+++ b/utils/src/net.rs
@@ -174,9 +174,8 @@ mod tests {
         collections::HashSet,
         env, fs,
         net::{TcpListener, UdpSocket},
-        path::{Path, PathBuf},
+        path::PathBuf,
         process::{Command, Stdio},
-        sync::Mutex,
         thread,
         time::{Duration, Instant},
     };
@@ -188,16 +187,20 @@ mod tests {
 
     const CHILD_MARKER_ENV: &str = "LOGOS_PORT_BLOCK_TEST_MARKER";
     const CHILD_RELEASE_ENV: &str = "LOGOS_PORT_BLOCK_TEST_RELEASE";
-    static RESERVATION_TEST_LOCK: Mutex<()> = Mutex::new(());
+    const CHILD_PORT_COUNT: usize = 16;
+
+    #[derive(Debug)]
+    struct ChildReservation {
+        block_start: u16,
+        claim_port: u16,
+        tcp_ports: Vec<u16>,
+        udp_ports: Vec<u16>,
+    }
 
     #[test]
     fn reservations_are_unique_across_processes() {
         const CHILD_COUNT: usize = 4;
         const TIMEOUT: Duration = Duration::from_secs(20);
-
-        let _guard = RESERVATION_TEST_LOCK
-            .lock()
-            .expect("reservation test lock should be available");
 
         let temp_dir = tempfile::tempdir().expect("temporary directory should be created");
         let release_path = temp_dir.path().join("release");
@@ -229,13 +232,13 @@ mod tests {
         }
 
         let all_children_ready = marker_paths.iter().all(|path| path.exists());
-        let block_starts = if all_children_ready {
+        let marker_contents = if all_children_ready {
             marker_paths
                 .iter()
-                .map(|path| read_block_start(path))
-                .collect::<Vec<_>>()
+                .map(fs::read_to_string)
+                .collect::<Result<Vec<_>, _>>()
         } else {
-            Vec::new()
+            Ok(Vec::new())
         };
 
         fs::write(&release_path, b"release").expect("children should be released");
@@ -252,18 +255,87 @@ mod tests {
             statuses.iter().all(std::process::ExitStatus::success),
             "all child processes should exit successfully"
         );
+
+        let reservations = marker_contents
+            .expect("child markers should be readable")
+            .iter()
+            .map(|contents| parse_child_reservation(contents))
+            .collect::<Vec<_>>();
+        assert_child_reservations(&reservations, CHILD_COUNT);
+    }
+
+    fn assert_child_reservations(reservations: &[ChildReservation], child_count: usize) {
+        let block_starts = reservations
+            .iter()
+            .map(|reservation| reservation.block_start)
+            .collect::<HashSet<_>>();
         assert_eq!(
-            block_starts.iter().copied().collect::<HashSet<_>>().len(),
-            CHILD_COUNT,
+            block_starts.len(),
+            child_count,
             "concurrent processes must reserve distinct port blocks"
+        );
+
+        let claim_ports = reservations
+            .iter()
+            .map(|reservation| reservation.claim_port)
+            .collect::<HashSet<_>>();
+        assert_eq!(
+            claim_ports.len(),
+            child_count,
+            "concurrent processes must hold distinct claim ports"
+        );
+
+        let mut allocated_ports = HashSet::new();
+        for reservation in reservations {
+            let tcp_end = reservation.block_start + TEST_PORT_BLOCK_SIZE / 2;
+            let udp_end = reservation.block_start + TEST_PORT_BLOCK_SIZE;
+
+            assert!(
+                (TEST_PORT_RANGE_START..=TEST_PORT_RANGE_END).contains(&reservation.block_start),
+                "child block must start inside the configured data-port range"
+            );
+            assert_eq!(
+                (reservation.block_start - TEST_PORT_RANGE_START) % TEST_PORT_BLOCK_SIZE,
+                0,
+                "child block must start on a configured block boundary"
+            );
+            assert!(
+                reservation.claim_port > TEST_PORT_RANGE_END,
+                "the claim port must be outside the data-port range"
+            );
+            assert_eq!(reservation.tcp_ports.len(), CHILD_PORT_COUNT);
+            assert_eq!(reservation.udp_ports.len(), CHILD_PORT_COUNT);
+            assert!(
+                reservation
+                    .tcp_ports
+                    .iter()
+                    .all(|port| (reservation.block_start..tcp_end).contains(port)),
+                "TCP ports must remain inside the child process's TCP half"
+            );
+            assert!(
+                reservation
+                    .udp_ports
+                    .iter()
+                    .all(|port| (tcp_end..udp_end).contains(port)),
+                "UDP ports must remain inside the child process's UDP half"
+            );
+
+            for port in reservation.tcp_ports.iter().chain(&reservation.udp_ports) {
+                assert!(
+                    allocated_ports.insert(*port),
+                    "data ports must be globally unique across child processes"
+                );
+            }
+        }
+        assert_eq!(
+            allocated_ports.len(),
+            child_count * CHILD_PORT_COUNT * 2,
+            "every child must retain all allocated TCP and UDP ports"
         );
     }
 
     #[test]
     fn reservation_preserves_full_tcp_and_udp_halves() {
-        let _guard = RESERVATION_TEST_LOCK
-            .lock()
-            .expect("reservation test lock should be available");
         let mut allocator = ReservedPortBlock::try_new().expect("a test port block should exist");
         let block_start = allocator.block_start();
         let half_block_size = TEST_PORT_BLOCK_SIZE / 2;
@@ -312,24 +384,40 @@ mod tests {
 
     #[test]
     fn reservation_skips_a_block_with_orphaned_data_ports() {
-        let _guard = RESERVATION_TEST_LOCK
-            .lock()
-            .expect("reservation test lock should be available");
-        let tcp_port = TEST_PORT_RANGE_START;
-        let udp_port = TEST_PORT_RANGE_START + TEST_PORT_BLOCK_SIZE / 2;
-        let tcp_socket = TcpListener::bind(("127.0.0.1", tcp_port))
-            .expect("the first block's TCP probe port should be available");
-        let udp_socket = UdpSocket::bind(("127.0.0.1", udp_port))
-            .expect("the first block's UDP probe port should be available");
+        let max_block_start = TEST_PORT_RANGE_END - (TEST_PORT_BLOCK_SIZE - 1);
+        let mut preceding_claims = Vec::new();
+        let (occupied_block_start, occupied_claim, tcp_socket, udp_socket) = (TEST_PORT_RANGE_START
+            ..=max_block_start)
+            .step_by(usize::from(TEST_PORT_BLOCK_SIZE))
+            .enumerate()
+            .find_map(|(block_index, block_start)| {
+                let claim_port = TEST_PORT_CLAIM_RANGE_START
+                    + u16::try_from(block_index).expect("block index should fit in u16");
+                let claim = TcpListener::bind(("127.0.0.1", claim_port)).ok()?;
+                let Ok(tcp_socket) = TcpListener::bind(("127.0.0.1", block_start)) else {
+                    preceding_claims.push(claim);
+                    return None;
+                };
+                let udp_port = block_start + TEST_PORT_BLOCK_SIZE / 2;
+                let Ok(udp_socket) = UdpSocket::bind(("127.0.0.1", udp_port)) else {
+                    preceding_claims.push(claim);
+                    return None;
+                };
+
+                Some((block_start, claim, tcp_socket, udp_socket))
+            })
+            .expect("a block should be available for the orphaned-port test");
+
+        drop(occupied_claim);
 
         let allocator = ReservedPortBlock::try_new().expect("a later test port block should exist");
 
         assert_ne!(
             allocator.block_start(),
-            TEST_PORT_RANGE_START,
+            occupied_block_start,
             "an occupied data port must make the allocator skip the entire block"
         );
-        drop((tcp_socket, udp_socket));
+        drop((preceding_claims, tcp_socket, udp_socket));
     }
 
     #[test]
@@ -344,10 +432,45 @@ mod tests {
             env::var_os(CHILD_RELEASE_ENV)
                 .expect("child release environment variable should exist"),
         );
-        let allocator = ReservedPortBlock::try_new().expect("child should reserve a port block");
+        let mut allocator =
+            ReservedPortBlock::try_new().expect("child should reserve a port block");
 
         let block_start = allocator.block_start();
-        fs::write(&marker_path, block_start.to_string()).expect("child marker should be written");
+        let claim_port = allocator
+            .claim_port()
+            .expect("child claim address should be available");
+        let mut tcp_ports = Vec::with_capacity(CHILD_PORT_COUNT);
+        let mut tcp_sockets = Vec::with_capacity(CHILD_PORT_COUNT);
+        let mut udp_ports = Vec::with_capacity(CHILD_PORT_COUNT);
+        let mut udp_sockets = Vec::with_capacity(CHILD_PORT_COUNT);
+
+        for _ in 0..CHILD_PORT_COUNT {
+            let port = allocator
+                .next_tcp_port()
+                .expect("child should allocate a TCP port");
+            let socket = TcpListener::bind(("127.0.0.1", port))
+                .expect("child should immediately bind its allocated TCP port");
+            tcp_ports.push(port);
+            tcp_sockets.push(socket);
+        }
+        for _ in 0..CHILD_PORT_COUNT {
+            let port = allocator
+                .next_udp_port()
+                .expect("child should allocate a UDP port");
+            let socket = UdpSocket::bind(("127.0.0.1", port))
+                .expect("child should immediately bind its allocated UDP port");
+            udp_ports.push(port);
+            udp_sockets.push(socket);
+        }
+
+        let marker = format!(
+            "{block_start}\n{claim_port}\n{}\n{}\n",
+            join_ports(&tcp_ports),
+            join_ports(&udp_ports)
+        );
+        let marker_temp_path = marker_path.with_extension("tmp");
+        fs::write(&marker_temp_path, marker).expect("child marker should be written");
+        fs::rename(marker_temp_path, &marker_path).expect("child marker should be published");
 
         let deadline = Instant::now() + TIMEOUT;
         while !release_path.exists() && Instant::now() < deadline {
@@ -355,12 +478,48 @@ mod tests {
         }
 
         assert!(release_path.exists(), "parent should release child process");
+        drop((tcp_sockets, udp_sockets));
     }
 
-    fn read_block_start(path: &Path) -> u16 {
-        fs::read_to_string(path)
-            .expect("child marker should be readable")
+    fn join_ports(ports: &[u16]) -> String {
+        ports
+            .iter()
+            .map(u16::to_string)
+            .collect::<Vec<_>>()
+            .join(",")
+    }
+
+    fn parse_child_reservation(contents: &str) -> ChildReservation {
+        let mut lines = contents.lines();
+        let block_start = lines
+            .next()
+            .expect("child marker should contain a block start")
             .parse()
-            .expect("child marker should contain a port block start")
+            .expect("child block start should be a port");
+        let claim_port = lines
+            .next()
+            .expect("child marker should contain a claim port")
+            .parse()
+            .expect("child claim port should be a port");
+        let tcp_ports = parse_ports(lines.next().expect("child marker should contain TCP ports"));
+        let udp_ports = parse_ports(lines.next().expect("child marker should contain UDP ports"));
+        assert!(
+            lines.next().is_none(),
+            "child marker should not contain extra fields"
+        );
+
+        ChildReservation {
+            block_start,
+            claim_port,
+            tcp_ports,
+            udp_ports,
+        }
+    }
+
+    fn parse_ports(ports: &str) -> Vec<u16> {
+        ports
+            .split(',')
+            .map(|port| port.parse().expect("child data port should be valid"))
+            .collect()
     }
 }

--- a/utils/src/net.rs
+++ b/utils/src/net.rs
@@ -4,8 +4,114 @@ use std::{
     sync::{LazyLock, Mutex},
 };
 
+const TEST_PORT_BLOCK_SIZE: u16 = 256;
+const TEST_PORT_RANGE_START: u16 = 20_000;
+const TEST_PORT_RANGE_END: u16 = 55_000;
+
 static USED_TCP_PORTS: LazyLock<Mutex<HashSet<u16>>> = LazyLock::new(|| Mutex::new(HashSet::new()));
 static USED_UDP_PORTS: LazyLock<Mutex<HashSet<u16>>> = LazyLock::new(|| Mutex::new(HashSet::new()));
+
+/// A process-local allocator backed by a kernel-owned TCP socket lease.
+///
+/// The lease remains bound for the lifetime of the allocator, so concurrent
+/// processes cannot reserve the same block. The operating system releases it
+/// automatically if the process terminates abnormally. Before accepting a
+/// block, all remaining ports are probed so blocks still used by orphaned child
+/// processes are skipped.
+#[derive(Debug)]
+pub struct ReservedPortBlock {
+    lease: TcpListener,
+    tcp_next: u16,
+    tcp_end: u16,
+    udp_next: u16,
+    udp_end: u16,
+}
+
+impl ReservedPortBlock {
+    /// Reserves one test port block for the lifetime of the returned allocator.
+    #[must_use]
+    pub fn try_new() -> Option<Self> {
+        let max_block_start =
+            TEST_PORT_RANGE_END.checked_sub(TEST_PORT_BLOCK_SIZE.saturating_sub(1))?;
+
+        for block_start in
+            (TEST_PORT_RANGE_START..=max_block_start).step_by(usize::from(TEST_PORT_BLOCK_SIZE))
+        {
+            let tcp_end = block_start + (TEST_PORT_BLOCK_SIZE / 2) - 1;
+            let udp_next = tcp_end + 1;
+            let udp_end = block_start + TEST_PORT_BLOCK_SIZE - 1;
+
+            // Holding this socket is the cross-process claim. Unlike a claim
+            // file, it cannot become stale or be removed by an ABA race.
+            let Ok(lease) = TcpListener::bind(("127.0.0.1", block_start)) else {
+                continue;
+            };
+
+            if !all_ports_available(block_start + 1, tcp_end, udp_next, udp_end) {
+                continue;
+            }
+
+            return Some(Self {
+                lease,
+                // The first TCP port is kept bound as the block lease and is
+                // therefore intentionally not returned to callers.
+                tcp_next: block_start + 1,
+                tcp_end,
+                udp_next,
+                udp_end,
+            });
+        }
+
+        None
+    }
+
+    /// Returns the first port in this allocator's reserved block.
+    #[must_use]
+    pub fn block_start(&self) -> Option<u16> {
+        self.lease.local_addr().ok().map(|address| address.port())
+    }
+
+    /// Returns an available TCP port from the reserved block.
+    pub fn next_tcp_port(&mut self) -> Option<u16> {
+        while self.tcp_next <= self.tcp_end {
+            let candidate = self.tcp_next;
+            self.tcp_next = self.tcp_next.saturating_add(1);
+
+            if is_tcp_port_available(candidate) {
+                return Some(candidate);
+            }
+        }
+
+        get_available_tcp_port()
+    }
+
+    /// Returns an available UDP port from the reserved block.
+    pub fn next_udp_port(&mut self) -> Option<u16> {
+        while self.udp_next <= self.udp_end {
+            let candidate = self.udp_next;
+            self.udp_next = self.udp_next.saturating_add(1);
+
+            if is_udp_port_available(candidate) {
+                return Some(candidate);
+            }
+        }
+
+        get_available_udp_port()
+    }
+}
+
+fn all_ports_available(tcp_start: u16, tcp_end: u16, udp_start: u16, udp_end: u16) -> bool {
+    (tcp_start..=tcp_end).all(is_tcp_port_available)
+        && (udp_start..=udp_end).all(is_udp_port_available)
+}
+
+fn is_tcp_port_available(port: u16) -> bool {
+    TcpListener::bind(("127.0.0.1", port)).is_ok()
+}
+
+fn is_udp_port_available(port: u16) -> bool {
+    UdpSocket::bind(("127.0.0.1", port)).is_ok()
+}
 
 /// Get an available TCP port from the OS by binding to port 0.
 ///
@@ -49,4 +155,120 @@ pub fn get_available_udp_port() -> Option<u16> {
         }
     }
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::HashSet,
+        env, fs,
+        path::{Path, PathBuf},
+        process::{Command, Stdio},
+        thread,
+        time::{Duration, Instant},
+    };
+
+    use super::ReservedPortBlock;
+
+    const CHILD_MARKER_ENV: &str = "LOGOS_PORT_BLOCK_TEST_MARKER";
+    const CHILD_RELEASE_ENV: &str = "LOGOS_PORT_BLOCK_TEST_RELEASE";
+
+    #[test]
+    fn reservations_are_unique_across_processes() {
+        const CHILD_COUNT: usize = 4;
+        const TIMEOUT: Duration = Duration::from_secs(20);
+
+        let temp_dir = tempfile::tempdir().expect("temporary directory should be created");
+        let release_path = temp_dir.path().join("release");
+        let current_exe = env::current_exe().expect("current test executable should be available");
+        let mut children = Vec::with_capacity(CHILD_COUNT);
+        let mut marker_paths = Vec::with_capacity(CHILD_COUNT);
+
+        for child_index in 0..CHILD_COUNT {
+            let marker_path = temp_dir.path().join(format!("child-{child_index}"));
+            let child = Command::new(&current_exe)
+                .args([
+                    "--ignored",
+                    "--exact",
+                    "net::tests::reservation_child_process",
+                ])
+                .env(CHILD_MARKER_ENV, &marker_path)
+                .env(CHILD_RELEASE_ENV, &release_path)
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .spawn()
+                .expect("child test process should start");
+            children.push(child);
+            marker_paths.push(marker_path);
+        }
+
+        let deadline = Instant::now() + TIMEOUT;
+        while marker_paths.iter().any(|path| !path.exists()) && Instant::now() < deadline {
+            thread::sleep(Duration::from_millis(10));
+        }
+
+        let all_children_ready = marker_paths.iter().all(|path| path.exists());
+        let block_starts = if all_children_ready {
+            marker_paths
+                .iter()
+                .map(|path| read_block_start(path))
+                .collect::<Vec<_>>()
+        } else {
+            Vec::new()
+        };
+
+        fs::write(&release_path, b"release").expect("children should be released");
+        let statuses = children
+            .iter_mut()
+            .map(|child| child.wait().expect("child test process should exit"))
+            .collect::<Vec<_>>();
+
+        assert!(
+            all_children_ready,
+            "all child processes should acquire a block"
+        );
+        assert!(
+            statuses.iter().all(std::process::ExitStatus::success),
+            "all child processes should exit successfully"
+        );
+        assert_eq!(
+            block_starts.iter().copied().collect::<HashSet<_>>().len(),
+            CHILD_COUNT,
+            "concurrent processes must reserve distinct port blocks"
+        );
+    }
+
+    #[test]
+    #[ignore = "helper process invoked by reservations_are_unique_across_processes"]
+    fn reservation_child_process() {
+        const TIMEOUT: Duration = Duration::from_secs(20);
+
+        let marker_path = PathBuf::from(
+            env::var_os(CHILD_MARKER_ENV).expect("child marker environment variable should exist"),
+        );
+        let release_path = PathBuf::from(
+            env::var_os(CHILD_RELEASE_ENV)
+                .expect("child release environment variable should exist"),
+        );
+        let allocator = ReservedPortBlock::try_new().expect("child should reserve a port block");
+
+        let block_start = allocator
+            .block_start()
+            .expect("lease address should be available");
+        fs::write(&marker_path, block_start.to_string()).expect("child marker should be written");
+
+        let deadline = Instant::now() + TIMEOUT;
+        while !release_path.exists() && Instant::now() < deadline {
+            thread::sleep(Duration::from_millis(10));
+        }
+
+        assert!(release_path.exists(), "parent should release child process");
+    }
+
+    fn read_block_start(path: &Path) -> u16 {
+        fs::read_to_string(path)
+            .expect("child marker should be readable")
+            .parse()
+            .expect("child marker should contain a port block start")
+    }
 }

--- a/utils/src/net.rs
+++ b/utils/src/net.rs
@@ -7,20 +7,23 @@ use std::{
 const TEST_PORT_BLOCK_SIZE: u16 = 256;
 const TEST_PORT_RANGE_START: u16 = 20_000;
 const TEST_PORT_RANGE_END: u16 = 55_000;
+const TEST_PORT_CLAIM_RANGE_START: u16 = TEST_PORT_RANGE_END + 1;
 
 static USED_TCP_PORTS: LazyLock<Mutex<HashSet<u16>>> = LazyLock::new(|| Mutex::new(HashSet::new()));
 static USED_UDP_PORTS: LazyLock<Mutex<HashSet<u16>>> = LazyLock::new(|| Mutex::new(HashSet::new()));
 
 /// A process-local allocator backed by a kernel-owned TCP socket lease.
 ///
+/// Each block maps to a dedicated claim port above the test data-port range.
 /// The lease remains bound for the lifetime of the allocator, so concurrent
 /// processes cannot reserve the same block. The operating system releases it
 /// automatically if the process terminates abnormally. Before accepting a
-/// block, all remaining ports are probed so blocks still used by orphaned child
+/// block, all data ports are probed so blocks still used by orphaned child
 /// processes are skipped.
 #[derive(Debug)]
 pub struct ReservedPortBlock {
     lease: TcpListener,
+    block_start: u16,
     tcp_next: u16,
     tcp_end: u16,
     udp_next: u16,
@@ -34,28 +37,30 @@ impl ReservedPortBlock {
         let max_block_start =
             TEST_PORT_RANGE_END.checked_sub(TEST_PORT_BLOCK_SIZE.saturating_sub(1))?;
 
-        for block_start in
-            (TEST_PORT_RANGE_START..=max_block_start).step_by(usize::from(TEST_PORT_BLOCK_SIZE))
+        for (block_index, block_start) in (TEST_PORT_RANGE_START..=max_block_start)
+            .step_by(usize::from(TEST_PORT_BLOCK_SIZE))
+            .enumerate()
         {
             let tcp_end = block_start + (TEST_PORT_BLOCK_SIZE / 2) - 1;
             let udp_next = tcp_end + 1;
             let udp_end = block_start + TEST_PORT_BLOCK_SIZE - 1;
+            let claim_port =
+                TEST_PORT_CLAIM_RANGE_START.checked_add(u16::try_from(block_index).ok()?)?;
 
             // Holding this socket is the cross-process claim. Unlike a claim
             // file, it cannot become stale or be removed by an ABA race.
-            let Ok(lease) = TcpListener::bind(("127.0.0.1", block_start)) else {
+            let Ok(lease) = TcpListener::bind(("127.0.0.1", claim_port)) else {
                 continue;
             };
 
-            if !all_ports_available(block_start + 1, tcp_end, udp_next, udp_end) {
+            if !all_ports_available(block_start, tcp_end, udp_next, udp_end) {
                 continue;
             }
 
             return Some(Self {
                 lease,
-                // The first TCP port is kept bound as the block lease and is
-                // therefore intentionally not returned to callers.
-                tcp_next: block_start + 1,
+                block_start,
+                tcp_next: block_start,
                 tcp_end,
                 udp_next,
                 udp_end,
@@ -67,7 +72,13 @@ impl ReservedPortBlock {
 
     /// Returns the first port in this allocator's reserved block.
     #[must_use]
-    pub fn block_start(&self) -> Option<u16> {
+    pub const fn block_start(&self) -> u16 {
+        self.block_start
+    }
+
+    /// Returns the dedicated TCP port that owns this block's kernel lease.
+    #[must_use]
+    pub fn claim_port(&self) -> Option<u16> {
         self.lease.local_addr().ok().map(|address| address.port())
     }
 
@@ -168,7 +179,10 @@ mod tests {
         time::{Duration, Instant},
     };
 
-    use super::ReservedPortBlock;
+    use super::{
+        ReservedPortBlock, TEST_PORT_BLOCK_SIZE, TEST_PORT_CLAIM_RANGE_START, TEST_PORT_RANGE_END,
+        TEST_PORT_RANGE_START,
+    };
 
     const CHILD_MARKER_ENV: &str = "LOGOS_PORT_BLOCK_TEST_MARKER";
     const CHILD_RELEASE_ENV: &str = "LOGOS_PORT_BLOCK_TEST_RELEASE";
@@ -239,6 +253,54 @@ mod tests {
     }
 
     #[test]
+    fn reservation_preserves_full_tcp_and_udp_halves() {
+        let mut allocator = ReservedPortBlock::try_new().expect("a test port block should exist");
+        let block_start = allocator.block_start();
+        let half_block_size = TEST_PORT_BLOCK_SIZE / 2;
+        let expected_tcp_end = block_start + half_block_size - 1;
+        let expected_udp_start = block_start + half_block_size;
+        let expected_block_end = block_start + TEST_PORT_BLOCK_SIZE - 1;
+        let claim_port = allocator
+            .claim_port()
+            .expect("lease address should be available");
+
+        assert_eq!(allocator.tcp_next, block_start);
+        assert_eq!(allocator.tcp_end, expected_tcp_end);
+        assert_eq!(allocator.udp_next, expected_udp_start);
+        assert_eq!(allocator.udp_end, expected_block_end);
+        assert_eq!(allocator.tcp_end - allocator.tcp_next + 1, half_block_size);
+        assert_eq!(allocator.udp_end - allocator.udp_next + 1, half_block_size);
+        assert_eq!(
+            allocator.next_tcp_port(),
+            Some(block_start),
+            "the first TCP data port must remain allocatable"
+        );
+        assert!(
+            claim_port >= TEST_PORT_CLAIM_RANGE_START,
+            "the lease must use the dedicated claim range"
+        );
+        assert!(
+            claim_port > TEST_PORT_RANGE_END,
+            "the lease must not consume a data port"
+        );
+
+        let candidate_count =
+            ((TEST_PORT_RANGE_END - TEST_PORT_RANGE_START + 1) / TEST_PORT_BLOCK_SIZE) as usize;
+        let claim_port_capacity = usize::from(u16::MAX - TEST_PORT_CLAIM_RANGE_START) + 1;
+        let claim_range_end = TEST_PORT_CLAIM_RANGE_START
+            + u16::try_from(candidate_count).expect("candidate count should fit in u16")
+            - 1;
+        assert!(
+            claim_port_capacity >= candidate_count,
+            "the claim range must cover every candidate block"
+        );
+        assert!(
+            claim_port <= claim_range_end,
+            "the lease must map into the candidate block's claim range"
+        );
+    }
+
+    #[test]
     #[ignore = "helper process invoked by reservations_are_unique_across_processes"]
     fn reservation_child_process() {
         const TIMEOUT: Duration = Duration::from_secs(20);
@@ -252,9 +314,7 @@ mod tests {
         );
         let allocator = ReservedPortBlock::try_new().expect("child should reserve a port block");
 
-        let block_start = allocator
-            .block_start()
-            .expect("lease address should be available");
+        let block_start = allocator.block_start();
         fs::write(&marker_path, block_start.to_string()).expect("child marker should be written");
 
         let deadline = Instant::now() + TIMEOUT;


### PR DESCRIPTION
## 1. What does this PR implement?

Closes #3431.

This replaces the duplicated PID/lock-file port-block allocators with a shared `ReservedPortBlock` backed by a kernel-held TCP claim socket. The claim cannot be removed by the stale-file ABA race and is released automatically when the process exits.

It also:
- maps every 256-port data block to a dedicated claim port above the data range;
- probes the full TCP/UDP block before claiming it, so blocks still used by orphaned children are skipped;
- preserves all 128 TCP and 128 UDP data ports;
- removes stale-file reapers that are no longer needed;
- adds a four-child cross-process uniqueness test and full-layout regression.

## 2. Does the code have enough context to be clearly understood?

The reproduced collision, port layout, ABA sequence, and orphan-process case are documented in #3431.

Each block index maps deterministically to one claim port in `55001..55136`, outside the data range `20000..55000`. Holding that socket is the cross-process lease; the full 256-port data block remains available to callers.

Checks:
- `cargo test -p logos-blockchain-utils` (85 passed, 1 ignored helper)
- `cargo clippy -p logos-blockchain-utils --all-targets -- -D warnings`
- `cargo fmt -p logos-blockchain-utils`
- `git diff --check`

The wider Windows consumer check is blocked before these crates by the existing `rust-rapidsnark` build script requiring `sh` and having no Windows target mapping.

## 3. Who are the specification authors and who is accountable for this PR?

#3431 was authored by @hansieodendaal. @zakazaka95 is accountable for this implementation.

## 4. Is the specification accurate and complete?

Yes. #3431 covers both the stale-claim ABA race and the orphaned-child case addressed here.

## 5. Does the implementation introduce changes in the specification?

No. The 256-port block layout and 128 TCP / 128 UDP split are preserved. Only the cross-process claim mechanism changes.

## Checklist

- [x] 1. The PR title follows Conventional Commits.
- [x] 2. Description added.
- [x] 3. Context and specification link added.
- [x] 4. Main contact and specification author added.
- [x] 5. Implementation and issue specification are in sync.
- [ ] 6. Link PR to a specific milestone.
- [x] 7. No logs were added or changed.