### PR TITLE
fix(release): remove non-existent inscribe subcommand from release template

### DIFF
--- a/.github/release/release-content.md
+++ b/.github/release/release-content.md
@@ -112,16 +112,6 @@ Approximately 3.5h (two epochs) after you receive funds from the faucet, your no
 
 ---
 
-## 📝 Inscribing
-
-Start publishing messages to the blockchain using the built in text sequencer:
-
-```bash
-./logos-blockchain-node inscribe
-```
-
----
-
 ## 🛟 Troubleshooting
 
 Having issues? Reach out to the Logos Blockchain team on [Discord][testnet-discord-public] or check the [testnet Notion page][release-notion] for FAQs and up-to-date instructions.


### PR DESCRIPTION
## 1. What does this PR implement?

Removes the "📝 Inscribing" section from `.github/release/release-content.md`. It instructed users to run:

```bash
./logos-blockchain-node inscribe
```

The node binary has no `inscribe` subcommand (see the `Command` enum in `nodes/node/binary/src/cli/mod.rs`), so anyone following the published release notes would hit a clap error. The section has been in the template since it was introduced in #3024.

The only `inscribe` subcommand in the repo belongs to `logos-blockchain-tools-genesis`, which generates the genesis `InscriptionOp` during the ceremony and is not a user-facing node command.

## 2. Does the code have enough context to be clearly understood?

Docs-only change to the release note template. No specification involved.

## 3. Who are the specification authors and who is accountable for this PR?

@davidrusu

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

N/A

## Checklist

* [x] 1. The PR title follows the Conventional Commits specification.
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added (N/A, template-only change).
* [x] 4. Main contact(s) added.
* [x] 5. Implementation and Specification are 100% in sync (N/A).
* [ ] 6. Link PR to a specific milestone.
* [x] 7. No log changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)