### PR TITLE
fix(sdp): make the last served epoch rewardable

### DIFF
--- a/core/src/events/mod.rs
+++ b/core/src/events/mod.rs
@@ -143,8 +143,8 @@ pub enum TxEventPayload {
 /// Events emitted while processing a block header
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum HeaderEvent {
-    /// A service note has been unlocked because its declaration's
-    /// `withdraw_at` epoch has been reached.
+    /// A service note has been unlocked because the epoch after its
+    /// declaration's `withdraw_at` has been reached.
     SdpNoteUnlocked {
         note_id: NoteId,
         service_type: ServiceType,

--- a/core/src/mantle/ops/sdp/active.rs
+++ b/core/src/mantle/ops/sdp/active.rs
@@ -71,10 +71,11 @@ impl VerifiableOperation<StandardMode> for SignedOperation<SDPActiveOp, Preverif
             return Err(SdpError::DeclarationNotFound(operation.declaration_id));
         };
 
-        // Check the declaration hasn't been withdrawn
-        // (Return error if `scheduled_withdrawal_epoch` epoch has passed)
+        // Check the declaration hasn't been withdrawn.
+        // The report attesting `withdraw_at - 1` is due during `withdraw_at`,
+        // so the message is valid while the current epoch is at most `withdraw_at`.
         if let Some(withdraw_at) = declaration.withdraw_at
-            && withdraw_at <= context.epoch
+            && withdraw_at < context.epoch
         {
             return Err(SdpError::DeclarationWithdrawn {
                 declaration_id: operation.declaration_id,
@@ -136,5 +137,88 @@ impl<State: VerificationState, Mode: VerificationMode> SignedOperationExecutionG
 {
     fn gas_multiplier(&self) -> Value {
         1
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use lb_blend_proofs::{quota::VerifiedProofOfQuota, selection::VerifiedProofOfSelection};
+    use lb_cryptarchia_engine::Epoch;
+    use lb_groth16::{AdditiveGroup as _, CompressedGroth16Proof, Fr};
+    use lb_key_management_system_keys::keys::{Ed25519Key, ZkKey, ZkSignature};
+    use num_bigint::BigUint;
+
+    use super::{SDPActiveOp, SDPActiveValidationContext, SdpError};
+    use crate::{
+        mantle::{
+            ledger::{Declarations, VerifiableOperation as _, verification_mode::StandardMode},
+            ops::{SignedOperation, sdp::SDPDeclareOp},
+            transactions::{
+                hash::{TxHash, TxHashView},
+                states::Preverified,
+            },
+        },
+        sdp::{ActivityMetadata, Declaration, ServiceType, blend::ActivityProof},
+    };
+
+    const WITHDRAW_AT: Epoch = Epoch::new(5);
+
+    /// The report attesting `withdraw_at - 1` is due during `withdraw_at`,
+    /// so an active message included at `withdraw_at` must be accepted.
+    #[test]
+    fn accepts_active_message_at_withdraw_at() {
+        verify_active_at(WITHDRAW_AT).unwrap();
+    }
+
+    #[test]
+    fn rejects_active_message_after_withdraw_at() {
+        assert!(matches!(
+            verify_active_at(WITHDRAW_AT.strict_add(Epoch::new(1))),
+            Err(SdpError::DeclarationWithdrawn { .. })
+        ));
+    }
+
+    /// Verifies an active message at `epoch` against a declaration whose
+    /// `withdraw_at` is [`WITHDRAW_AT`].
+    fn verify_active_at(epoch: Epoch) -> Result<(), SdpError> {
+        let signing_key = Ed25519Key::from_bytes(&[1; 32]);
+        let declare_op = SDPDeclareOp {
+            service_type: ServiceType::BlendNetwork,
+            locators: vec!["/ip4/1.1.1.1/udp/0".parse().unwrap()]
+                .try_into()
+                .unwrap(),
+            provider_id: signing_key.public_key().into(),
+            zk_id: ZkKey::from(BigUint::from(1u64)).to_public_key(),
+            service_note_id: Fr::ZERO.into(),
+        };
+        let mut declaration = Declaration::new(Epoch::new(0), &declare_op);
+        declaration.withdraw_at = Some(WITHDRAW_AT);
+        let declarations = Declarations::new_sync().insert(declare_op.id(), declaration);
+
+        let active_op = SDPActiveOp {
+            declaration_id: declare_op.id(),
+            nonce: 1,
+            metadata: ActivityMetadata::Blend(Box::new(ActivityProof {
+                epoch: Epoch::new(0),
+                signing_key: signing_key.public_key(),
+                proof_of_quota: VerifiedProofOfQuota::from_bytes_unchecked([0; _]).into(),
+                proof_of_selection: VerifiedProofOfSelection::from_bytes_unchecked([0; _]).into(),
+            })),
+        };
+        let signed_operation: SignedOperation<SDPActiveOp, Preverified, StandardMode> =
+            SignedOperation::new(
+                active_op,
+                ZkSignature::new(CompressedGroth16Proof::from_bytes(&[0u8; 128])),
+            )
+            .into_state_trusted();
+
+        let tx_hash_view = TxHashView::from(TxHash::default());
+        signed_operation
+            .verify(&SDPActiveValidationContext {
+                declarations: &declarations,
+                tx_hash_view: &tx_hash_view,
+                epoch,
+            })
+            .map(|_| ())
     }
 }

--- a/ledger/src/mantle/sdp/mod.rs
+++ b/ledger/src/mantle/sdp/mod.rs
@@ -217,7 +217,7 @@ impl<R: Rewards> ServiceState<R> {
         (self, reward_utxos, events)
     }
 
-    /// For every withdrawn declaration whose `withdrawn` epoch has been
+    /// For every withdrawn declaration whose `withdraw_at + 1` epoch has been
     /// reached, unlock the service note and remove the declaration from the
     /// set.
     ///
@@ -236,7 +236,7 @@ impl<R: Rewards> ServiceState<R> {
             .declarations
             .iter()
             .filter_map(|(id, declaration)| {
-                if epoch < declaration.withdraw_at? {
+                if epoch <= declaration.withdraw_at? {
                     return None;
                 }
                 if service_notes
@@ -1290,8 +1290,8 @@ mod tests {
         }
     }
 
-    /// Once a Blend declaration is withdrawn/removed at its `withdraw_at`
-    /// epoch, its `provider_id` and `zk_id` become reusable
+    /// Once a Blend declaration is removed, the epoch after its `withdraw_at`,
+    /// its `provider_id` and `zk_id` become reusable
     /// — a fresh declaration reusing both must be accepted.
     #[test]
     fn accepts_reused_ids_after_withdrawn_epoch() {
@@ -1349,10 +1349,10 @@ mod tests {
             .withdraw_at
             .expect("withdraw_at must be set after withdraw tx is accepted");
 
-        // Advance epochs until A is removed at `withdraw_epoch`.
+        // Advance epochs until A is removed at `withdraw_epoch + 1`.
         let mut sdp_ledger = sdp_ledger;
         let mut last_epoch_state = epoch0;
-        for epoch in 1..=withdraw_epoch.into_inner() {
+        for epoch in 1..=withdraw_epoch.into_inner() + 1 {
             let new_epoch_state = next_epoch_state(epoch.into(), &sdp_ledger, &config);
             (sdp_ledger, _) = sdp_ledger
                 .try_apply_header(&config, &last_epoch_state, &new_epoch_state)
@@ -1361,7 +1361,7 @@ mod tests {
         }
         assert!(
             sdp_ledger.get_declaration(&declaration_id_a).is_none(),
-            "declaration A must be removed at the withdrawn epoch"
+            "declaration A must be removed at the `withdraw_at + 1` epoch"
         );
 
         // Re-declare reusing A's `provider_id` and `zk_id` (fresh service note
@@ -1449,11 +1449,11 @@ mod tests {
             .withdraw_at
             .expect("withdraw_at must be set after withdraw tx is accepted");
 
-        // Move forward to the epoch just before the withdrawn epoch.
+        // Move forward up to and including `withdraw_at`.
         // The declaration must still be present and the note still in service.
         let mut sdp_ledger = sdp_ledger;
         let mut last_epoch_state = epoch0;
-        for epoch in 1..withdraw_epoch.into_inner() {
+        for epoch in 1..=withdraw_epoch.into_inner() {
             let new_epoch_state = next_epoch_state(epoch.into(), &sdp_ledger, &config);
             let events;
             (sdp_ledger, HeaderEffect { events, .. }) = sdp_ledger
@@ -1467,18 +1467,22 @@ mod tests {
         }
         assert!(
             sdp_ledger.get_declaration(&declaration_id).is_some(),
-            "declaration must still exist before the withdrawn epoch is reached"
+            "declaration must still exist at `withdraw_at`"
         );
         assert!(
             sdp_ledger
                 .service_notes()
                 .is_used_for_service(&operation_service_note_id, &ServiceType::BlendNetwork),
-            "the provider's note must still be used by the service before the withdrawn epoch is reached"
+            "the provider's note must still be used by the service at `withdraw_at`"
         );
 
-        // Move forward to the withdrawn epoch. The declaration must be removed
-        // and the note must be unlocked.
-        let new_epoch_state = next_epoch_state(withdraw_epoch, &sdp_ledger, &config);
+        // Move forward to the `withdraw_at + 1` epoch. The declaration must
+        // be removed and the note must be unlocked.
+        let new_epoch_state = next_epoch_state(
+            withdraw_epoch.strict_add(Epoch::new(1)),
+            &sdp_ledger,
+            &config,
+        );
         let events;
         (sdp_ledger, HeaderEffect { events, .. }) = sdp_ledger
             .try_apply_header(&config, &last_epoch_state, &new_epoch_state)
@@ -1489,13 +1493,162 @@ mod tests {
         );
         assert!(
             sdp_ledger.get_declaration(&declaration_id).is_none(),
-            "declaration must be removed at the withdrawn epoch"
+            "declaration must be removed the epoch after `withdraw_at`"
         );
         assert!(
             !sdp_ledger
                 .service_notes()
                 .is_used_for_service(&operation_service_note_id, &ServiceType::BlendNetwork),
-            "the provider's note must no longer be used by the service at the withdrawn epoch"
+            "the provider's note must no longer be used by the service the epoch after `withdraw_at`"
+        );
+    }
+
+    /// A withdrawal included in epoch `e` sets `withdraw_at = e + 2`. The node
+    /// still serves epoch `e + 1`, its report attesting `e + 1` is accepted
+    /// during `e + 2`, and the epoch-`e + 1` reward is distributed in the first
+    /// block of `e + 3`, right before the declaration is removed.
+    #[test]
+    #[expect(
+        clippy::too_many_lines,
+        reason = "This test walks the full withdraw timeline epoch by epoch, and splitting it would not improve readability"
+    )]
+    fn last_served_epoch_is_rewarded_before_removal() {
+        let config = setup(ServiceParameters {
+            inactivity_period: 2.try_into().unwrap(),
+            epoch: 0.into(),
+        });
+
+        let epoch0 = dummy_epoch_state(0.into());
+        let mut ledger = dummy_sdp_ledger(0.into(), &config);
+
+        // Declare at epoch 1.
+        let epoch1 = next_epoch_state(1.into(), &ledger, &config);
+        (ledger, _) = ledger.try_apply_header(&config, &epoch0, &epoch1).unwrap();
+
+        let (_utxo_sk, utxo) = utxo_with_sk();
+        let note_id = utxo.id();
+        let signing_key = create_signing_key();
+        let zk_key = create_zk_key(1);
+        let declare_op = SDPDeclareOp {
+            service_type: ServiceType::BlendNetwork,
+            service_note_id: note_id,
+            zk_id: zk_key.to_public_key(),
+            provider_id: ProviderId(signing_key.public_key()),
+            locators: "/ip4/1.1.1.1/udp/0".parse::<Locator>().unwrap().into(),
+        };
+        let declaration_id = declare_op.id();
+        let proof = ZkAndEd25519Proof {
+            zk_sig: ZkSignature::new(CompressedGroth16Proof::from_bytes(&[0u8; 128])),
+            ed25519_sig: Ed25519Signature::zero(),
+        };
+        let signed_operation_declare = SignedOperation::new(declare_op, proof).into_state_trusted();
+        ledger = ledger
+            .try_apply_sdp_declaration(&utxo_tree(vec![utxo]), signed_operation_declare, &config)
+            .map(|(sdp_ledger, _)| sdp_ledger)
+            .unwrap();
+
+        // Withdraw at epoch 2 (`e`): `withdraw_at = 4`.
+        let epoch2 = next_epoch_state(2.into(), &ledger, &config);
+        (ledger, _) = ledger.try_apply_header(&config, &epoch1, &epoch2).unwrap();
+        let withdraw_op = SDPWithdrawOp {
+            declaration_id,
+            nonce: 1,
+            service_note_id: note_id,
+        };
+        let proof_withdraw = ZkSignature::new(CompressedGroth16Proof::from_bytes(&[0u8; 128]));
+        let signed_operation_withdraw =
+            SignedOperation::new(withdraw_op, proof_withdraw).into_state_trusted();
+        ledger = ledger
+            .apply_withdrawn_msg(signed_operation_withdraw, &config)
+            .map(|(sdp_ledger, _)| sdp_ledger)
+            .unwrap();
+        let withdraw_at = ledger
+            .get_declaration(&declaration_id)
+            .unwrap()
+            .withdraw_at
+            .expect("withdraw must set the withdraw_at");
+        assert_eq!(withdraw_at, Epoch::new(4));
+
+        // Epoch 3 (`e + 1`) is the last served epoch: the node is still in the
+        // snapshot and block-reward income accrues.
+        let epoch3 = next_epoch_state(3.into(), &ledger, &config);
+        (ledger, _) = ledger.try_apply_header(&config, &epoch2, &epoch3).unwrap();
+        assert!(
+            epoch_snapshot_contains(&declaration_id, 3.into(), &ledger, &config),
+            "the node must still serve the epoch before `withdraw_at`"
+        );
+        let income: Value = 1000;
+        ledger.add_blend_income(income);
+
+        // Epoch 4 (`withdraw_at`): the node leaves the snapshot but is not
+        // removed yet, and its report attesting epoch 3 is accepted.
+        let epoch4 = next_epoch_state(4.into(), &ledger, &config);
+        let events;
+        (ledger, HeaderEffect { events, .. }) =
+            ledger.try_apply_header(&config, &epoch3, &epoch4).unwrap();
+        assert!(!epoch_snapshot_contains(
+            &declaration_id,
+            4.into(),
+            &ledger,
+            &config
+        ));
+        assert_eq!(
+            count_unlock_events(events, note_id, ServiceType::BlendNetwork, declaration_id),
+            0,
+            "the note must not be unlocked at `withdraw_at`"
+        );
+        assert!(ledger.get_declaration(&declaration_id).is_some());
+
+        let active_op = SDPActiveOp {
+            declaration_id,
+            nonce: 2,
+            metadata: ActivityMetadata::Blend(Box::new(generate_activity_proof(
+                &zk_key,
+                &epoch3,
+                &epoch4,
+                &config.service_rewards_params.blend,
+            ))),
+        };
+        let proof_active = ZkSignature::new(CompressedGroth16Proof::from_bytes(&[0u8; 128]));
+        let signed_operation_active =
+            SignedOperation::new(active_op, proof_active).into_state_trusted();
+        ledger = ledger
+            .apply_active_msg(signed_operation_active, &config)
+            .map(|(sdp_ledger, _)| sdp_ledger)
+            .expect("the report attesting `withdraw_at - 1` must be accepted at `withdraw_at`");
+
+        // Epoch 5 (`withdraw_at + 1`): the epoch-3 reward is distributed and
+        // the declaration removed in the same header.
+        let epoch5 = next_epoch_state(5.into(), &ledger, &config);
+        let (ledger, effect) = ledger.try_apply_header(&config, &epoch4, &epoch5).unwrap();
+        let received: Vec<&Utxo> = effect
+            .reward_utxos
+            .iter()
+            .filter(|utxo| utxo.note.pk == zk_key.to_public_key())
+            .collect();
+        assert_eq!(
+            received.len(),
+            1,
+            "the withdrawing provider must be paid for its last served epoch"
+        );
+        assert_eq!(received[0].note.value, income);
+        assert_eq!(
+            count_unlock_events(
+                effect.events,
+                note_id,
+                ServiceType::BlendNetwork,
+                declaration_id
+            ),
+            1
+        );
+        assert!(
+            ledger.get_declaration(&declaration_id).is_none(),
+            "declaration must be removed the epoch after `withdraw_at`"
+        );
+        assert!(
+            !ledger
+                .service_notes()
+                .is_used_for_service(&note_id, &ServiceType::BlendNetwork)
         );
     }
 

--- a/tests/src/tests/mantle/sdp/ops.rs
+++ b/tests/src/tests/mantle/sdp/ops.rs
@@ -194,11 +194,11 @@ async fn sdp_ops_e2e() {
         .withdraw_at
         .expect("withdraw_at must be set after withdraw tx is accepted");
 
-    // Wait for the snapshot finalization delay to pass. At the `withdrawn`
-    // epoch the service note is unlocked and the declaration is removed.
+    // Wait until the `withdraw_at + 1` epoch has started: in its first block
+    // the service note is unlocked and the declaration is removed.
     wait_for_tip_slot(
         &node0,
-        (u64::from(withdraw_epoch.strict_add(Epoch::new(1)).into_inner()) * slots_per_epoch).into(),
+        (u64::from(withdraw_epoch.strict_add(Epoch::new(2)).into_inner()) * slots_per_epoch).into(),
         Duration::from_mins(3),
     )
     .await


### PR DESCRIPTION
## 1. What does this PR implement?

This PR implements the RFC https://github.com/logos-co/logos-lips/pull/435. 

When we accept an withdraw message at epoch `e`, we are setting `Declaration.withdraw_at` to `e+2`. This behavior doesn't change.

What the RFC changes is that:
- Now we remove the declaration at epoch `withdraw_at + 1` (not `withdraw_at`).
- Now we accept an activity message, attesting epoch `withdraw_at - 1`, which is received at epoch `withdraw_at`. 

Why?
By doing so, we can give a reward to the service provider who provided its service during epoch `withdraw_at - 1`. Previously, we didn't give a reward for service provided during epoch `withdraw_at - 1` because we never accepted any activity message at epoch `withdraw_at`. Please see the RFC for more details.

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@youngjoon-lee 
spec: @madxor 

## 4. Is the specification accurate and complete?

Yes

## 5. Does the implementation introduce changes in the specification?

No

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
