### PR TITLE
fix(chain-leader): correctly use total gas for max gas check

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -4,6 +4,12 @@
 # Tests are marked SLOW after `period`.
 # They are killed after `period * terminate-after`.
 
+# This end-to-end block-selection regression is expected to exceed the default
+# unit-test timeout.
+[[profile.default.overrides]]
+filter       = "package(logos-blockchain-chain-leader-service) and test(gas_limited_selection_returns_canonically_applicable_prefix)"
+slow-timeout = { period = "1m", terminate-after = 4 }
+
 # For unit tests, kill after 30s * 4 = 2m
 [[profile.default.overrides]]
 filter       = "not package(logos-blockchain-tests)"

--- a/ledger/benches/zk_batch.rs
+++ b/ledger/benches/zk_batch.rs
@@ -228,7 +228,7 @@ fn apply(
 ) -> (LedgerState, DeferredZkpVerifications) {
     let (state, _, deferred) = state
         .clone()
-        .try_apply_contents::<_, HeaderId, MainnetGasProfile>(&TX_POOL.config, txs)
+        .try_apply_block_contents::<_, HeaderId, MainnetGasProfile>(&TX_POOL.config, txs)
         .expect("block should apply");
     (state, deferred)
 }

--- a/ledger/src/gas_and_fees.rs
+++ b/ledger/src/gas_and_fees.rs
@@ -1,0 +1,53 @@
+use lb_core::mantle::gas::{Gas, GasCost};
+
+use crate::LedgerError;
+
+pub const EXECUTION_GAS_LIMIT: Gas = Gas::new(3_193_460);
+
+/// Gas consumed and fees paid by applied transactions.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct GasAndFees {
+    pub(super) execution_gas: Gas,
+    pub(super) storage_gas: Gas,
+    pub(super) fee_burned: GasCost,
+    pub(super) fee_tip: GasCost,
+}
+
+impl Default for GasAndFees {
+    fn default() -> Self {
+        Self {
+            execution_gas: 0.into(),
+            storage_gas: 0.into(),
+            fee_burned: 0.into(),
+            fee_tip: 0.into(),
+        }
+    }
+}
+
+impl GasAndFees {
+    /// Adds one transaction's gas and fees, enforcing the execution gas limit.
+    /// An oversized transaction is distinguished from exhausted capacity.
+    pub fn checked_add<Id>(self, transaction: Self) -> Result<Self, LedgerError<Id>> {
+        if transaction.execution_gas > EXECUTION_GAS_LIMIT {
+            return Err(LedgerError::TooMuchTransactionExecutionGas {
+                gas: transaction.execution_gas,
+                limit: EXECUTION_GAS_LIMIT,
+            });
+        }
+
+        let execution_gas = self.execution_gas.checked_add(transaction.execution_gas)?;
+        if execution_gas > EXECUTION_GAS_LIMIT {
+            return Err(LedgerError::TooMuchExecutionGas {
+                gas: execution_gas,
+                limit: EXECUTION_GAS_LIMIT,
+            });
+        }
+
+        Ok(Self {
+            execution_gas,
+            storage_gas: self.storage_gas.checked_add(transaction.storage_gas)?,
+            fee_burned: self.fee_burned.checked_add(transaction.fee_burned)?,
+            fee_tip: self.fee_tip.checked_add(transaction.fee_tip)?,
+        })
+    }
+}

--- a/ledger/src/gas_and_fees.rs
+++ b/ledger/src/gas_and_fees.rs
@@ -51,3 +51,49 @@ impl GasAndFees {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn with_execution_gas(execution_gas: Gas) -> GasAndFees {
+        GasAndFees {
+            execution_gas,
+            ..GasAndFees::default()
+        }
+    }
+
+    #[test]
+    fn rejects_a_transaction_that_exceeds_the_block_limit() {
+        let excessive_gas = EXECUTION_GAS_LIMIT
+            .checked_add(Gas::new(1))
+            .expect("the test gas value should not overflow");
+        let transaction = with_execution_gas(excessive_gas);
+
+        assert_eq!(
+            GasAndFees::default().checked_add::<()>(transaction),
+            Err(LedgerError::TooMuchTransactionExecutionGas {
+                gas: excessive_gas,
+                limit: EXECUTION_GAS_LIMIT,
+            })
+        );
+    }
+
+    #[test]
+    fn distinguishes_exhausted_block_capacity_from_an_oversized_transaction() {
+        let accumulated = with_execution_gas(EXECUTION_GAS_LIMIT);
+        let transaction = with_execution_gas(Gas::new(1));
+
+        let cumulative_gas = EXECUTION_GAS_LIMIT
+            .checked_add(transaction.execution_gas)
+            .expect("the test gas value should not overflow");
+
+        assert_eq!(
+            accumulated.checked_add::<()>(transaction),
+            Err(LedgerError::TooMuchExecutionGas {
+                gas: cumulative_gas,
+                limit: EXECUTION_GAS_LIMIT,
+            })
+        );
+    }
+}

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -141,7 +141,9 @@ pub enum LedgerError<Id> {
     MissingTransferGenesis(),
     #[error("Fees don't cover the minimal execution base fee cost")]
     InsufficientExecutionFee,
-    #[error("The execution gas of the block ({gas:?}) exceeds the maximum limit ({limit:?}")]
+    #[error("The execution gas of the transaction ({gas:?}) exceeds the block limit ({limit:?})")]
+    TooMuchTransactionExecutionGas { gas: Gas, limit: Gas },
+    #[error("The execution gas of the block ({gas:?}) exceeds the maximum limit ({limit:?})")]
     TooMuchExecutionGas { gas: Gas, limit: Gas },
     #[error("Storage fees aren't equal to the storage fee of the current epoch")]
     InvalidStoragePrice,
@@ -250,7 +252,144 @@ pub struct LedgerState {
     mantle_ledger: MantleLedger,
 }
 
+/// Block-wide gas and fee totals collected before block finalization.
+#[derive(Clone, Debug)]
+struct BlockTotals {
+    total_execution_gas: Gas,
+    total_storage_gas: Gas,
+    total_fee_burned: GasCost,
+    total_fee_tip: GasCost,
+}
+
+impl Default for BlockTotals {
+    fn default() -> Self {
+        Self {
+            total_execution_gas: 0.into(),
+            total_storage_gas: 0.into(),
+            total_fee_burned: 0.into(),
+            total_fee_tip: 0.into(),
+        }
+    }
+}
+
+impl BlockTotals {
+    fn try_add<Id>(
+        self,
+        execution_gas: Gas,
+        storage_gas: Gas,
+        fee_burned: GasCost,
+        fee_tip: GasCost,
+    ) -> Result<Self, LedgerError<Id>> {
+        if execution_gas > EXECUTION_GAS_LIMIT {
+            return Err(LedgerError::TooMuchTransactionExecutionGas {
+                gas: execution_gas,
+                limit: EXECUTION_GAS_LIMIT,
+            });
+        }
+
+        let total_execution_gas = self.total_execution_gas.checked_add(execution_gas)?;
+        if total_execution_gas > EXECUTION_GAS_LIMIT {
+            return Err(LedgerError::TooMuchExecutionGas {
+                gas: total_execution_gas,
+                limit: EXECUTION_GAS_LIMIT,
+            });
+        }
+
+        Ok(Self {
+            total_execution_gas,
+            total_storage_gas: self.total_storage_gas.checked_add(storage_gas)?,
+            total_fee_burned: self.total_fee_burned.checked_add(fee_burned)?,
+            total_fee_tip: self.total_fee_tip.checked_add(fee_tip)?,
+        })
+    }
+}
+
+/// Ledger state and block-wide accounting while transactions are applied.
+///
+/// Transactions can be attempted incrementally. Block rewards and fee markets
+/// are updated only when [`Self::finish`] is called.
+#[derive(Clone, Debug)]
+pub struct PendingBlockState {
+    ledger_state: LedgerState,
+    gas_prices: GasPrices,
+    totals: BlockTotals,
+}
+
+impl PendingBlockState {
+    /// Returns the ledger state after the transactions accepted so far, before
+    /// block-wide finalization.
+    #[must_use]
+    pub const fn ledger_state(&self) -> &LedgerState {
+        &self.ledger_state
+    }
+
+    /// Attempts to apply one transaction and update the block-wide accounting.
+    pub fn try_apply_transaction<Tx, Id, Profile: GasProfile>(
+        mut self,
+        config: &Config,
+        tx: &Tx,
+    ) -> Result<(Self, Vec<TxEvent>, DeferredZkpVerifications), LedgerError<Id>>
+    where
+        Tx: PreverifiedMantleTransaction + StorageSize + Clone,
+    {
+        let (ledger_state, balance, execution_gas, events, deferred_zkps) = self
+            .ledger_state
+            .try_apply_tx::<_, _, Profile>(config, tx.clone())?;
+        self.ledger_state = ledger_state;
+
+        let storage_gas = Gas::new(tx.storage_size() as u64);
+        let execution_base_fees =
+            GasCost::calculate(execution_gas, self.gas_prices.execution_base_gas_price)?;
+        let permanent_storage_fees =
+            GasCost::calculate(storage_gas, self.gas_prices.storage_gas_price)?;
+        let total_gas_cost = execution_base_fees.checked_add(permanent_storage_fees)?;
+        tracing::debug!(
+            target: LOG_TARGET,
+            balance,
+            total_gas_cost = total_gas_cost.into_inner(),
+            storage_gas_price = ?self.gas_prices.storage_gas_price,
+            execution_gas_price = ?self.gas_prices.execution_base_gas_price,
+            "tx balance check"
+        );
+
+        if balance < Balance::from(total_gas_cost.into_inner()) {
+            return Err(LedgerError::InsufficientBalance);
+        }
+
+        let fee_burned = total_gas_cost;
+        let fee_tip = GasCost::from(balance as Value).checked_sub(fee_burned)?;
+
+        self.totals = self
+            .totals
+            .try_add(execution_gas, storage_gas, fee_burned, fee_tip)?;
+
+        Ok((self, events, deferred_zkps))
+    }
+
+    /// Applies block-wide rewards and fee-market updates exactly once.
+    pub fn finish<Id>(self) -> Result<LedgerState, LedgerError<Id>> {
+        let mut ledger_state = self
+            .ledger_state
+            .compute_block_rewards(self.totals.total_fee_burned, self.totals.total_fee_tip)?;
+        ledger_state = ledger_state.update_execution_market(self.totals.total_execution_gas);
+        ledger_state = ledger_state.add_storage_gas_consumed(self.totals.total_storage_gas)?;
+        Ok(ledger_state)
+    }
+}
+
 impl LedgerState {
+    /// Starts applying transactions for one block without finalizing after each
+    /// transaction.
+    #[must_use]
+    pub fn begin_pending_block(self) -> PendingBlockState {
+        let gas_prices = self.get_gas_prices();
+        PendingBlockState {
+            ledger_state: self,
+            gas_prices,
+            totals: BlockTotals::default(),
+        }
+    }
+
     fn try_update<Tx, LeaderProof, Id, Profile>(
         self,
         block_id: Id,
@@ -474,83 +613,26 @@ impl LedgerState {
 
     /// Apply the contents of an update to the ledger state.
     pub fn try_apply_contents<Tx, Id, Profile: GasProfile>(
-        mut self,
+        self,
         config: &Config,
         txs: impl Iterator<Item = Tx>,
     ) -> Result<(Self, Vec<TxEvent>, DeferredZkpVerifications), LedgerError<Id>>
     where
         Tx: PreverifiedMantleTransaction + StorageSize + Clone,
     {
-        let mut total_block_execution_gas: Gas = 0.into();
-        let mut total_block_storage_gas: Gas = 0.into();
-        let mut total_fee_burned: GasCost = 0.into();
-        let mut total_fee_tip: GasCost = 0.into();
+        let mut pending_block_state = self.begin_pending_block();
         let mut tx_events = Vec::new();
         let mut deferred_zkps = DeferredZkpVerifications::new();
 
         for tx in txs {
-            let balance;
-            let execution_gas;
-            let events;
-            let deferred;
-            (self, balance, execution_gas, events, deferred) =
-                self.try_apply_tx::<_, _, Profile>(config, tx.clone())?;
+            let (next_pending_block_state, events, deferred) =
+                pending_block_state.try_apply_transaction::<_, Id, Profile>(config, &tx)?;
+            pending_block_state = next_pending_block_state;
             tx_events.extend(events);
             deferred_zkps.extend(deferred);
-
-            let gas_prices = GasPrices {
-                execution_base_gas_price: *self.cryptarchia_ledger.execution_base_fee(),
-                storage_gas_price: *self.cryptarchia_ledger.storage_gas_price(),
-            };
-
-            // The permanent storage gas is the encoded size of the signed transaction.
-            let storage_gas = Gas::new(tx.storage_size() as u64);
-            let execution_base_fees =
-                GasCost::calculate(execution_gas, gas_prices.execution_base_gas_price)?;
-            let permanent_storage_fees =
-                GasCost::calculate(storage_gas, gas_prices.storage_gas_price)?;
-            // Check the transaction is balanced
-            let total_gas_cost = execution_base_fees.checked_add(permanent_storage_fees)?;
-            tracing::debug!(
-                target: LOG_TARGET,
-                balance,
-                total_gas_cost = total_gas_cost.into_inner(),
-                storage_gas_price = ?self.cryptarchia_ledger.storage_gas_price(),
-                execution_gas_price = ?self.cryptarchia_ledger.execution_base_fee(),
-                "tx balance check"
-            );
-
-            // Check that the transaction at least pays for the base execution fee and
-            // storage
-            if balance < Balance::from(total_gas_cost.into_inner()) {
-                return Err(LedgerError::InsufficientBalance);
-            }
-
-            // Update the total of fee burned and tipped in the block
-            let tx_fee_burned = total_gas_cost;
-
-            let tx_fee_tip = GasCost::from(balance as Value).checked_sub(tx_fee_burned)?;
-            total_fee_burned = total_fee_burned.checked_add(tx_fee_burned)?;
-            total_fee_tip = total_fee_tip.checked_add(tx_fee_tip)?;
-            total_block_execution_gas = total_block_execution_gas.checked_add(execution_gas)?;
-            total_block_storage_gas = total_block_storage_gas.checked_add(storage_gas)?;
-
-            // Check that the block is not exceeding the Gas limit
-            if total_block_execution_gas > EXECUTION_GAS_LIMIT {
-                return Err(LedgerError::TooMuchExecutionGas {
-                    gas: total_block_execution_gas,
-                    limit: EXECUTION_GAS_LIMIT,
-                });
-            }
         }
-        // Compute Block rewards and give tips
-        self = self.compute_block_rewards(total_fee_burned, total_fee_tip)?;
-        // Update Execution market state
-        self = self.update_execution_market(total_block_execution_gas);
-        // Accumulate storage gas consumed so the storage market can update the
-        // price at the next epoch rotation.
-        self = self.add_storage_gas_consumed(total_block_storage_gas)?;
-        Ok((self, tx_events, deferred_zkps))
+        let ledger_state = pending_block_state.finish()?;
+        Ok((ledger_state, tx_events, deferred_zkps))
     }
 
     pub fn from_utxos(utxos: impl IntoIterator<Item = Utxo>, config: &Config) -> Self {
@@ -1105,6 +1187,105 @@ mod tests {
             .cryptarchia_ledger
             .clone()
             .set_execution_base_fee(new_execution.into());
+    }
+
+    #[test]
+    fn block_totals_distinguish_transaction_and_cumulative_gas_limits() {
+        let oversized_transaction_gas = EXECUTION_GAS_LIMIT.checked_add(1.into()).unwrap();
+        let error = BlockTotals::default()
+            .try_add::<HeaderId>(oversized_transaction_gas, 0.into(), 0.into(), 0.into())
+            .unwrap_err();
+        assert_eq!(
+            error,
+            LedgerError::TooMuchTransactionExecutionGas {
+                gas: oversized_transaction_gas,
+                limit: EXECUTION_GAS_LIMIT,
+            }
+        );
+
+        let totals = BlockTotals::default()
+            .try_add::<HeaderId>(EXECUTION_GAS_LIMIT, 0.into(), 0.into(), 0.into())
+            .unwrap();
+
+        let error = totals
+            .try_add::<HeaderId>(1.into(), 0.into(), 0.into(), 0.into())
+            .unwrap_err();
+
+        assert_eq!(
+            error,
+            LedgerError::TooMuchExecutionGas {
+                gas: EXECUTION_GAS_LIMIT.checked_add(1.into()).unwrap(),
+                limit: EXECUTION_GAS_LIMIT,
+            }
+        );
+    }
+
+    #[test]
+    fn pending_block_defers_block_updates_until_finish() {
+        let config = config();
+        let (first_key, first_utxo) = utxo_with_sk();
+        let (second_key, second_utxo) = utxo_with_sk();
+        let first_tx = create_tx(vec![first_utxo.id()], Vec::new(), &[first_key])
+            .preverify()
+            .unwrap();
+        let second_tx = create_tx(vec![second_utxo.id()], Vec::new(), &[second_key])
+            .preverify()
+            .unwrap();
+        let mut ledger = LedgerState::from_utxos([first_utxo, second_utxo], &config);
+        update_ledger_prices(&mut ledger, 1, 1);
+
+        let initial_pending_rewards = ledger.mantle_ledger.leaders.get_pending_rewards();
+        let initial_storage_gas = ledger.cryptarchia_ledger.storage_gas_consumed_in_epoch();
+        let expected_storage_gas = Gas::new(first_tx.storage_size() as u64)
+            .checked_add(Gas::new(second_tx.storage_size() as u64))
+            .unwrap();
+
+        let mut pending_block_state = ledger.begin_pending_block();
+        for tx in [&first_tx, &second_tx] {
+            let (next_pending_block_state, _events, _) = pending_block_state
+                .try_apply_transaction::<_, HeaderId, MainnetGasProfile>(&config, tx)
+                .unwrap();
+            assert_eq!(
+                next_pending_block_state
+                    .ledger_state()
+                    .mantle_ledger
+                    .leaders
+                    .get_pending_rewards(),
+                initial_pending_rewards,
+            );
+            assert_eq!(
+                next_pending_block_state
+                    .ledger_state()
+                    .cryptarchia_ledger
+                    .storage_gas_consumed_in_epoch(),
+                initial_storage_gas,
+            );
+            pending_block_state = next_pending_block_state;
+        }
+
+        assert!(
+            !pending_block_state
+                .ledger_state()
+                .latest_utxos()
+                .contains(&first_utxo.id())
+        );
+        assert!(
+            !pending_block_state
+                .ledger_state()
+                .latest_utxos()
+                .contains(&second_utxo.id())
+        );
+
+        let finalized_state = pending_block_state.finish::<HeaderId>().unwrap();
+        assert_eq!(
+            finalized_state
+                .cryptarchia_ledger
+                .storage_gas_consumed_in_epoch(),
+            expected_storage_gas,
+        );
+        assert!(
+            finalized_state.mantle_ledger.leaders.get_pending_rewards() > initial_pending_rewards
+        );
     }
 
     enum Key {

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -4,6 +4,7 @@ pub mod config;
 //   algorithm, including a minimal UTxO model.
 // - `mantle_ops`: our extensions in the form of Mantle operations, e.g. SDP.
 pub mod cryptarchia;
+mod gas_and_fees;
 mod intent;
 pub mod mantle;
 mod update;
@@ -13,6 +14,9 @@ use std::hash::Hash;
 pub use config::Config;
 use cryptarchia::LedgerState as CryptarchiaLedger;
 pub use cryptarchia::{EpochState, UtxoTree};
+#[cfg(test)]
+use gas_and_fees::EXECUTION_GAS_LIMIT;
+pub use gas_and_fees::GasAndFees;
 pub use intent::{Intent, IntentStatus};
 use lb_core::{
     block::BlockNumber,
@@ -96,8 +100,6 @@ const BLEND_REWARD_SHARE_DENOMINATOR: u128 = 10;
 // (blend+leadership)
 const POW_REWARD_SHARE_NUMERATOR: u128 = 0;
 const POW_REWARD_SHARE_DENOMINATOR: u128 = 4;
-const EXECUTION_GAS_LIMIT: Gas = Gas::new(3_193_460);
-
 // While individual notes are constrained to be `u64`, intermediate calculations
 // may overflow, so we use `i128` to avoid that and to easily represent negative
 // balances which may arise in special circumstances (e.g. rewards calculation).
@@ -250,54 +252,6 @@ pub struct LedgerState {
     block_number: BlockNumber,
     cryptarchia_ledger: CryptarchiaLedger,
     mantle_ledger: MantleLedger,
-}
-
-/// Gas consumed and fees paid by applied transactions.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct GasAndFees {
-    execution_gas: Gas,
-    storage_gas: Gas,
-    fee_burned: GasCost,
-    fee_tip: GasCost,
-}
-
-impl Default for GasAndFees {
-    fn default() -> Self {
-        Self {
-            execution_gas: 0.into(),
-            storage_gas: 0.into(),
-            fee_burned: 0.into(),
-            fee_tip: 0.into(),
-        }
-    }
-}
-
-impl GasAndFees {
-    /// Adds one transaction's gas and fees, enforcing the execution gas limit.
-    /// An oversized transaction is distinguished from exhausted capacity.
-    pub fn checked_add<Id>(self, transaction: Self) -> Result<Self, LedgerError<Id>> {
-        if transaction.execution_gas > EXECUTION_GAS_LIMIT {
-            return Err(LedgerError::TooMuchTransactionExecutionGas {
-                gas: transaction.execution_gas,
-                limit: EXECUTION_GAS_LIMIT,
-            });
-        }
-
-        let execution_gas = self.execution_gas.checked_add(transaction.execution_gas)?;
-        if execution_gas > EXECUTION_GAS_LIMIT {
-            return Err(LedgerError::TooMuchExecutionGas {
-                gas: execution_gas,
-                limit: EXECUTION_GAS_LIMIT,
-            });
-        }
-
-        Ok(Self {
-            execution_gas,
-            storage_gas: self.storage_gas.checked_add(transaction.storage_gas)?,
-            fee_burned: self.fee_burned.checked_add(transaction.fee_burned)?,
-            fee_tip: self.fee_tip.checked_add(transaction.fee_tip)?,
-        })
-    }
 }
 
 impl LedgerState {

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -252,144 +252,55 @@ pub struct LedgerState {
     mantle_ledger: MantleLedger,
 }
 
-/// Block-wide gas and fee totals collected before block finalization.
-#[derive(Clone, Debug)]
-struct BlockTotals {
-    total_execution_gas: Gas,
-    total_storage_gas: Gas,
-    total_fee_burned: GasCost,
-    total_fee_tip: GasCost,
+/// Gas consumed and fees paid by applied transactions.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct GasAndFees {
+    execution_gas: Gas,
+    storage_gas: Gas,
+    fee_burned: GasCost,
+    fee_tip: GasCost,
 }
 
-impl Default for BlockTotals {
+impl Default for GasAndFees {
     fn default() -> Self {
         Self {
-            total_execution_gas: 0.into(),
-            total_storage_gas: 0.into(),
-            total_fee_burned: 0.into(),
-            total_fee_tip: 0.into(),
+            execution_gas: 0.into(),
+            storage_gas: 0.into(),
+            fee_burned: 0.into(),
+            fee_tip: 0.into(),
         }
     }
 }
 
-impl BlockTotals {
-    fn try_add<Id>(
-        self,
-        execution_gas: Gas,
-        storage_gas: Gas,
-        fee_burned: GasCost,
-        fee_tip: GasCost,
-    ) -> Result<Self, LedgerError<Id>> {
-        if execution_gas > EXECUTION_GAS_LIMIT {
+impl GasAndFees {
+    /// Adds one transaction's gas and fees, enforcing the execution gas limit.
+    /// An oversized transaction is distinguished from exhausted capacity.
+    pub fn checked_add<Id>(self, transaction: Self) -> Result<Self, LedgerError<Id>> {
+        if transaction.execution_gas > EXECUTION_GAS_LIMIT {
             return Err(LedgerError::TooMuchTransactionExecutionGas {
+                gas: transaction.execution_gas,
+                limit: EXECUTION_GAS_LIMIT,
+            });
+        }
+
+        let execution_gas = self.execution_gas.checked_add(transaction.execution_gas)?;
+        if execution_gas > EXECUTION_GAS_LIMIT {
+            return Err(LedgerError::TooMuchExecutionGas {
                 gas: execution_gas,
                 limit: EXECUTION_GAS_LIMIT,
             });
         }
 
-        let total_execution_gas = self.total_execution_gas.checked_add(execution_gas)?;
-        if total_execution_gas > EXECUTION_GAS_LIMIT {
-            return Err(LedgerError::TooMuchExecutionGas {
-                gas: total_execution_gas,
-                limit: EXECUTION_GAS_LIMIT,
-            });
-        }
-
         Ok(Self {
-            total_execution_gas,
-            total_storage_gas: self.total_storage_gas.checked_add(storage_gas)?,
-            total_fee_burned: self.total_fee_burned.checked_add(fee_burned)?,
-            total_fee_tip: self.total_fee_tip.checked_add(fee_tip)?,
+            execution_gas,
+            storage_gas: self.storage_gas.checked_add(transaction.storage_gas)?,
+            fee_burned: self.fee_burned.checked_add(transaction.fee_burned)?,
+            fee_tip: self.fee_tip.checked_add(transaction.fee_tip)?,
         })
     }
 }
 
-/// Ledger state and block-wide accounting while transactions are applied.
-///
-/// Transactions can be attempted incrementally. Block rewards and fee markets
-/// are updated only when [`Self::finish`] is called.
-#[derive(Clone, Debug)]
-pub struct PendingBlockState {
-    ledger_state: LedgerState,
-    gas_prices: GasPrices,
-    totals: BlockTotals,
-}
-
-impl PendingBlockState {
-    /// Returns the ledger state after the transactions accepted so far, before
-    /// block-wide finalization.
-    #[must_use]
-    pub const fn ledger_state(&self) -> &LedgerState {
-        &self.ledger_state
-    }
-
-    /// Attempts to apply one transaction and update the block-wide accounting.
-    pub fn try_apply_transaction<Tx, Id, Profile: GasProfile>(
-        mut self,
-        config: &Config,
-        tx: &Tx,
-    ) -> Result<(Self, Vec<TxEvent>, DeferredZkpVerifications), LedgerError<Id>>
-    where
-        Tx: PreverifiedMantleTransaction + StorageSize + Clone,
-    {
-        let (ledger_state, balance, execution_gas, events, deferred_zkps) = self
-            .ledger_state
-            .try_apply_tx::<_, _, Profile>(config, tx.clone())?;
-        self.ledger_state = ledger_state;
-
-        let storage_gas = Gas::new(tx.storage_size() as u64);
-        let execution_base_fees =
-            GasCost::calculate(execution_gas, self.gas_prices.execution_base_gas_price)?;
-        let permanent_storage_fees =
-            GasCost::calculate(storage_gas, self.gas_prices.storage_gas_price)?;
-        let total_gas_cost = execution_base_fees.checked_add(permanent_storage_fees)?;
-        tracing::debug!(
-            target: LOG_TARGET,
-            balance,
-            total_gas_cost = total_gas_cost.into_inner(),
-            storage_gas_price = ?self.gas_prices.storage_gas_price,
-            execution_gas_price = ?self.gas_prices.execution_base_gas_price,
-            "tx balance check"
-        );
-
-        if balance < Balance::from(total_gas_cost.into_inner()) {
-            return Err(LedgerError::InsufficientBalance);
-        }
-
-        let fee_burned = total_gas_cost;
-        let fee_tip = GasCost::from(balance as Value).checked_sub(fee_burned)?;
-
-        self.totals = self
-            .totals
-            .try_add(execution_gas, storage_gas, fee_burned, fee_tip)?;
-
-        Ok((self, events, deferred_zkps))
-    }
-
-    /// Applies block-wide rewards and fee-market updates exactly once.
-    pub fn finish<Id>(self) -> Result<LedgerState, LedgerError<Id>> {
-        let mut ledger_state = self
-            .ledger_state
-            .compute_block_rewards(self.totals.total_fee_burned, self.totals.total_fee_tip)?;
-        ledger_state = ledger_state.update_execution_market(self.totals.total_execution_gas);
-        ledger_state = ledger_state.add_storage_gas_consumed(self.totals.total_storage_gas)?;
-        Ok(ledger_state)
-    }
-}
-
 impl LedgerState {
-    /// Starts applying transactions for one block without finalizing after each
-    /// transaction.
-    #[must_use]
-    pub fn begin_pending_block(self) -> PendingBlockState {
-        let gas_prices = self.get_gas_prices();
-        PendingBlockState {
-            ledger_state: self,
-            gas_prices,
-            totals: BlockTotals::default(),
-        }
-    }
-
     fn try_update<Tx, LeaderProof, Id, Profile>(
         self,
         block_id: Id,
@@ -611,28 +522,83 @@ impl LedgerState {
         })
     }
 
+    /// Validates and applies one transaction to the current ledger state.
+    ///
+    /// Returns the updated state, gas and fees, emitted events, and
+    /// deferred proof verifications. Block-wide accounting is not finalized.
+    pub fn try_apply_transaction<Tx, Id, Profile: GasProfile>(
+        self,
+        config: &Config,
+        tx: &Tx,
+    ) -> Result<(Self, GasAndFees, Vec<TxEvent>, DeferredZkpVerifications), LedgerError<Id>>
+    where
+        Tx: PreverifiedMantleTransaction + StorageSize + Clone,
+    {
+        let (ledger_state, balance, execution_gas, events, deferred_zkps) =
+            self.try_apply_tx::<_, _, Profile>(config, tx.clone())?;
+
+        let gas_prices = ledger_state.get_gas_prices();
+        let storage_gas = Gas::new(tx.storage_size() as u64);
+        let execution_base_fees =
+            GasCost::calculate(execution_gas, gas_prices.execution_base_gas_price)?;
+        let permanent_storage_fees =
+            GasCost::calculate(storage_gas, gas_prices.storage_gas_price)?;
+        let total_gas_cost = execution_base_fees.checked_add(permanent_storage_fees)?;
+        tracing::debug!(
+            target: LOG_TARGET,
+            balance,
+            total_gas_cost = total_gas_cost.into_inner(),
+            storage_gas_price = ?gas_prices.storage_gas_price,
+            execution_gas_price = ?gas_prices.execution_base_gas_price,
+            "tx balance check"
+        );
+
+        if balance < Balance::from(total_gas_cost.into_inner()) {
+            return Err(LedgerError::InsufficientBalance);
+        }
+
+        let fee_burned = total_gas_cost;
+        let fee_tip = GasCost::from(balance as Value).checked_sub(fee_burned)?;
+        let gas_and_fees = GasAndFees {
+            execution_gas,
+            storage_gas,
+            fee_burned,
+            fee_tip,
+        };
+
+        Ok((ledger_state, gas_and_fees, events, deferred_zkps))
+    }
+
     /// Apply the contents of an update to the ledger state.
     pub fn try_apply_contents<Tx, Id, Profile: GasProfile>(
-        self,
+        mut self,
         config: &Config,
         txs: impl Iterator<Item = Tx>,
     ) -> Result<(Self, Vec<TxEvent>, DeferredZkpVerifications), LedgerError<Id>>
     where
         Tx: PreverifiedMantleTransaction + StorageSize + Clone,
     {
-        let mut pending_block_state = self.begin_pending_block();
+        let mut gas_and_fees = GasAndFees::default();
         let mut tx_events = Vec::new();
         let mut deferred_zkps = DeferredZkpVerifications::new();
 
         for tx in txs {
-            let (next_pending_block_state, events, deferred) =
-                pending_block_state.try_apply_transaction::<_, Id, Profile>(config, &tx)?;
-            pending_block_state = next_pending_block_state;
+            let (next_state, tx_gas_and_fees, events, deferred) =
+                self.try_apply_transaction::<_, Id, Profile>(config, &tx)?;
+            gas_and_fees = gas_and_fees.checked_add::<Id>(tx_gas_and_fees)?;
+            self = next_state;
             tx_events.extend(events);
             deferred_zkps.extend(deferred);
         }
-        let ledger_state = pending_block_state.finish()?;
-        Ok((ledger_state, tx_events, deferred_zkps))
+
+        // Compute Block rewards and give tips
+        self = self.compute_block_rewards(gas_and_fees.fee_burned, gas_and_fees.fee_tip)?;
+        // Update Execution market state
+        self = self.update_execution_market(gas_and_fees.execution_gas);
+        // Accumulate storage gas consumed so the storage market can update the
+        // price at the next epoch rotation.
+        self = self.add_storage_gas_consumed(gas_and_fees.storage_gas)?;
+        Ok((self, tx_events, deferred_zkps))
     }
 
     pub fn from_utxos(utxos: impl IntoIterator<Item = Utxo>, config: &Config) -> Self {
@@ -1187,105 +1153,6 @@ mod tests {
             .cryptarchia_ledger
             .clone()
             .set_execution_base_fee(new_execution.into());
-    }
-
-    #[test]
-    fn block_totals_distinguish_transaction_and_cumulative_gas_limits() {
-        let oversized_transaction_gas = EXECUTION_GAS_LIMIT.checked_add(1.into()).unwrap();
-        let error = BlockTotals::default()
-            .try_add::<HeaderId>(oversized_transaction_gas, 0.into(), 0.into(), 0.into())
-            .unwrap_err();
-        assert_eq!(
-            error,
-            LedgerError::TooMuchTransactionExecutionGas {
-                gas: oversized_transaction_gas,
-                limit: EXECUTION_GAS_LIMIT,
-            }
-        );
-
-        let totals = BlockTotals::default()
-            .try_add::<HeaderId>(EXECUTION_GAS_LIMIT, 0.into(), 0.into(), 0.into())
-            .unwrap();
-
-        let error = totals
-            .try_add::<HeaderId>(1.into(), 0.into(), 0.into(), 0.into())
-            .unwrap_err();
-
-        assert_eq!(
-            error,
-            LedgerError::TooMuchExecutionGas {
-                gas: EXECUTION_GAS_LIMIT.checked_add(1.into()).unwrap(),
-                limit: EXECUTION_GAS_LIMIT,
-            }
-        );
-    }
-
-    #[test]
-    fn pending_block_defers_block_updates_until_finish() {
-        let config = config();
-        let (first_key, first_utxo) = utxo_with_sk();
-        let (second_key, second_utxo) = utxo_with_sk();
-        let first_tx = create_tx(vec![first_utxo.id()], Vec::new(), &[first_key])
-            .preverify()
-            .unwrap();
-        let second_tx = create_tx(vec![second_utxo.id()], Vec::new(), &[second_key])
-            .preverify()
-            .unwrap();
-        let mut ledger = LedgerState::from_utxos([first_utxo, second_utxo], &config);
-        update_ledger_prices(&mut ledger, 1, 1);
-
-        let initial_pending_rewards = ledger.mantle_ledger.leaders.get_pending_rewards();
-        let initial_storage_gas = ledger.cryptarchia_ledger.storage_gas_consumed_in_epoch();
-        let expected_storage_gas = Gas::new(first_tx.storage_size() as u64)
-            .checked_add(Gas::new(second_tx.storage_size() as u64))
-            .unwrap();
-
-        let mut pending_block_state = ledger.begin_pending_block();
-        for tx in [&first_tx, &second_tx] {
-            let (next_pending_block_state, _events, _) = pending_block_state
-                .try_apply_transaction::<_, HeaderId, MainnetGasProfile>(&config, tx)
-                .unwrap();
-            assert_eq!(
-                next_pending_block_state
-                    .ledger_state()
-                    .mantle_ledger
-                    .leaders
-                    .get_pending_rewards(),
-                initial_pending_rewards,
-            );
-            assert_eq!(
-                next_pending_block_state
-                    .ledger_state()
-                    .cryptarchia_ledger
-                    .storage_gas_consumed_in_epoch(),
-                initial_storage_gas,
-            );
-            pending_block_state = next_pending_block_state;
-        }
-
-        assert!(
-            !pending_block_state
-                .ledger_state()
-                .latest_utxos()
-                .contains(&first_utxo.id())
-        );
-        assert!(
-            !pending_block_state
-                .ledger_state()
-                .latest_utxos()
-                .contains(&second_utxo.id())
-        );
-
-        let finalized_state = pending_block_state.finish::<HeaderId>().unwrap();
-        assert_eq!(
-            finalized_state
-                .cryptarchia_ledger
-                .storage_gas_consumed_in_epoch(),
-            expected_storage_gas,
-        );
-        assert!(
-            finalized_state.mantle_ledger.leaders.get_pending_rewards() > initial_pending_rewards
-        );
     }
 
     enum Key {

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -328,10 +328,11 @@ impl LedgerState {
         // block that is actually applied, contents included, belongs in the
         // epoch's average.
         let mut txs_in_block = 0u64;
-        let (mut state, tx_events, deferred_zkp) = state.try_apply_contents::<_, _, Profile>(
-            config,
-            txs.inspect(|_| txs_in_block = txs_in_block.saturating_add(1)),
-        )?;
+        let (mut state, tx_events, deferred_zkp) = state
+            .try_apply_block_contents::<_, _, Profile>(
+                config,
+                txs.inspect(|_| txs_in_block = txs_in_block.saturating_add(1)),
+            )?;
         state.mantle_ledger.pow.record_block_txs(txs_in_block);
         state.update_pow_reward_difficulty(
             // count all claimed rewards
@@ -535,14 +536,13 @@ impl LedgerState {
         Tx: PreverifiedMantleTransaction + StorageSize + Clone,
     {
         let (ledger_state, balance, execution_gas, events, deferred_zkps) =
-            self.try_apply_tx::<_, _, Profile>(config, tx.clone())?;
+            self.try_apply_tx_operations::<_, _, Profile>(config, tx.clone())?;
 
         let gas_prices = ledger_state.get_gas_prices();
         let storage_gas = Gas::new(tx.storage_size() as u64);
         let execution_base_fees =
             GasCost::calculate(execution_gas, gas_prices.execution_base_gas_price)?;
-        let permanent_storage_fees =
-            GasCost::calculate(storage_gas, gas_prices.storage_gas_price)?;
+        let permanent_storage_fees = GasCost::calculate(storage_gas, gas_prices.storage_gas_price)?;
         let total_gas_cost = execution_base_fees.checked_add(permanent_storage_fees)?;
         tracing::debug!(
             target: LOG_TARGET,
@@ -569,8 +569,8 @@ impl LedgerState {
         Ok((ledger_state, gas_and_fees, events, deferred_zkps))
     }
 
-    /// Apply the contents of an update to the ledger state.
-    pub fn try_apply_contents<Tx, Id, Profile: GasProfile>(
+    /// Applies all transactions in a block and finalizes block-wide accounting.
+    pub fn try_apply_block_contents<Tx, Id, Profile: GasProfile>(
         mut self,
         config: &Config,
         txs: impl Iterator<Item = Tx>,
@@ -967,7 +967,7 @@ impl LedgerState {
     ///
     /// If any operation fails verification or execution, returns a
     /// [`LedgerError`] describing the failure.
-    fn try_apply_tx<Tx, Id, Profile: GasProfile>(
+    fn try_apply_tx_operations<Tx, Id, Profile: GasProfile>(
         mut self,
         config: &Config,
         tx: Tx,
@@ -1211,7 +1211,7 @@ mod tests {
             &Key::Ed25519(signing_key.clone()),
         );
         ledger_state
-            .try_apply_tx::<_, HeaderId, MainnetGasProfile>(config, tx)
+            .try_apply_tx_operations::<_, HeaderId, MainnetGasProfile>(config, tx)
             .unwrap()
             .0
     }
@@ -1379,7 +1379,8 @@ mod tests {
         };
 
         let tx = create_signed_tx(Op::ChannelInscribe(inscribe_op), &Key::Ed25519(signing_key));
-        let result = state.try_apply_tx::<_, HeaderId, MainnetGasProfile>(&test_config, tx);
+        let result =
+            state.try_apply_tx_operations::<_, HeaderId, MainnetGasProfile>(&test_config, tx);
         assert!(result.is_ok());
 
         let (new_state, _, _, events, deferred_zkps) = result.unwrap();
@@ -1413,7 +1414,8 @@ mod tests {
         };
 
         let tx = create_genesis_config_tx(config_op);
-        let result = state.try_apply_tx::<_, HeaderId, MainnetGasProfile>(&test_config, tx);
+        let result =
+            state.try_apply_tx_operations::<_, HeaderId, MainnetGasProfile>(&test_config, tx);
         assert!(result.is_ok());
 
         let (new_state, _, _, events, deferred_zkps) = result.unwrap();
@@ -1459,7 +1461,7 @@ mod tests {
         let dangling_tx = create_genesis_config_tx(dangling_config.clone());
         let result = state
             .clone()
-            .try_apply_tx::<_, HeaderId, MainnetGasProfile>(&test_config, dangling_tx);
+            .try_apply_tx_operations::<_, HeaderId, MainnetGasProfile>(&test_config, dangling_tx);
         assert!(matches!(
             result,
             Err(LedgerError::VerificationError(
@@ -1476,7 +1478,7 @@ mod tests {
         };
         let rooted_tx = create_genesis_config_tx(rooted_config.clone());
         let new_state = state
-            .try_apply_tx::<_, HeaderId, MainnetGasProfile>(&test_config, rooted_tx)
+            .try_apply_tx_operations::<_, HeaderId, MainnetGasProfile>(&test_config, rooted_tx)
             .unwrap()
             .0;
         let channel = new_state
@@ -1509,7 +1511,7 @@ mod tests {
             &Key::Ed25519(signing_key.clone()),
         );
         state = state
-            .try_apply_tx::<_, HeaderId, MainnetGasProfile>(&test_config, first_tx)
+            .try_apply_tx_operations::<_, HeaderId, MainnetGasProfile>(&test_config, first_tx)
             .unwrap()
             .0;
 
@@ -1539,14 +1541,14 @@ mod tests {
                 &Key::Ed25519(signing_key.clone()),
             );
             state = state
-                .try_apply_tx::<_, HeaderId, MainnetGasProfile>(&test_config, tx)
+                .try_apply_tx_operations::<_, HeaderId, MainnetGasProfile>(&test_config, tx)
                 .unwrap()
                 .0;
         }
 
         // The configuration is still valid and leaves the message tip untouched
         let new_state = state
-            .try_apply_tx::<_, HeaderId, MainnetGasProfile>(&test_config, config_tx)
+            .try_apply_tx_operations::<_, HeaderId, MainnetGasProfile>(&test_config, config_tx)
             .unwrap()
             .0;
         let channel = new_state
@@ -1578,7 +1580,10 @@ mod tests {
         };
         let config1_tx = create_genesis_config_tx(config1.clone());
         state = state
-            .try_apply_tx::<_, HeaderId, MainnetGasProfile>(&test_config, config1_tx.clone())
+            .try_apply_tx_operations::<_, HeaderId, MainnetGasProfile>(
+                &test_config,
+                config1_tx.clone(),
+            )
             .unwrap()
             .0;
         let config2 = ChannelConfigOp {
@@ -1587,7 +1592,7 @@ mod tests {
         };
         let config2_tx = create_config_tx(config2, &signing_key);
         state = state
-            .try_apply_tx::<_, HeaderId, MainnetGasProfile>(&test_config, config2_tx)
+            .try_apply_tx_operations::<_, HeaderId, MainnetGasProfile>(&test_config, config2_tx)
             .unwrap()
             .0;
 
@@ -1595,7 +1600,7 @@ mod tests {
         // reorganization abandons its block
         let result = state
             .clone()
-            .try_apply_tx::<_, HeaderId, MainnetGasProfile>(&test_config, config1_tx);
+            .try_apply_tx_operations::<_, HeaderId, MainnetGasProfile>(&test_config, config1_tx);
         assert!(matches!(
             result,
             Err(LedgerError::VerificationError(
@@ -1612,7 +1617,8 @@ mod tests {
             ..config1
         };
         let sibling_tx = create_config_tx(sibling, &signing_key);
-        let result = state.try_apply_tx::<_, HeaderId, MainnetGasProfile>(&test_config, sibling_tx);
+        let result = state
+            .try_apply_tx_operations::<_, HeaderId, MainnetGasProfile>(&test_config, sibling_tx);
         assert!(matches!(
             result,
             Err(LedgerError::VerificationError(
@@ -1642,7 +1648,7 @@ mod tests {
             &Key::Ed25519(signing_key.clone()),
         );
         state = state
-            .try_apply_tx::<_, HeaderId, MainnetGasProfile>(&test_config, first_tx)
+            .try_apply_tx_operations::<_, HeaderId, MainnetGasProfile>(&test_config, first_tx)
             .unwrap()
             .0;
 
@@ -1658,7 +1664,7 @@ mod tests {
         };
         let config_tx = create_config_tx(config_op.clone(), &signing_key);
         state = state
-            .try_apply_tx::<_, HeaderId, MainnetGasProfile>(&test_config, config_tx)
+            .try_apply_tx_operations::<_, HeaderId, MainnetGasProfile>(&test_config, config_tx)
             .unwrap()
             .0;
 
@@ -1674,7 +1680,7 @@ mod tests {
             &Key::Ed25519(signing_key),
         );
         let new_state = state
-            .try_apply_tx::<_, HeaderId, MainnetGasProfile>(&test_config, second_tx)
+            .try_apply_tx_operations::<_, HeaderId, MainnetGasProfile>(&test_config, second_tx)
             .unwrap()
             .0;
         let channel = new_state
@@ -1720,7 +1726,8 @@ mod tests {
         let ops = vec![Op::ChannelDeposit(deposit.clone())];
         let tx = create_multi_signed_tx(ops, vec![&Key::Zk(sk)]);
         let tx_hash = tx.hash();
-        let result = ledger_state.try_apply_tx::<_, HeaderId, MainnetGasProfile>(&test_config, tx);
+        let result = ledger_state
+            .try_apply_tx_operations::<_, HeaderId, MainnetGasProfile>(&test_config, tx);
         let (new_state, balance, _, events, deferred_zkps) = result.unwrap();
         deferred_zkps.verify().unwrap();
 
@@ -1807,7 +1814,7 @@ mod tests {
         let deposit_ops = vec![Op::ChannelDeposit(deposit)];
         let tx = create_multi_signed_tx(deposit_ops, vec![&Key::Zk(sk)]);
         ledger_state = ledger_state
-            .try_apply_tx::<_, HeaderId, MainnetGasProfile>(&test_config, tx)
+            .try_apply_tx_operations::<_, HeaderId, MainnetGasProfile>(&test_config, tx)
             .unwrap()
             .0;
 
@@ -1840,8 +1847,8 @@ mod tests {
             vec![&Key::MultiSequencer(withdraw_proof)],
         );
 
-        let result =
-            ledger_state.try_apply_tx::<_, HeaderId, MainnetGasProfile>(&test_config, signed_tx);
+        let result = ledger_state
+            .try_apply_tx_operations::<_, HeaderId, MainnetGasProfile>(&test_config, signed_tx);
         assert!(result.is_ok());
 
         let (new_state, tx_balance, _, events, deferred_zkps) = result.unwrap();
@@ -1923,7 +1930,7 @@ mod tests {
             .unwrap();
 
         let (_, tx_balance, execution_gas, _, deferred_zkps) = ledger_state
-            .try_apply_tx::<_, HeaderId, MainnetGasProfile>(&test_config, tx.clone())
+            .try_apply_tx_operations::<_, HeaderId, MainnetGasProfile>(&test_config, tx.clone())
             .unwrap();
         deferred_zkps.verify().unwrap();
         assert_eq!(tx_balance, 0);
@@ -1990,7 +1997,7 @@ mod tests {
             .unwrap();
 
         let (_, _, execution_gas, _, deferred_zkps) = state
-            .try_apply_tx::<_, HeaderId, MainnetGasProfile>(&test_config, tx.clone())
+            .try_apply_tx_operations::<_, HeaderId, MainnetGasProfile>(&test_config, tx.clone())
             .unwrap();
         deferred_zkps.verify().unwrap();
 
@@ -2062,7 +2069,7 @@ mod tests {
             .unwrap();
 
         let (_, _, execution_gas, _, deferred_zkps) = ledger_state
-            .try_apply_tx::<_, HeaderId, MainnetGasProfile>(&test_config, tx.clone())
+            .try_apply_tx_operations::<_, HeaderId, MainnetGasProfile>(&test_config, tx.clone())
             .unwrap();
         deferred_zkps.verify().unwrap();
         assert_eq!(execution_gas.into_inner(), 56 + 590 + 56);
@@ -2132,7 +2139,7 @@ mod tests {
             .unwrap();
 
         let (_, _, execution_gas, _, deferred_zkps) = ledger_state
-            .try_apply_tx::<_, HeaderId, MainnetGasProfile>(&test_config, tx.clone())
+            .try_apply_tx_operations::<_, HeaderId, MainnetGasProfile>(&test_config, tx.clone())
             .unwrap();
         deferred_zkps.verify().unwrap();
         assert_eq!(execution_gas.into_inner(), 56 + 590 + 56);
@@ -2171,7 +2178,10 @@ mod tests {
         let deposit_tx =
             create_multi_signed_tx(vec![Op::ChannelDeposit(deposit)], vec![&Key::Zk(sk)]);
         ledger_state = ledger_state
-            .try_apply_tx::<_, HeaderId, MainnetGasProfile>(&test_config, deposit_tx.clone())
+            .try_apply_tx_operations::<_, HeaderId, MainnetGasProfile>(
+                &test_config,
+                deposit_tx.clone(),
+            )
             .unwrap()
             .0;
 
@@ -2194,15 +2204,18 @@ mod tests {
             vec![&Key::MultiSequencer(withdraw_proof)],
         );
         ledger_state = ledger_state
-            .try_apply_tx::<_, HeaderId, MainnetGasProfile>(&test_config, signed_withdraw)
+            .try_apply_tx_operations::<_, HeaderId, MainnetGasProfile>(
+                &test_config,
+                signed_withdraw,
+            )
             .unwrap()
             .0;
 
         assert!(!ledger_state.latest_utxos().contains(&utxo.id()));
 
         // Replaying the signed deposit fails: its input no longer exists.
-        let result =
-            ledger_state.try_apply_tx::<_, HeaderId, MainnetGasProfile>(&test_config, deposit_tx);
+        let result = ledger_state
+            .try_apply_tx_operations::<_, HeaderId, MainnetGasProfile>(&test_config, deposit_tx);
         assert!(result.is_err());
     }
 
@@ -2232,7 +2245,7 @@ mod tests {
         let deposit_ops = vec![Op::ChannelDeposit(deposit)];
         let tx = create_multi_signed_tx(deposit_ops, vec![&Key::Zk(sk)]);
         ledger_state = ledger_state
-            .try_apply_tx::<_, HeaderId, MainnetGasProfile>(&test_config, tx)
+            .try_apply_tx_operations::<_, HeaderId, MainnetGasProfile>(&test_config, tx)
             .unwrap()
             .0;
         // The deposit re-created the note as a channel note
@@ -2267,7 +2280,7 @@ mod tests {
 
         let err = ledger_state
             .clone()
-            .try_apply_tx::<_, HeaderId, MainnetGasProfile>(&test_config, signed_tx)
+            .try_apply_tx_operations::<_, HeaderId, MainnetGasProfile>(&test_config, signed_tx)
             .err()
             .unwrap();
         assert_eq!(
@@ -2306,7 +2319,7 @@ mod tests {
             &Key::Ed25519(signing_key.clone()),
         );
         state = state
-            .try_apply_tx::<_, HeaderId, MainnetGasProfile>(&test_config, first_tx)
+            .try_apply_tx_operations::<_, HeaderId, MainnetGasProfile>(&test_config, first_tx)
             .unwrap()
             .0;
 
@@ -2325,7 +2338,7 @@ mod tests {
         );
         let result = state
             .clone()
-            .try_apply_tx::<_, HeaderId, MainnetGasProfile>(&test_config, second_tx);
+            .try_apply_tx_operations::<_, HeaderId, MainnetGasProfile>(&test_config, second_tx);
         assert!(matches!(
             result,
             Err(LedgerError::VerificationError(
@@ -2349,7 +2362,7 @@ mod tests {
             &Key::Ed25519(signing_key),
         );
         let empty_result =
-            state.try_apply_tx::<_, HeaderId, MainnetGasProfile>(&test_config, empty_tx);
+            state.try_apply_tx_operations::<_, HeaderId, MainnetGasProfile>(&test_config, empty_tx);
         assert!(matches!(
             empty_result,
             Err(LedgerError::VerificationError(
@@ -2382,7 +2395,7 @@ mod tests {
             &Key::Ed25519(signing_key),
         );
         state = state
-            .try_apply_tx::<_, HeaderId, MainnetGasProfile>(&test_config, first_tx)
+            .try_apply_tx_operations::<_, HeaderId, MainnetGasProfile>(&test_config, first_tx)
             .unwrap()
             .0;
 
@@ -2398,7 +2411,8 @@ mod tests {
             Op::ChannelInscribe(second_inscribe),
             &Key::Ed25519(unauthorized_signing_key),
         );
-        let result = state.try_apply_tx::<_, HeaderId, MainnetGasProfile>(&test_config, second_tx);
+        let result = state
+            .try_apply_tx_operations::<_, HeaderId, MainnetGasProfile>(&test_config, second_tx);
         assert!(matches!(
             result,
             Err(LedgerError::VerificationError(
@@ -2484,7 +2498,7 @@ mod tests {
         );
 
         let result = state
-            .try_apply_tx::<_, HeaderId, MainnetGasProfile>(&test_config, tx)
+            .try_apply_tx_operations::<_, HeaderId, MainnetGasProfile>(&test_config, tx)
             .unwrap()
             .0;
 
@@ -2647,7 +2661,7 @@ mod tests {
 
         let result = ledger
             .clone()
-            .try_apply_contents::<_, HeaderId, MainnetGasProfile>(
+            .try_apply_block_contents::<_, HeaderId, MainnetGasProfile>(
                 &config,
                 std::iter::once(tx.clone()),
             );
@@ -2658,7 +2672,10 @@ mod tests {
         ledger.cryptarchia_ledger = ledger.cryptarchia_ledger.set_execution_base_fee(10.into());
 
         let err = ledger
-            .try_apply_contents::<_, HeaderId, MainnetGasProfile>(&config, std::iter::once(tx))
+            .try_apply_block_contents::<_, HeaderId, MainnetGasProfile>(
+                &config,
+                std::iter::once(tx),
+            )
             .err()
             .unwrap();
         // The transaction should be rejected because the price indicated for execution
@@ -2698,7 +2715,10 @@ mod tests {
 
         let result = ledger
             .clone()
-            .try_apply_contents::<_, HeaderId, MainnetGasProfile>(&config, std::iter::once(tx));
+            .try_apply_block_contents::<_, HeaderId, MainnetGasProfile>(
+                &config,
+                std::iter::once(tx),
+            );
         // The `unwrap` should succeed because the user pays at least the base fee of
         // 794
         let (no_priority_fee_ledger, events, _) = result.unwrap();
@@ -2715,8 +2735,10 @@ mod tests {
         .preverify()
         .unwrap();
 
-        let result = ledger
-            .try_apply_contents::<_, HeaderId, MainnetGasProfile>(&config, std::iter::once(tx));
+        let result = ledger.try_apply_block_contents::<_, HeaderId, MainnetGasProfile>(
+            &config,
+            std::iter::once(tx),
+        );
         // The `unwrap` should succeed because the user pays at least the base fee of
         // 794
         let (priority_fee_ledger, events, _) = result.unwrap();
@@ -2756,7 +2778,10 @@ mod tests {
         assert!(storage_gas.into_inner() > 0);
 
         let (applied, _, _) = ledger
-            .try_apply_contents::<_, HeaderId, MainnetGasProfile>(&config, std::iter::once(tx))
+            .try_apply_block_contents::<_, HeaderId, MainnetGasProfile>(
+                &config,
+                std::iter::once(tx),
+            )
             .unwrap();
 
         // Storage gas consumed by the tx should be accumulated in the ledger
@@ -3027,7 +3052,7 @@ mod tests {
 
         #[test]
         fn claim_tx_validation_rejects_disabled_rewards() {
-            // End-to-end through `try_apply_tx`: with `sigma_e` forced to
+            // End-to-end through `try_apply_tx_operations`: with `sigma_e` forced to
             // zero the claim fails the §5.6 safety cutoff. This exercises
             // the full wiring: preverification, the stateful
             // `ClaimPowReward` arm and the helper-built context.
@@ -3038,7 +3063,7 @@ mod tests {
             assert_eq!(state.mantle_ledger.pow.epoch_reward(), 0);
 
             let err = state
-                .try_apply_tx::<_, HeaderId, MainnetGasProfile>(&config, claim_tx())
+                .try_apply_tx_operations::<_, HeaderId, MainnetGasProfile>(&config, claim_tx())
                 .err()
                 .expect("claim should fail validation");
 
@@ -3058,7 +3083,7 @@ mod tests {
             let (state, config) = pow_ledger_state(1_000);
 
             let err = state
-                .try_apply_tx::<_, HeaderId, MainnetGasProfile>(&config, claim_tx())
+                .try_apply_tx_operations::<_, HeaderId, MainnetGasProfile>(&config, claim_tx())
                 .err()
                 .expect("claim should fail validation");
 
@@ -3088,7 +3113,7 @@ mod tests {
 
         #[test]
         fn claim_tx_end_to_end_pays_the_reward() {
-            // The full §5.3 pipeline through `try_apply_tx`: preverification,
+            // The full §5.3 pipeline through `try_apply_tx_operations`: preverification,
             // helper-built validation context (pool, window, epoch nonce,
             // difficulty, double-claim) and execution.
             let (state, config) = claim_accepting_state();
@@ -3096,7 +3121,7 @@ mod tests {
             let epoch_reward = state.mantle_ledger.pow.epoch_reward();
 
             let (state, _balance, _, events, deferred_zkps) = state
-                .try_apply_tx::<_, HeaderId, MainnetGasProfile>(&config, claim_tx())
+                .try_apply_tx_operations::<_, HeaderId, MainnetGasProfile>(&config, claim_tx())
                 .expect("claim should validate and execute");
             deferred_zkps.verify().unwrap();
 
@@ -3136,12 +3161,12 @@ mod tests {
             // during tx-level validation.
             let (state, config) = claim_accepting_state();
             let (state, _, _, _, deferred_zkps) = state
-                .try_apply_tx::<_, HeaderId, MainnetGasProfile>(&config, claim_tx())
+                .try_apply_tx_operations::<_, HeaderId, MainnetGasProfile>(&config, claim_tx())
                 .expect("first claim should succeed");
             deferred_zkps.verify().unwrap();
 
             let err = state
-                .try_apply_tx::<_, HeaderId, MainnetGasProfile>(&config, claim_tx())
+                .try_apply_tx_operations::<_, HeaderId, MainnetGasProfile>(&config, claim_tx())
                 .err()
                 .expect("second claim should be rejected");
 
@@ -3224,7 +3249,7 @@ mod tests {
         fn claim_execution_alone_has_no_double_claim_guard() {
             // `try_apply_op` is execute-only by design (like the other op
             // arms): the double-claim check lives in
-            // `ClaimPowRewardOp::validate`, which `try_apply_tx` runs via
+            // `ClaimPowRewardOp::validate`, which `try_apply_tx_operations` runs via
             // `verify_stateful_op` before execution (see
             // `claim_tx_double_claim_is_rejected`). Calling the execution
             // path directly therefore pays the same solution twice — pinned

--- a/services/chain/chain-leader/src/leadership.rs
+++ b/services/chain/chain-leader/src/leadership.rs
@@ -27,6 +27,8 @@ use lb_wallet_service::{
     api::{WalletApi, WalletApiError, WalletServiceData},
 };
 use overwatch::services::{AsServiceId, relay::OutboundRelay};
+#[cfg(test)]
+pub use pol_tests::test_config;
 use rand::rngs::OsRng;
 use tokio::{
     sync::{mpsc, oneshot},
@@ -742,7 +744,7 @@ mod pol_tests {
         }
     }
 
-    fn test_config() -> lb_ledger::Config {
+    pub fn test_config() -> lb_ledger::Config {
         lb_ledger::Config {
             epoch_config: EpochConfig {
                 epoch_stake_distribution_stabilization: NonZero::new(3u8).unwrap(),

--- a/services/chain/chain-leader/src/lib.rs
+++ b/services/chain/chain-leader/src/lib.rs
@@ -8,7 +8,7 @@ mod relays;
 mod wallet;
 
 use core::fmt::Debug;
-use std::{fmt::Display, iter, pin::Pin, time::Duration};
+use std::{fmt::Display, pin::Pin, time::Duration};
 
 use futures::{Stream, StreamExt as _, stream};
 use lb_chain_network_service::api::{ChainNetworkServiceApi, ChainNetworkServiceData};
@@ -32,7 +32,7 @@ use lb_core::{
 };
 use lb_cryptarchia_engine::Slot;
 use lb_key_management_system_service::{api::KmsServiceApi, keys::Ed25519Key};
-use lb_ledger::LedgerState;
+use lb_ledger::{LedgerState, PendingBlockState};
 use lb_log_targets::chain;
 use lb_services_utils::wait_until_services_are_ready;
 use lb_storage_service::StorageService;
@@ -120,6 +120,105 @@ pub type WinningSlotFuture = Pin<Box<dyn Future<Output = Option<LeaderPrivate>> 
 /// [`WinningSlotFuture`] per slot in the epoch's range. The consumer drives the
 /// futures and filters out the non-winning (`None`) slots.
 pub type WinningPolSlotStream = Pin<Box<dyn Stream<Item = WinningSlotFuture> + Send + Unpin>>;
+
+/// Progress made while selecting transactions for a block proposal.
+enum AssemblyState {
+    Progress,
+    NoProgress,
+    GasCapacityReached,
+}
+
+/// Result of applying mempool candidates to the pending block state.
+struct TransactionSelection {
+    pending_block_state: PendingBlockState,
+    selected_txs: Vec<SignedOps<Preverified, StandardMode>>,
+    invalid_tx_hashes: Vec<TxHash>,
+}
+
+#[expect(
+    clippy::cognitive_complexity,
+    reason = "Dependency retries and distinct invalid, proof, and block-capacity outcomes"
+)]
+fn select_transactions(
+    mut pending_block_state: PendingBlockState,
+    mut pending: Vec<SignedOps<Preverified, StandardMode>>,
+    ledger_config: &lb_ledger::Config,
+) -> TransactionSelection {
+    let mut selected_txs = Vec::new();
+
+    // A transaction may only become valid once another transaction it depends
+    // on has already been applied. Repeatedly attempt to apply the pending
+    // transactions, retrying the full set of failures each round, while a
+    // round keeps adding new transactions to the block.
+    let mut assembly_state = AssemblyState::Progress;
+    while matches!(assembly_state, AssemblyState::Progress) {
+        assembly_state = AssemblyState::NoProgress;
+        let mut still_pending = Vec::with_capacity(pending.len());
+
+        for tx in std::mem::take(&mut pending) {
+            match pending_block_state
+                .clone()
+                .try_apply_transaction::<_, HeaderId, MainnetGasProfile>(ledger_config, &tx)
+            {
+                Ok((next_pending_block_state, _events, deferred_zkps)) => {
+                    match deferred_zkps.verify() {
+                        Ok(()) => {
+                            pending_block_state = next_pending_block_state;
+                            selected_txs.push(tx);
+                            assembly_state = AssemblyState::Progress;
+                        }
+                        Err(err) => {
+                            tracing::trace!(
+                                target: LOG_TARGET,
+                                tx = ?tx.hash(),
+                                %err,
+                                "deferred ZKP verification failed during block assembly",
+                            );
+                            still_pending.push(tx);
+                        }
+                    }
+                }
+                Err(err @ lb_ledger::LedgerError::TooMuchExecutionGas { .. }) => {
+                    tracing::trace!(
+                        target: LOG_TARGET,
+                        tx = ?tx.hash(),
+                        %err,
+                        "block execution gas limit reached during block assembly",
+                    );
+                    assembly_state = AssemblyState::GasCapacityReached;
+                    break;
+                }
+                Err(err) => {
+                    tracing::trace!(
+                        target: LOG_TARGET,
+                        "tx {:?} not (yet) applicable during block assembly: {:?}",
+                        tx.hash(),
+                        err
+                    );
+                    still_pending.push(tx);
+                }
+            }
+        }
+
+        pending = still_pending;
+    }
+
+    // Transactions that never became applicable are genuinely invalid against
+    // this block's ledger state and can be evicted from the mempool. If assembly
+    // stopped at the gas limit, unprocessed transactions are not invalid and
+    // must remain in the mempool.
+    let invalid_tx_hashes = if matches!(assembly_state, AssemblyState::GasCapacityReached) {
+        Vec::new()
+    } else {
+        pending.iter().map(Hashable::hash).collect()
+    };
+
+    TransactionSelection {
+        pending_block_state,
+        selected_txs,
+        invalid_tx_hashes,
+    }
+}
 
 /// Number of epochs to buffer for late subscribers to the winning `PoL` slots
 /// stream. Subscribers will almost certainly consume each epoch at some point,
@@ -667,66 +766,19 @@ where
                 &uncle_headers.slots(),
                 ledger_config,
             )?;
+        let pending_block_state = ledger_state.begin_pending_block();
 
         // Collect all candidate transactions up front so the ones that fail can
         // be retried across multiple rounds.
-        let mut pending: Vec<_> = tx_stream.collect().await;
-
-        let mut valid_txs = Vec::new();
-
-        // A transaction may only become valid once another transaction it depends
-        // on has already been applied. Repeatedly attempt to apply the pending
-        // transactions, retrying the full set of failures each round, while a
-        // round keeps adding new transactions to the block.
-        let mut applied_any = true;
-        while applied_any {
-            applied_any = false;
-            let mut still_pending = Vec::with_capacity(pending.len());
-
-            for tx in pending {
-                match ledger_state
-                    .clone()
-                    .try_apply_contents::<_, HeaderId, MainnetGasProfile>(
-                        ledger_config,
-                        // Tx is cloned eagerly: `try_apply_contents` consumes the tx, but we need
-                        // it for the block if it is valid.
-                        // Avoidable if we made the ledger hand it back.
-                        iter::once(tx.clone()),
-                    ) {
-                    Ok((new_state, _events, deferred_zkps)) => match deferred_zkps.verify() {
-                        Ok(()) => {
-                            ledger_state = new_state;
-                            valid_txs.push(tx);
-                            applied_any = true;
-                        }
-                        Err(err) => {
-                            tracing::trace!(
-                                target: LOG_TARGET,
-                                tx = ?tx.hash(),
-                                %err,
-                                "deferred ZKP verification failed during block assembly",
-                            );
-                            still_pending.push(tx);
-                        }
-                    },
-                    Err(err) => {
-                        tracing::trace!(
-                            target: LOG_TARGET,
-                            "tx {:?} not (yet) applicable during block assembly: {:?}",
-                            tx.hash(),
-                            err
-                        );
-                        still_pending.push(tx);
-                    }
-                }
-            }
-
-            pending = still_pending;
-        }
-
-        // Transactions that never became applicable are genuinely invalid against
-        // this block's ledger state and can be evicted from the mempool.
-        let invalid_tx_hashes: Vec<_> = pending.iter().map(Hashable::hash).collect();
+        let TransactionSelection {
+            pending_block_state,
+            selected_txs,
+            invalid_tx_hashes,
+        } = select_transactions(
+            pending_block_state,
+            tx_stream.collect().await,
+            ledger_config,
+        );
 
         if !invalid_tx_hashes.is_empty()
             && let Err(e) = relays
@@ -737,12 +789,12 @@ where
             error!(target: LOG_TARGET, "Failed to remove invalid transactions from mempool: {e:?}");
         }
 
-        let valid_tx_stream = stream::iter(valid_txs);
+        let valid_tx_stream = stream::iter(selected_txs);
         let txs = txs_for_block(valid_tx_stream).await;
 
         let block = Block::create(parent, slot, uncle_headers, proof, txs, signing_key)?;
         if tracing::enabled!(Level::DEBUG) {
-            log_sdp_activity_selected_for_proposal(&block, &ledger_state);
+            log_sdp_activity_selected_for_proposal(&block, pending_block_state.ledger_state());
         }
 
         info!(
@@ -912,6 +964,24 @@ where
 
 #[cfg(test)]
 mod tests {
+    use lb_core::{
+        mantle::{
+            Note, Op, OpProof, TxGasCalculator as _, Utxo,
+            channel::{SlotTimeframe, SlotTimeout},
+            ledger::{Inputs, Outputs},
+            ops::{
+                channel::{
+                    ChannelId, MsgId,
+                    config::{ChannelConfigOp, Keys},
+                },
+                transfer::TransferOp,
+            },
+            transactions::{OpProofs, Ops, states::Unverified},
+        },
+        proofs::channel_multi_sig_proof::{ChannelMultiSigProof, IndexedSignature},
+    };
+    use lb_key_management_system_service::keys::ZkKey;
+
     use super::*;
 
     #[derive(Clone)]
@@ -923,6 +993,144 @@ mod tests {
         fn storage_size(&self) -> usize {
             self.size
         }
+    }
+
+    // Two transactions at this multiplier exceed the block execution-gas limit,
+    // while each transaction remains below it.
+    const HIGH_GAS_CONFIG_SIGNATURES: usize = 28_514;
+
+    fn build_high_execution_gas_ops(
+        transaction_index: usize,
+        channel_signing_key: &Ed25519Key,
+        funding_key: &ZkKey,
+    ) -> (Utxo, Ops) {
+        let mut channel_id = [0; 32];
+        channel_id[..size_of::<usize>()].copy_from_slice(&transaction_index.to_le_bytes());
+
+        let funding_utxo = Utxo::new(
+            channel_id,
+            0,
+            Note::new(10_000_000, funding_key.to_public_key()),
+        );
+        let transfer = TransferOp::new(
+            Inputs::try_new(vec![funding_utxo.id()]).unwrap(),
+            Outputs::try_new(Vec::new()).unwrap(),
+        );
+
+        let channel_config = ChannelConfigOp {
+            channel: ChannelId::from(channel_id),
+            parent: MsgId::root(),
+            keys: Keys::from(channel_signing_key.public_key()),
+            posting_timeframe: SlotTimeframe::from(0),
+            posting_timeout: SlotTimeout::from(0),
+            configuration_threshold: 1,
+            transfer_threshold: 1,
+        };
+
+        let ops = Ops::from([Op::Transfer(transfer), Op::ChannelConfig(channel_config)]);
+        (funding_utxo, ops)
+    }
+
+    fn sign_high_execution_gas_ops(
+        ops: Ops,
+        channel_signing_key: &Ed25519Key,
+        funding_key: &ZkKey,
+    ) -> SignedOps<Preverified, StandardMode> {
+        let tx_hash = ops.hash();
+        let zk_signature =
+            ZkKey::multi_sign(std::slice::from_ref(funding_key), &tx_hash.to_fr()).unwrap();
+        let channel_signature =
+            channel_signing_key.sign_payload(tx_hash.as_signing_bytes().as_ref());
+        let channel_signatures = (0..HIGH_GAS_CONFIG_SIGNATURES)
+            .map(|index| IndexedSignature::new(index as u16, channel_signature))
+            .collect::<Vec<_>>()
+            .try_into()
+            .unwrap();
+        let channel_proof = ChannelMultiSigProof::try_new(channel_signatures).unwrap();
+        let proofs = OpProofs::from([
+            OpProof::ZkSig(zk_signature),
+            OpProof::ChannelMultiSigProof(channel_proof),
+        ]);
+
+        SignedOps::<Unverified, StandardMode>::from_parts(ops, proofs)
+            .unwrap()
+            .preverify()
+            .unwrap()
+    }
+
+    fn high_execution_gas_transaction(
+        transaction_index: usize,
+        channel_signing_key: &Ed25519Key,
+        funding_key: &ZkKey,
+    ) -> (Utxo, SignedOps<Preverified, StandardMode>) {
+        let (funding_utxo, ops) =
+            build_high_execution_gas_ops(transaction_index, channel_signing_key, funding_key);
+        let transaction = sign_high_execution_gas_ops(ops, channel_signing_key, funding_key);
+
+        (funding_utxo, transaction)
+    }
+
+    #[tokio::test]
+    async fn gas_limited_selection_returns_canonically_applicable_prefix() {
+        const CANDIDATE_COUNT: usize = 2;
+
+        let config = leadership::test_config();
+        let channel_signing_key = Ed25519Key::from_bytes(&[7; 32]);
+        let funding_key = ZkKey::zero();
+        let (funding_utxos, candidates): (Vec<_>, Vec<_>) = (0..CANDIDATE_COUNT)
+            .map(|transaction_index| {
+                high_execution_gas_transaction(
+                    transaction_index,
+                    &channel_signing_key,
+                    &funding_key,
+                )
+            })
+            .unzip();
+
+        let ledger_state = LedgerState::from_utxos(funding_utxos, &config);
+        let gas_prices = ledger_state.get_gas_prices();
+        let individual_gas = candidates[0]
+            .execution_gas_consumption::<MainnetGasProfile>(&gas_prices)
+            .unwrap();
+        assert!(candidates.iter().all(|candidate| {
+            candidate
+                .execution_gas_consumption::<MainnetGasProfile>(&gas_prices)
+                .unwrap()
+                == individual_gas
+        }));
+        assert!(
+            candidates
+                .iter()
+                .all(|candidate| candidate.storage_size() <= MAX_BLOCK_TRANSACTIONS_SIZE)
+        );
+        let all_candidates_result = ledger_state
+            .clone()
+            .try_apply_contents::<_, HeaderId, MainnetGasProfile>(
+                &config,
+                candidates.iter().cloned(),
+            );
+        let all_candidates_error = all_candidates_result.err();
+        assert!(
+            matches!(
+                &all_candidates_error,
+                Some(lb_ledger::LedgerError::TooMuchExecutionGas { .. })
+            ),
+            "individual gas: {individual_gas:?}, error: {all_candidates_error:?}"
+        );
+
+        let selection = select_transactions(
+            ledger_state.clone().begin_pending_block(),
+            candidates,
+            &config,
+        );
+        assert_eq!(selection.selected_txs.len(), CANDIDATE_COUNT - 1);
+        assert!(selection.invalid_tx_hashes.is_empty());
+
+        let block_txs = txs_for_block(stream::iter(selection.selected_txs)).await;
+        assert_eq!(block_txs.len(), CANDIDATE_COUNT - 1);
+        ledger_state
+            .try_apply_contents::<_, HeaderId, MainnetGasProfile>(&config, block_txs.into_iter())
+            .expect("the selected prefix must pass canonical application");
     }
 
     #[tokio::test]

--- a/services/chain/chain-leader/src/lib.rs
+++ b/services/chain/chain-leader/src/lib.rs
@@ -23,6 +23,7 @@ use lb_core::{
     header::HeaderId,
     mantle::{
         OpRef, SignedOps,
+        batch::DeferredZkpVerifications,
         gas::MainnetGasProfile,
         ledger::verification_mode::StandardMode,
         traits::{Hashable, MantleTx, SignedMantleTx, StorageSize},
@@ -32,7 +33,7 @@ use lb_core::{
 };
 use lb_cryptarchia_engine::Slot;
 use lb_key_management_system_service::{api::KmsServiceApi, keys::Ed25519Key};
-use lb_ledger::{LedgerState, PendingBlockState};
+use lb_ledger::{GasAndFees, LedgerState};
 use lb_log_targets::chain;
 use lb_services_utils::wait_until_services_are_ready;
 use lb_storage_service::StorageService;
@@ -128,9 +129,54 @@ enum AssemblyState {
     GasCapacityReached,
 }
 
-/// Result of applying mempool candidates to the pending block state.
+/// Ledger state, gas, and fees for a proposal under construction.
+#[derive(Clone)]
+struct BlockBuilder {
+    ledger_state: LedgerState,
+    gas_and_fees: GasAndFees,
+}
+
+impl BlockBuilder {
+    #[must_use]
+    fn new(ledger_state: LedgerState) -> Self {
+        Self {
+            ledger_state,
+            gas_and_fees: GasAndFees::default(),
+        }
+    }
+
+    fn try_apply_transaction(
+        self,
+        tx: &SignedOps<Preverified, StandardMode>,
+        ledger_config: &lb_ledger::Config,
+    ) -> Result<(Self, DeferredZkpVerifications), lb_ledger::LedgerError<HeaderId>> {
+        let Self {
+            ledger_state,
+            gas_and_fees,
+        } = self;
+        let (ledger_state, tx_gas_and_fees, _events, deferred_zkps) =
+            ledger_state
+                .try_apply_transaction::<_, HeaderId, MainnetGasProfile>(ledger_config, tx)?;
+        let gas_and_fees = gas_and_fees.checked_add::<HeaderId>(tx_gas_and_fees)?;
+
+        Ok((
+            Self {
+                ledger_state,
+                gas_and_fees,
+            },
+            deferred_zkps,
+        ))
+    }
+
+    #[must_use]
+    fn finish(self) -> LedgerState {
+        self.ledger_state
+    }
+}
+
+/// Result of selecting mempool candidates for a block proposal.
 struct TransactionSelection {
-    pending_block_state: PendingBlockState,
+    ledger_state: LedgerState,
     selected_txs: Vec<SignedOps<Preverified, StandardMode>>,
     invalid_tx_hashes: Vec<TxHash>,
 }
@@ -140,7 +186,7 @@ struct TransactionSelection {
     reason = "Dependency retries and distinct invalid, proof, and block-capacity outcomes"
 )]
 fn select_transactions(
-    mut pending_block_state: PendingBlockState,
+    mut block_builder: BlockBuilder,
     mut pending: Vec<SignedOps<Preverified, StandardMode>>,
     ledger_config: &lb_ledger::Config,
 ) -> TransactionSelection {
@@ -156,28 +202,26 @@ fn select_transactions(
         let mut still_pending = Vec::with_capacity(pending.len());
 
         for tx in std::mem::take(&mut pending) {
-            match pending_block_state
+            match block_builder
                 .clone()
-                .try_apply_transaction::<_, HeaderId, MainnetGasProfile>(ledger_config, &tx)
+                .try_apply_transaction(&tx, ledger_config)
             {
-                Ok((next_pending_block_state, _events, deferred_zkps)) => {
-                    match deferred_zkps.verify() {
-                        Ok(()) => {
-                            pending_block_state = next_pending_block_state;
-                            selected_txs.push(tx);
-                            assembly_state = AssemblyState::Progress;
-                        }
-                        Err(err) => {
-                            tracing::trace!(
-                                target: LOG_TARGET,
-                                tx = ?tx.hash(),
-                                %err,
-                                "deferred ZKP verification failed during block assembly",
-                            );
-                            still_pending.push(tx);
-                        }
+                Ok((next_block_builder, deferred_zkps)) => match deferred_zkps.verify() {
+                    Ok(()) => {
+                        block_builder = next_block_builder;
+                        selected_txs.push(tx);
+                        assembly_state = AssemblyState::Progress;
                     }
-                }
+                    Err(err) => {
+                        tracing::trace!(
+                            target: LOG_TARGET,
+                            tx = ?tx.hash(),
+                            %err,
+                            "deferred ZKP verification failed during block assembly",
+                        );
+                        still_pending.push(tx);
+                    }
+                },
                 Err(err @ lb_ledger::LedgerError::TooMuchExecutionGas { .. }) => {
                     tracing::trace!(
                         target: LOG_TARGET,
@@ -214,7 +258,7 @@ fn select_transactions(
     };
 
     TransactionSelection {
-        pending_block_state,
+        ledger_state: block_builder.finish(),
         selected_txs,
         invalid_tx_hashes,
     }
@@ -766,19 +810,15 @@ where
                 &uncle_headers.slots(),
                 ledger_config,
             )?;
-        let pending_block_state = ledger_state.begin_pending_block();
+        let block_builder = BlockBuilder::new(ledger_state);
 
         // Collect all candidate transactions up front so the ones that fail can
         // be retried across multiple rounds.
         let TransactionSelection {
-            pending_block_state,
+            ledger_state,
             selected_txs,
             invalid_tx_hashes,
-        } = select_transactions(
-            pending_block_state,
-            tx_stream.collect().await,
-            ledger_config,
-        );
+        } = select_transactions(block_builder, tx_stream.collect().await, ledger_config);
 
         if !invalid_tx_hashes.is_empty()
             && let Err(e) = relays
@@ -794,7 +834,7 @@ where
 
         let block = Block::create(parent, slot, uncle_headers, proof, txs, signing_key)?;
         if tracing::enabled!(Level::DEBUG) {
-            log_sdp_activity_selected_for_proposal(&block, pending_block_state.ledger_state());
+            log_sdp_activity_selected_for_proposal(&block, &ledger_state);
         }
 
         info!(
@@ -1118,11 +1158,8 @@ mod tests {
             "individual gas: {individual_gas:?}, error: {all_candidates_error:?}"
         );
 
-        let selection = select_transactions(
-            ledger_state.clone().begin_pending_block(),
-            candidates,
-            &config,
-        );
+        let selection =
+            select_transactions(BlockBuilder::new(ledger_state.clone()), candidates, &config);
         assert_eq!(selection.selected_txs.len(), CANDIDATE_COUNT - 1);
         assert!(selection.invalid_tx_hashes.is_empty());
 

--- a/services/chain/chain-leader/src/lib.rs
+++ b/services/chain/chain-leader/src/lib.rs
@@ -145,7 +145,7 @@ impl BlockBuilder {
         }
     }
 
-    fn try_apply_transaction(
+    fn try_add_transaction(
         self,
         tx: &SignedOps<Preverified, StandardMode>,
         ledger_config: &lb_ledger::Config,
@@ -169,7 +169,7 @@ impl BlockBuilder {
     }
 
     #[must_use]
-    fn finish(self) -> LedgerState {
+    fn into_ledger_state(self) -> LedgerState {
         self.ledger_state
     }
 }
@@ -204,7 +204,7 @@ fn select_transactions(
         for tx in std::mem::take(&mut pending) {
             match block_builder
                 .clone()
-                .try_apply_transaction(&tx, ledger_config)
+                .try_add_transaction(&tx, ledger_config)
             {
                 Ok((next_block_builder, deferred_zkps)) => match deferred_zkps.verify() {
                     Ok(()) => {
@@ -258,7 +258,7 @@ fn select_transactions(
     };
 
     TransactionSelection {
-        ledger_state: block_builder.finish(),
+        ledger_state: block_builder.into_ledger_state(),
         selected_txs,
         invalid_tx_hashes,
     }
@@ -1145,7 +1145,7 @@ mod tests {
         );
         let all_candidates_result = ledger_state
             .clone()
-            .try_apply_contents::<_, HeaderId, MainnetGasProfile>(
+            .try_apply_block_contents::<_, HeaderId, MainnetGasProfile>(
                 &config,
                 candidates.iter().cloned(),
             );
@@ -1166,7 +1166,10 @@ mod tests {
         let block_txs = txs_for_block(stream::iter(selection.selected_txs)).await;
         assert_eq!(block_txs.len(), CANDIDATE_COUNT - 1);
         ledger_state
-            .try_apply_contents::<_, HeaderId, MainnetGasProfile>(&config, block_txs.into_iter())
+            .try_apply_block_contents::<_, HeaderId, MainnetGasProfile>(
+                &config,
+                block_txs.into_iter(),
+            )
             .expect("the selected prefix must pass canonical application");
     }
 

--- a/services/chain/chain-leader/src/lib.rs
+++ b/services/chain/chain-leader/src/lib.rs
@@ -191,6 +191,7 @@ fn select_transactions(
     ledger_config: &lb_ledger::Config,
 ) -> TransactionSelection {
     let mut selected_txs = Vec::new();
+    let mut invalid_tx_hashes = Vec::new();
 
     // A transaction may only become valid once another transaction it depends
     // on has already been applied. Repeatedly attempt to apply the pending
@@ -232,6 +233,15 @@ fn select_transactions(
                     assembly_state = AssemblyState::GasCapacityReached;
                     break;
                 }
+                Err(err @ lb_ledger::LedgerError::TooMuchTransactionExecutionGas { .. }) => {
+                    tracing::trace!(
+                        target: LOG_TARGET,
+                        tx = ?tx.hash(),
+                        %err,
+                        "transaction execution gas exceeds the block limit",
+                    );
+                    invalid_tx_hashes.push(tx.hash());
+                }
                 Err(err) => {
                     tracing::trace!(
                         target: LOG_TARGET,
@@ -251,11 +261,9 @@ fn select_transactions(
     // this block's ledger state and can be evicted from the mempool. If assembly
     // stopped at the gas limit, unprocessed transactions are not invalid and
     // must remain in the mempool.
-    let invalid_tx_hashes = if matches!(assembly_state, AssemblyState::GasCapacityReached) {
-        Vec::new()
-    } else {
-        pending.iter().map(Hashable::hash).collect()
-    };
+    if !matches!(assembly_state, AssemblyState::GasCapacityReached) {
+        invalid_tx_hashes.extend(pending.iter().map(Hashable::hash));
+    }
 
     TransactionSelection {
         ledger_state: block_builder.into_ledger_state(),
@@ -1075,13 +1083,14 @@ mod tests {
         ops: Ops,
         channel_signing_key: &Ed25519Key,
         funding_key: &ZkKey,
+        signature_count: usize,
     ) -> SignedOps<Preverified, StandardMode> {
         let tx_hash = ops.hash();
         let zk_signature =
             ZkKey::multi_sign(std::slice::from_ref(funding_key), &tx_hash.to_fr()).unwrap();
         let channel_signature =
             channel_signing_key.sign_payload(tx_hash.as_signing_bytes().as_ref());
-        let channel_signatures = (0..HIGH_GAS_CONFIG_SIGNATURES)
+        let channel_signatures = (0..signature_count)
             .map(|index| IndexedSignature::new(index as u16, channel_signature))
             .collect::<Vec<_>>()
             .try_into()
@@ -1105,7 +1114,12 @@ mod tests {
     ) -> (Utxo, SignedOps<Preverified, StandardMode>) {
         let (funding_utxo, ops) =
             build_high_execution_gas_ops(transaction_index, channel_signing_key, funding_key);
-        let transaction = sign_high_execution_gas_ops(ops, channel_signing_key, funding_key);
+        let transaction = sign_high_execution_gas_ops(
+            ops,
+            channel_signing_key,
+            funding_key,
+            HIGH_GAS_CONFIG_SIGNATURES,
+        );
 
         (funding_utxo, transaction)
     }
@@ -1171,6 +1185,41 @@ mod tests {
                 block_txs.into_iter(),
             )
             .expect("the selected prefix must pass canonical application");
+    }
+
+    #[test]
+    fn oversized_transaction_is_evicted_without_stopping_selection() {
+        const OVERSIZED_SIGNATURES: usize = 60_000;
+
+        let config = leadership::test_config();
+        let channel_signing_key = Ed25519Key::from_bytes(&[7; 32]);
+        let funding_key = ZkKey::zero();
+        let (oversized_utxo, oversized_ops) =
+            build_high_execution_gas_ops(0, &channel_signing_key, &funding_key);
+        let oversized_tx = sign_high_execution_gas_ops(
+            oversized_ops,
+            &channel_signing_key,
+            &funding_key,
+            OVERSIZED_SIGNATURES,
+        );
+        let oversized_hash = oversized_tx.hash();
+        let (valid_utxo, valid_tx) =
+            high_execution_gas_transaction(1, &channel_signing_key, &funding_key);
+        let ledger_state = LedgerState::from_utxos([oversized_utxo, valid_utxo], &config);
+
+        assert!(matches!(
+            BlockBuilder::new(ledger_state.clone()).try_add_transaction(&oversized_tx, &config),
+            Err(lb_ledger::LedgerError::TooMuchTransactionExecutionGas { .. })
+        ));
+
+        let selection = select_transactions(
+            BlockBuilder::new(ledger_state),
+            vec![oversized_tx, valid_tx.clone()],
+            &config,
+        );
+
+        assert_eq!(selection.selected_txs, vec![valid_tx]);
+        assert_eq!(selection.invalid_tx_hashes, vec![oversized_hash]);
     }
 
     #[tokio::test]

--- a/services/chain/chain-leader/src/lib.rs
+++ b/services/chain/chain-leader/src/lib.rs
@@ -5,6 +5,7 @@ mod leadership;
 mod mempool;
 mod metrics;
 mod relays;
+mod tx_selection;
 mod wallet;
 
 use core::fmt::Debug;
@@ -23,8 +24,6 @@ use lb_core::{
     header::HeaderId,
     mantle::{
         OpRef, SignedOps,
-        batch::DeferredZkpVerifications,
-        gas::MainnetGasProfile,
         ledger::verification_mode::StandardMode,
         traits::{Hashable, MantleTx, SignedMantleTx, StorageSize},
         transactions::{hash::TxHash, states::Preverified},
@@ -33,7 +32,7 @@ use lb_core::{
 };
 use lb_cryptarchia_engine::Slot;
 use lb_key_management_system_service::{api::KmsServiceApi, keys::Ed25519Key};
-use lb_ledger::{GasAndFees, LedgerState};
+use lb_ledger::LedgerState;
 use lb_log_targets::chain;
 use lb_services_utils::wait_until_services_are_ready;
 use lb_storage_service::StorageService;
@@ -56,6 +55,7 @@ use tokio::sync::{mpsc, oneshot};
 use tokio_stream::wrappers::ReceiverStream;
 use tracing::{Level, error, info, instrument, span, trace};
 use tracing_futures::Instrument as _;
+use tx_selection::{TransactionSelection, select_transactions};
 
 pub use crate::wallet::LeaderWalletConfig;
 use crate::{
@@ -121,156 +121,6 @@ pub type WinningSlotFuture = Pin<Box<dyn Future<Output = Option<LeaderPrivate>> 
 /// [`WinningSlotFuture`] per slot in the epoch's range. The consumer drives the
 /// futures and filters out the non-winning (`None`) slots.
 pub type WinningPolSlotStream = Pin<Box<dyn Stream<Item = WinningSlotFuture> + Send + Unpin>>;
-
-/// Progress made while selecting transactions for a block proposal.
-enum AssemblyState {
-    Progress,
-    NoProgress,
-    GasCapacityReached,
-}
-
-/// Ledger state, gas, and fees for a proposal under construction.
-#[derive(Clone)]
-struct BlockBuilder {
-    ledger_state: LedgerState,
-    gas_and_fees: GasAndFees,
-}
-
-impl BlockBuilder {
-    #[must_use]
-    fn new(ledger_state: LedgerState) -> Self {
-        Self {
-            ledger_state,
-            gas_and_fees: GasAndFees::default(),
-        }
-    }
-
-    fn try_add_transaction(
-        self,
-        tx: &SignedOps<Preverified, StandardMode>,
-        ledger_config: &lb_ledger::Config,
-    ) -> Result<(Self, DeferredZkpVerifications), lb_ledger::LedgerError<HeaderId>> {
-        let Self {
-            ledger_state,
-            gas_and_fees,
-        } = self;
-        let (ledger_state, tx_gas_and_fees, _events, deferred_zkps) =
-            ledger_state
-                .try_apply_transaction::<_, HeaderId, MainnetGasProfile>(ledger_config, tx)?;
-        let gas_and_fees = gas_and_fees.checked_add::<HeaderId>(tx_gas_and_fees)?;
-
-        Ok((
-            Self {
-                ledger_state,
-                gas_and_fees,
-            },
-            deferred_zkps,
-        ))
-    }
-
-    #[must_use]
-    fn into_ledger_state(self) -> LedgerState {
-        self.ledger_state
-    }
-}
-
-/// Result of selecting mempool candidates for a block proposal.
-struct TransactionSelection {
-    ledger_state: LedgerState,
-    selected_txs: Vec<SignedOps<Preverified, StandardMode>>,
-    invalid_tx_hashes: Vec<TxHash>,
-}
-
-#[expect(
-    clippy::cognitive_complexity,
-    reason = "Dependency retries and distinct invalid, proof, and block-capacity outcomes"
-)]
-fn select_transactions(
-    mut block_builder: BlockBuilder,
-    mut pending: Vec<SignedOps<Preverified, StandardMode>>,
-    ledger_config: &lb_ledger::Config,
-) -> TransactionSelection {
-    let mut selected_txs = Vec::new();
-    let mut invalid_tx_hashes = Vec::new();
-
-    // A transaction may only become valid once another transaction it depends
-    // on has already been applied. Repeatedly attempt to apply the pending
-    // transactions, retrying the full set of failures each round, while a
-    // round keeps adding new transactions to the block.
-    let mut assembly_state = AssemblyState::Progress;
-    while matches!(assembly_state, AssemblyState::Progress) {
-        assembly_state = AssemblyState::NoProgress;
-        let mut still_pending = Vec::with_capacity(pending.len());
-
-        for tx in std::mem::take(&mut pending) {
-            match block_builder
-                .clone()
-                .try_add_transaction(&tx, ledger_config)
-            {
-                Ok((next_block_builder, deferred_zkps)) => match deferred_zkps.verify() {
-                    Ok(()) => {
-                        block_builder = next_block_builder;
-                        selected_txs.push(tx);
-                        assembly_state = AssemblyState::Progress;
-                    }
-                    Err(err) => {
-                        tracing::trace!(
-                            target: LOG_TARGET,
-                            tx = ?tx.hash(),
-                            %err,
-                            "deferred ZKP verification failed during block assembly",
-                        );
-                        still_pending.push(tx);
-                    }
-                },
-                Err(err @ lb_ledger::LedgerError::TooMuchExecutionGas { .. }) => {
-                    tracing::trace!(
-                        target: LOG_TARGET,
-                        tx = ?tx.hash(),
-                        %err,
-                        "block execution gas limit reached during block assembly",
-                    );
-                    assembly_state = AssemblyState::GasCapacityReached;
-                    break;
-                }
-                Err(err @ lb_ledger::LedgerError::TooMuchTransactionExecutionGas { .. }) => {
-                    tracing::trace!(
-                        target: LOG_TARGET,
-                        tx = ?tx.hash(),
-                        %err,
-                        "transaction execution gas exceeds the block limit",
-                    );
-                    invalid_tx_hashes.push(tx.hash());
-                }
-                Err(err) => {
-                    tracing::trace!(
-                        target: LOG_TARGET,
-                        "tx {:?} not (yet) applicable during block assembly: {:?}",
-                        tx.hash(),
-                        err
-                    );
-                    still_pending.push(tx);
-                }
-            }
-        }
-
-        pending = still_pending;
-    }
-
-    // Transactions that never became applicable are genuinely invalid against
-    // this block's ledger state and can be evicted from the mempool. If assembly
-    // stopped at the gas limit, unprocessed transactions are not invalid and
-    // must remain in the mempool.
-    if !matches!(assembly_state, AssemblyState::GasCapacityReached) {
-        invalid_tx_hashes.extend(pending.iter().map(Hashable::hash));
-    }
-
-    TransactionSelection {
-        ledger_state: block_builder.into_ledger_state(),
-        selected_txs,
-        invalid_tx_hashes,
-    }
-}
 
 /// Number of epochs to buffer for late subscribers to the winning `PoL` slots
 /// stream. Subscribers will almost certainly consume each epoch at some point,
@@ -818,15 +668,13 @@ where
                 &uncle_headers.slots(),
                 ledger_config,
             )?;
-        let block_builder = BlockBuilder::new(ledger_state);
-
         // Collect all candidate transactions up front so the ones that fail can
         // be retried across multiple rounds.
         let TransactionSelection {
             ledger_state,
             selected_txs,
             invalid_tx_hashes,
-        } = select_transactions(block_builder, tx_stream.collect().await, ledger_config);
+        } = select_transactions(ledger_state, tx_stream.collect().await, ledger_config);
 
         if !invalid_tx_hashes.is_empty()
             && let Err(e) = relays
@@ -1012,24 +860,6 @@ where
 
 #[cfg(test)]
 mod tests {
-    use lb_core::{
-        mantle::{
-            Note, Op, OpProof, TxGasCalculator as _, Utxo,
-            channel::{SlotTimeframe, SlotTimeout},
-            ledger::{Inputs, Outputs},
-            ops::{
-                channel::{
-                    ChannelId, MsgId,
-                    config::{ChannelConfigOp, Keys},
-                },
-                transfer::TransferOp,
-            },
-            transactions::{OpProofs, Ops, states::Unverified},
-        },
-        proofs::channel_multi_sig_proof::{ChannelMultiSigProof, IndexedSignature},
-    };
-    use lb_key_management_system_service::keys::ZkKey;
-
     use super::*;
 
     #[derive(Clone)]
@@ -1041,185 +871,6 @@ mod tests {
         fn storage_size(&self) -> usize {
             self.size
         }
-    }
-
-    // Two transactions at this multiplier exceed the block execution-gas limit,
-    // while each transaction remains below it.
-    const HIGH_GAS_CONFIG_SIGNATURES: usize = 28_514;
-
-    fn build_high_execution_gas_ops(
-        transaction_index: usize,
-        channel_signing_key: &Ed25519Key,
-        funding_key: &ZkKey,
-    ) -> (Utxo, Ops) {
-        let mut channel_id = [0; 32];
-        channel_id[..size_of::<usize>()].copy_from_slice(&transaction_index.to_le_bytes());
-
-        let funding_utxo = Utxo::new(
-            channel_id,
-            0,
-            Note::new(10_000_000, funding_key.to_public_key()),
-        );
-        let transfer = TransferOp::new(
-            Inputs::try_new(vec![funding_utxo.id()]).unwrap(),
-            Outputs::try_new(Vec::new()).unwrap(),
-        );
-
-        let channel_config = ChannelConfigOp {
-            channel: ChannelId::from(channel_id),
-            parent: MsgId::root(),
-            keys: Keys::from(channel_signing_key.public_key()),
-            posting_timeframe: SlotTimeframe::from(0),
-            posting_timeout: SlotTimeout::from(0),
-            configuration_threshold: 1,
-            transfer_threshold: 1,
-        };
-
-        let ops = Ops::from([Op::Transfer(transfer), Op::ChannelConfig(channel_config)]);
-        (funding_utxo, ops)
-    }
-
-    fn sign_high_execution_gas_ops(
-        ops: Ops,
-        channel_signing_key: &Ed25519Key,
-        funding_key: &ZkKey,
-        signature_count: usize,
-    ) -> SignedOps<Preverified, StandardMode> {
-        let tx_hash = ops.hash();
-        let zk_signature =
-            ZkKey::multi_sign(std::slice::from_ref(funding_key), &tx_hash.to_fr()).unwrap();
-        let channel_signature =
-            channel_signing_key.sign_payload(tx_hash.as_signing_bytes().as_ref());
-        let channel_signatures = (0..signature_count)
-            .map(|index| IndexedSignature::new(index as u16, channel_signature))
-            .collect::<Vec<_>>()
-            .try_into()
-            .unwrap();
-        let channel_proof = ChannelMultiSigProof::try_new(channel_signatures).unwrap();
-        let proofs = OpProofs::from([
-            OpProof::ZkSig(zk_signature),
-            OpProof::ChannelMultiSigProof(channel_proof),
-        ]);
-
-        SignedOps::<Unverified, StandardMode>::from_parts(ops, proofs)
-            .unwrap()
-            .preverify()
-            .unwrap()
-    }
-
-    fn high_execution_gas_transaction(
-        transaction_index: usize,
-        channel_signing_key: &Ed25519Key,
-        funding_key: &ZkKey,
-    ) -> (Utxo, SignedOps<Preverified, StandardMode>) {
-        let (funding_utxo, ops) =
-            build_high_execution_gas_ops(transaction_index, channel_signing_key, funding_key);
-        let transaction = sign_high_execution_gas_ops(
-            ops,
-            channel_signing_key,
-            funding_key,
-            HIGH_GAS_CONFIG_SIGNATURES,
-        );
-
-        (funding_utxo, transaction)
-    }
-
-    #[tokio::test]
-    async fn gas_limited_selection_returns_canonically_applicable_prefix() {
-        const CANDIDATE_COUNT: usize = 2;
-
-        let config = leadership::test_config();
-        let channel_signing_key = Ed25519Key::from_bytes(&[7; 32]);
-        let funding_key = ZkKey::zero();
-        let (funding_utxos, candidates): (Vec<_>, Vec<_>) = (0..CANDIDATE_COUNT)
-            .map(|transaction_index| {
-                high_execution_gas_transaction(
-                    transaction_index,
-                    &channel_signing_key,
-                    &funding_key,
-                )
-            })
-            .unzip();
-
-        let ledger_state = LedgerState::from_utxos(funding_utxos, &config);
-        let gas_prices = ledger_state.get_gas_prices();
-        let individual_gas = candidates[0]
-            .execution_gas_consumption::<MainnetGasProfile>(&gas_prices)
-            .unwrap();
-        assert!(candidates.iter().all(|candidate| {
-            candidate
-                .execution_gas_consumption::<MainnetGasProfile>(&gas_prices)
-                .unwrap()
-                == individual_gas
-        }));
-        assert!(
-            candidates
-                .iter()
-                .all(|candidate| candidate.storage_size() <= MAX_BLOCK_TRANSACTIONS_SIZE)
-        );
-        let all_candidates_result = ledger_state
-            .clone()
-            .try_apply_block_contents::<_, HeaderId, MainnetGasProfile>(
-                &config,
-                candidates.iter().cloned(),
-            );
-        let all_candidates_error = all_candidates_result.err();
-        assert!(
-            matches!(
-                &all_candidates_error,
-                Some(lb_ledger::LedgerError::TooMuchExecutionGas { .. })
-            ),
-            "individual gas: {individual_gas:?}, error: {all_candidates_error:?}"
-        );
-
-        let selection =
-            select_transactions(BlockBuilder::new(ledger_state.clone()), candidates, &config);
-        assert_eq!(selection.selected_txs.len(), CANDIDATE_COUNT - 1);
-        assert!(selection.invalid_tx_hashes.is_empty());
-
-        let block_txs = txs_for_block(stream::iter(selection.selected_txs)).await;
-        assert_eq!(block_txs.len(), CANDIDATE_COUNT - 1);
-        ledger_state
-            .try_apply_block_contents::<_, HeaderId, MainnetGasProfile>(
-                &config,
-                block_txs.into_iter(),
-            )
-            .expect("the selected prefix must pass canonical application");
-    }
-
-    #[test]
-    fn oversized_transaction_is_evicted_without_stopping_selection() {
-        const OVERSIZED_SIGNATURES: usize = 60_000;
-
-        let config = leadership::test_config();
-        let channel_signing_key = Ed25519Key::from_bytes(&[7; 32]);
-        let funding_key = ZkKey::zero();
-        let (oversized_utxo, oversized_ops) =
-            build_high_execution_gas_ops(0, &channel_signing_key, &funding_key);
-        let oversized_tx = sign_high_execution_gas_ops(
-            oversized_ops,
-            &channel_signing_key,
-            &funding_key,
-            OVERSIZED_SIGNATURES,
-        );
-        let oversized_hash = oversized_tx.hash();
-        let (valid_utxo, valid_tx) =
-            high_execution_gas_transaction(1, &channel_signing_key, &funding_key);
-        let ledger_state = LedgerState::from_utxos([oversized_utxo, valid_utxo], &config);
-
-        assert!(matches!(
-            BlockBuilder::new(ledger_state.clone()).try_add_transaction(&oversized_tx, &config),
-            Err(lb_ledger::LedgerError::TooMuchTransactionExecutionGas { .. })
-        ));
-
-        let selection = select_transactions(
-            BlockBuilder::new(ledger_state),
-            vec![oversized_tx, valid_tx.clone()],
-            &config,
-        );
-
-        assert_eq!(selection.selected_txs, vec![valid_tx]);
-        assert_eq!(selection.invalid_tx_hashes, vec![oversized_hash]);
     }
 
     #[tokio::test]

--- a/services/chain/chain-leader/src/tx_selection.rs
+++ b/services/chain/chain-leader/src/tx_selection.rs
@@ -1,0 +1,403 @@
+use lb_core::{
+    header::HeaderId,
+    mantle::{
+        SignedOps,
+        batch::DeferredZkpVerifications,
+        gas::MainnetGasProfile,
+        ledger::verification_mode::StandardMode,
+        traits::Hashable,
+        transactions::{hash::TxHash, states::Preverified},
+    },
+};
+use lb_ledger::{GasAndFees, LedgerState};
+
+use crate::LOG_TARGET;
+
+/// Progress made while selecting transactions for a block proposal.
+enum AssemblyState {
+    Progress,
+    NoProgress,
+    GasCapacityReached,
+}
+
+/// Ledger state, gas, and fees for a proposal under construction.
+#[derive(Clone)]
+struct BlockBuilder {
+    ledger_state: LedgerState,
+    gas_and_fees: GasAndFees,
+}
+
+impl BlockBuilder {
+    #[must_use]
+    fn new(ledger_state: LedgerState) -> Self {
+        Self {
+            ledger_state,
+            gas_and_fees: GasAndFees::default(),
+        }
+    }
+
+    fn try_add_transaction(
+        self,
+        tx: &SignedOps<Preverified, StandardMode>,
+        ledger_config: &lb_ledger::Config,
+    ) -> Result<(Self, DeferredZkpVerifications), lb_ledger::LedgerError<HeaderId>> {
+        let Self {
+            ledger_state,
+            gas_and_fees,
+        } = self;
+        let (ledger_state, tx_gas_and_fees, _events, deferred_zkps) =
+            ledger_state
+                .try_apply_transaction::<_, HeaderId, MainnetGasProfile>(ledger_config, tx)?;
+        let gas_and_fees = gas_and_fees.checked_add::<HeaderId>(tx_gas_and_fees)?;
+
+        Ok((
+            Self {
+                ledger_state,
+                gas_and_fees,
+            },
+            deferred_zkps,
+        ))
+    }
+
+    #[must_use]
+    fn into_ledger_state(self) -> LedgerState {
+        self.ledger_state
+    }
+}
+
+/// Result of selecting mempool candidates for a block proposal.
+pub struct TransactionSelection {
+    pub(super) ledger_state: LedgerState,
+    pub(super) selected_txs: Vec<SignedOps<Preverified, StandardMode>>,
+    pub(super) invalid_tx_hashes: Vec<TxHash>,
+}
+
+#[expect(
+    clippy::cognitive_complexity,
+    reason = "Dependency retries and distinct invalid, proof, and block-capacity outcomes"
+)]
+pub fn select_transactions(
+    ledger_state: LedgerState,
+    mut pending: Vec<SignedOps<Preverified, StandardMode>>,
+    ledger_config: &lb_ledger::Config,
+) -> TransactionSelection {
+    let mut block_builder = BlockBuilder::new(ledger_state);
+    let mut selected_txs = Vec::new();
+    let mut invalid_tx_hashes = Vec::new();
+
+    // A transaction may only become valid once another transaction it depends
+    // on has already been applied. Repeatedly attempt to apply the pending
+    // transactions, retrying the full set of failures each round, while a
+    // round keeps adding new transactions to the block.
+    let mut assembly_state = AssemblyState::Progress;
+    while matches!(assembly_state, AssemblyState::Progress) {
+        assembly_state = AssemblyState::NoProgress;
+        let mut still_pending = Vec::with_capacity(pending.len());
+
+        for tx in std::mem::take(&mut pending) {
+            match block_builder
+                .clone()
+                .try_add_transaction(&tx, ledger_config)
+            {
+                Ok((next_block_builder, deferred_zkps)) => match deferred_zkps.verify() {
+                    Ok(()) => {
+                        block_builder = next_block_builder;
+                        selected_txs.push(tx);
+                        assembly_state = AssemblyState::Progress;
+                    }
+                    Err(err) => {
+                        tracing::trace!(
+                            target: LOG_TARGET,
+                            tx = ?tx.hash(),
+                            %err,
+                            "deferred ZKP verification failed during block assembly",
+                        );
+                        still_pending.push(tx);
+                    }
+                },
+                Err(err @ lb_ledger::LedgerError::TooMuchExecutionGas { .. }) => {
+                    tracing::trace!(
+                        target: LOG_TARGET,
+                        tx = ?tx.hash(),
+                        %err,
+                        "block execution gas limit reached during block assembly",
+                    );
+                    assembly_state = AssemblyState::GasCapacityReached;
+                    break;
+                }
+                Err(err @ lb_ledger::LedgerError::TooMuchTransactionExecutionGas { .. }) => {
+                    tracing::trace!(
+                        target: LOG_TARGET,
+                        tx = ?tx.hash(),
+                        %err,
+                        "transaction execution gas exceeds the block limit",
+                    );
+                    invalid_tx_hashes.push(tx.hash());
+                }
+                Err(err) => {
+                    tracing::trace!(
+                        target: LOG_TARGET,
+                        "tx {:?} not (yet) applicable during block assembly: {:?}",
+                        tx.hash(),
+                        err
+                    );
+                    still_pending.push(tx);
+                }
+            }
+        }
+
+        pending = still_pending;
+    }
+
+    // Transactions that never became applicable are genuinely invalid against
+    // this block's ledger state and can be evicted from the mempool. If assembly
+    // stopped at the gas limit, unprocessed transactions are not invalid and
+    // must remain in the mempool.
+    if !matches!(assembly_state, AssemblyState::GasCapacityReached) {
+        invalid_tx_hashes.extend(pending.iter().map(Hashable::hash));
+    }
+
+    TransactionSelection {
+        ledger_state: block_builder.into_ledger_state(),
+        selected_txs,
+        invalid_tx_hashes,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use futures::stream;
+    use lb_core::{
+        block::MAX_BLOCK_TRANSACTIONS_SIZE,
+        mantle::{
+            Note, Op, OpProof, Utxo,
+            channel::{SlotTimeframe, SlotTimeout},
+            gas::TxGasCalculator as _,
+            ledger::{Inputs, Outputs},
+            ops::{
+                channel::{ChannelId, MsgId, config::ChannelConfigOp},
+                transfer::TransferOp,
+            },
+            traits::StorageSize,
+            transactions::{OpProofs, Ops, states::Unverified},
+        },
+        proofs::channel_multi_sig_proof::{ChannelMultiSigProof, IndexedSignature},
+    };
+    use lb_key_management_system_service::keys::{Ed25519Key, ZkKey};
+
+    use super::*;
+    use crate::{leadership, txs_for_block};
+
+    fn build_high_execution_gas_ops(
+        transaction_index: usize,
+        channel_signing_key: &Ed25519Key,
+        funding_key: &ZkKey,
+        signature_count: usize,
+    ) -> (Utxo, Ops) {
+        let mut channel_id = [0; 32];
+        channel_id[..size_of::<usize>()].copy_from_slice(&transaction_index.to_le_bytes());
+
+        let funding_utxo = Utxo::new(
+            channel_id,
+            0,
+            Note::new(100_000_000, funding_key.to_public_key()),
+        );
+        let transfer = TransferOp::new(
+            Inputs::try_new(vec![funding_utxo.id()]).unwrap(),
+            Outputs::try_new(Vec::new()).unwrap(),
+        );
+
+        let channel_keys = std::iter::repeat_with(|| channel_signing_key.public_key())
+            .take(signature_count)
+            .collect::<Vec<_>>()
+            .try_into()
+            .unwrap();
+        let initial_channel_config = ChannelConfigOp {
+            channel: ChannelId::from(channel_id),
+            parent: MsgId::root(),
+            keys: channel_keys,
+            posting_timeframe: SlotTimeframe::from(0),
+            posting_timeout: SlotTimeout::from(0),
+            configuration_threshold: signature_count as u16,
+            transfer_threshold: 1,
+        };
+        let updated_channel_config = ChannelConfigOp {
+            parent: initial_channel_config.id(),
+            ..initial_channel_config.clone()
+        };
+
+        let ops = Ops::from([
+            Op::Transfer(transfer),
+            Op::ChannelConfig(initial_channel_config),
+            Op::ChannelConfig(updated_channel_config),
+        ]);
+        (funding_utxo, ops)
+    }
+
+    fn sign_high_execution_gas_ops(
+        ops: Ops,
+        channel_signing_key: &Ed25519Key,
+        funding_key: &ZkKey,
+        signature_count: usize,
+    ) -> SignedOps<Preverified, StandardMode> {
+        let tx_hash = ops.hash();
+        let zk_signature =
+            ZkKey::multi_sign(std::slice::from_ref(funding_key), &tx_hash.to_fr()).unwrap();
+        let channel_signature =
+            channel_signing_key.sign_payload(tx_hash.as_signing_bytes().as_ref());
+        let channel_signatures = (0..signature_count)
+            .map(|index| IndexedSignature::new(index as u16, channel_signature))
+            .collect::<Vec<_>>()
+            .try_into()
+            .unwrap();
+        let initial_channel_proof = ChannelMultiSigProof::try_new([].into()).unwrap();
+        let updated_channel_proof = ChannelMultiSigProof::try_new(channel_signatures).unwrap();
+        let proofs = OpProofs::from([
+            OpProof::ZkSig(zk_signature),
+            OpProof::ChannelMultiSigProof(initial_channel_proof),
+            OpProof::ChannelMultiSigProof(updated_channel_proof),
+        ]);
+
+        SignedOps::<Unverified, StandardMode>::from_parts(ops, proofs)
+            .unwrap()
+            .preverify()
+            .unwrap()
+    }
+
+    fn transfer_heavy_transaction(
+        transaction_index: usize,
+        funding_key: &ZkKey,
+        transfer_count: usize,
+    ) -> (Vec<Utxo>, SignedOps<Preverified, StandardMode>) {
+        let funding_utxos = (0..transfer_count)
+            .map(|transfer_index| {
+                let utxo_index = transaction_index * transfer_count + transfer_index;
+                let mut op_id = [0; 32];
+                op_id[..size_of::<usize>()].copy_from_slice(&utxo_index.to_le_bytes());
+                Utxo::new(op_id, 0, Note::new(10_000_000, funding_key.to_public_key()))
+            })
+            .collect::<Vec<_>>();
+        let ops = Ops::try_from_iter(funding_utxos.iter().map(|utxo| {
+            Op::Transfer(TransferOp::new(
+                Inputs::try_new(vec![utxo.id()]).unwrap(),
+                Outputs::try_new(Vec::new()).unwrap(),
+            ))
+        }))
+        .unwrap();
+        let tx_hash = ops.hash();
+        let signature =
+            ZkKey::multi_sign(std::slice::from_ref(funding_key), &tx_hash.to_fr()).unwrap();
+        let proofs = OpProofs::try_from_iter(
+            std::iter::repeat_with(|| OpProof::ZkSig(signature.clone())).take(transfer_count),
+        )
+        .unwrap();
+        let transaction = SignedOps::<Unverified, StandardMode>::from_parts(ops, proofs)
+            .unwrap()
+            .preverify()
+            .unwrap();
+
+        (funding_utxos, transaction)
+    }
+
+    #[tokio::test]
+    async fn gas_limited_selection_returns_canonically_applicable_prefix() {
+        const CANDIDATE_COUNT: usize = 22;
+        const TRANSFERS_PER_TRANSACTION: usize = 255;
+
+        let config = leadership::test_config();
+        let funding_key = ZkKey::zero();
+        let (funding_utxos, candidates): (Vec<_>, Vec<_>) = (0..CANDIDATE_COUNT)
+            .map(|transaction_index| {
+                transfer_heavy_transaction(
+                    transaction_index,
+                    &funding_key,
+                    TRANSFERS_PER_TRANSACTION,
+                )
+            })
+            .unzip();
+
+        let ledger_state = LedgerState::from_utxos(funding_utxos.into_iter().flatten(), &config);
+        let gas_context = ledger_state.tx_context().gas_context;
+        let individual_gas = candidates[0]
+            .op_refs()
+            .execution_gas_consumption::<MainnetGasProfile>(&gas_context)
+            .unwrap();
+        assert!(candidates.iter().all(|candidate| {
+            candidate
+                .op_refs()
+                .execution_gas_consumption::<MainnetGasProfile>(&gas_context)
+                .unwrap()
+                == individual_gas
+        }));
+        assert!(
+            candidates
+                .iter()
+                .map(StorageSize::storage_size)
+                .sum::<usize>()
+                <= MAX_BLOCK_TRANSACTIONS_SIZE
+        );
+        let all_candidates_result = ledger_state
+            .clone()
+            .try_apply_block_contents::<_, HeaderId, MainnetGasProfile>(
+                &config,
+                candidates.iter().cloned(),
+            );
+        let all_candidates_error = all_candidates_result.err();
+        assert!(
+            matches!(
+                &all_candidates_error,
+                Some(lb_ledger::LedgerError::TooMuchExecutionGas { .. })
+            ),
+            "individual gas: {individual_gas:?}, error: {all_candidates_error:?}"
+        );
+
+        let selection = select_transactions(ledger_state.clone(), candidates, &config);
+        assert_eq!(selection.selected_txs.len(), CANDIDATE_COUNT - 1);
+        assert!(selection.invalid_tx_hashes.is_empty());
+
+        let block_txs = txs_for_block(stream::iter(selection.selected_txs)).await;
+        assert_eq!(block_txs.len(), CANDIDATE_COUNT - 1);
+        ledger_state
+            .try_apply_block_contents::<_, HeaderId, MainnetGasProfile>(
+                &config,
+                block_txs.into_iter(),
+            )
+            .expect("the selected prefix must pass canonical application");
+    }
+
+    #[test]
+    fn oversized_transaction_is_evicted_without_stopping_selection() {
+        const OVERSIZED_SIGNATURES: usize = 60_000;
+
+        let config = leadership::test_config();
+        let channel_signing_key = Ed25519Key::from_bytes(&[7; 32]);
+        let funding_key = ZkKey::zero();
+        let (oversized_utxo, oversized_ops) = build_high_execution_gas_ops(
+            0,
+            &channel_signing_key,
+            &funding_key,
+            OVERSIZED_SIGNATURES,
+        );
+        let oversized_tx = sign_high_execution_gas_ops(
+            oversized_ops,
+            &channel_signing_key,
+            &funding_key,
+            OVERSIZED_SIGNATURES,
+        );
+        let oversized_hash = oversized_tx.hash();
+        let (valid_utxos, valid_tx) = transfer_heavy_transaction(1, &funding_key, 1);
+        let ledger_state =
+            LedgerState::from_utxos(std::iter::once(oversized_utxo).chain(valid_utxos), &config);
+
+        assert!(matches!(
+            BlockBuilder::new(ledger_state.clone()).try_add_transaction(&oversized_tx, &config),
+            Err(lb_ledger::LedgerError::TooMuchTransactionExecutionGas { .. })
+        ));
+
+        let selection =
+            select_transactions(ledger_state, vec![oversized_tx, valid_tx.clone()], &config);
+
+        assert_eq!(selection.selected_txs, vec![valid_tx]);
+        assert_eq!(selection.invalid_tx_hashes, vec![oversized_hash]);
+    }
+}

--- a/services/chain/chain-leader/src/tx_selection.rs
+++ b/services/chain/chain-leader/src/tx_selection.rs
@@ -171,98 +171,17 @@ mod tests {
         block::MAX_BLOCK_TRANSACTIONS_SIZE,
         mantle::{
             Note, Op, OpProof, Utxo,
-            channel::{SlotTimeframe, SlotTimeout},
             gas::TxGasCalculator as _,
             ledger::{Inputs, Outputs},
-            ops::{
-                channel::{ChannelId, MsgId, config::ChannelConfigOp},
-                transfer::TransferOp,
-            },
+            ops::transfer::TransferOp,
             traits::StorageSize,
             transactions::{OpProofs, Ops, states::Unverified},
         },
-        proofs::channel_multi_sig_proof::{ChannelMultiSigProof, IndexedSignature},
     };
-    use lb_key_management_system_service::keys::{Ed25519Key, ZkKey};
+    use lb_key_management_system_service::keys::ZkKey;
 
     use super::*;
     use crate::{leadership, txs_for_block};
-
-    fn build_high_execution_gas_ops(
-        transaction_index: usize,
-        channel_signing_key: &Ed25519Key,
-        funding_key: &ZkKey,
-        signature_count: usize,
-    ) -> (Utxo, Ops) {
-        let mut channel_id = [0; 32];
-        channel_id[..size_of::<usize>()].copy_from_slice(&transaction_index.to_le_bytes());
-
-        let funding_utxo = Utxo::new(
-            channel_id,
-            0,
-            Note::new(100_000_000, funding_key.to_public_key()),
-        );
-        let transfer = TransferOp::new(
-            Inputs::try_new(vec![funding_utxo.id()]).unwrap(),
-            Outputs::try_new(Vec::new()).unwrap(),
-        );
-
-        let channel_keys = std::iter::repeat_with(|| channel_signing_key.public_key())
-            .take(signature_count)
-            .collect::<Vec<_>>()
-            .try_into()
-            .unwrap();
-        let initial_channel_config = ChannelConfigOp {
-            channel: ChannelId::from(channel_id),
-            parent: MsgId::root(),
-            keys: channel_keys,
-            posting_timeframe: SlotTimeframe::from(0),
-            posting_timeout: SlotTimeout::from(0),
-            configuration_threshold: signature_count as u16,
-            transfer_threshold: 1,
-        };
-        let updated_channel_config = ChannelConfigOp {
-            parent: initial_channel_config.id(),
-            ..initial_channel_config.clone()
-        };
-
-        let ops = Ops::from([
-            Op::Transfer(transfer),
-            Op::ChannelConfig(initial_channel_config),
-            Op::ChannelConfig(updated_channel_config),
-        ]);
-        (funding_utxo, ops)
-    }
-
-    fn sign_high_execution_gas_ops(
-        ops: Ops,
-        channel_signing_key: &Ed25519Key,
-        funding_key: &ZkKey,
-        signature_count: usize,
-    ) -> SignedOps<Preverified, StandardMode> {
-        let tx_hash = ops.hash();
-        let zk_signature =
-            ZkKey::multi_sign(std::slice::from_ref(funding_key), &tx_hash.to_fr()).unwrap();
-        let channel_signature =
-            channel_signing_key.sign_payload(tx_hash.as_signing_bytes().as_ref());
-        let channel_signatures = (0..signature_count)
-            .map(|index| IndexedSignature::new(index as u16, channel_signature))
-            .collect::<Vec<_>>()
-            .try_into()
-            .unwrap();
-        let initial_channel_proof = ChannelMultiSigProof::try_new([].into()).unwrap();
-        let updated_channel_proof = ChannelMultiSigProof::try_new(channel_signatures).unwrap();
-        let proofs = OpProofs::from([
-            OpProof::ZkSig(zk_signature),
-            OpProof::ChannelMultiSigProof(initial_channel_proof),
-            OpProof::ChannelMultiSigProof(updated_channel_proof),
-        ]);
-
-        SignedOps::<Unverified, StandardMode>::from_parts(ops, proofs)
-            .unwrap()
-            .preverify()
-            .unwrap()
-    }
 
     fn transfer_heavy_transaction(
         transaction_index: usize,
@@ -363,41 +282,5 @@ mod tests {
                 block_txs.into_iter(),
             )
             .expect("the selected prefix must pass canonical application");
-    }
-
-    #[test]
-    fn oversized_transaction_is_evicted_without_stopping_selection() {
-        const OVERSIZED_SIGNATURES: usize = 60_000;
-
-        let config = leadership::test_config();
-        let channel_signing_key = Ed25519Key::from_bytes(&[7; 32]);
-        let funding_key = ZkKey::zero();
-        let (oversized_utxo, oversized_ops) = build_high_execution_gas_ops(
-            0,
-            &channel_signing_key,
-            &funding_key,
-            OVERSIZED_SIGNATURES,
-        );
-        let oversized_tx = sign_high_execution_gas_ops(
-            oversized_ops,
-            &channel_signing_key,
-            &funding_key,
-            OVERSIZED_SIGNATURES,
-        );
-        let oversized_hash = oversized_tx.hash();
-        let (valid_utxos, valid_tx) = transfer_heavy_transaction(1, &funding_key, 1);
-        let ledger_state =
-            LedgerState::from_utxos(std::iter::once(oversized_utxo).chain(valid_utxos), &config);
-
-        assert!(matches!(
-            BlockBuilder::new(ledger_state.clone()).try_add_transaction(&oversized_tx, &config),
-            Err(lb_ledger::LedgerError::TooMuchTransactionExecutionGas { .. })
-        ));
-
-        let selection =
-            select_transactions(ledger_state, vec![oversized_tx, valid_tx.clone()], &config);
-
-        assert_eq!(selection.selected_txs, vec![valid_tx]);
-        assert_eq!(selection.invalid_tx_hashes, vec![oversized_hash]);
     }
 }


### PR DESCRIPTION
## 1. What does this PR implement?

A block leader could select transactions whose combined execution gas exceeded the block limit. The resulting proposal would be rejected during normal block validation, causing the leader to lose its slot.

This happened because the leader validated candidate transactions one at a time. Each validation started with an empty gas total, so it checked only whether each transaction fit individually. Validators apply all transactions together and therefore enforce the correct cumulative limit.

Block creation now keeps one pending block state throughout transaction selection. Each accepted transaction updates the same cumulative gas total and ledger state. If the next transaction would exceed the remaining block capacity, selection stops and leaves that transaction in the mempool. A transaction that exceeds the limit even in an empty block is invalid and is removed.

Block-level fees, rewards, storage accounting, and gas-price updates are finalized once after transaction selection.

## 2. Does the code have enough context to be clearly understood?
Yes

## 3. Who are the specification authors and who is accountable for this PR?
@andrussal 

## 4. Is the specification accurate and complete?
N/A

## 5. Does the implementation introduce changes in the specification?
N/A

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
