### PR TITLE
feat(blend): implement failure detection and reaction [for node 0.2]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -965,9 +965,9 @@ dependencies = [
 
 [[package]]
 name = "chacha20"
-version = "0.10.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",

--- a/nodes/node/binary/src/config/blend/mod.rs
+++ b/nodes/node/binary/src/config/blend/mod.rs
@@ -71,7 +71,7 @@ impl ServiceConfig {
                         .rounds_per_epoch(slots_per_epoch, &slot_duration),
                 },
                 data_replication_factor: self.deployment.common.data_replication_factor,
-                blend_failure_fallback: self.user.blend_failure_fallback,
+                abstain_on_failure: self.user.abstain_on_failure,
             },
             core: CoreSettings {
                 backend: Libp2pCoreBlendBackendSettings {

--- a/nodes/node/binary/src/config/blend/mod.rs
+++ b/nodes/node/binary/src/config/blend/mod.rs
@@ -71,6 +71,7 @@ impl ServiceConfig {
                         .rounds_per_epoch(slots_per_epoch, &slot_duration),
                 },
                 data_replication_factor: self.deployment.common.data_replication_factor,
+                blend_failure_fallback: self.user.blend_failure_fallback,
             },
             core: CoreSettings {
                 backend: Libp2pCoreBlendBackendSettings {

--- a/nodes/node/binary/src/config/blend/serde/mod.rs
+++ b/nodes/node/binary/src/config/blend/serde/mod.rs
@@ -22,6 +22,14 @@ pub struct Config {
     pub core: CoreConfig,
     #[serde(default)]
     pub edge: EdgeConfig,
+    /// Whether a payload the Blend network fails to deliver within the delivery
+    /// deadline is broadcast in the clear rather than lost.
+    #[serde(default = "default_blend_failure_fallback")]
+    pub blend_failure_fallback: bool,
+}
+
+const fn default_blend_failure_fallback() -> bool {
+    true
 }
 
 pub struct RequiredValues {
@@ -43,6 +51,7 @@ impl Config {
                 zk: ZkSettings { secret_key_kms_id },
                 backend: BackendConfig::default(),
             },
+            blend_failure_fallback: default_blend_failure_fallback(),
             edge: EdgeConfig::default(),
         }
     }
@@ -53,6 +62,10 @@ impl Config {
 
     pub fn set_non_ephemeral_signing_key_id(&mut self, key_id: KeyId) {
         self.non_ephemeral_signing_key_id = key_id;
+    }
+
+    pub const fn disable_blend_failure_fallback(&mut self) {
+        self.blend_failure_fallback = false;
     }
 
     pub fn set_secret_zk_key_id(&mut self, key_id: KeyId) {

--- a/nodes/node/binary/src/config/blend/serde/mod.rs
+++ b/nodes/node/binary/src/config/blend/serde/mod.rs
@@ -22,14 +22,8 @@ pub struct Config {
     pub core: CoreConfig,
     #[serde(default)]
     pub edge: EdgeConfig,
-    /// Whether a payload the Blend network fails to deliver within the delivery
-    /// deadline is broadcast in the clear rather than lost.
-    #[serde(default = "default_blend_failure_fallback")]
-    pub blend_failure_fallback: bool,
-}
-
-const fn default_blend_failure_fallback() -> bool {
-    true
+    #[serde(default)]
+    pub abstain_on_failure: bool,
 }
 
 pub struct RequiredValues {
@@ -51,7 +45,7 @@ impl Config {
                 zk: ZkSettings { secret_key_kms_id },
                 backend: BackendConfig::default(),
             },
-            blend_failure_fallback: default_blend_failure_fallback(),
+            abstain_on_failure: bool::default(),
             edge: EdgeConfig::default(),
         }
     }
@@ -64,8 +58,8 @@ impl Config {
         self.non_ephemeral_signing_key_id = key_id;
     }
 
-    pub const fn disable_blend_failure_fallback(&mut self) {
-        self.blend_failure_fallback = false;
+    pub const fn abstain_on_failure(&mut self) {
+        self.abstain_on_failure = true;
     }
 
     pub fn set_secret_zk_key_id(&mut self, key_id: KeyId) {

--- a/nodes/node/binary/src/config/mod.rs
+++ b/nodes/node/binary/src/config/mod.rs
@@ -252,6 +252,13 @@ pub struct BlendArgs {
 
     #[clap(long = "blend-secret-key-id", env = "BLEND_SECRET_KEY_ID")]
     pub blend_secret_key_id: Option<KeyId>,
+
+    #[clap(
+        long = "no-blend-fallback",
+        env = "BLEND_NO_FAILURE_FALLBACK",
+        default_value_t = false
+    )]
+    pub no_blend_fallback: bool,
 }
 
 #[derive(Parser, Debug, Default, Clone, Copy)]
@@ -475,7 +482,12 @@ pub fn update_blend(blend: &mut BlendConfig, blend_args: BlendArgs) {
         blend_addr,
         blend_signing_key_id,
         blend_secret_key_id,
+        no_blend_fallback,
     } = blend_args;
+
+    if no_blend_fallback {
+        blend.disable_blend_failure_fallback();
+    }
 
     if let Some(addr) = blend_addr {
         blend.set_listening_address(addr);

--- a/nodes/node/binary/src/config/mod.rs
+++ b/nodes/node/binary/src/config/mod.rs
@@ -254,11 +254,11 @@ pub struct BlendArgs {
     pub blend_secret_key_id: Option<KeyId>,
 
     #[clap(
-        long = "no-blend-fallback",
-        env = "BLEND_NO_FAILURE_FALLBACK",
+        long = "blend-abstain-on-failure",
+        env = "BLEND_ABSTAIN_ON_FAILURE",
         default_value_t = false
     )]
-    pub no_blend_fallback: bool,
+    pub abstain_on_failure: bool,
 }
 
 #[derive(Parser, Debug, Default, Clone, Copy)]
@@ -482,11 +482,11 @@ pub fn update_blend(blend: &mut BlendConfig, blend_args: BlendArgs) {
         blend_addr,
         blend_signing_key_id,
         blend_secret_key_id,
-        no_blend_fallback,
+        abstain_on_failure,
     } = blend_args;
 
-    if no_blend_fallback {
-        blend.disable_blend_failure_fallback();
+    if abstain_on_failure {
+        blend.abstain_on_failure();
     }
 
     if let Some(addr) = blend_addr {

--- a/nodes/node/binary/src/generic_services/blend/mod.rs
+++ b/nodes/node/binary/src/generic_services/blend/mod.rs
@@ -66,15 +66,15 @@ impl LeaderProofsGenerator for MockLeaderProofsGenerator {
 }
 
 pub type BlendEdgeService<RuntimeServiceId> = lb_blend_service::edge::BlendService<
-        lb_blend_service::edge::backends::libp2p::Libp2pBlendBackend,
-        PeerId,
-        <lb_blend_service::core::network::libp2p::Libp2pAdapter<RuntimeServiceId> as lb_blend_service::core::network::NetworkAdapter<RuntimeServiceId>>::BroadcastSettings,
-        RealLeaderProofsGenerator,
-        NtpTimeBackend,
-        CryptarchiaService<RuntimeServiceId>,
-        PolInfoProvider,
-        RuntimeServiceId
-    >;
+    lb_blend_service::edge::backends::libp2p::Libp2pBlendBackend,
+    PeerId,
+    lb_blend_service::core::network::libp2p::Libp2pAdapter<RuntimeServiceId>,
+    RealLeaderProofsGenerator,
+    NtpTimeBackend,
+    CryptarchiaService<RuntimeServiceId>,
+    PolInfoProvider,
+    RuntimeServiceId,
+>;
 pub type BlendService<RuntimeServiceId> = lb_blend_service::BlendService<
     BlendCoreService<RuntimeServiceId>,
     BlendEdgeService<RuntimeServiceId>,

--- a/services/blend/src/core/delivery.rs
+++ b/services/blend/src/core/delivery.rs
@@ -1,0 +1,283 @@
+use core::{
+    hash::Hash,
+    num::NonZeroU64,
+    pin::Pin,
+    task::{Context, Poll},
+    time::Duration,
+};
+use std::collections::HashMap;
+
+use futures::{Stream, StreamExt as _, stream::BoxStream};
+use lb_blend::message::MessageIdentifier;
+use lb_chain_service::Epoch;
+
+use crate::{
+    core::{LOG_TARGET, network::NetworkAdapter},
+    delivery::FailureDetector as InnerFailureDetector,
+    message::NetworkMessage,
+};
+
+/// Wrapper around [`crate::delivery::FailureDetector`] that adds support for
+/// encapsulated-but-not-yet-blended messages.
+pub struct FailureDetector<BroadcastSettings> {
+    inner: InnerFailureDetector<BroadcastSettings>,
+    /// Payloads encapsulated and waiting to be blended.
+    encapsulated: HashMap<MessageIdentifier, (Epoch, NetworkMessage<BroadcastSettings>)>,
+}
+
+impl<BroadcastSettings> FailureDetector<BroadcastSettings>
+where
+    BroadcastSettings: Eq + Hash,
+{
+    #[must_use]
+    pub fn new(
+        maximum_blending_delay: NonZeroU64,
+        round_duration: Duration,
+        payload_broadcasts: BoxStream<'static, NetworkMessage<BroadcastSettings>>,
+    ) -> Self {
+        Self {
+            inner: InnerFailureDetector::new(
+                maximum_blending_delay,
+                round_duration,
+                payload_broadcasts,
+            ),
+            encapsulated: HashMap::new(),
+        }
+    }
+
+    /// Register the link between a payload and its outermost encapsulation, so
+    /// that when the encapsulated message is actually released, we can record
+    /// what payload it belongs to.
+    pub fn mark_payload_as_encapsulated(
+        &mut self,
+        id: MessageIdentifier,
+        payload: NetworkMessage<BroadcastSettings>,
+        epoch: Epoch,
+    ) {
+        assert!(
+            self.encapsulated.insert(id, (epoch, payload)).is_none(),
+            "Two locally-generated messages share the identifier {id:?}, which means a key was spent twice."
+        );
+    }
+
+    /// Mark a previously-recorded encapsulated payload as released at this
+    /// round.
+    ///
+    /// An `id` that was never recorded is ignored rather than refused: the
+    /// release path reports every message it puts on the wire and lets this map
+    /// pick out the ones that were ours, so most of what arrives here is
+    /// traffic this node only relays, or messages a previous run left in the
+    /// recovery state. Claiming a payload twice is what cannot happen, and
+    /// `remove` is what stops it.
+    pub fn mark_encapsulated_payload_as_released(&mut self, id: MessageIdentifier) {
+        if let Some((_, payload)) = self.encapsulated.remove(&id) {
+            self.inner.mark_payload_as_blended(payload);
+        }
+    }
+
+    /// When the transition period for an old epoch ends, any pending block
+    /// proposals are discarded. This function allows the caller to clear the
+    /// queue of proposals that have been encapsulated but not yet released for
+    /// such epochs.
+    pub fn drop_unreleased_payloads_for_epoch(&mut self, expiring: Epoch) {
+        let before = self.encapsulated.len();
+        self.encapsulated.retain(|_, (epoch, _)| *epoch != expiring);
+        let dropped = before.checked_sub(self.encapsulated.len()).unwrap();
+        if dropped > 0 {
+            tracing::debug!(
+                target: LOG_TARGET,
+                "Epoch {expiring:?} ended without releasing {dropped} locally-generated message(s). No need to monitor as they will never be broadcasted."
+            );
+        }
+    }
+
+    /// How many payloads are waiting for the Blend network to deliver them.
+    #[cfg(test)]
+    #[must_use]
+    pub fn outstanding_payloads_count(&self) -> usize {
+        self.inner.outstanding_payloads_count()
+    }
+}
+
+impl<BroadcastSettings> FailureDetector<BroadcastSettings>
+where
+    BroadcastSettings: Eq + Hash + Send + Unpin,
+{
+    /// See
+    /// [`FailureDetector::drain_pending_message_queue`](InnerFailureDetector::drain_pending_message_queue).
+    pub async fn drain_pending_message_queue<NetAdapter, RuntimeServiceId>(
+        self,
+        network_adapter: &NetAdapter,
+    ) where
+        NetAdapter: NetworkAdapter<RuntimeServiceId, BroadcastSettings = BroadcastSettings> + Sync,
+    {
+        self.inner
+            .drain_pending_message_queue(network_adapter)
+            .await;
+    }
+}
+
+impl<BroadcastSettings> Stream for FailureDetector<BroadcastSettings>
+where
+    BroadcastSettings: Eq + Hash + Unpin,
+{
+    type Item = <InnerFailureDetector<BroadcastSettings> as Stream>::Item;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.inner.poll_next_unpin(cx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use futures::StreamExt as _;
+    use lb_blend::{message::MessageIdentifier, proofs::quota::VerifiedProofOfQuota};
+    use lb_chain_service::Epoch;
+    use tokio::{sync::mpsc, time::Instant};
+    use tokio_stream::wrappers::UnboundedReceiverStream;
+
+    use crate::{
+        core::delivery::FailureDetector,
+        delivery::test_utils::{DEADLINE, ROUND, another_payload, proposal, until},
+        message::NetworkMessage,
+    };
+
+    /// Rounds a message spends waiting on the proofs that back it, before it is
+    /// released.
+    const HELD_FOR: u64 = 3;
+
+    /// A core sender, the instant its round clock started, and the handle that
+    /// puts payloads on the broadcasting channel it watches.
+    fn new_failure_monitor() -> (
+        FailureDetector<()>,
+        Instant,
+        mpsc::UnboundedSender<NetworkMessage<()>>,
+    ) {
+        let (channel, broadcasts) = mpsc::unbounded_channel();
+        let detection = FailureDetector::new(
+            DEADLINE,
+            ROUND,
+            UnboundedReceiverStream::new(broadcasts).boxed(),
+        );
+        (detection, Instant::now(), channel)
+    }
+
+    fn id(byte: u8) -> MessageIdentifier {
+        VerifiedProofOfQuota::from_bytes_unchecked([byte; _]).key_nullifier()
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn a_released_payload_the_network_never_delivers_is_broadcast_at_the_deadline() {
+        let (mut detection, start, _channel) = new_failure_monitor();
+        detection.mark_payload_as_encapsulated(id(1), proposal(), Epoch::new(0));
+        detection.mark_encapsulated_payload_as_released(id(1));
+
+        assert!(
+            until(&mut detection, start, DEADLINE.get() - 2)
+                .await
+                .is_empty(),
+            "revealing a proposal the network is still delivering is the one thing the deadline exists to prevent"
+        );
+        assert_eq!(
+            until(&mut detection, start, DEADLINE.get() + 2).await,
+            vec![proposal()]
+        );
+        assert_eq!(
+            detection.outstanding_payloads_count(),
+            0,
+            "it is broadcast exactly once"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn the_deadline_runs_from_the_release_and_not_from_the_encapsulation() {
+        let (mut detection, start, _channel) = new_failure_monitor();
+        // Built now, but held back — waiting on the proofs that will back it.
+        detection.mark_payload_as_encapsulated(id(1), proposal(), Epoch::new(0));
+        assert!(until(&mut detection, start, HELD_FOR).await.is_empty());
+        detection.mark_encapsulated_payload_as_released(id(1));
+
+        assert!(
+            until(&mut detection, start, DEADLINE.get() + 1)
+                .await
+                .is_empty(),
+            "the wait for proofs is not time the network was given to deliver anything"
+        );
+        assert_eq!(
+            until(&mut detection, start, DEADLINE.get() + HELD_FOR + 2).await,
+            vec![proposal()]
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn a_message_this_node_only_relays_is_nothing_it_waits_on() {
+        let (mut detection, start, _channel) = new_failure_monitor();
+        detection.mark_encapsulated_payload_as_released(id(9));
+
+        assert_eq!(detection.outstanding_payloads_count(), 0);
+        assert!(
+            until(&mut detection, start, DEADLINE.get() + 3)
+                .await
+                .is_empty()
+        );
+    }
+
+    /// A message that expires with its epoch never reached a peer, so there is
+    /// no delivery to have failed and nothing to answer for in the clear.
+    #[tokio::test(start_paused = true)]
+    async fn an_expiring_epoch_drops_what_it_never_released() {
+        let (mut detection, start, _channel) = new_failure_monitor();
+        detection.mark_payload_as_encapsulated(id(1), proposal(), Epoch::new(0));
+        detection.mark_payload_as_encapsulated(id(2), another_payload(), Epoch::new(0));
+
+        detection.drop_unreleased_payloads_for_epoch(Epoch::new(0));
+
+        assert_eq!(detection.outstanding_payloads_count(), 0);
+        assert!(
+            until(&mut detection, start, DEADLINE.get() + 2)
+                .await
+                .is_empty(),
+            "a payload no peer ever saw must not be revealed by the fallback"
+        );
+    }
+
+    /// Nothing of the expiring epoch may be left in the map: its scheduler is
+    /// gone, so the release that would claim the entry can no longer happen and
+    /// the entry would sit there for the life of the process.
+    #[tokio::test(start_paused = true)]
+    async fn an_expiring_epoch_leaves_nothing_that_can_never_be_claimed() {
+        let (mut detection, ..) = new_failure_monitor();
+        detection.mark_payload_as_encapsulated(id(1), proposal(), Epoch::new(0));
+        detection.mark_payload_as_encapsulated(id(2), another_payload(), Epoch::new(0));
+
+        detection.drop_unreleased_payloads_for_epoch(Epoch::new(0));
+        detection.drop_unreleased_payloads_for_epoch(Epoch::new(0));
+
+        for released in [id(1), id(2)] {
+            detection.mark_encapsulated_payload_as_released(released);
+        }
+        assert_eq!(
+            detection.outstanding_payloads_count(),
+            0,
+            "the entries are gone, and a release that arrives late finds nothing to start a deadline for"
+        );
+    }
+
+    /// The epoch still running keeps what it has: its scheduler is alive and
+    /// those messages are still going out.
+    #[tokio::test(start_paused = true)]
+    async fn an_expiring_epoch_leaves_the_current_one_alone() {
+        let (mut detection, ..) = new_failure_monitor();
+        detection.mark_payload_as_encapsulated(id(1), proposal(), Epoch::new(1));
+
+        detection.drop_unreleased_payloads_for_epoch(Epoch::new(0));
+
+        assert_eq!(detection.outstanding_payloads_count(), 0);
+        detection.mark_encapsulated_payload_as_released(id(1));
+        assert_eq!(
+            detection.outstanding_payloads_count(),
+            1,
+            "the current epoch's message still goes out, and its deadline starts when it does"
+        );
+    }
+}

--- a/services/blend/src/core/mod.rs
+++ b/services/blend/src/core/mod.rs
@@ -81,6 +81,7 @@ use tracing::{debug, error, info};
 
 use crate::{
     core::{
+        delivery::FailureDetector,
         kms::{KmsPoQAdapter, PreloadKMSBackendCorePoQGenerator},
         processor::{
             CoreCryptographicProcessor, DecapsulatedMessageType, Error,
@@ -90,6 +91,7 @@ use crate::{
         settings::{RunningBlendConfig, StartingBlendConfig},
         state::{RecoveryServiceState, ServiceState, StateUpdater as ServiceStateUpdater},
     },
+    delivery::{broadcast_undelivered_messages, next_undelivered_messages},
     epoch::{CoreEpochInfo, CoreEpochPublicInfo, MaybeEmptyCoreEpochInfo},
     epoch_info::{PolEpochInfo, PolInfoProvider as PolInfoProviderTrait},
     kms::PreloadKmsService,
@@ -98,6 +100,7 @@ use crate::{
 };
 
 pub mod backends;
+pub mod delivery;
 pub mod kms;
 pub mod network;
 pub mod settings;
@@ -375,6 +378,7 @@ where
             zk: blend_config.zk,
             data_replication_factor: blend_config.data_replication_factor,
             activity_threshold_sensitivity: blend_config.activity_threshold_sensitivity,
+            blend_failure_fallback: blend_config.blend_failure_fallback,
         };
         let (
             mut remaining_epoch_stream,
@@ -420,6 +424,19 @@ where
         // epochs. When the node becomes a non-core node in a new epoch, the
         // old epoch's components (crypto processor, scheduler, blending token
         // collector, public info, and epoch) are returned for the retirement phase.
+        // What this node has handed to the Blend network and not seen come out of
+        // it. `None` when the operator has turned the fallback off, which records
+        // nothing, watches nothing and can reveal nothing.
+        let mut failure_detector = if running_blend_config.blend_failure_fallback {
+            Some(FailureDetector::new(
+                running_blend_config.max_data_message_delay_in_rounds(),
+                running_blend_config.time.round_duration,
+                network_adapter.observe_broadcasts().await,
+            ))
+        } else {
+            None
+        };
+
         let (
             old_epoch_crypto_processor,
             old_epoch_message_scheduler,
@@ -438,6 +455,7 @@ where
             crypto_processor,
             current_public_info,
             current_recovery_checkpoint,
+            failure_detector.as_mut(),
         )
         .await;
 
@@ -453,6 +471,7 @@ where
             backend,
             network_adapter,
             sdp_relay,
+            failure_detector,
             old_epoch_message_scheduler,
             rng,
             old_epoch_blending_token_collector,
@@ -738,6 +757,10 @@ where
 //
 // Returns the old epoch components when the node is no longer a core node.
 #[expect(clippy::too_many_arguments, reason = "categorize args")]
+#[expect(
+    clippy::cognitive_complexity,
+    reason = "TODO: address this in a dedicated refactor"
+)]
 async fn run_event_loop<
     NodeId,
     Backend,
@@ -781,6 +804,7 @@ async fn run_event_loop<
     >,
     mut current_epoch_info: CoreEpochPublicInfo<NodeId>,
     mut recovery_checkpoint: ServiceState<Backend::Settings, NetAdapter::BroadcastSettings>,
+    mut failure_detector: Option<&mut FailureDetector<NetAdapter::BroadcastSettings>>,
 ) -> (
     CoreCryptographicProcessor<NodeId, CorePoQGenerator, ProofsGenerator, ProofsVerifier>,
     OldEpochMessageScheduler<Rng, ProcessedMessage<NetAdapter::BroadcastSettings>>,
@@ -831,7 +855,7 @@ where
 
                         let message_copies = blend_config.data_replication_factor.checked_add(1).unwrap();
                         for _ in 0..message_copies {
-                            recovery_checkpoint = handle_serialized_local_data_message(&serialized_data_message, &mut crypto_processor, &mut message_scheduler, recovery_checkpoint).await;
+                            recovery_checkpoint = handle_serialized_local_data_message(&serialized_data_message, &message_payload, &mut crypto_processor, &mut message_scheduler, failure_detector.as_deref_mut(), recovery_checkpoint).await;
                         }
                     }
                     ServiceMessage::GetNetworkInfo { reply } => {
@@ -844,7 +868,7 @@ where
                 recovery_checkpoint = handle_incoming_blend_message(incoming_message, &mut message_scheduler, old_epoch_message_scheduler.as_mut(), &crypto_processor, old_epoch_crypto_processor.as_ref(),  recovery_checkpoint);
             }
             Some(round_info) = message_scheduler.next() => {
-                recovery_checkpoint = handle_release_round(round_info, &mut crypto_processor, rng, backend, network_adapter, recovery_checkpoint).await;
+                recovery_checkpoint = handle_release_round(round_info, &mut crypto_processor, rng, backend, network_adapter, failure_detector.as_deref_mut(), recovery_checkpoint).await;
             }
             Some((Some(processed_messages_to_release), previous_epoch)) = async {
                 match (&mut old_epoch_message_scheduler, old_epoch) {
@@ -854,7 +878,7 @@ where
                     _ => None
                 }
             } => {
-                handle_release_round_for_old_epoch(processed_messages_to_release, rng, backend, network_adapter, previous_epoch).await;
+                handle_release_round_for_old_epoch(processed_messages_to_release, rng, backend, network_adapter, failure_detector.as_deref_mut(), previous_epoch).await;
             }
             Some(pol_secret_info) = secret_pol_info_stream.next() => {
                 if current_epoch_info.epoch == pol_secret_info.epoch {
@@ -867,7 +891,18 @@ where
                     latest_secret_pol_info = Some(pol_secret_info);
                 }
             }
+            Some(undelivered) = next_undelivered_messages(failure_detector.as_deref_mut()) => {
+                broadcast_undelivered_messages(undelivered.into_iter(), network_adapter).await;
+            }
             Some(epoch_event) = remaining_epoch_stream.next() => {
+                // Past its transition period the drained epoch has no peers left that
+                // would accept what it releases, so whatever of it this node
+                // encapsulated and never released can no longer be sent.
+                if matches!(epoch_event, EpochEvent::TransitionPeriodExpired)
+                    && let (Some(failure_detector), Some(old_epoch)) = (failure_detector.as_deref_mut(), old_epoch)
+                {
+                    failure_detector.drop_unreleased_payloads_for_epoch(old_epoch);
+                }
                 match handle_epoch_event(epoch_event, blend_config, crypto_processor, message_scheduler, current_epoch_info, recovery_checkpoint, backend, sdp_relay, &mut latest_secret_pol_info).await {
                     // Current epoch info updated to new one
                     HandleEpochEventOutput::Transitioning { new_crypto_processor, old_crypto_processor, new_scheduler, old_scheduler, new_epoch_info, new_recovery_checkpoint } => {
@@ -926,6 +961,7 @@ async fn retire<
     mut backend: Backend,
     network_adapter: NetAdapter,
     sdp_relay: OutboundRelay<SdpMessage>,
+    mut failure_detector: Option<FailureDetector<NetAdapter::BroadcastSettings>>,
     mut message_scheduler: OldEpochMessageScheduler<
         Rng,
         ProcessedMessage<NetAdapter::BroadcastSettings>,
@@ -966,13 +1002,24 @@ async fn retire<
                 handle_incoming_blend_message_from_old_epoch(incoming_message, &mut message_scheduler, &crypto_processor, &mut blending_token_collector);
             }
             Some(processed_messages_to_release) = message_scheduler.next() => {
-                handle_release_round_for_old_epoch(processed_messages_to_release, &mut rng, &backend, &network_adapter, crypto_processor.epoch()).await;
+                handle_release_round_for_old_epoch(processed_messages_to_release, &mut rng, &backend, &network_adapter, failure_detector.as_mut(), crypto_processor.epoch()).await;
+            }
+            Some(undelivered) = next_undelivered_messages(failure_detector.as_mut()) => {
+                broadcast_undelivered_messages(undelivered.into_iter(), &network_adapter).await;
             }
             Some(EpochEvent::TransitionPeriodExpired) = remaining_epoch_stream.next() => {
+                // This epoch's scheduler goes with the service, so what it
+                // encapsulated and never released can no longer be sent.
+                if let Some(failure_detector) = failure_detector.as_mut() {
+                    failure_detector.drop_unreleased_payloads_for_epoch(crypto_processor.epoch());
+                }
                 handle_epoch_transition_expired(&mut backend, blending_token_collector, &sdp_relay).await;
                 // Now the core service is no longer needed for the current (new) epoch,
-                // and the remaining epoch transition has been completed,
-                // so finishing the retirement process.
+                // and the remaining epoch transition has been completed, bar the
+                // deadlines this epoch's own releases are still owed.
+                if let Some(failure_detector) = failure_detector {
+                    failure_detector.drain_pending_message_queue(&network_adapter).await;
+                }
                 return;
             }
         }
@@ -1261,6 +1308,7 @@ async fn handle_serialized_local_data_message<
     CorePoQGenerator,
 >(
     serialized_local_data_message: &[u8],
+    payload: &NetworkMessage<BroadcastSettings>,
     cryptographic_processor: &mut CoreCryptographicProcessor<
         NodeId,
         CorePoQGenerator,
@@ -1272,6 +1320,7 @@ async fn handle_serialized_local_data_message<
         ProcessedMessage<BroadcastSettings>,
         EncapsulatedMessageWithVerifiedPublicHeader,
     >,
+    failure_detector: Option<&mut FailureDetector<BroadcastSettings>>,
     current_recovery_checkpoint: ServiceState<BackendSettings, BroadcastSettings>,
 ) -> ServiceState<BackendSettings, BroadcastSettings>
 where
@@ -1294,6 +1343,9 @@ where
     };
 
     let mut state_updater = current_recovery_checkpoint.start_updating();
+    // The epoch this message is built under, and the one whose end takes it with
+    // it if it is never released.
+    let epoch = cryptographic_processor.epoch();
 
     // Before blending the data message, we try to peel off any outer layers that
     // are addressed to us. In this case, we collect the blending tokens and we
@@ -1305,6 +1357,15 @@ where
         // The outermost layer of the data message is not for us, hence we treat this as
         // a regular data message that should be released at the next round.
         tracing::debug!(target: LOG_TARGET, "Locally generated data message does not have its outermost layer addressed to us. Sending it out as a data message...");
+        // What goes out is this message, so that is the form whose release starts
+        // the payload's delivery deadline.
+        if let Some(failure_detector) = failure_detector {
+            failure_detector.mark_payload_as_encapsulated(
+                wrapped_message.id(),
+                payload.clone(),
+                epoch,
+            );
+        }
         scheduler.queue_data_message(wrapped_message.clone());
         assert_eq!(
             state_updater.add_unsent_data_message(wrapped_message.clone()),
@@ -1335,11 +1396,22 @@ where
         DecapsulatedMessageType::Incompleted(remaining_encapsulated_message) => {
             tracing::trace!(target: LOG_TARGET, "Locally generated data message had the outermost {} layers addressed to this same node. Propagating only the remaining encapsulated layers.", blending_tokens.len());
             // Locally-generated message, so we know it's valid.
-            ProcessedMessage::from(
-                EncapsulatedMessageWithVerifiedPublicHeader::from_message_unchecked(
-                    *remaining_encapsulated_message,
-                ),
-            )
+            let remaining = EncapsulatedMessageWithVerifiedPublicHeader::from_message_unchecked(
+                *remaining_encapsulated_message,
+            );
+            // What goes out is the remaining layers, so that is the form whose
+            // release starts the payload's delivery deadline. The fully decapsulated
+            // case above needs nothing: this node is the exit for its own message
+            // there, so the payload goes straight to the broadcasting channel and
+            // the network never carried it.
+            if let Some(failure_detector) = failure_detector {
+                failure_detector.mark_payload_as_encapsulated(
+                    remaining.id(),
+                    payload.clone(),
+                    epoch,
+                );
+            }
+            ProcessedMessage::from(remaining)
         }
     };
     state_updater.collect_current_epoch_tokens(blending_tokens.into_iter());
@@ -1768,6 +1840,7 @@ async fn handle_release_round<
     rng: &mut Rng,
     backend: &Backend,
     network_adapter: &NetAdapter,
+    mut failure_detector: Option<&mut FailureDetector<NetAdapter::BroadcastSettings>>,
     current_recovery_checkpoint: ServiceState<Backend::Settings, NetAdapter::BroadcastSettings>,
 ) -> ServiceState<Backend::Settings, NetAdapter::BroadcastSettings>
 where
@@ -1796,6 +1869,11 @@ where
             }
             // Each data message that is sent is one less cover message that should be generated, hence we consume one core quota per data message here.
             state_updater.consume_core_quota(1);
+            // The message is on its way to every peer this round, which is where its
+            // payload's delivery deadline starts.
+            if let Some(failure_detector) = failure_detector.as_deref_mut() {
+                failure_detector.mark_encapsulated_payload_as_released(data_message_to_blend.id());
+            }
         }).map(
             |data_message_to_blend| -> BoxFuture<'_, ()> {
                 backend.publish(data_message_to_blend, current_epoch).boxed()
@@ -1806,6 +1884,7 @@ where
         processed_messages,
         backend,
         network_adapter,
+        failure_detector,
         Some(&mut state_updater),
         current_epoch,
     );
@@ -1850,6 +1929,7 @@ async fn handle_release_round_for_old_epoch<NodeId, Rng, Backend, NetAdapter, Ru
     rng: &mut Rng,
     backend: &Backend,
     network_adapter: &NetAdapter,
+    failure_detector: Option<&mut FailureDetector<NetAdapter::BroadcastSettings>>,
     epoch: Epoch,
 ) where
     NodeId: Eq + Hash + 'static,
@@ -1861,6 +1941,7 @@ async fn handle_release_round_for_old_epoch<NodeId, Rng, Backend, NetAdapter, Ru
         processed_messages_to_release,
         backend,
         network_adapter,
+        failure_detector,
         None,
         epoch,
     );
@@ -1910,6 +1991,7 @@ fn build_futures_to_release_processed_messages<
     processed_messages_to_release: Vec<ProcessedMessage<NetAdapter::BroadcastSettings>>,
     backend: &'fut Backend,
     network_adapter: &'fut NetAdapter,
+    mut failure_detector: Option<&mut FailureDetector<NetAdapter::BroadcastSettings>>,
     mut state_updater: Option<
         &mut ServiceStateUpdater<Backend::Settings, NetAdapter::BroadcastSettings>,
     >,
@@ -1934,6 +2016,14 @@ where
                             target: LOG_TARGET,
                             "Previously processed message should be present in the recovery state but was not found."
                         );
+            }
+            // A payload this node fully decapsulated itself is one it is the exit for:
+            // it goes straight to the broadcasting channel from here and was never
+            // carried by the network, so there is no delivery of it to fail.
+            if let ProcessedMessage::Encapsulated(encapsulated_message) = processed_message_to_release
+                && let Some(failure_detector) = failure_detector.as_deref_mut()
+            {
+                failure_detector.mark_encapsulated_payload_as_released(encapsulated_message.id());
             }
         })
         .map(

--- a/services/blend/src/core/mod.rs
+++ b/services/blend/src/core/mod.rs
@@ -378,7 +378,7 @@ where
             zk: blend_config.zk,
             data_replication_factor: blend_config.data_replication_factor,
             activity_threshold_sensitivity: blend_config.activity_threshold_sensitivity,
-            blend_failure_fallback: blend_config.blend_failure_fallback,
+            abstain_on_failure: blend_config.abstain_on_failure,
         };
         let (
             mut remaining_epoch_stream,
@@ -427,14 +427,14 @@ where
         // What this node has handed to the Blend network and not seen come out of
         // it. `None` when the operator has turned the fallback off, which records
         // nothing, watches nothing and can reveal nothing.
-        let mut failure_detector = if running_blend_config.blend_failure_fallback {
+        let mut failure_detector = if running_blend_config.abstain_on_failure {
+            None
+        } else {
             Some(FailureDetector::new(
                 running_blend_config.max_data_message_delay_in_rounds(),
                 running_blend_config.time.round_duration,
                 network_adapter.observe_broadcasts().await,
             ))
-        } else {
-            None
         };
 
         let (

--- a/services/blend/src/core/network/libp2p.rs
+++ b/services/blend/src/core/network/libp2p.rs
@@ -1,12 +1,21 @@
+use core::future::ready;
+
+use futures::{StreamExt as _, stream, stream::BoxStream};
+use lb_log_targets::blend;
 use lb_network_service::{
     NetworkService,
-    backends::libp2p::{Command, Libp2p, PubSubCommand},
+    backends::libp2p::{Command, Libp2p, Message, PubSubCommand},
     message::NetworkMsg,
 };
 use overwatch::services::{ServiceData, relay::OutboundRelay};
 use serde::{Deserialize, Serialize};
+use tokio::sync::oneshot;
+use tokio_stream::wrappers::errors::BroadcastStreamRecvError;
 
 use super::NetworkAdapter;
+use crate::message::NetworkMessage;
+
+const LOG_TARGET: &str = blend::service::CORE;
 
 /// A network adapter for the network service that uses libp2p backend.
 #[derive(Clone)]
@@ -48,7 +57,44 @@ impl<RuntimeServiceId> NetworkAdapter<RuntimeServiceId> for Libp2pAdapter<Runtim
             )))
             .await
         {
-            tracing::error!("error broadcasting message: {e}");
+            tracing::error!(target: LOG_TARGET, "error broadcasting message: {e}");
         }
+    }
+
+    async fn observe_broadcasts(
+        &self,
+    ) -> BoxStream<'static, NetworkMessage<Self::BroadcastSettings>> {
+        let network_relay = self.network_relay.clone();
+        let (sender, receiver) = oneshot::channel();
+        if let Err((e, _)) = network_relay
+            .send(NetworkMsg::SubscribeToPubSub { sender })
+            .await
+        {
+            tracing::error!(target: LOG_TARGET, "Failed to ask the network service for the broadcasting channel: {e}");
+            return stream::empty().boxed();
+        }
+        let Ok(broadcasts) = receiver.await else {
+            tracing::error!(target: LOG_TARGET, "The network service dropped the broadcasting-channel subscription.");
+            return stream::empty().boxed();
+        };
+
+        broadcasts.filter_map(|message| {
+            ready(match message {
+                // A payload's broadcast settings are its topic, so the pair the
+                // sender handed over is what comes back and comparing them is all
+                // it has to do.
+                Ok(Message { data, topic, .. }) => Some(NetworkMessage {
+                    message: data,
+                    broadcast_settings: Libp2pBroadcastSettings {
+                        topic: topic.into_string(),
+                    },
+                }),
+                Err(BroadcastStreamRecvError::Lagged(missed)) => {
+                    tracing::warn!(target: LOG_TARGET, "Missed {missed} broadcasting-channel messages; a delivered payload may be broadcast directly anyway.");
+                    None
+                }
+            })
+        })
+        .boxed()
     }
 }

--- a/services/blend/src/core/network/libp2p.rs
+++ b/services/blend/src/core/network/libp2p.rs
@@ -1,6 +1,6 @@
 use core::future::ready;
 
-use futures::{StreamExt as _, stream, stream::BoxStream};
+use futures::{Stream, StreamExt as _, stream, stream::BoxStream};
 use lb_log_targets::blend;
 use lb_network_service::{
     NetworkService,
@@ -10,12 +10,37 @@ use lb_network_service::{
 use overwatch::services::{ServiceData, relay::OutboundRelay};
 use serde::{Deserialize, Serialize};
 use tokio::sync::oneshot;
-use tokio_stream::wrappers::errors::BroadcastStreamRecvError;
+use tokio_stream::wrappers::{BroadcastStream, errors::BroadcastStreamRecvError};
 
 use super::NetworkAdapter;
 use crate::message::NetworkMessage;
 
 const LOG_TARGET: &str = blend::service::CORE;
+
+/// The observations of `subscription`, up to the moment it lags.
+///
+/// A missed observation is a delivery this node cannot see, and a delivery it
+/// cannot see is a payload it reveals. Carrying on past a lag would hand an
+/// adversary a way to force those reveals by flooding the node into one, so the
+/// stream ends instead, and the detection that reads it stops with it.
+fn stop_observing_on_lag<Observed>(
+    subscription: BroadcastStream<Observed>,
+) -> impl Stream<Item = Observed> + Send
+where
+    Observed: Clone + Send + 'static,
+{
+    subscription
+        .take_while(|subscribed| {
+            ready(match subscribed {
+                Ok(_) => true,
+                Err(BroadcastStreamRecvError::Lagged(missed)) => {
+                    tracing::error!(target: LOG_TARGET, "Missed {missed} broadcasting-channel messages; a delivery can no longer be told from a loss, so the direct broadcast is disabled for the rest of this run.");
+                    false
+                }
+            })
+        })
+        .filter_map(|subscribed| ready(subscribed.ok()))
+}
 
 /// A network adapter for the network service that uses libp2p backend.
 #[derive(Clone)]
@@ -78,23 +103,18 @@ impl<RuntimeServiceId> NetworkAdapter<RuntimeServiceId> for Libp2pAdapter<Runtim
             return stream::empty().boxed();
         };
 
-        broadcasts.filter_map(|message| {
-            ready(match message {
+        stop_observing_on_lag(broadcasts)
+            .map(|Message { data, topic, .. }| {
                 // A payload's broadcast settings are its topic, so the pair the
                 // sender handed over is what comes back and comparing them is all
                 // it has to do.
-                Ok(Message { data, topic, .. }) => Some(NetworkMessage {
+                NetworkMessage {
                     message: data,
                     broadcast_settings: Libp2pBroadcastSettings {
                         topic: topic.into_string(),
                     },
-                }),
-                Err(BroadcastStreamRecvError::Lagged(missed)) => {
-                    tracing::warn!(target: LOG_TARGET, "Missed {missed} broadcasting-channel messages; a delivered payload may be broadcast directly anyway.");
-                    None
                 }
             })
-        })
-        .boxed()
+            .boxed()
     }
 }

--- a/services/blend/src/core/network/mod.rs
+++ b/services/blend/src/core/network/mod.rs
@@ -2,9 +2,12 @@ pub mod libp2p;
 
 use std::fmt::Debug;
 
+use futures::stream::BoxStream;
 use lb_network_service::{NetworkService, backends::NetworkBackend};
 use overwatch::services::{ServiceData, relay::OutboundRelay};
 use serde::{Serialize, de::DeserializeOwned};
+
+use crate::message::NetworkMessage;
 
 /// A trait for communicating with the network service, which is used to
 /// broadcast fully unwrapped messages returned from the blend backend.
@@ -23,4 +26,9 @@ pub trait NetworkAdapter<RuntimeServiceId> {
     /// Broadcast a message to the network service using the specified broadcast
     /// settings.
     async fn broadcast(&self, message: Vec<u8>, broadcast_settings: Self::BroadcastSettings);
+
+    /// Return a stream of payloads appearing on the broadcasting channel.
+    async fn observe_broadcasts(
+        &self,
+    ) -> BoxStream<'static, NetworkMessage<Self::BroadcastSettings>>;
 }

--- a/services/blend/src/core/settings.rs
+++ b/services/blend/src/core/settings.rs
@@ -6,7 +6,9 @@ use lb_services_utils::overwatch::{RecoveryData, StorageRecoverySettings};
 use lb_utils::math::NonNegativeF64;
 use serde::{Deserialize, Serialize};
 
-use crate::settings::TimingSettings;
+use crate::settings::{
+    TimingSettings, max_data_message_delay_in_rounds, round_duration_in_seconds,
+};
 
 #[derive(Clone, Debug)]
 pub struct StartingBlendConfig<BackendSettings> {
@@ -21,6 +23,7 @@ pub struct StartingBlendConfig<BackendSettings> {
     /// `R_c`: replication factor for data messages.
     pub data_replication_factor: u64,
     pub activity_threshold_sensitivity: u64,
+    pub blend_failure_fallback: bool,
 }
 
 /// Same values as [`StartingBlendConfig`] but with the secret key exfiltrated
@@ -36,6 +39,7 @@ pub struct RunningBlendConfig<BackendSettings> {
     pub minimum_network_size: NonZeroU64,
     pub data_replication_factor: u64,
     pub activity_threshold_sensitivity: u64,
+    pub blend_failure_fallback: bool,
 }
 
 impl<BackendSettings> RunningBlendConfig<BackendSettings> {
@@ -64,6 +68,15 @@ impl<BackendSettings> RunningBlendConfig<BackendSettings> {
             rounds_per_epoch: self.time.rounds_per_epoch,
             num_blend_layers: self.num_blend_layers,
         }
+    }
+
+    #[must_use]
+    pub const fn max_data_message_delay_in_rounds(&self) -> NonZeroU64 {
+        max_data_message_delay_in_rounds(
+            self.num_blend_layers,
+            self.scheduler.delayer.maximum_release_delay_in_rounds,
+            round_duration_in_seconds(self.time.round_duration),
+        )
     }
 }
 

--- a/services/blend/src/core/settings.rs
+++ b/services/blend/src/core/settings.rs
@@ -6,9 +6,7 @@ use lb_services_utils::overwatch::{RecoveryData, StorageRecoverySettings};
 use lb_utils::math::NonNegativeF64;
 use serde::{Deserialize, Serialize};
 
-use crate::settings::{
-    TimingSettings, max_data_message_delay_in_rounds, round_duration_in_seconds,
-};
+use crate::settings::{TimingSettings, max_data_message_delay_in_rounds};
 
 #[derive(Clone, Debug)]
 pub struct StartingBlendConfig<BackendSettings> {
@@ -23,7 +21,7 @@ pub struct StartingBlendConfig<BackendSettings> {
     /// `R_c`: replication factor for data messages.
     pub data_replication_factor: u64,
     pub activity_threshold_sensitivity: u64,
-    pub blend_failure_fallback: bool,
+    pub abstain_on_failure: bool,
 }
 
 /// Same values as [`StartingBlendConfig`] but with the secret key exfiltrated
@@ -39,7 +37,7 @@ pub struct RunningBlendConfig<BackendSettings> {
     pub minimum_network_size: NonZeroU64,
     pub data_replication_factor: u64,
     pub activity_threshold_sensitivity: u64,
-    pub blend_failure_fallback: bool,
+    pub abstain_on_failure: bool,
 }
 
 impl<BackendSettings> RunningBlendConfig<BackendSettings> {
@@ -75,7 +73,6 @@ impl<BackendSettings> RunningBlendConfig<BackendSettings> {
         max_data_message_delay_in_rounds(
             self.num_blend_layers,
             self.scheduler.delayer.maximum_release_delay_in_rounds,
-            round_duration_in_seconds(self.time.round_duration),
         )
     }
 }

--- a/services/blend/src/core/tests/mod.rs
+++ b/services/blend/src/core/tests/mod.rs
@@ -1136,6 +1136,7 @@ async fn complete_old_epoch_after_main_loop_done() {
             crypto_processor,
             current_public_info,
             current_recovery_checkpoint,
+            None,
         )
         .await;
 
@@ -1145,6 +1146,7 @@ async fn complete_old_epoch_after_main_loop_done() {
             backend,
             TestNetworkAdapter,
             sdp_relay,
+            None,
             old_epoch_message_scheduler,
             rng,
             old_epoch_blending_token_collector,
@@ -1283,6 +1285,7 @@ async fn stop_on_empty_epoch() {
             crypto_processor,
             current_public_info,
             current_recovery_checkpoint,
+            None,
         )
         .await;
 
@@ -1292,6 +1295,7 @@ async fn stop_on_empty_epoch() {
             backend,
             TestNetworkAdapter,
             sdp_relay,
+            None,
             old_epoch_message_scheduler,
             rng,
             old_epoch_blending_token_collector,
@@ -1419,6 +1423,7 @@ async fn stop_on_non_empty_epoch_without_local_core_path() {
             crypto_processor,
             current_public_info,
             current_recovery_checkpoint,
+            None,
         )
         .await;
 
@@ -1428,6 +1433,7 @@ async fn stop_on_non_empty_epoch_without_local_core_path() {
             backend,
             TestNetworkAdapter,
             sdp_relay,
+            None,
             old_epoch_message_scheduler,
             rng,
             old_epoch_blending_token_collector,

--- a/services/blend/src/core/tests/utils.rs
+++ b/services/blend/src/core/tests/utils.rs
@@ -112,7 +112,7 @@ pub fn settings<BackendSettings>(
         num_blend_layers: NonZeroU64::try_from(1).unwrap(),
         minimum_network_size,
         data_replication_factor,
-        blend_failure_fallback: true,
+        abstain_on_failure: false,
         activity_threshold_sensitivity: 1,
     }
 }

--- a/services/blend/src/core/tests/utils.rs
+++ b/services/blend/src/core/tests/utils.rs
@@ -2,7 +2,7 @@ use core::cell::RefCell;
 use std::{num::NonZeroU64, pin::Pin, sync::Arc, time::Duration};
 
 use async_trait::async_trait;
-use futures::Stream;
+use futures::{Stream, StreamExt as _, stream::BoxStream};
 use lb_blend::{
     message::{
         crypto::{key_ext::Ed25519SecretKeyExt as _, proofs::PoQVerificationInputsMinusSigningKey},
@@ -112,6 +112,7 @@ pub fn settings<BackendSettings>(
         num_blend_layers: NonZeroU64::try_from(1).unwrap(),
         minimum_network_size,
         data_replication_factor,
+        blend_failure_fallback: true,
         activity_threshold_sensitivity: 1,
     }
 }
@@ -256,6 +257,12 @@ impl<RuntimeServiceId> NetworkAdapter<RuntimeServiceId> for TestNetworkAdapter {
     }
 
     async fn broadcast(&self, _message: Vec<u8>, _broadcast_settings: Self::BroadcastSettings) {}
+
+    async fn observe_broadcasts(
+        &self,
+    ) -> BoxStream<'static, crate::message::NetworkMessage<Self::BroadcastSettings>> {
+        futures::stream::empty().boxed()
+    }
 }
 
 pub struct TestNetworkBackend {

--- a/services/blend/src/delivery/failure_detection.rs
+++ b/services/blend/src/delivery/failure_detection.rs
@@ -24,7 +24,7 @@ use crate::{
 
 struct BlendedPayloadDetails {
     released_at: Round,
-    broadcasted: bool,
+    delivered: bool,
 }
 
 pub struct FailureDetector<BroadcastSettings> {
@@ -71,13 +71,13 @@ where
             .and_modify(|blended| blended.released_at = released_at)
             .or_insert(BlendedPayloadDetails {
                 released_at,
-                broadcasted: false,
+                delivered: false,
             });
     }
 
     fn mark_payload_as_delivered(&mut self, payload: &NetworkMessage<BroadcastSettings>) {
         if let Some(blended) = self.unacknowledged_blended_payloads.get_mut(payload) {
-            blended.broadcasted = true;
+            blended.delivered = true;
         }
     }
 
@@ -97,7 +97,7 @@ where
         expired
             .into_iter()
             // Only yield the ones that have not already been seen in the meanwhile.
-            .filter_map(|(payload, blended)| (!blended.broadcasted).then_some(payload))
+            .filter_map(|(payload, blended)| (!blended.delivered).then_some(payload))
             .collect()
     }
 
@@ -112,6 +112,12 @@ impl<BroadcastSettings> FailureDetector<BroadcastSettings>
 where
     BroadcastSettings: Eq + Hash + Send + Unpin,
 {
+    fn nothing_left_to_broadcast(&self) -> bool {
+        self.unacknowledged_blended_payloads
+            .values()
+            .all(|blended| blended.delivered)
+    }
+
     /// Waits out the delivery deadlines this node still owes, broadcasting in
     /// the clear each payload whose deadline expires.
     pub async fn drain_pending_message_queue<NetAdapter, RuntimeServiceId>(
@@ -122,14 +128,12 @@ where
     {
         loop {
             let expired = poll_fn(|cx| {
-                if self.unacknowledged_blended_payloads.is_empty() {
+                if self.nothing_left_to_broadcast() {
                     return Poll::Ready(None);
                 }
                 match self.poll_next_unpin(cx) {
                     Poll::Ready(expired) => Poll::Ready(expired),
-                    Poll::Pending if self.unacknowledged_blended_payloads.is_empty() => {
-                        Poll::Ready(None)
-                    }
+                    Poll::Pending if self.nothing_left_to_broadcast() => Poll::Ready(None),
                     Poll::Pending => Poll::Pending,
                 }
             })
@@ -199,6 +203,7 @@ mod tests {
             test_utils::{DEADLINE, ROUND, another_payload, proposal, until},
         },
         message::NetworkMessage,
+        test_utils::network::TestNetworkAdapter,
     };
 
     /// An edge sender, the instant its round clock started, and the handle that
@@ -370,6 +375,31 @@ mod tests {
                 .await
                 .is_empty(),
             "the proposal is on the chain; a later copy of it is not a reason to reveal it"
+        );
+    }
+
+    /// Everything outstanding has been seen on the channel, so nothing is left
+    /// that the wait could hand over: it has no reason to sit out the rounds
+    /// those payloads have left.
+    #[tokio::test(start_paused = true)]
+    async fn waiting_out_the_deadlines_ends_once_nothing_can_be_broadcast() {
+        let (mut detection, start, channel) = watching();
+        let (network_adapter, mut broadcasting_channel) = TestNetworkAdapter::new();
+        detection.mark_payload_as_blended(proposal());
+        channel.send(proposal()).expect("the watch is listening");
+        // One round in, so the delivery has landed and the deadline has not.
+        assert!(until(&mut detection, start, 1).await.is_empty());
+
+        tokio::time::timeout(
+            ROUND,
+            detection.drain_pending_message_queue::<_, ()>(&network_adapter),
+        )
+        .await
+        .expect("a set of nothing but delivered payloads has nothing left to wait for");
+
+        assert!(
+            broadcasting_channel.broadcasted.try_recv().is_err(),
+            "the payload was delivered, so nothing is owed a broadcast in the clear"
         );
     }
 }

--- a/services/blend/src/delivery/failure_detection.rs
+++ b/services/blend/src/delivery/failure_detection.rs
@@ -1,0 +1,375 @@
+use core::{
+    future::poll_fn,
+    hash::Hash,
+    mem::take,
+    num::NonZeroU64,
+    pin::Pin,
+    task::{Context, Poll},
+    time::Duration,
+};
+use std::collections::HashMap;
+
+use futures::{
+    Stream, StreamExt as _,
+    stream::{BoxStream, Fuse},
+};
+use lb_blend::scheduling::message_scheduler::round_info::Round;
+use tokio::time::{MissedTickBehavior, interval};
+use tokio_stream::wrappers::IntervalStream;
+
+use crate::{
+    LOG_TARGET, core::network::NetworkAdapter, delivery::broadcast_undelivered_messages,
+    message::NetworkMessage,
+};
+
+struct BlendedPayloadDetails {
+    released_at: Round,
+    broadcasted: bool,
+}
+
+pub struct FailureDetector<BroadcastSettings> {
+    maximum_blending_delay: NonZeroU64,
+    rounds_clock: IntervalStream,
+    current_round: Round,
+    payload_broadcasts: Fuse<BoxStream<'static, NetworkMessage<BroadcastSettings>>>,
+    /// Messages sent out via Blend, up to the round their deadline passes.
+    unacknowledged_blended_payloads:
+        HashMap<NetworkMessage<BroadcastSettings>, BlendedPayloadDetails>,
+}
+
+impl<BroadcastSettings> FailureDetector<BroadcastSettings>
+where
+    BroadcastSettings: Eq + Hash,
+{
+    #[must_use]
+    pub fn new(
+        maximum_blending_delay: NonZeroU64,
+        round_duration: Duration,
+        payload_broadcasts: BoxStream<'static, NetworkMessage<BroadcastSettings>>,
+    ) -> Self {
+        let clock = {
+            let mut clock = interval(round_duration);
+            clock.set_missed_tick_behavior(MissedTickBehavior::Skip);
+            clock
+        };
+        Self {
+            maximum_blending_delay,
+            rounds_clock: IntervalStream::new(clock),
+            current_round: Round::from(0),
+            payload_broadcasts: payload_broadcasts.fuse(),
+            unacknowledged_blended_payloads: HashMap::new(),
+        }
+    }
+
+    pub fn mark_payload_as_blended(&mut self, payload: NetworkMessage<BroadcastSettings>) {
+        let released_at = self.current_round;
+        self.unacknowledged_blended_payloads
+            .entry(payload)
+            // Overwrite the release time if the payload is blended again (in case of multiple
+            // copies), so that the last copy released is the one whose deadline
+            // decides.
+            .and_modify(|blended| blended.released_at = released_at)
+            .or_insert(BlendedPayloadDetails {
+                released_at,
+                broadcasted: false,
+            });
+    }
+
+    fn mark_payload_as_delivered(&mut self, payload: &NetworkMessage<BroadcastSettings>) {
+        if let Some(blended) = self.unacknowledged_blended_payloads.get_mut(payload) {
+            blended.broadcasted = true;
+        }
+    }
+
+    fn take_expired_payloads(&mut self, now: Round) -> Vec<NetworkMessage<BroadcastSettings>> {
+        let (expired, still_waiting): (HashMap<_, _>, HashMap<_, _>) =
+            take(&mut self.unacknowledged_blended_payloads)
+                .into_iter()
+                .partition(|(_, blended)| {
+                    blended
+                        .released_at
+                        .inner()
+                        .checked_add(u128::from(self.maximum_blending_delay.get()))
+                        .expect("Round calculation overflow.")
+                        < now.inner()
+                });
+        self.unacknowledged_blended_payloads = still_waiting;
+        expired
+            .into_iter()
+            // Only yield the ones that have not already been seen in the meanwhile.
+            .filter_map(|(payload, blended)| (!blended.broadcasted).then_some(payload))
+            .collect()
+    }
+
+    #[cfg(test)]
+    #[must_use]
+    pub fn outstanding_payloads_count(&self) -> usize {
+        self.unacknowledged_blended_payloads.len()
+    }
+}
+
+impl<BroadcastSettings> FailureDetector<BroadcastSettings>
+where
+    BroadcastSettings: Eq + Hash + Send + Unpin,
+{
+    /// Waits out the delivery deadlines this node still owes, broadcasting in
+    /// the clear each payload whose deadline expires.
+    pub async fn drain_pending_message_queue<NetAdapter, RuntimeServiceId>(
+        mut self,
+        network_adapter: &NetAdapter,
+    ) where
+        NetAdapter: NetworkAdapter<RuntimeServiceId, BroadcastSettings = BroadcastSettings> + Sync,
+    {
+        loop {
+            let expired = poll_fn(|cx| {
+                if self.unacknowledged_blended_payloads.is_empty() {
+                    return Poll::Ready(None);
+                }
+                match self.poll_next_unpin(cx) {
+                    Poll::Ready(expired) => Poll::Ready(expired),
+                    Poll::Pending if self.unacknowledged_blended_payloads.is_empty() => {
+                        Poll::Ready(None)
+                    }
+                    Poll::Pending => Poll::Pending,
+                }
+            })
+            .await;
+            let Some(undelivered) = expired else {
+                return;
+            };
+            broadcast_undelivered_messages(undelivered.into_iter(), network_adapter).await;
+        }
+    }
+}
+
+impl<BroadcastSettings> Stream for FailureDetector<BroadcastSettings>
+where
+    BroadcastSettings: Eq + Hash + Unpin,
+{
+    type Item = Vec<NetworkMessage<BroadcastSettings>>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        loop {
+            // Take what the broadcasting channel has for us before looking at the clock,
+            // so that a payload delivered in this very round is never the one the same
+            // round reveals.
+            loop {
+                match self.payload_broadcasts.poll_next_unpin(cx) {
+                    Poll::Pending => break,
+                    Poll::Ready(Some(delivered)) => self.mark_payload_as_delivered(&delivered),
+                    Poll::Ready(None) => {
+                        tracing::error!(
+                            target: LOG_TARGET,
+                            "Lost sight of the broadcasting channel; a delivery can no longer be told from a loss, so the direct broadcast is disabled for the rest of this run."
+                        );
+                        return Poll::Ready(None);
+                    }
+                }
+            }
+            match self.rounds_clock.poll_next_unpin(cx) {
+                Poll::Pending => return Poll::Pending,
+                Poll::Ready(None) => return Poll::Ready(None),
+                Poll::Ready(Some(_)) => {
+                    let now = Round::from(
+                        self.current_round
+                            .inner()
+                            .checked_add(1)
+                            .expect("Round computation overflow."),
+                    );
+                    self.current_round = now;
+                    let expired = self.take_expired_payloads(now);
+                    if !expired.is_empty() {
+                        return Poll::Ready(Some(expired));
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use futures::{StreamExt as _, stream};
+    use tokio::{sync::mpsc, time::Instant};
+    use tokio_stream::wrappers::UnboundedReceiverStream;
+
+    use crate::{
+        delivery::{
+            FailureDetector,
+            test_utils::{DEADLINE, ROUND, another_payload, proposal, until},
+        },
+        message::NetworkMessage,
+    };
+
+    /// An edge sender, the instant its round clock started, and the handle that
+    /// puts payloads on the broadcasting channel it watches.
+    fn watching() -> (
+        FailureDetector<()>,
+        Instant,
+        mpsc::UnboundedSender<NetworkMessage<()>>,
+    ) {
+        let (channel, broadcasts) = mpsc::unbounded_channel();
+        let detection = FailureDetector::new(
+            DEADLINE,
+            ROUND,
+            UnboundedReceiverStream::new(broadcasts).boxed(),
+        );
+        (detection, Instant::now(), channel)
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn a_payload_the_network_never_delivers_is_broadcast_at_the_deadline() {
+        let (mut detection, start, _channel) = watching();
+        detection.mark_payload_as_blended(proposal());
+
+        assert!(
+            until(&mut detection, start, DEADLINE.get() - 2)
+                .await
+                .is_empty(),
+            "revealing a proposal the network is still delivering is the one thing the deadline exists to prevent"
+        );
+        assert_eq!(
+            until(&mut detection, start, DEADLINE.get() + 2).await,
+            vec![proposal()]
+        );
+        assert_eq!(
+            detection.outstanding_payloads_count(),
+            0,
+            "it is broadcast exactly once"
+        );
+    }
+
+    /// The deadline is a count of rounds, but what it owes a payload is a
+    /// duration, and a payload is recorded against the round already in
+    /// progress. Counting from that round number alone would spend whatever of
+    /// it had already elapsed before the payload was ever released.
+    #[tokio::test(start_paused = true)]
+    async fn a_payload_is_never_revealed_before_its_full_deadline_has_elapsed() {
+        let (mut detection, start, _channel) = watching();
+        // Half a round in: the worst case for a count of rounds, and the case an
+        // inclusive comparison against the round number gets wrong.
+        let released_at = start + ROUND * 2 + ROUND / 2;
+        let _turned = until(&mut detection, start, 2).await;
+        tokio::time::sleep_until(released_at).await;
+        detection.mark_payload_as_blended(proposal());
+
+        let rounds = u32::try_from(DEADLINE.get()).expect("The deadline is a few rounds.");
+        let expired = tokio::time::timeout(ROUND * (rounds + 3), detection.next())
+            .await
+            .expect("the deadline must expire eventually")
+            .expect("an interval never ends, so neither does the detector");
+
+        assert_eq!(expired, vec![proposal()]);
+        assert!(
+            released_at.elapsed() >= ROUND * rounds,
+            "revealing a proposal before the network has had its full deadline is the one thing the deadline exists to prevent"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn a_delivered_payload_is_never_broadcast_in_the_clear() {
+        let (mut detection, start, channel) = watching();
+        detection.mark_payload_as_blended(proposal());
+        channel.send(proposal()).expect("the watch is listening");
+
+        assert!(
+            until(&mut detection, start, DEADLINE.get() + 3)
+                .await
+                .is_empty(),
+            "the deadline passing means nothing once the proposal is on the channel"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn the_last_copy_released_is_the_one_whose_deadline_decides() {
+        /// Rounds between the two copies going out.
+        const APART: u64 = 3;
+
+        let (mut detection, start, _channel) = watching();
+        detection.mark_payload_as_blended(proposal());
+        assert!(until(&mut detection, start, APART).await.is_empty());
+        detection.mark_payload_as_blended(proposal());
+
+        assert!(
+            until(&mut detection, start, DEADLINE.get() + 1)
+                .await
+                .is_empty(),
+            "a proposal is lost only once every copy carrying it has failed"
+        );
+        assert_eq!(
+            until(&mut detection, start, DEADLINE.get() + APART + 2).await,
+            vec![proposal()]
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn everything_released_in_one_round_expires_together() {
+        let (mut detection, start, _channel) = watching();
+        detection.mark_payload_as_blended(proposal());
+        detection.mark_payload_as_blended(another_payload());
+
+        assert_eq!(
+            until(&mut detection, start, DEADLINE.get() + 2).await.len(),
+            2
+        );
+        assert_eq!(detection.outstanding_payloads_count(), 0);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn a_round_in_which_nothing_expires_does_not_wake_the_loop() {
+        // The channel is held open: an idle sender is one that can still see the
+        // broadcasting channel, not one that has lost it.
+        let (mut detection, _start, _channel) = watching();
+        assert!(
+            tokio::time::timeout(ROUND * 40, detection.next())
+                .await
+                .is_err(),
+            "an idle sender must not wake its service loop every round"
+        );
+    }
+
+    /// The broadcasting channel is the only evidence of delivery there is.
+    /// Without it every payload looks lost, so carrying on would answer a
+    /// broken observer by revealing everything this node sends — the
+    /// opposite of what the fallback is for.
+    #[tokio::test(start_paused = true)]
+    async fn losing_sight_of_the_broadcasting_channel_stops_the_detection() {
+        let mut detection = FailureDetector::new(DEADLINE, ROUND, stream::empty().boxed());
+        let start = Instant::now();
+        detection.mark_payload_as_blended(proposal());
+
+        assert!(
+            until(&mut detection, start, DEADLINE.get() + 2)
+                .await
+                .is_empty(),
+            "a node that cannot see the channel must not answer that by revealing its own traffic"
+        );
+        assert_eq!(
+            detection.next().await,
+            None,
+            "the branch this feeds is disabled outright rather than polled forever"
+        );
+    }
+
+    /// With replication a proposal goes out as two messages, and the second may
+    /// be released after the first has already been seen delivered. Gossipsub
+    /// drops the duplicate, so no second observation is coming to cancel a
+    /// deadline the second release would start.
+    #[tokio::test(start_paused = true)]
+    async fn a_copy_released_after_a_delivery_is_not_revealed() {
+        let (mut detection, start, channel) = watching();
+        detection.mark_payload_as_blended(proposal());
+        channel.send(proposal()).expect("the watch is listening");
+        // Let the delivery land before the second copy goes out.
+        assert!(until(&mut detection, start, 2).await.is_empty());
+
+        detection.mark_payload_as_blended(proposal());
+
+        assert!(
+            until(&mut detection, start, DEADLINE.get() + 4)
+                .await
+                .is_empty(),
+            "the proposal is on the chain; a later copy of it is not a reason to reveal it"
+        );
+    }
+}

--- a/services/blend/src/delivery/mod.rs
+++ b/services/blend/src/delivery/mod.rs
@@ -1,0 +1,57 @@
+use futures::{Stream, StreamExt as _, future::join_all};
+
+pub use self::failure_detection::FailureDetector;
+use crate::{LOG_TARGET, core::network::NetworkAdapter, message::NetworkMessage, metrics};
+
+mod failure_detection;
+
+#[cfg(test)]
+pub mod test_utils;
+
+/// The payloads whose deadline has just passed, from a sender that is watching
+/// for them.
+///
+/// A sender that is not — the operator turned the fallback off — waits forever
+/// instead, which leaves the `select!` branch this feeds permanently idle
+/// rather than firing.
+pub async fn next_undelivered_messages<Detection, BroadcastSettings>(
+    failure_detection: Option<&mut Detection>,
+) -> Option<Vec<NetworkMessage<BroadcastSettings>>>
+where
+    Detection: Stream<Item = Vec<NetworkMessage<BroadcastSettings>>> + Unpin + Send,
+{
+    match failure_detection {
+        Some(failure_detection) => failure_detection.next().await,
+        None => core::future::pending().await,
+    }
+}
+
+/// Broadcasts, in the clear, the payloads the Blend network did not deliver
+/// within the delivery deadline.
+pub async fn broadcast_undelivered_messages<NetAdapter, UndeliveredPayloads, RuntimeServiceId>(
+    undelivered: UndeliveredPayloads,
+    network_adapter: &NetAdapter,
+) where
+    NetAdapter: NetworkAdapter<RuntimeServiceId> + Sync,
+    UndeliveredPayloads:
+        ExactSizeIterator<Item = NetworkMessage<NetAdapter::BroadcastSettings>> + Send,
+{
+    // TODO: Once we switch to a well-defined API for blending payloads, we can and
+    // should show the relevant details for each payload that failed. E.g., for
+    // blocks we could log the block ID.
+    tracing::warn!(
+        target: LOG_TARGET,
+        "The Blend network did not deliver {} locally-originated payload(s) within the delivery deadline; broadcasting them directly.",
+        undelivered.len()
+    );
+    join_all(undelivered.into_iter().map(
+        |NetworkMessage {
+             message,
+             broadcast_settings,
+         }| {
+            metrics::message_bypassed_blend();
+            network_adapter.broadcast(message, broadcast_settings)
+        },
+    ))
+    .await;
+}

--- a/services/blend/src/delivery/test_utils.rs
+++ b/services/blend/src/delivery/test_utils.rs
@@ -1,0 +1,47 @@
+use core::{num::NonZeroU64, time::Duration};
+
+use futures::{Stream, StreamExt as _};
+use tokio::time::Instant;
+
+use crate::message::NetworkMessage;
+
+pub const ROUND: Duration = Duration::from_secs(1);
+pub const DEADLINE: NonZeroU64 = NonZeroU64::new(6).unwrap();
+
+#[must_use]
+pub fn proposal() -> NetworkMessage<()> {
+    NetworkMessage {
+        message: b"proposal".to_vec(),
+        broadcast_settings: (),
+    }
+}
+
+#[must_use]
+pub fn another_payload() -> NetworkMessage<()> {
+    NetworkMessage {
+        message: b"another".to_vec(),
+        broadcast_settings: (),
+    }
+}
+
+/// Turns the clock until `round`, collecting whatever expired on the way.
+/// Rounds are counted from `start` rather than from now, so a test that
+/// calls this several times does not accumulate an offset.
+pub async fn until<Detection>(
+    detection: &mut Detection,
+    start: Instant,
+    round: u64,
+) -> Vec<NetworkMessage<()>>
+where
+    Detection: Stream<Item = Vec<NetworkMessage<()>>> + Unpin,
+{
+    let stop = start + ROUND * u32::try_from(round).expect("The tests turn few rounds.");
+    let mut expired = Vec::new();
+    let _timed_out = tokio::time::timeout_at(stop, async {
+        while let Some(batch) = detection.next().await {
+            expired.extend(batch);
+        }
+    })
+    .await;
+    expired
+}

--- a/services/blend/src/edge/mod.rs
+++ b/services/blend/src/edge/mod.rs
@@ -29,6 +29,7 @@ use lb_key_management_system_service::{
     operators::ed25519::exfiltrate_secret_key::LeakSecretKeyOperator,
 };
 use lb_log_targets::blend;
+use lb_network_service::NetworkService;
 use lb_services_utils::wait_until_services_are_ready;
 use lb_time_service::TimeService;
 use overwatch::{
@@ -46,6 +47,8 @@ use tokio::sync::oneshot;
 use tracing::{debug, error, info};
 
 use crate::{
+    core::network::NetworkAdapter,
+    delivery::{FailureDetector, broadcast_undelivered_messages, next_undelivered_messages},
     edge::{
         handlers::{Error, MessageHandler},
         settings::RunningBlendConfig,
@@ -64,7 +67,7 @@ type RunningSettings<Backend, NodeId, RuntimeServiceId> =
 pub struct BlendService<
     Backend,
     NodeId,
-    BroadcastSettings,
+    NetAdapter,
     ProofsGenerator,
     TimeBackend,
     ChainService,
@@ -73,15 +76,22 @@ pub struct BlendService<
 > where
     Backend: BlendBackend<NodeId, RuntimeServiceId>,
     NodeId: Clone,
+    NetAdapter: NetworkAdapter<RuntimeServiceId>,
 {
     service_resources_handle: OpaqueServiceResourcesHandle<Self, RuntimeServiceId>,
-    _phantom: PhantomData<(ProofsGenerator, TimeBackend, ChainService, PolInfoProvider)>,
+    _phantom: PhantomData<(
+        NetAdapter,
+        ProofsGenerator,
+        TimeBackend,
+        ChainService,
+        PolInfoProvider,
+    )>,
 }
 
 impl<
     Backend,
     NodeId,
-    BroadcastSettings,
+    NetAdapter,
     ProofsGenerator,
     TimeBackend,
     ChainService,
@@ -91,7 +101,7 @@ impl<
     for BlendService<
         Backend,
         NodeId,
-        BroadcastSettings,
+        NetAdapter,
         ProofsGenerator,
         TimeBackend,
         ChainService,
@@ -101,18 +111,19 @@ impl<
 where
     Backend: BlendBackend<NodeId, RuntimeServiceId>,
     NodeId: Clone,
+    NetAdapter: NetworkAdapter<RuntimeServiceId>,
 {
     type Settings = StartingBlendConfig<Backend::Settings>;
     type State = NoState<Self::Settings>;
     type StateOperator = NoOperator<Self::State>;
-    type Message = ServiceMessage<BroadcastSettings, NodeId>;
+    type Message = ServiceMessage<NetAdapter::BroadcastSettings, NodeId>;
 }
 
 #[async_trait::async_trait]
 impl<
     Backend,
     NodeId,
-    BroadcastSettings,
+    NetAdapter,
     ProofsGenerator,
     TimeBackend,
     ChainService,
@@ -122,7 +133,7 @@ impl<
     for BlendService<
         Backend,
         NodeId,
-        BroadcastSettings,
+        NetAdapter,
         ProofsGenerator,
         TimeBackend,
         ChainService,
@@ -132,7 +143,11 @@ impl<
 where
     Backend: BlendBackend<NodeId, RuntimeServiceId> + Send + Sync,
     NodeId: Clone + Debug + Eq + Hash + Send + Sync + node_id::TryFrom + 'static,
-    BroadcastSettings: Serialize + DeserializeOwned + Send,
+    NetAdapter: NetworkAdapter<
+            RuntimeServiceId,
+            BroadcastSettings: Serialize + DeserializeOwned + Eq + Hash + Unpin + Send + Sync,
+        > + Send
+        + Sync,
     ProofsGenerator: LeaderProofsGenerator + Send,
     TimeBackend: lb_time_service::backends::TimeBackend + Send,
     ChainService: CryptarchiaServiceData<Tx: Send + Sync>,
@@ -141,6 +156,7 @@ where
         + AsServiceId<TimeService<TimeBackend, RuntimeServiceId>>
         + AsServiceId<ChainService>
         + AsServiceId<PreloadKmsService<RuntimeServiceId>>
+        + AsServiceId<NetworkService<NetAdapter::Backend, RuntimeServiceId>>
         + Display
         + Debug
         + Clone
@@ -214,29 +230,32 @@ where
             )
             .await;
 
-        let messages_to_blend_stream = Box::pin(inbound_relay.filter_map(async |msg| {
-            match msg {
-                ServiceMessage::Blend(message) => Some(
-                    NetworkMessage::<BroadcastSettings>::to_bytes(&message)
-                        .expect("NetworkMessage should be able to be serialized")
-                        .to_vec(),
-                ),
-                ServiceMessage::GetNetworkInfo { reply } => {
-                    drop(reply.send(Some(NetworkInfo {
-                        node_id: local_node_id.clone(),
-                        core_info: None,
-                    })));
-                    None
-                }
+        let messages_to_blend_stream = Box::pin(inbound_relay.filter_map(async |msg| match msg {
+            ServiceMessage::Blend(message) => Some(message),
+            ServiceMessage::GetNetworkInfo { reply } => {
+                drop(reply.send(Some(NetworkInfo {
+                    node_id: local_node_id.clone(),
+                    core_info: None,
+                })));
+                None
             }
         }));
 
-        run::<Backend, _, ProofsGenerator, PolInfoProvider, _>(
+        let network_adapter = {
+            let network_relay = overwatch_handle
+                .relay::<NetworkService<_, _>>()
+                .await
+                .expect("Relay with network service should be available.");
+            NetAdapter::new(network_relay)
+        };
+
+        run::<Backend, _, NetAdapter, ProofsGenerator, PolInfoProvider, _>(
             UninitializedEpochEventStream::new(
                 public_epoch_stream,
                 settings.time.epoch_transition_period,
             ),
             messages_to_blend_stream,
+            network_adapter,
             RunningSettings::<Backend, _, _> {
                 backend: settings.backend,
                 cover: settings.cover,
@@ -245,6 +264,8 @@ where
                 minimum_network_size: settings.minimum_network_size,
                 time: settings.time,
                 data_replication_factor: settings.data_replication_factor,
+                blend_failure_fallback: settings.blend_failure_fallback,
+                max_blend_delay_in_rounds: settings.max_blend_delay_in_rounds,
             },
             &overwatch_handle,
             || {
@@ -288,11 +309,14 @@ where
     clippy::cognitive_complexity,
     reason = "TODO: address this in a dedicated refactor"
 )]
-async fn run<Backend, NodeId, ProofsGenerator, PolInfoProvider, RuntimeServiceId>(
+async fn run<Backend, NodeId, NetAdapter, ProofsGenerator, PolInfoProvider, RuntimeServiceId>(
     public_epoch_stream: UninitializedEpochEventStream<
         impl Stream<Item = BlendEpochState<NodeId>> + Unpin,
     >,
-    mut incoming_message_stream: impl Stream<Item = Vec<u8>> + Send + Unpin,
+    mut incoming_message_stream: impl Stream<Item = NetworkMessage<NetAdapter::BroadcastSettings>>
+    + Send
+    + Unpin,
+    network_adapter: NetAdapter,
     settings: RunningSettings<Backend, NodeId, RuntimeServiceId>,
     overwatch_handle: &OverwatchHandle<RuntimeServiceId>,
     notify_ready: impl Fn(),
@@ -300,6 +324,10 @@ async fn run<Backend, NodeId, ProofsGenerator, PolInfoProvider, RuntimeServiceId
 where
     Backend: BlendBackend<NodeId, RuntimeServiceId> + Sync + Send,
     NodeId: Clone + Debug + Eq + Hash + Send + Sync + 'static,
+    NetAdapter: NetworkAdapter<
+            RuntimeServiceId,
+            BroadcastSettings: Serialize + Eq + Hash + Unpin + Send + Sync,
+        > + Sync,
     ProofsGenerator: LeaderProofsGenerator + Send,
     PolInfoProvider: PolInfoProviderTrait<RuntimeServiceId, Stream: Unpin>,
     RuntimeServiceId: Clone + Send + Sync,
@@ -331,6 +359,20 @@ where
         MessageHandler<Backend, NodeId, ProofsGenerator, RuntimeServiceId>,
     > = None;
 
+    // What this node has handed to the Blend network and not seen come out of it.
+    // An edge node reaches the same verdict as a core node and reacts the same way,
+    // only later: it sees none of the network's traffic, so the deadline is all it
+    // has. `None` when the operator has turned the fallback off.
+    let mut failure_detector = if settings.blend_failure_fallback {
+        Some(FailureDetector::new(
+            settings.max_data_message_delay_in_rounds(),
+            settings.time.round_duration,
+            network_adapter.observe_broadcasts().await,
+        ))
+    } else {
+        None
+    };
+
     loop {
         tokio::select! {
             Some(EpochEvent::NewEpoch(new_public_epoch_info)) = remaining_public_epoch_stream.next() => {
@@ -338,10 +380,16 @@ where
                 match handle_new_epoch_event(&current_epoch_info, &mut current_secret_epoch_info, &mut current_epoch_message_handler, settings.clone(), overwatch_handle.clone()) {
                     Err(Error::NetworkIsTooSmall(_)) => {
                         info!(target: LOG_TARGET, "New membership does not satisfy edge node condition, edge service shutting down.");
+                        if let Some(failure_detector) = failure_detector {
+                            failure_detector.drain_pending_message_queue(&network_adapter).await;
+                        }
                         return Ok(());
                     }
                     Err(e) => {
                         error!(target: LOG_TARGET, "Error when handling new public epoch: {e:?}, edge service shutting down.");
+                        if let Some(failure_detector) = failure_detector {
+                            failure_detector.drain_pending_message_queue(&network_adapter).await;
+                        }
                         return Err(e);
                     }
                     Ok(()) => {}
@@ -352,10 +400,16 @@ where
                 match handle_new_epoch_event(&current_epoch_info, &mut current_secret_epoch_info, &mut current_epoch_message_handler, settings.clone(), overwatch_handle.clone()) {
                     Err(Error::NetworkIsTooSmall(_)) => {
                         info!(target: LOG_TARGET, "New membership does not satisfy edge node condition, edge service shutting down.");
+                        if let Some(failure_detector) = failure_detector {
+                            failure_detector.drain_pending_message_queue(&network_adapter).await;
+                        }
                         return Ok(());
                     }
                     Err(e) => {
                         error!(target: LOG_TARGET, "Error when handling new secret epoch: {e:?}, edge service shutting down.");
+                        if let Some(failure_detector) = failure_detector {
+                            failure_detector.drain_pending_message_queue(&network_adapter).await;
+                        }
                         return Err(e);
                     }
                     Ok(()) => {}
@@ -367,15 +421,29 @@ where
                     tracing::warn!(target: LOG_TARGET, "Received a message to blend, but no active message handler is available to process it because the secret PoL info for the current epoch is not yet available. Ignoring the message.");
                     continue;
                 };
+                let serialized = NetworkMessage::<NetAdapter::BroadcastSettings>::to_bytes(&message)
+                    .expect("NetworkMessage should be able to be serialized")
+                    .to_vec();
                 let message_copies = settings.data_replication_factor.checked_add(1).unwrap();
                 for _ in 0..message_copies {
-                    handler.handle_message_to_blend(message.clone()).await;
+                    handler.handle_message_to_blend(serialized.clone()).await;
                 }
+                // An edge node sends what it encapsulates, so the deadline of what it
+                // carries starts here rather than at some later release round.
+                if let Some(failure_detector) = failure_detector.as_mut() {
+                    failure_detector.mark_payload_as_blended(message);
+                }
+            }
+            Some(undelivered) = next_undelivered_messages(failure_detector.as_mut()) => {
+                broadcast_undelivered_messages(undelivered.into_iter(), &network_adapter).await;
             }
             else => {
                 // All input streams have terminated (e.g. disorderly shutdown).
                 // Exit cleanly instead of letting `select!` panic.
                 debug!(target: LOG_TARGET, "All input streams terminated, edge service shutting down.");
+                if let Some(failure_detector) = failure_detector {
+                    failure_detector.drain_pending_message_queue(&network_adapter).await;
+                }
                 return Ok(());
             }
         }

--- a/services/blend/src/edge/mod.rs
+++ b/services/blend/src/edge/mod.rs
@@ -264,7 +264,7 @@ where
                 minimum_network_size: settings.minimum_network_size,
                 time: settings.time,
                 data_replication_factor: settings.data_replication_factor,
-                blend_failure_fallback: settings.blend_failure_fallback,
+                abstain_on_failure: settings.abstain_on_failure,
                 max_blend_delay_in_rounds: settings.max_blend_delay_in_rounds,
             },
             &overwatch_handle,
@@ -363,14 +363,14 @@ where
     // An edge node reaches the same verdict as a core node and reacts the same way,
     // only later: it sees none of the network's traffic, so the deadline is all it
     // has. `None` when the operator has turned the fallback off.
-    let mut failure_detector = if settings.blend_failure_fallback {
+    let mut failure_detector = if settings.abstain_on_failure {
+        None
+    } else {
         Some(FailureDetector::new(
             settings.max_data_message_delay_in_rounds(),
             settings.time.round_duration,
             network_adapter.observe_broadcasts().await,
         ))
-    } else {
-        None
     };
 
     loop {

--- a/services/blend/src/edge/service_components.rs
+++ b/services/blend/src/edge/service_components.rs
@@ -1,4 +1,7 @@
-use crate::edge::{BlendService, backends::BlendBackend};
+use crate::{
+    core::network::NetworkAdapter,
+    edge::{BlendService, backends::BlendBackend},
+};
 
 /// Exposes associated types for external modules that depend on
 /// [`BlendService`], without requiring them to specify its generic parameters.
@@ -6,6 +9,9 @@ pub trait ServiceComponents {
     /// Settings for broadcasting messages that have passed through the blend
     /// network.
     type BroadcastSettings;
+    /// The adapter that puts a payload on the broadcasting channel, which an
+    /// edge node needs to broadcast one the network failed to deliver.
+    type NetworkAdapter;
     type ProofsGenerator;
     type BackendSettings;
     /// Chain service, used by the proxy to derive membership from the chain.
@@ -17,7 +23,7 @@ pub trait ServiceComponents {
 impl<
     Backend,
     NodeId,
-    BroadcastSettings,
+    NetAdapter,
     ProofsGenerator,
     TimeBackend,
     ChainService,
@@ -27,7 +33,7 @@ impl<
     for BlendService<
         Backend,
         NodeId,
-        BroadcastSettings,
+        NetAdapter,
         ProofsGenerator,
         TimeBackend,
         ChainService,
@@ -37,9 +43,11 @@ impl<
 where
     Backend: BlendBackend<NodeId, RuntimeServiceId>,
     NodeId: Clone,
+    NetAdapter: NetworkAdapter<RuntimeServiceId>,
 {
     type BackendSettings = Backend::Settings;
-    type BroadcastSettings = BroadcastSettings;
+    type BroadcastSettings = NetAdapter::BroadcastSettings;
+    type NetworkAdapter = NetAdapter;
     type ProofsGenerator = ProofsGenerator;
     type ChainService = ChainService;
     type TimeBackend = TimeBackend;

--- a/services/blend/src/edge/settings.rs
+++ b/services/blend/src/edge/settings.rs
@@ -4,7 +4,7 @@ use lb_key_management_system_service::{backend::preload::KeyId, keys::UnsecuredE
 
 use crate::{
     core::settings::CoverTrafficSettings,
-    settings::{TimingSettings, max_data_message_delay_in_rounds, round_duration_in_seconds},
+    settings::{TimingSettings, max_data_message_delay_in_rounds},
 };
 
 #[derive(Clone, Debug)]
@@ -17,7 +17,7 @@ pub struct StartingBlendConfig<BackendSettings> {
     pub cover: CoverTrafficSettings,
     /// `R_c`: replication factor for data messages.
     pub data_replication_factor: u64,
-    pub blend_failure_fallback: bool,
+    pub abstain_on_failure: bool,
     pub max_blend_delay_in_rounds: NonZeroU64,
 }
 
@@ -32,7 +32,7 @@ pub struct RunningBlendConfig<BackendSettings> {
     pub minimum_network_size: NonZeroU64,
     pub cover: CoverTrafficSettings,
     pub data_replication_factor: u64,
-    pub blend_failure_fallback: bool,
+    pub abstain_on_failure: bool,
     pub max_blend_delay_in_rounds: NonZeroU64,
 }
 
@@ -49,10 +49,6 @@ impl<BackendSettings> RunningBlendConfig<BackendSettings> {
 
     #[must_use]
     pub const fn max_data_message_delay_in_rounds(&self) -> NonZeroU64 {
-        max_data_message_delay_in_rounds(
-            self.num_blend_layers,
-            self.max_blend_delay_in_rounds,
-            round_duration_in_seconds(self.time.round_duration),
-        )
+        max_data_message_delay_in_rounds(self.num_blend_layers, self.max_blend_delay_in_rounds)
     }
 }

--- a/services/blend/src/edge/settings.rs
+++ b/services/blend/src/edge/settings.rs
@@ -2,7 +2,10 @@ use core::num::NonZeroU64;
 
 use lb_key_management_system_service::{backend::preload::KeyId, keys::UnsecuredEd25519Key};
 
-use crate::{core::settings::CoverTrafficSettings, settings::TimingSettings};
+use crate::{
+    core::settings::CoverTrafficSettings,
+    settings::{TimingSettings, max_data_message_delay_in_rounds, round_duration_in_seconds},
+};
 
 #[derive(Clone, Debug)]
 pub struct StartingBlendConfig<BackendSettings> {
@@ -14,6 +17,8 @@ pub struct StartingBlendConfig<BackendSettings> {
     pub cover: CoverTrafficSettings,
     /// `R_c`: replication factor for data messages.
     pub data_replication_factor: u64,
+    pub blend_failure_fallback: bool,
+    pub max_blend_delay_in_rounds: NonZeroU64,
 }
 
 /// Same values as [`StartingBlendConfig`] but with the secret key exfiltrated
@@ -27,6 +32,8 @@ pub struct RunningBlendConfig<BackendSettings> {
     pub minimum_network_size: NonZeroU64,
     pub cover: CoverTrafficSettings,
     pub data_replication_factor: u64,
+    pub blend_failure_fallback: bool,
+    pub max_blend_delay_in_rounds: NonZeroU64,
 }
 
 impl<BackendSettings> RunningBlendConfig<BackendSettings> {
@@ -38,5 +45,14 @@ impl<BackendSettings> RunningBlendConfig<BackendSettings> {
         num_blend_layers
             .checked_add(additional_encapsulations)
             .expect("Overflow when computing leadership quota.")
+    }
+
+    #[must_use]
+    pub const fn max_data_message_delay_in_rounds(&self) -> NonZeroU64 {
+        max_data_message_delay_in_rounds(
+            self.num_blend_layers,
+            self.max_blend_delay_in_rounds,
+            round_duration_in_seconds(self.time.round_duration),
+        )
     }
 }

--- a/services/blend/src/edge/tests/mod.rs
+++ b/services/blend/src/edge/tests/mod.rs
@@ -8,17 +8,19 @@ use lb_blend::{
 use lb_chain_service::Epoch;
 use lb_core::crypto::ZkHash;
 use lb_groth16::{AdditiveGroup as _, Fr};
-use tokio::time::sleep;
+use tokio::{sync::mpsc, time::sleep};
 
 use crate::{
     edge::{
         handlers::Error,
         tests::utils::{
-            MockLeaderProofsGenerator, NodeId, TestBackend, overwatch_handle, settings, spawn_run,
+            MockLeaderProofsGenerator, NodeId, TEST_DELIVERY_DEADLINE, TEST_ROUND, TestBackend,
+            overwatch_handle, settings, spawn_run,
         },
     },
     epoch_info::PolEpochInfo,
     membership::chain::BlendEpochState,
+    message::NetworkMessage,
     test_utils::membership::membership,
 };
 
@@ -31,7 +33,7 @@ async fn run_with_epoch_transition() {
     let local_node = NodeId(99);
     let mut core_node = NodeId(0);
     let minimal_network_size = 1;
-    let (_, epoch_sender, msg_sender, mut node_id_receiver) = spawn_run(
+    let (_, epoch_sender, msg_sender, mut node_id_receiver, _broadcasting_channel) = spawn_run(
         local_node,
         minimal_network_size,
         Some(membership(&[core_node], local_node)),
@@ -39,7 +41,13 @@ async fn run_with_epoch_transition() {
     .await;
 
     // A message should be forwarded to the core node 0.
-    msg_sender.send(vec![0]).await.expect("channel opened");
+    msg_sender
+        .send(NetworkMessage {
+            message: vec![0],
+            broadcast_settings: (),
+        })
+        .await
+        .expect("channel opened");
     assert_eq!(
         node_id_receiver.recv().await.expect("channel opened"),
         core_node
@@ -54,7 +62,13 @@ async fn run_with_epoch_transition() {
     sleep(Duration::from_millis(100)).await;
 
     // A message should be forwarded to the core node 1.
-    msg_sender.send(vec![0]).await.expect("channel opened");
+    msg_sender
+        .send(NetworkMessage {
+            message: vec![0],
+            broadcast_settings: (),
+        })
+        .await
+        .expect("channel opened");
     assert_eq!(
         node_id_receiver.recv().await.expect("channel opened"),
         core_node
@@ -68,7 +82,7 @@ async fn run_shuts_down_if_new_membership_is_small() {
     let local_node = NodeId(99);
     let core_node = NodeId(0);
     let minimal_network_size = 1;
-    let (join_handle, epoch_sender, _, _) = spawn_run(
+    let (join_handle, epoch_sender, _, _, _broadcasting_channel) = spawn_run(
         local_node,
         minimal_network_size,
         Some(membership(&[core_node], local_node)),
@@ -89,7 +103,7 @@ async fn run_fails_if_local_is_core_in_new_membership() {
     let local_node = NodeId(99);
     let core_node = NodeId(0);
     let minimal_network_size = 1;
-    let (join_handle, epoch_sender, _, _) = spawn_run(
+    let (join_handle, epoch_sender, _, _, _broadcasting_channel) = spawn_run(
         local_node,
         minimal_network_size,
         Some(membership(&[core_node], local_node)),
@@ -127,7 +141,7 @@ fn test_pol_epoch_info(epoch: Epoch) -> PolEpochInfo {
 async fn handle_new_secret_epoch_info_recreates_handler() {
     let local_node = NodeId(99);
     let core_node = NodeId(0);
-    let (node_id_sender, _node_id_receiver) = tokio::sync::mpsc::channel(1);
+    let (node_id_sender, _node_id_receiver) = mpsc::channel(1);
 
     let settings = settings(local_node, 1, node_id_sender);
     let overwatch = overwatch_handle();
@@ -186,7 +200,7 @@ fn test_blend_epoch_state(epoch: Epoch, membership: Membership<NodeId>) -> Blend
 async fn two_publics_without_private_in_between() {
     let local_node = NodeId(99);
     let core_node = NodeId(0);
-    let (node_id_sender, _node_id_receiver) = tokio::sync::mpsc::channel(1);
+    let (node_id_sender, _node_id_receiver) = mpsc::channel(1);
 
     let settings = settings(local_node, 1, node_id_sender);
     let overwatch = overwatch_handle();
@@ -230,7 +244,7 @@ async fn two_publics_without_private_in_between() {
 async fn public_then_private_same_epoch_creates_handler() {
     let local_node = NodeId(99);
     let core_node = NodeId(0);
-    let (node_id_sender, _node_id_receiver) = tokio::sync::mpsc::channel(1);
+    let (node_id_sender, _node_id_receiver) = mpsc::channel(1);
 
     let settings = settings(local_node, 1, node_id_sender);
     let overwatch = overwatch_handle();
@@ -276,7 +290,7 @@ async fn public_then_private_same_epoch_creates_handler() {
 async fn private_then_public_same_epoch_creates_handler() {
     let local_node = NodeId(99);
     let core_node = NodeId(0);
-    let (node_id_sender, _node_id_receiver) = tokio::sync::mpsc::channel(1);
+    let (node_id_sender, _node_id_receiver) = mpsc::channel(1);
 
     let settings = settings(local_node, 1, node_id_sender);
     let overwatch = overwatch_handle();
@@ -317,5 +331,89 @@ async fn private_then_public_same_epoch_creates_handler() {
             .expect("Handler must be created")
             .epoch(),
         Epoch::new(1)
+    );
+}
+
+/// Blends `payload` and waits until the backend reports it going out, so that
+/// what follows is timed from a release that has actually happened.
+async fn blend_and_await_release(
+    msg_sender: &mpsc::Sender<NetworkMessage<()>>,
+    node_ids: &mut mpsc::Receiver<NodeId>,
+    payload: NetworkMessage<()>,
+) {
+    // The handler needs this epoch's secret `PoL` info, which arrives on its own
+    // task; until it has, a message to blend is dropped with a warning.
+    for _ in 0..RELEASE_ATTEMPTS {
+        msg_sender
+            .send(payload.clone())
+            .await
+            .expect("channel opened");
+        if tokio::time::timeout(TEST_ROUND, node_ids.recv())
+            .await
+            .is_ok_and(|sent| sent.is_some())
+        {
+            return;
+        }
+    }
+    panic!("the edge node never blended the payload");
+}
+
+/// How many rounds the helper above will keep offering the payload for.
+const RELEASE_ATTEMPTS: usize = 10;
+
+/// A payload the Blend network never delivers is put on the broadcasting
+/// channel by its sender, once the deadline has passed and not before.
+#[test_log::test(tokio::test(start_paused = true))]
+async fn a_payload_the_network_never_delivers_is_broadcast_in_the_clear() {
+    let local_node = NodeId(99);
+    let (_, epoch_sender, msg_sender, mut node_ids, mut broadcasting_channel) =
+        spawn_run(local_node, 1, Some(membership(&[NodeId(0)], local_node))).await;
+    drop(epoch_sender);
+
+    let payload = NetworkMessage {
+        message: b"proposal".to_vec(),
+        broadcast_settings: (),
+    };
+    blend_and_await_release(&msg_sender, &mut node_ids, payload.clone()).await;
+
+    let rounds = u32::try_from(TEST_DELIVERY_DEADLINE.get()).expect("a few rounds");
+    let broadcast = tokio::time::timeout(
+        TEST_ROUND * (rounds + 4),
+        broadcasting_channel.broadcasted.recv(),
+    )
+    .await
+    .expect("the deadline should have expired by now")
+    .expect("the service should still be running");
+    assert_eq!(broadcast, payload);
+}
+
+/// Seeing the payload come out of the Blend network is what cancels the direct
+/// broadcast, and it does not matter whose exit node put it there.
+#[test_log::test(tokio::test(start_paused = true))]
+async fn a_payload_the_network_delivers_is_never_broadcast_in_the_clear() {
+    let local_node = NodeId(99);
+    let (_, epoch_sender, msg_sender, mut node_ids, mut broadcasting_channel) =
+        spawn_run(local_node, 1, Some(membership(&[NodeId(0)], local_node))).await;
+    drop(epoch_sender);
+
+    let payload = NetworkMessage {
+        message: b"proposal".to_vec(),
+        broadcast_settings: (),
+    };
+    blend_and_await_release(&msg_sender, &mut node_ids, payload.clone()).await;
+    broadcasting_channel
+        .carrying
+        .send(payload)
+        .expect("the service is subscribed");
+
+    let rounds = u32::try_from(TEST_DELIVERY_DEADLINE.get()).expect("a few rounds");
+    assert!(
+        tokio::time::timeout(
+            TEST_ROUND * (rounds + 4),
+            broadcasting_channel.broadcasted.recv()
+        )
+        .await
+        .is_err(),
+        "a delivered payload must not be revealed by its sender"
     );
 }

--- a/services/blend/src/edge/tests/utils.rs
+++ b/services/blend/src/edge/tests/utils.rs
@@ -26,8 +26,14 @@ use crate::{
         backends::BlendBackend, handlers::Error, run, settings::RunningBlendConfig as BlendConfig,
         tests::test_blend_epoch_state,
     },
-    settings::TimingSettings,
-    test_utils::{crypto::mock_blend_proof, epoch::OncePolStreamProvider, membership::key},
+    message::NetworkMessage,
+    settings::{TimingSettings, max_data_message_delay_in_rounds, round_duration_in_seconds},
+    test_utils::{
+        crypto::mock_blend_proof,
+        epoch::OncePolStreamProvider,
+        membership::key,
+        network::{TestBroadcastingChannel, TestNetworkAdapter},
+    },
 };
 
 pub struct MockLeaderProofsGenerator;
@@ -46,6 +52,26 @@ impl LeaderProofsGenerator for MockLeaderProofsGenerator {
     }
 }
 
+/// The round these tests run on, which is the shortest a deployment may use.
+///
+/// Sitting through a whole delivery deadline costs them nothing: the fallback
+/// tests run on a paused clock, which jumps to the next timer the moment every
+/// task is idle.
+pub const TEST_ROUND: Duration = Duration::from_secs(1);
+/// `∆max` for the tests: the rounds a blend node may hold a message for.
+pub const TEST_MAX_BLEND_DELAY: NonZeroU64 = NonZeroU64::new(1).unwrap();
+/// `ß_c` for the tests.
+pub const TEST_BLEND_LAYERS: NonZeroU64 = NonZeroU64::new(1).unwrap();
+
+/// `T_D` for the tests, in rounds: the very derivation the service makes from
+/// the settings above, so the tests wait exactly as long as the code they
+/// exercise and the two cannot drift apart.
+pub const TEST_DELIVERY_DEADLINE: NonZeroU64 = max_data_message_delay_in_rounds(
+    TEST_BLEND_LAYERS,
+    TEST_MAX_BLEND_DELAY,
+    round_duration_in_seconds(TEST_ROUND),
+);
+
 pub async fn spawn_run(
     local_node: NodeId,
     minimal_network_size: u64,
@@ -53,8 +79,9 @@ pub async fn spawn_run(
 ) -> (
     JoinHandle<Result<(), Error>>,
     mpsc::Sender<Membership<NodeId>>,
-    mpsc::Sender<Vec<u8>>,
+    mpsc::Sender<NetworkMessage<()>>,
     mpsc::Receiver<NodeId>,
+    TestBroadcastingChannel,
 ) {
     let (epoch_sender, epoch_receiver) = mpsc::channel(1);
     let (msg_sender, msg_receiver) = mpsc::channel(1);
@@ -71,16 +98,19 @@ pub async fn spawn_run(
         .map(|membership| test_blend_epoch_state(0.into(), membership));
 
     let settings = settings(local_node, minimal_network_size, node_id_sender);
+    let (network_adapter, broadcasting_channel) = TestNetworkAdapter::new();
     let join_handle = tokio::spawn(async move {
         Box::pin(run::<
             TestBackend,
             _,
+            TestNetworkAdapter,
             MockLeaderProofsGenerator,
             OncePolStreamProvider,
             _,
         >(
             UninitializedEpochEventStream::new(epoch_stream, Duration::ZERO),
             ReceiverStream::new(msg_receiver),
+            network_adapter,
             settings,
             &overwatch_handle(),
             || {},
@@ -88,7 +118,13 @@ pub async fn spawn_run(
         .await
     });
 
-    (join_handle, epoch_sender, msg_sender, node_id_receiver)
+    (
+        join_handle,
+        epoch_sender,
+        msg_sender,
+        node_id_receiver,
+        broadcasting_channel,
+    )
 }
 
 pub fn settings(
@@ -99,16 +135,18 @@ pub fn settings(
     BlendConfig {
         time: TimingSettings {
             rounds_per_epoch: NonZeroU64::new(1).unwrap(),
-            round_duration: Duration::from_secs(1),
+            round_duration: TEST_ROUND,
             rounds_per_observation_window: NonZeroU64::new(1).unwrap(),
             epoch_transition_period: Duration::from_secs(1),
         },
         non_ephemeral_signing_key: key(local_id).0,
-        num_blend_layers: NonZeroU64::new(1).unwrap(),
+        num_blend_layers: TEST_BLEND_LAYERS,
         backend: msg_sender,
         minimum_network_size: NonZeroU64::new(minimum_network_size).unwrap(),
         cover: CoverTrafficSettings::default(),
         data_replication_factor: 0,
+        blend_failure_fallback: true,
+        max_blend_delay_in_rounds: TEST_MAX_BLEND_DELAY,
     }
 }
 

--- a/services/blend/src/edge/tests/utils.rs
+++ b/services/blend/src/edge/tests/utils.rs
@@ -27,7 +27,7 @@ use crate::{
         tests::test_blend_epoch_state,
     },
     message::NetworkMessage,
-    settings::{TimingSettings, max_data_message_delay_in_rounds, round_duration_in_seconds},
+    settings::{TimingSettings, max_data_message_delay_in_rounds},
     test_utils::{
         crypto::mock_blend_proof,
         epoch::OncePolStreamProvider,
@@ -66,11 +66,8 @@ pub const TEST_BLEND_LAYERS: NonZeroU64 = NonZeroU64::new(1).unwrap();
 /// `T_D` for the tests, in rounds: the very derivation the service makes from
 /// the settings above, so the tests wait exactly as long as the code they
 /// exercise and the two cannot drift apart.
-pub const TEST_DELIVERY_DEADLINE: NonZeroU64 = max_data_message_delay_in_rounds(
-    TEST_BLEND_LAYERS,
-    TEST_MAX_BLEND_DELAY,
-    round_duration_in_seconds(TEST_ROUND),
-);
+pub const TEST_DELIVERY_DEADLINE: NonZeroU64 =
+    max_data_message_delay_in_rounds(TEST_BLEND_LAYERS, TEST_MAX_BLEND_DELAY);
 
 pub async fn spawn_run(
     local_node: NodeId,
@@ -145,7 +142,7 @@ pub fn settings(
         minimum_network_size: NonZeroU64::new(minimum_network_size).unwrap(),
         cover: CoverTrafficSettings::default(),
         data_replication_factor: 0,
-        blend_failure_fallback: true,
+        abstain_on_failure: false,
         max_blend_delay_in_rounds: TEST_MAX_BLEND_DELAY,
     }
 }

--- a/services/blend/src/lib.rs
+++ b/services/blend/src/lib.rs
@@ -53,6 +53,7 @@ use crate::{
 };
 
 pub mod core;
+pub mod delivery;
 pub mod edge;
 pub mod epoch;
 pub mod epoch_info;

--- a/services/blend/src/metrics.rs
+++ b/services/blend/src/metrics.rs
@@ -70,6 +70,12 @@ mod imp {
     pub fn inbound_messages_dropped(count: u64) {
         lb_tracing::increase_counter_u64!(blend_inbound_messages_dropped_total, count);
     }
+
+    /// Reports a payload the Blend network failed to deliver within the
+    /// delivery deadline, and that this node therefore broadcast in the clear.
+    pub fn message_bypassed_blend() {
+        lb_tracing::increase_counter_u64!(blend_messages_bypassed_total, 1);
+    }
 }
 
 pub use imp::*;

--- a/services/blend/src/modes/broadcast.rs
+++ b/services/blend/src/modes/broadcast.rs
@@ -260,6 +260,15 @@ pub mod tests {
             }
         }
 
+        async fn observe_broadcasts(
+            &self,
+        ) -> futures::stream::BoxStream<
+            'static,
+            crate::message::NetworkMessage<Self::BroadcastSettings>,
+        > {
+            futures::StreamExt::boxed(futures::stream::empty())
+        }
+
         async fn broadcast(&self, message: Vec<u8>, _: Self::BroadcastSettings) {
             debug!("Broadcasting message: {message:?}");
             self.relay

--- a/services/blend/src/settings/common.rs
+++ b/services/blend/src/settings/common.rs
@@ -18,4 +18,5 @@ pub struct CommonSettings {
     #[serde(skip)]
     pub recovery_data: RecoveryData,
     pub data_replication_factor: u64,
+    pub blend_failure_fallback: bool,
 }

--- a/services/blend/src/settings/common.rs
+++ b/services/blend/src/settings/common.rs
@@ -18,5 +18,5 @@ pub struct CommonSettings {
     #[serde(skip)]
     pub recovery_data: RecoveryData,
     pub data_replication_factor: u64,
-    pub blend_failure_fallback: bool,
+    pub abstain_on_failure: bool,
 }

--- a/services/blend/src/settings/mod.rs
+++ b/services/blend/src/settings/mod.rs
@@ -1,3 +1,5 @@
+use std::{num::NonZeroU64, time::Duration};
+
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -34,6 +36,7 @@ impl<CoreBackendSettings, EdgeBackendSettings>
                     non_ephemeral_signing_key_id,
                     num_blend_layers,
                     data_replication_factor,
+                    blend_failure_fallback,
                 },
             core:
                 CoreSettings {
@@ -56,6 +59,7 @@ impl<CoreBackendSettings, EdgeBackendSettings>
             recovery_data,
             data_replication_factor,
             activity_threshold_sensitivity,
+            blend_failure_fallback,
         }
     }
 }
@@ -72,12 +76,13 @@ impl<CoreBackendSettings, EdgeBackendSettings>
                     non_ephemeral_signing_key_id,
                     num_blend_layers,
                     data_replication_factor,
+                    blend_failure_fallback,
                     ..
                 },
             edge: EdgeSettings { backend },
             core:
                 CoreSettings {
-                    scheduler: SchedulerSettings { cover, .. },
+                    scheduler: SchedulerSettings { cover, delayer },
                     ..
                 },
         }: Settings<CoreBackendSettings, EdgeBackendSettings>,
@@ -90,6 +95,44 @@ impl<CoreBackendSettings, EdgeBackendSettings>
             minimum_network_size,
             cover,
             data_replication_factor,
+            blend_failure_fallback,
+            // An edge node has no release schedule of its own, but the deadline it
+            // waits out is the one a core node's schedule implies, so it takes the
+            // same delay bound the core scheduler is configured with.
+            max_blend_delay_in_rounds: delayer.maximum_release_delay_in_rounds,
         }
+    }
+}
+
+#[must_use]
+pub const fn round_duration_in_seconds(round_duration: Duration) -> NonZeroU64 {
+    match NonZeroU64::new(round_duration.as_secs()) {
+        Some(seconds) => seconds,
+        None => panic!("Round duration must be at least one second."),
+    }
+}
+
+#[must_use]
+pub const fn max_data_message_delay_in_rounds(
+    num_blend_layers: NonZeroU64,
+    max_blend_delay_in_rounds: NonZeroU64,
+    round_duration_in_seconds: NonZeroU64,
+) -> NonZeroU64 {
+    let dissemination_delay_in_rounds = Duration::from_secs(1)
+        .as_secs()
+        .div_ceil(round_duration_in_seconds.get());
+    match NonZeroU64::new(
+        num_blend_layers
+            .get()
+            .saturating_mul(
+                max_blend_delay_in_rounds
+                    .get()
+                    .saturating_add(dissemination_delay_in_rounds),
+            )
+            .saturating_add(dissemination_delay_in_rounds),
+    ) {
+        Some(delay) => delay,
+        // Not `expect`, to keep this a `const fn`.
+        None => panic!("Both factors of the delivery deadline are non-zero."),
     }
 }

--- a/services/blend/src/settings/mod.rs
+++ b/services/blend/src/settings/mod.rs
@@ -1,4 +1,4 @@
-use std::{num::NonZeroU64, time::Duration};
+use std::num::NonZeroU64;
 
 use serde::{Deserialize, Serialize};
 
@@ -36,7 +36,7 @@ impl<CoreBackendSettings, EdgeBackendSettings>
                     non_ephemeral_signing_key_id,
                     num_blend_layers,
                     data_replication_factor,
-                    blend_failure_fallback,
+                    abstain_on_failure,
                 },
             core:
                 CoreSettings {
@@ -59,7 +59,7 @@ impl<CoreBackendSettings, EdgeBackendSettings>
             recovery_data,
             data_replication_factor,
             activity_threshold_sensitivity,
-            blend_failure_fallback,
+            abstain_on_failure,
         }
     }
 }
@@ -76,7 +76,7 @@ impl<CoreBackendSettings, EdgeBackendSettings>
                     non_ephemeral_signing_key_id,
                     num_blend_layers,
                     data_replication_factor,
-                    blend_failure_fallback,
+                    abstain_on_failure,
                     ..
                 },
             edge: EdgeSettings { backend },
@@ -95,7 +95,7 @@ impl<CoreBackendSettings, EdgeBackendSettings>
             minimum_network_size,
             cover,
             data_replication_factor,
-            blend_failure_fallback,
+            abstain_on_failure,
             // An edge node has no release schedule of its own, but the deadline it
             // waits out is the one a core node's schedule implies, so it takes the
             // same delay bound the core scheduler is configured with.
@@ -104,32 +104,30 @@ impl<CoreBackendSettings, EdgeBackendSettings>
     }
 }
 
-#[must_use]
-pub const fn round_duration_in_seconds(round_duration: Duration) -> NonZeroU64 {
-    match NonZeroU64::new(round_duration.as_secs()) {
-        Some(seconds) => seconds,
-        None => panic!("Round duration must be at least one second."),
-    }
-}
+/// `η`: the network absorption of one hop, the rounds a message spends crossing
+/// the network between two blend nodes.
+const NETWORK_ABSORPTION_IN_ROUNDS: u64 = 2;
 
+/// `T_M`: the message traversal time, which is what a sender waits for its
+/// payload to appear on the broadcasting channel before treating the message
+/// carrying it as lost.
+///
+/// A message crosses `ß` blend nodes, each of which holds it for at most the
+/// maximal blending delay `∆max`, and the network carries it for the absorption
+/// `η` of one hop:
+///
+/// `T_M = ß · (∆max + η)`
 #[must_use]
 pub const fn max_data_message_delay_in_rounds(
     num_blend_layers: NonZeroU64,
     max_blend_delay_in_rounds: NonZeroU64,
-    round_duration_in_seconds: NonZeroU64,
 ) -> NonZeroU64 {
-    let dissemination_delay_in_rounds = Duration::from_secs(1)
-        .as_secs()
-        .div_ceil(round_duration_in_seconds.get());
     match NonZeroU64::new(
-        num_blend_layers
-            .get()
-            .saturating_mul(
-                max_blend_delay_in_rounds
-                    .get()
-                    .saturating_add(dissemination_delay_in_rounds),
-            )
-            .saturating_add(dissemination_delay_in_rounds),
+        num_blend_layers.get().saturating_mul(
+            max_blend_delay_in_rounds
+                .get()
+                .saturating_add(NETWORK_ABSORPTION_IN_ROUNDS),
+        ),
     ) {
         Some(delay) => delay,
         // Not `expect`, to keep this a `const fn`.

--- a/services/blend/src/test_utils/mod.rs
+++ b/services/blend/src/test_utils/mod.rs
@@ -1,6 +1,7 @@
 pub mod crypto;
 pub mod epoch;
 pub mod membership;
+pub mod network;
 
 mod libp2p;
 pub use self::libp2p::*;

--- a/services/blend/src/test_utils/network.rs
+++ b/services/blend/src/test_utils/network.rs
@@ -1,0 +1,105 @@
+//! A network adapter for tests: both sides of Blend's exit door in the test's
+//! hands.
+
+use async_trait::async_trait;
+use futures::{StreamExt as _, stream::BoxStream};
+use lb_network_service::{NetworkService, backends::NetworkBackend};
+use overwatch::{
+    overwatch::handle::OverwatchHandle,
+    services::{ServiceData, relay::OutboundRelay},
+};
+use tokio::sync::{broadcast, mpsc};
+use tokio_stream::wrappers::BroadcastStream;
+
+use crate::{core::network::NetworkAdapter, message::NetworkMessage};
+
+const CHANNEL_SIZE: usize = 16;
+
+/// The two ends of the broadcasting channel a test drives: what this node put
+/// on it, and what the test says the rest of the network put on it.
+pub struct TestBroadcastingChannel {
+    /// What Blend's exit door published, this node's direct broadcasts among
+    /// it.
+    pub broadcasted: mpsc::UnboundedReceiver<NetworkMessage<()>>,
+    /// What the test wants this node to see arriving on the channel.
+    pub carrying: broadcast::Sender<NetworkMessage<()>>,
+}
+
+pub struct TestNetworkAdapter {
+    broadcasted: mpsc::UnboundedSender<NetworkMessage<()>>,
+    carrying: broadcast::Sender<NetworkMessage<()>>,
+}
+
+impl TestNetworkAdapter {
+    #[must_use]
+    pub fn new() -> (Self, TestBroadcastingChannel) {
+        let (broadcasted_sender, broadcasted) = mpsc::unbounded_channel();
+        let (carrying, _) = broadcast::channel(CHANNEL_SIZE);
+        (
+            Self {
+                broadcasted: broadcasted_sender,
+                carrying: carrying.clone(),
+            },
+            TestBroadcastingChannel {
+                broadcasted,
+                carrying,
+            },
+        )
+    }
+}
+
+#[async_trait]
+impl<RuntimeServiceId> NetworkAdapter<RuntimeServiceId> for TestNetworkAdapter
+where
+    RuntimeServiceId: Send + Sync + 'static,
+{
+    type Backend = TestNetworkBackend;
+    type BroadcastSettings = ();
+
+    fn new(
+        _network_relay: OutboundRelay<
+            <NetworkService<Self::Backend, RuntimeServiceId> as ServiceData>::Message,
+        >,
+    ) -> Self {
+        Self::new().0
+    }
+
+    async fn broadcast(&self, message: Vec<u8>, broadcast_settings: Self::BroadcastSettings) {
+        drop(self.broadcasted.send(NetworkMessage {
+            message,
+            broadcast_settings,
+        }));
+    }
+
+    async fn observe_broadcasts(
+        &self,
+    ) -> BoxStream<'static, NetworkMessage<Self::BroadcastSettings>> {
+        BroadcastStream::new(self.carrying.subscribe())
+            .filter_map(async |observed| observed.ok())
+            .boxed()
+    }
+}
+
+pub struct TestNetworkBackend;
+
+#[async_trait]
+impl<RuntimeServiceId> NetworkBackend<RuntimeServiceId> for TestNetworkBackend {
+    type Settings = ();
+    type Message = ();
+    type PubSubEvent = ();
+    type ChainSyncEvent = ();
+
+    fn new(_config: Self::Settings, _overwatch_handle: OverwatchHandle<RuntimeServiceId>) -> Self {
+        Self
+    }
+
+    async fn process(&self, (): Self::Message) {}
+
+    async fn subscribe_to_pubsub(&mut self) -> BroadcastStream<Self::PubSubEvent> {
+        BroadcastStream::new(broadcast::channel(CHANNEL_SIZE).1)
+    }
+
+    async fn subscribe_to_chainsync(&mut self) -> BroadcastStream<Self::ChainSyncEvent> {
+        BroadcastStream::new(broadcast::channel(CHANNEL_SIZE).1)
+    }
+}

--- a/services/blend/src/test_utils/network.rs
+++ b/services/blend/src/test_utils/network.rs
@@ -96,10 +96,10 @@ impl<RuntimeServiceId> NetworkBackend<RuntimeServiceId> for TestNetworkBackend {
     async fn process(&self, (): Self::Message) {}
 
     async fn subscribe_to_pubsub(&mut self) -> BroadcastStream<Self::PubSubEvent> {
-        BroadcastStream::new(broadcast::channel(CHANNEL_SIZE).1)
+        unimplemented!()
     }
 
     async fn subscribe_to_chainsync(&mut self) -> BroadcastStream<Self::ChainSyncEvent> {
-        BroadcastStream::new(broadcast::channel(CHANNEL_SIZE).1)
+        unimplemented!()
     }
 }


### PR DESCRIPTION
## 1. What does this PR implement?

Same as https://github.com/logos-blockchain/logos-blockchain/pull/3473, but implemented on the release branch as Blend codebase has changed quite a bit since this release branch forked off of `master`. Fallback mechanism is equivalent, with the major difference being that on this testnet version we don't support blending transactions, and we blend the block proposal along with the broadcast settings (wrong), while we fixed that a while ago on `master`.

## 2. Does the code have enough context to be clearly understood?

Yes. For more context see the PR against `master`: https://github.com/logos-blockchain/logos-blockchain/pull/3473.

## 3. Who are the specification authors and who is accountable for this PR?

@madxor spec @ntn-x2 impl

## 4. Is the specification accurate and complete?

Yes.

## 5. Does the implementation introduce changes in the specification?

No.