### PR TITLE
refactor(sdp): swap the order of declaration removal and reward distribution

### DIFF
--- a/ledger/src/mantle/sdp/mod.rs
+++ b/ledger/src/mantle/sdp/mod.rs
@@ -187,10 +187,6 @@ impl<R: Rewards> ServiceState<R> {
         let mut events = Vec::new();
 
         if last_epoch_state.epoch() < epoch_state.epoch() {
-            events.extend(
-                self.unlock_and_remove_withdrawn_declarations(service_notes, epoch_state.epoch()),
-            );
-
             // Update and distribute rewards
             (self.rewards, reward_utxos) = self.rewards.update_epoch(
                 last_epoch_state,
@@ -212,6 +208,11 @@ impl<R: Rewards> ServiceState<R> {
                     utxo: *utxo,
                 }
             }));
+
+            // Remove withdrawn declarations and unlock their notes.
+            events.extend(
+                self.unlock_and_remove_withdrawn_declarations(service_notes, epoch_state.epoch()),
+            );
         }
 
         (self, reward_utxos, events)
@@ -1618,7 +1619,7 @@ mod tests {
             .expect("the report attesting `withdraw_at - 1` must be accepted at `withdraw_at`");
 
         // Epoch 5 (`withdraw_at + 1`): the epoch-3 reward is distributed and
-        // the declaration removed in the same header.
+        // the declaration removed in the same header, in that order.
         let epoch5 = next_epoch_state(5.into(), &ledger, &config);
         let (ledger, effect) = ledger.try_apply_header(&config, &epoch4, &epoch5).unwrap();
         let received: Vec<&Utxo> = effect
@@ -1632,6 +1633,14 @@ mod tests {
             "the withdrawing provider must be paid for its last served epoch"
         );
         assert_eq!(received[0].note.value, income);
+        assert!(matches!(
+            effect.events.first(),
+            Some(HeaderEvent::SdpRewardDistributed { .. })
+        ));
+        assert!(matches!(
+            effect.events.last(),
+            Some(HeaderEvent::SdpNoteUnlocked { .. })
+        ));
         assert_eq!(
             count_unlock_events(
                 effect.events,


### PR DESCRIPTION
## 1. What does this PR implement?

This PR is just a refactoring stacked on PR #3492 

As the RFC https://github.com/logos-co/logos-lips/pull/435, we have to distribute rewards after removing withdrawn declarations at an epoch boundary.

The existing behavior is already correct. No logic needs to be fixed. 
However, the order in `try_apply_header` may be confusing because declarations are removed before rewards are distributed. This currently produces the correct result because reward distribution does not read the declaration set, but the ordering is unclear and could lead to future bugs.

So, this PR just swaps the order of those two operations to better reflect the intended flow in the spec.

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?
@youngjoon-lee 
spec: @madxor 

## 4. Is the specification accurate and complete?

Yes

## 5. Does the implementation introduce changes in the specification?

No

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
