### PR TITLE
chore: Bump logos-blockchain-circuits to 0.5.6 in flake.nix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,16 +20,16 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1785937360,
-        "narHash": "sha256-Id4IZ1pQ5qcTabs4fFWbfSZPHEbyDAx/3CDKv4CawII=",
+        "lastModified": 1786522397,
+        "narHash": "sha256-qaQNoq+n60WrpuCZuSNwcNV3ZXm1JXhBh1btehJTlWQ=",
         "owner": "logos-blockchain",
         "repo": "logos-blockchain-circuits",
-        "rev": "32f1ac43f331f0eeff3a2a0aec0f153564d03583",
+        "rev": "07c439356435eb6a2f1f4a8daa973bd04bd0b088",
         "type": "github"
       },
       "original": {
         "owner": "logos-blockchain",
-        "ref": "v0.5.5",
+        "ref": "v0.5.6",
         "repo": "logos-blockchain-circuits",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
 
     # Must stay in sync with the lbc-* tags in Cargo.toml.
     logos-blockchain-circuits = {
-      url = "github:logos-blockchain/logos-blockchain-circuits/v0.5.5";
+      url = "github:logos-blockchain/logos-blockchain-circuits/v0.5.6";
     };
 
     # Must stay in sync with the rust-rapidsnark rev in Cargo.toml.


### PR DESCRIPTION
## 1. What does this PR implement?

Comment from our `Cargo.toml`:
```
When bumping any lbc-* tag, also update the logos-blockchain-circuits flake input tag in flake.nix
and run `nix flake lock --update-input logos-blockchain-circuits`.
```

The crate was bumped to `0.5.6`, but `flake.nix` still had `0.5.5`.

## 2. Does the code have enough context to be clearly understood?

Versions need to match for circuits to work.

## 3. Who are the specification authors and who is accountable for this PR?

@thomaslavaur 

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

N/A

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
