### PR TITLE
fix(pow): Clamp claims to blend network payload size

### DIFF
--- a/services/blend/src/message.rs
+++ b/services/blend/src/message.rs
@@ -1,8 +1,8 @@
 use core::fmt::{self, Debug, Formatter};
 
+pub use lb_blend::message::MAX_PAYLOAD_BODY_SIZE;
 use lb_blend::message::{
-    MAX_PAYLOAD_BODY_SIZE, PayloadType,
-    encap::validated::EncapsulatedMessageWithVerifiedPublicHeader,
+    PayloadType, encap::validated::EncapsulatedMessageWithVerifiedPublicHeader,
 };
 use lb_core::{
     mantle::NoteId,

--- a/services/pow/Cargo.toml
+++ b/services/pow/Cargo.toml
@@ -23,6 +23,7 @@ tracing      = { workspace = true }
 lb-blend-service              = { workspace = true }
 lb-chain-service              = { workspace = true }
 lb-core                       = { workspace = true }
+lb-groth16                    = { workspace = true }
 lb-key-management-system-keys = { workspace = true }
 lb-ledger                     = { workspace = true }
 lb-log-targets                = { workspace = true }
@@ -35,7 +36,6 @@ lb-zksign                     = { workspace = true }
 overwatch                     = { workspace = true }
 
 [dev-dependencies]
-lb-groth16 = { workspace = true }
 serde_json = { workspace = true }
 tokio      = { features = ["macros", "rt"], workspace = true }
 

--- a/services/pow/src/service.rs
+++ b/services/pow/src/service.rs
@@ -5,14 +5,14 @@ use std::{
     marker::PhantomData,
     num::{NonZeroU64, NonZeroUsize},
     pin::Pin,
-    sync::Arc,
+    sync::{Arc, LazyLock},
     time::Duration,
 };
 
 use futures::{Stream, StreamExt as _};
 use lb_blend_service::{
     api::{ApiError as BlendApiError, BlendServiceApi, BlendServiceData},
-    message::{BlendPayload, TransactionTooLarge},
+    message::{BlendPayload, MAX_PAYLOAD_BODY_SIZE, TransactionTooLarge},
 };
 use lb_chain_service::{
     ProcessedBlockEvent, Slot,
@@ -40,7 +40,10 @@ use lb_core::{
         },
     },
 };
-use lb_key_management_system_keys::keys::{MAX_ZK_SIGNING_KEYS, UnsecuredZkKey, ZkPublicKey};
+use lb_groth16::COMPRESSED_PROOF_SIZE;
+use lb_key_management_system_keys::keys::{
+    MAX_ZK_SIGNING_KEYS, UnsecuredZkKey, ZkPublicKey, ZkSignature,
+};
 use lb_ledger::LedgerState;
 use lb_log_targets::pow;
 use lb_services_utils::{
@@ -53,7 +56,7 @@ use lb_storage_service::{
 use lb_time_service::{TimeService, TimeServiceMessage, backends::TimeBackend};
 use lb_utils::bounded::BoundedError;
 use lb_wallet_service::api::{WalletApi, WalletApiError, WalletServiceData};
-use lb_zksign::ZkSignError;
+use lb_zksign::{ZkSignError, ZkSignProof};
 use overwatch::{
     DynError, OpaqueServiceResourcesHandle,
     overwatch::OverwatchHandle,
@@ -73,7 +76,7 @@ use tracing::{
     error,
     log::{info, warn},
 };
-
+use crate::PoWError::SignedOps;
 use crate::tickets::{TicketGenerator, WinningTicket};
 
 const LOG_TARGET: &str = pow::ROOT;
@@ -1251,6 +1254,59 @@ const fn max_claims_by_ops() -> usize {
     claims
 }
 
+/// Size, in bytes, of the claim transaction a batch of `claims` tickets
+/// produces once signed, measured through the codec [`publish_reward_claim`]
+/// encodes with on a transaction of exactly that shape.
+///
+/// The probe is assembled from zeroed claims and a zeroed signature, and
+/// shares [`transfer_ops`], [`push_reward_claim_ops`] and
+/// [`claim_ops_proofs`] with the real builder so its shape cannot drift from
+/// one. Values do not change the encoded length — the codec uses fixed-width
+/// integers, and a signature is a fixed-size byte triple — so the probe
+/// measures the real batch, and nothing here is signed: it costs microseconds
+/// rather than a proof per transfer group.
+///
+/// [`claim_tx_size_matches_a_signed_transaction`] pins that equivalence.
+fn claim_tx_size(claims: usize) -> Result<u64, PoWError> {
+    let claim = ClaimPowRewardOp {
+        epoch_nonce: *ZkPublicKey::zero().as_fr(),
+        block_hash: [0u8; 32],
+        public_key: ZkPublicKey::zero(),
+    };
+    let signature = ZkSignature::new(ZkSignProof::from_bytes(&[0u8; COMPRESSED_PROOF_SIZE]));
+    let groups = claims.div_ceil(MAX_TRANSFER_INPUTS);
+
+    let probe_claims = vec![claim.clone(); claims];
+    let note_ids = vec![Utxo::new(claim.op_id(), 0, Note::new(0, claim.public_key)).id(); claims];
+    let transfers = transfer_ops(&note_ids, ZkPublicKey::zero(), &vec![0; groups])?;
+
+    let mantle_tx =
+        push_reward_claim_ops(MantleTxBuilder::new(), &probe_claims, transfers)?.build()?;
+    let ops_proofs = claim_ops_proofs(claims, std::iter::repeat_n(signature, groups))?;
+
+    Ok(SignedOps::new(mantle_tx, ops_proofs).bytes_size()?)
+}
+
+/// Largest claim count whose transaction still fits the body of a Blend
+/// payload, the transport every claim is published over.
+///
+/// This binds well before [`max_claims_by_ops`] does: 255 ops' worth of claims
+/// serializes to nearly twice what a payload can carry, and a transaction over
+/// the limit is rejected by [`publish_reward_claim`] *after* its (CPU-heavy)
+/// signatures have been produced. Capping the batch here keeps that failure
+/// from ever being reached.
+///
+/// Resolved once, by shrinking a probe batch from the op cap until it fits, so
+/// the limit follows the encoding rather than restating it.
+static MAX_CLAIMS_BY_PAYLOAD_SIZE: LazyLock<usize> = LazyLock::new(|| {
+    (1..=max_claims_by_ops())
+        .rev()
+        .find(|&claims| {
+            claim_tx_size(claims).is_ok_and(|size| size <= MAX_PAYLOAD_BODY_SIZE as u64)
+        })
+        .expect("a single-claim tx fits a Blend payload")
+});
+
 /// Builds and signs a single self-funding reward-claim transaction from a batch
 /// of winning tickets.
 ///
@@ -1261,9 +1317,9 @@ const fn max_claims_by_ops() -> usize {
 /// freshly minted UTXOs, reconstructed here from the same data the ledger uses,
 /// and is signed by those notes' owning keys.
 ///
-/// Only as many claims are taken as `reward_pool` can fund and the per-tx op
-/// limit allows. Returns the signed tx together with the number of tickets (a
-/// prefix of `tickets`) it actually claims.
+/// Only as many claims are taken as `reward_pool` can fund, the per-tx op
+/// limit allows, and a Blend payload can carry. Returns the signed tx together
+/// with the number of tickets (a prefix of `tickets`) it actually claims.
 ///
 /// `reward_pool` is passed in rather than read from `ledger_state` so a caller
 /// publishing several transactions back to back can draw down its own running
@@ -1304,32 +1360,33 @@ async fn build_reward_claim_tx_inner(
         leader_reward_amount: 0,
     };
 
-    // Take as many claims as the pool can fund and the op budget allows.
+    // Take as many claims as the pool can fund, the op budget allows, and a
+    // Blend payload can carry.
     let claim_count = tickets
         .len()
         .min((reward_pool / reward_value) as usize)
-        .min(max_claims_by_ops());
+        .min(max_claims_by_ops())
+        .min(*MAX_CLAIMS_BY_PAYLOAD_SIZE);
     if claim_count == 0 {
         return Err(PoWError::RewardPoolExhausted);
     }
     let tickets = &tickets[..claim_count];
+    let claims: Vec<ClaimPowRewardOp> = tickets.iter().map(|(_, claim)| claim.clone()).collect();
 
     // Reconstruct the id of the UTXO each claim mints (op_id, output 0, reward
     // note), so the transfers can spend them.
-    let note_ids: Vec<NoteId> = tickets
+    let note_ids: Vec<NoteId> = claims
         .iter()
-        .map(|(_, claim)| {
-            Utxo::new(claim.op_id(), 0, Note::new(reward_value, claim.public_key)).id()
-        })
+        .map(|claim| Utxo::new(claim.op_id(), 0, Note::new(reward_value, claim.public_key)).id())
         .collect();
 
     // Size the change against the final tx shape, then spread the fee across
     // the transfer outputs.
-    let fee = estimate_reward_claim_fee(tickets, &note_ids, claim_address, &context)?;
+    let fee = estimate_reward_claim_fee(&claims, &note_ids, claim_address, &context)?;
     let change_outputs = change_outputs(&note_ids, reward_value, fee)?;
     let transfers = transfer_ops(&note_ids, claim_address, &change_outputs)?;
 
-    let mantle_tx = push_reward_claim_ops(MantleTxBuilder::new(), tickets, transfers)?.build()?;
+    let mantle_tx = push_reward_claim_ops(MantleTxBuilder::new(), &claims, transfers)?.build()?;
 
     // Sign each transfer with the keys owning its input notes (a
     // multi-signature over the whole tx hash). Signing is a ZK proof
@@ -1347,16 +1404,9 @@ async fn build_reward_claim_tx_inner(
     })
     .await??;
 
-    // Proofs follow the op order: a `None` per claim in the group, then that
-    // group's transfer `ZkSig`.
-    let mut ops_proofs = OpProofs::empty();
-    for (group, zk_sig) in tickets.chunks(MAX_TRANSFER_INPUTS).zip(zk_sigs) {
-        for _ in group {
-            ops_proofs.try_push(OpProof::None(NoOpProof))?;
-        }
-        ops_proofs.try_push(OpProof::ZkSig(zk_sig))?;
-    }
+    let ops_proofs = claim_ops_proofs(claim_count, zk_sigs)?;
     let tx = SignedOps::from_parts(mantle_tx, ops_proofs)?;
+
     Ok((tx, claim_count))
 }
 
@@ -1385,19 +1435,37 @@ fn transfer_ops(
 /// transfer. This is where the leaf ops are wrapped into their [`Op`] variants.
 fn push_reward_claim_ops(
     mut builder: MantleTxBuilder,
-    tickets: &[(UnsecuredZkKey, ClaimPowRewardOp)],
+    claims: &[ClaimPowRewardOp],
     transfers: Vec<TransferOp>,
 ) -> Result<MantleTxBuilder, PoWError> {
-    for (claim_group, transfer) in tickets.chunks(MAX_TRANSFER_INPUTS).zip(transfers) {
+    for (claim_group, transfer) in claims.chunks(MAX_TRANSFER_INPUTS).zip(transfers) {
         builder = builder
-            .extend_ops(
-                claim_group
-                    .iter()
-                    .map(|(_, claim)| Op::ClaimPowReward(claim.clone())),
-            )?
+            .extend_ops(claim_group.iter().cloned().map(Op::ClaimPowReward))?
             .push_op(Op::Transfer(transfer))?;
     }
     Ok(builder)
+}
+
+/// The proof list a claim transaction carries, in op order: a `None` proof per
+/// claim in a group, then that group's transfer signature.
+///
+/// Shared with [`claim_tx_size`], so a probe transaction is proved-for exactly
+/// as the real one is.
+fn claim_ops_proofs(
+    claims: usize,
+    zk_sigs: impl IntoIterator<Item = ZkSignature>,
+) -> Result<OpProofs, PoWError> {
+    let mut ops_proofs = OpProofs::empty();
+    let mut remaining = claims;
+    for zk_sig in zk_sigs {
+        let group = remaining.min(MAX_TRANSFER_INPUTS);
+        remaining -= group;
+        for _ in 0..group {
+            ops_proofs.try_push(OpProof::None(NoOpProof))?;
+        }
+        ops_proofs.try_push(OpProof::ZkSig(zk_sig))?;
+    }
+    Ok(ops_proofs)
 }
 
 /// The change value each transfer group returns: the reward its notes carry,
@@ -1452,7 +1520,7 @@ where
 /// shape. The change output values do not affect gas, so it is measured against
 /// zero-value outputs.
 fn estimate_reward_claim_fee(
-    tickets: &[(UnsecuredZkKey, ClaimPowRewardOp)],
+    claims: &[ClaimPowRewardOp],
     note_ids: &[NoteId],
     claim_address: ZkPublicKey,
     context: &OpsContext,
@@ -1460,7 +1528,7 @@ fn estimate_reward_claim_fee(
     // Change values don't affect gas, so probe with zero-value outputs.
     let num_groups = note_ids.len().div_ceil(MAX_TRANSFER_INPUTS);
     let transfers = transfer_ops(note_ids, claim_address, &vec![0; num_groups])?;
-    let fee = push_reward_claim_ops(MantleTxBuilder::new(), tickets, transfers)?
+    let fee = push_reward_claim_ops(MantleTxBuilder::new(), claims, transfers)?
         .minimum_gas_cost::<MainnetGasProfile>(context)?
         .into_inner();
     Ok(fee)
@@ -1472,6 +1540,7 @@ mod tests {
 
     use lb_chain_service::Slot;
     use lb_core::{
+        codec::SerializeOp as _,
         header::HeaderId,
         mantle::{
             Note, NoteId, OpProofRef, OpRef, SignedOps, Utxo,
@@ -1488,8 +1557,9 @@ mod tests {
     use lb_key_management_system_keys::keys::{UnsecuredZkKey, ZkPublicKey};
 
     use super::{
-        AutoClaimSettings, AutoClaimTick, ClaimTarget, MAX_TRANSFER_INPUTS, PoWError,
-        PoWServiceState, build_reward_claim_tx_inner, change_outputs, claimable_rewards_info,
+        AutoClaimSettings, AutoClaimTick, ClaimTarget, MAX_CLAIMS_BY_PAYLOAD_SIZE,
+        MAX_PAYLOAD_BODY_SIZE, MAX_TRANSFER_INPUTS, PoWError, PoWServiceState,
+        build_reward_claim_tx_inner, change_outputs, claim_tx_size, claimable_rewards_info,
         estimate_reward_claim_fee, max_claims_by_ops, neediest_target, prune_expired_tickets,
         push_reward_claim_ops, slot_period_elapsed, transfer_ops,
     };
@@ -1527,10 +1597,16 @@ mod tests {
         }
     }
 
-    /// Asserts a built tx respects the transaction's own structural limits: the
-    /// op budget, the per-transfer signing-key limit, and a correctly-typed
-    /// proof per op (the last via the ledger's stateless `preverify`).
+    /// Asserts a built tx respects every limit it has to clear: the op budget,
+    /// the per-transfer signing-key limit, a correctly-typed proof per op (via
+    /// the ledger's stateless `preverify`), and the Blend payload body it is
+    /// published in.
     fn assert_within_tx_limits(tx: &SignedOps<Unverified, StandardMode>) {
+        let size = tx.to_bytes().expect("built tx should serialize").len();
+        assert!(
+            size <= MAX_PAYLOAD_BODY_SIZE,
+            "tx of {size} bytes exceeds the {MAX_PAYLOAD_BODY_SIZE} a Blend payload carries"
+        );
         let op_refs = tx.op_refs();
         assert!(
             op_refs.len() <= MAX_OPS_PER_TX,
@@ -1734,12 +1810,12 @@ mod tests {
 
     #[test]
     fn push_reward_claim_ops_interleaves_claims_and_transfers() {
-        let tickets: Vec<_> = std::iter::repeat_with(ticket).take(40).collect();
+        let claims: Vec<_> = std::iter::repeat_with(|| ticket().1).take(40).collect();
         let notes: Vec<NoteId> = (0u8..40).map(note_id).collect();
         let changes = change_outputs(&notes, 100, 0).unwrap();
         let transfers = transfer_ops(&notes, ZkPublicKey::zero(), &changes).unwrap();
 
-        let tx = push_reward_claim_ops(MantleTxBuilder::new(), &tickets, transfers)
+        let tx = push_reward_claim_ops(MantleTxBuilder::new(), &claims, transfers)
             .unwrap()
             .build()
             .unwrap();
@@ -1762,10 +1838,10 @@ mod tests {
 
     #[test]
     fn estimate_reward_claim_fee_is_positive_with_nonzero_gas_prices() {
-        let tickets = vec![ticket()];
+        let claims = vec![ticket().1];
         let notes = vec![note_id(0)];
         let fee =
-            estimate_reward_claim_fee(&tickets, &notes, ZkPublicKey::zero(), &context()).unwrap();
+            estimate_reward_claim_fee(&claims, &notes, ZkPublicKey::zero(), &context()).unwrap();
         assert!(fee > 0);
     }
 
@@ -1912,15 +1988,20 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn build_reward_claim_tx_caps_claims_to_the_op_limit_and_stays_within_it() {
-        // More tickets and pool room than the op budget allows: the cap is the
-        // op limit, and the resulting tx must still fit within it.
-        let cap = max_claims_by_ops();
+    async fn build_reward_claim_tx_caps_claims_to_what_a_blend_payload_carries() {
+        // More tickets and pool room than any cap allows. The payload budget
+        // is the tightest of the three, so it is the one that binds, and the
+        // resulting tx must fit the payload a claim is published in.
+        let cap = *MAX_CLAIMS_BY_PAYLOAD_SIZE;
+        assert!(
+            cap < max_claims_by_ops(),
+            "the payload budget is expected to bind before the op budget"
+        );
         let tickets: Vec<_> = std::iter::repeat_with(ticket).take(cap + 50).collect();
         let (tx, claimed) = build_reward_claim_tx_inner(
             ZkPublicKey::zero(),
             REWARD,
-            POOL, // POOL / REWARD = 1000 > cap, so the op limit binds
+            POOL, // POOL / REWARD = 1000 > cap, so the pool does not bind
             GasPrices::new(1, 1),
             &tickets,
         )
@@ -1937,9 +2018,48 @@ mod tests {
         let transfers = ops.len() - claims;
         assert_eq!(claims, cap);
         assert_eq!(transfers, cap.div_ceil(MAX_TRANSFER_INPUTS));
-        // The cap is the largest batch that still fits the op budget exactly.
-        assert!(ops.len() <= MAX_OPS_PER_TX);
-        assert!(claims + 1 + (claims + 1).div_ceil(MAX_TRANSFER_INPUTS) > MAX_OPS_PER_TX);
+    }
+
+    /// [`claim_tx_size`] measures a probe transaction rather than the one that
+    /// is published, so the two shapes have to encode identically. This is
+    /// what pins that: it compares the probe against really signed
+    /// transactions at a single claim, a pair in one group, a full group, and
+    /// the claim that opens the next one, so both the per-claim and per-group
+    /// terms are covered.
+    ///
+    /// A failure here means the probe has drifted from what
+    /// `build_reward_claim_tx_inner` builds — an op, a proof, or a transfer
+    /// the real transaction carries and the probe does not, or vice versa.
+    /// Fix the probe to match the builder; do not adjust the expected sizes,
+    /// and do not relax this test. A probe that over-estimates needlessly
+    /// shrinks every batch, and one that under-estimates puts the node back to
+    /// building claims Blend refuses to carry.
+    #[tokio::test]
+    async fn claim_tx_size_matches_a_signed_transaction() {
+        for claims in [1, 2, MAX_TRANSFER_INPUTS, MAX_TRANSFER_INPUTS + 1] {
+            let tickets: Vec<_> = std::iter::repeat_with(ticket).take(claims).collect();
+            let (tx, _) = build_reward_claim_tx_inner(
+                ZkPublicKey::zero(),
+                REWARD,
+                POOL,
+                GasPrices::new(1, 1),
+                &tickets,
+            )
+            .await
+            .unwrap();
+            assert_eq!(
+                tx.to_bytes().unwrap().len() as u64,
+                claim_tx_size(claims).unwrap(),
+                "probe disagrees with a signed tx at {claims} claim(s)"
+            );
+        }
+    }
+
+    #[test]
+    fn the_payload_cap_is_the_largest_batch_a_payload_carries() {
+        let claims = *MAX_CLAIMS_BY_PAYLOAD_SIZE;
+        assert!(claim_tx_size(claims).unwrap() <= MAX_PAYLOAD_BODY_SIZE as u64);
+        assert!(claim_tx_size(claims + 1).unwrap() > MAX_PAYLOAD_BODY_SIZE as u64);
     }
 
     /// A winning ticket anchored to a block at `block_slot`.

--- a/services/pow/src/service.rs
+++ b/services/pow/src/service.rs
@@ -19,7 +19,7 @@ use lb_chain_service::{
     api::{ApiError as ChainApiError, CryptarchiaServiceApi, CryptarchiaServiceData},
 };
 use lb_core::{
-    codec::{Error as CodecError, SerializeOp as _},
+    codec::{Error as CodecError, SerializeOp},
     events::{Event, TxEvent, TxEventPayload},
     header::HeaderId,
     mantle::{
@@ -76,7 +76,7 @@ use tracing::{
     error,
     log::{info, warn},
 };
-use crate::PoWError::SignedOps;
+
 use crate::tickets::{TicketGenerator, WinningTicket};
 
 const LOG_TARGET: &str = pow::ROOT;
@@ -1280,11 +1280,12 @@ fn claim_tx_size(claims: usize) -> Result<u64, PoWError> {
     let note_ids = vec![Utxo::new(claim.op_id(), 0, Note::new(0, claim.public_key)).id(); claims];
     let transfers = transfer_ops(&note_ids, ZkPublicKey::zero(), &vec![0; groups])?;
 
-    let mantle_tx =
-        push_reward_claim_ops(MantleTxBuilder::new(), &probe_claims, transfers)?.build()?;
+    let ops = push_reward_claim_ops(MantleTxBuilder::new(), &probe_claims, transfers)?.build()?;
     let ops_proofs = claim_ops_proofs(claims, std::iter::repeat_n(signature, groups))?;
 
-    Ok(SignedOps::new(mantle_tx, ops_proofs).bytes_size()?)
+    Ok(SerializeOp::bytes_size(
+        &SignedOps::<_, StandardMode>::from_parts(ops, ops_proofs)?,
+    )?)
 }
 
 /// Largest claim count whose transaction still fits the body of a Blend

--- a/tests/cucumber_tests/features/pow_mining.feature
+++ b/tests/cucumber_tests/features/pow_mining.feature
@@ -70,6 +70,57 @@ Feature: PoW mining
     And wallet "WALLET_MINER" balance increased by exactly the reward from claim "POW_CLAIM_TX" over "MINER_BASELINE" in 120 seconds
     Then I stop all nodes
 
+  # The two scenarios above deliberately fund the pool for a single claim
+  # (`reward_pool_genesis == epoch_reward_genesis`), which keeps every claim
+  # transaction to one op and makes them fast — but it also means the batching
+  # caps are never reached. This one funds the pool for many claims and lets a
+  # backlog of tickets build up first, so the batch is capped by the node's own
+  # limits instead. That is the path where a claim can be built larger than the
+  # Blend payload it has to travel in: such a transaction is refused at publish
+  # time and never reaches a block, so the claim step below fails outright.
+  @blend_ci
+  Scenario: A mining node claims a backlog of rewards in one transaction
+    Given the genesis block has the following wallet resources:
+      | account_index | token_count | token_amount |
+      | 1             | 0           | 0            |
+      | 2             | 1           | 1000         |
+    And I have a cluster with capacity of 3 nodes
+    And the first 2 nodes are declared as blend providers
+    And I have user config override "cryptarchia.service.bootstrap.prolonged_bootstrap_period" as "seconds(0)"
+    And I have deployment config override "time.slot_duration" as "seconds(1)"
+    And I have deployment config override "cryptarchia.slot_activation_coeff.numerator" as "1"
+    And I have deployment config override "cryptarchia.slot_activation_coeff.denominator" as "2"
+    And I have deployment config override "cryptarchia.pow_config.reward.rate_num" as "1"
+    And I have deployment config override "cryptarchia.pow_config.reward.epoch_reward_genesis" as "1000000"
+    # Funds 1000 claims, so `reward_pool / reward` no longer caps the batch and
+    # the node's own per-transaction limits decide how many tickets it takes.
+    And I have deployment config override "cryptarchia.pow_config.reward.reward_pool_genesis" as "1000000000"
+    And I have deployment config override "cryptarchia.pow_config.reward.initial_difficulty_seed" as "0"
+    And I have deployment config override "cryptarchia.pow_config.reward.ema_smoothing_factor" as "1"
+    And I have deployment config override "cryptarchia.pow_config.reward.ema_smoothing_precision" as "1000000000000000000"
+    And I have deployment config override "cryptarchia.pow_config.reward.target_claims_per_block" as "1000000000000000000"
+    And I start node "NODE_1"
+    And I start peer node "NODE_2" connected to node "NODE_1"
+    When node "NODE_1" is at height 5 in 300 seconds
+    And I start mining nodes with wallet resources:
+      | node_name | account_index | wallet_name  | is_mining_wallet | connected_to |
+      | NODE_3    | 1             | WALLET_MINER | true             | NODE_1       |
+      | NODE_3    | 2             | OTHER_WALLET | false            | NODE_1       |
+    And node "NODE_3" is at height 6 in 180 seconds
+    And I record the balance of wallet "WALLET_MINER" as "MINER_BASELINE"
+    And I start mining on node "NODE_3"
+    # Mine until the ready set is far past any per-transaction cap, so the
+    # batch the node builds is the largest one it believes it may build.
+    And node "NODE_3" has at least 500 claimable PoW rewards within 120 seconds
+    And I stop mining on node "NODE_3"
+    And I claim PoW rewards on node "NODE_3" as "POW_CLAIM_TX" within 120 seconds
+    Then transaction "POW_CLAIM_TX" is included on node "NODE_1" in 120 seconds
+    # The claim must have batched the backlog rather than quietly falling back
+    # to a single reward, and it must be publishable while doing so.
+    And claim "POW_CLAIM_TX" batched at least 2 PoW rewards on node "NODE_1"
+    And wallet "WALLET_MINER" balance increased by exactly the reward from claim "POW_CLAIM_TX" over "MINER_BASELINE" in 120 seconds
+    Then I stop all nodes
+
   # Same setup as above, but nothing ever calls the claim endpoint: the node is
   # configured with a `pow.auto_claim` target and claims on its own. The miner's
   # account starts empty, so any balance at all proves auto-claim ran.

--- a/tests/src/cucumber/steps/pow.rs
+++ b/tests/src/cucumber/steps/pow.rs
@@ -141,19 +141,31 @@ async fn step_claim_pow_rewards(
     // winning ticket, so poll `claim` until it submits one (or we time out).
     let deadline = Duration::from_secs(timeout_seconds);
     let started = Instant::now();
+    // A claim can come back empty (nothing mined yet) or fail outright (the
+    // node could not build or publish the transaction). Only the first is
+    // worth waiting out, so the last error is carried to the timeout: a node
+    // that keeps refusing to claim should say why, not report "no rewards".
+    let mut last_error: Option<String> = None;
     let tx_hash = loop {
         match node.claim_pow_rewards(Some(claim_address)).await {
             Ok(Some(tx_hash)) => break tx_hash,
             Ok(None) => {}
             Err(e) => {
                 warn!(target: TARGET, "PoW claim attempt on node `{node_name}` failed: {e}");
+                last_error = Some(e.to_string());
             }
         }
 
         if started.elapsed() >= deadline {
             return Err(StepError::Timeout {
-                message: format!(
-                    "node `{node_name}` produced no claimable PoW rewards within {timeout_seconds} seconds"
+                message: last_error.map_or_else(
+                    || format!(
+                        "node `{node_name}` produced no claimable PoW rewards within {timeout_seconds} seconds"
+                    ),
+                    |e| format!(
+                        "node `{node_name}` failed to claim within {timeout_seconds} seconds; \
+                        last error: {e}"
+                    ),
                 ),
             });
         }
@@ -248,6 +260,78 @@ async fn claim_reward_credited_to(
     credited.ok_or_else(|| StepError::LogicalError {
         message: format!("claim transaction {tx_hash:?} was not found on the chain"),
     })
+}
+
+/// Counts the `ClaimPowReward` ops the landed claim transaction carried.
+async fn claims_in_transaction(node: &NodeHttpClient, tx_hash: TxHash) -> Result<usize, StepError> {
+    let tip = node.consensus_info().await?.cryptarchia_info.tip;
+    let mut scanned_blocks = HashSet::new();
+
+    let claims = scan_chain_until(
+        tip,
+        &mut scanned_blocks,
+        |header_id| {
+            let node = node.clone();
+            async move { node.block(&header_id).await.ok().flatten() }
+        },
+        |block| {
+            let tx = block.transactions.iter().find(|tx| tx.hash() == tx_hash)?;
+            Some(
+                tx.ops_with_proof()
+                    .filter(|(op, _proof)| matches!(op, Op::ClaimPowReward(_)))
+                    .count(),
+            )
+        },
+    )
+    .await;
+
+    claims.ok_or_else(|| StepError::LogicalError {
+        message: format!("claim transaction {tx_hash:?} was not found on the chain"),
+    })
+}
+
+/// Asserts a claim transaction batched at least `minimum` rewards.
+///
+/// A node with a backlog of tickets batches as many as its caps allow, so this
+/// is what distinguishes a working batch from one that quietly shrank to a
+/// single claim. It also pins the transport bug this scenario exists for: a
+/// batch capped only by the op budget serializes past what a Blend payload
+/// carries, so it never reaches a block at all and this step finds no
+/// transaction.
+#[when(expr = "claim {string} batched at least {int} PoW rewards on node {string}")]
+#[then(expr = "claim {string} batched at least {int} PoW rewards on node {string}")]
+#[expect(
+    clippy::needless_pass_by_ref_mut,
+    reason = "Cucumber step functions require the world as the first `&mut` argument"
+)]
+async fn step_claim_batched_at_least(
+    world: &mut CucumberWorld,
+    step: &Step,
+    claim_alias: String,
+    minimum: usize,
+    node_name: String,
+) -> StepResult {
+    let tx_hash = world.resolve_submitted_transaction(&claim_alias)?;
+    let node = world
+        .resolve_node_http_client(&node_name)
+        .inspect_err(|e| {
+            warn!(target: TARGET, "Step `{}` error: {e}", step.value);
+        })?;
+
+    let claims = claims_in_transaction(&node, tx_hash).await?;
+    if claims < minimum {
+        return Err(StepError::StepFail {
+            message: format!(
+                "claim `{claim_alias}` batched {claims} PoW reward(s), expected at least {minimum}"
+            ),
+        });
+    }
+
+    info!(
+        target: TARGET,
+        "Claim `{claim_alias}` batched {claims} PoW reward(s) (>= {minimum})"
+    );
+    Ok(())
 }
 
 #[when(

--- a/tests/src/cucumber/steps/pow.rs
+++ b/tests/src/cucumber/steps/pow.rs
@@ -277,8 +277,8 @@ async fn claims_in_transaction(node: &NodeHttpClient, tx_hash: TxHash) -> Result
         |block| {
             let tx = block.transactions.iter().find(|tx| tx.hash() == tx_hash)?;
             Some(
-                tx.ops_with_proof()
-                    .filter(|(op, _proof)| matches!(op, Op::ClaimPowReward(_)))
+                tx.op_refs_iter()
+                    .filter(|op| matches!(op, OpRef::ClaimPowReward(_)))
                     .count(),
             )
         },


### PR DESCRIPTION
## 1. What does this PR implement?

Fix building claim txs. There was no size limit and we were breaking it constantly on huge claims. It computes the size by building a fake tx with the expected size first to check the cap. This is computed once during startime.

## 2. Does the code have enough context to be clearly understood?

Yes, I added a test to reproduce the issue which is now working.

## 3. Who are the specification authors and who is accountable for this PR?

@danielSanchezQ 

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

N/A

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
