### PR TITLE
fix(blend): do not affect cover traffic schedule when blending transactions

### DIFF
--- a/blend/scheduling/src/message_scheduler/mod.rs
+++ b/blend/scheduling/src/message_scheduler/mod.rs
@@ -200,12 +200,19 @@ where
         (new_scheduler, self.consume())
     }
 
-    /// Notify the cover message submodule that a new data message has been
-    /// generated in this epoch, which will reduce the number of cover
+    /// Mark a new data message to be released in the next round and notify the
+    /// cover message submodule that a new data message has been
+    /// generated in this epoch, which will decrement the number of cover
     /// messages generated going forward.
-    pub fn queue_data_message(&mut self, message: DataMessage) {
-        self.data_messages.push(message);
+    pub fn queue_data_message_and_skip_cover_message(&mut self, message: DataMessage) {
+        self.queue_data_message_without_skipping_cover_message(message);
         self.cover_traffic.notify_new_data_message();
+    }
+
+    /// Mark a new data message to be released in the next round, without
+    /// affecting the cover message generation schedule.
+    pub fn queue_data_message_without_skipping_cover_message(&mut self, message: DataMessage) {
+        self.data_messages.push(message);
     }
 }
 

--- a/blend/scheduling/src/message_scheduler/tests.rs
+++ b/blend/scheduling/src/message_scheduler/tests.rs
@@ -213,7 +213,7 @@ async fn round_change() {
     );
     assert!(scheduler.data_messages.is_empty());
 
-    scheduler.queue_data_message(3);
+    scheduler.queue_data_message_and_skip_cover_message(3);
 
     // Poll for round `1`: cover traffic release round (prob = 1/1 = 1.0) but
     // skipped due to unprocessed data message (threshold = 1/1 = 1.0, always

--- a/services/api/src/http/blend.rs
+++ b/services/api/src/http/blend.rs
@@ -1,6 +1,6 @@
 use std::fmt::{Debug, Display};
 
-use lb_blend_service::message::{BlendPayload, NetworkInfo, ProxyServiceMessage, ServiceMessage};
+use lb_blend_service::message::{DataPayload, NetworkInfo, ProxyServiceMessage, ServiceMessage};
 use lb_core::codec::{DeserializeOp, SerializeOp};
 use lb_network_service::backends::libp2p::PeerId;
 use overwatch::services::{AsServiceId, ServiceData};
@@ -71,7 +71,7 @@ where
 {
     // Encoded the same way the mempool gossips transactions, so that whichever
     // node exits this one decodes what it expects.
-    let payload = BlendPayload::try_from_transaction(&transaction)?;
+    let payload = DataPayload::try_from_transaction(&transaction)?;
     let relay = handle.relay::<BlendService>().await?;
 
     relay

--- a/services/blend/src/api.rs
+++ b/services/blend/src/api.rs
@@ -5,7 +5,7 @@ use thiserror::Error;
 
 use crate::{
     ServiceComponents,
-    message::{BlendPayload, ProxyServiceMessage, ServiceMessage},
+    message::{DataPayload, ProxyServiceMessage, ServiceMessage},
 };
 
 /// Marker trait for the top-level blend service, used to parametrize
@@ -76,7 +76,7 @@ where
 {
     /// Publish a payload to the blend network. The exit node hands it over to
     /// whichever local service owns that kind of payload. Fire-and-forget.
-    pub async fn publish(&self, payload: BlendPayload) -> Result<(), ApiError> {
+    pub async fn publish(&self, payload: DataPayload) -> Result<(), ApiError> {
         self.relay
             .send(ServiceMessage::Blend(payload).into())
             .await

--- a/services/blend/src/core/delivery.rs
+++ b/services/blend/src/core/delivery.rs
@@ -136,11 +136,7 @@ mod tests {
 
     /// A core sender, the instant its round clock started, and the handle that
     /// puts payloads on the broadcasting channel it watches.
-    fn new_failure_monitor() -> (
-        FailureDetector,
-        Instant,
-        mpsc::UnboundedSender<DataPayload>,
-    ) {
+    fn new_failure_monitor() -> (FailureDetector, Instant, mpsc::UnboundedSender<DataPayload>) {
         let (channel, broadcasts) = mpsc::unbounded_channel();
         let detection = FailureDetector::new(
             DEADLINE,

--- a/services/blend/src/core/delivery.rs
+++ b/services/blend/src/core/delivery.rs
@@ -13,7 +13,7 @@ use lb_chain_service::Epoch;
 use crate::{
     core::{LOG_TARGET, dispatcher::PayloadDispatcher},
     delivery::FailureDetector as InnerFailureDetector,
-    message::BlendPayload,
+    message::DataPayload,
 };
 
 /// Wrapper around [`crate::delivery::FailureDetector`] that adds support for
@@ -21,7 +21,7 @@ use crate::{
 pub struct FailureDetector {
     inner: InnerFailureDetector,
     /// Payloads encapsulated and waiting to be blended.
-    encapsulated: HashMap<MessageIdentifier, (Epoch, BlendPayload)>,
+    encapsulated: HashMap<MessageIdentifier, (Epoch, DataPayload)>,
 }
 
 impl FailureDetector {
@@ -29,7 +29,7 @@ impl FailureDetector {
     pub fn new(
         maximum_blending_delay: NonZeroU64,
         round_duration: Duration,
-        payload_broadcasts: BoxStream<'static, BlendPayload>,
+        payload_broadcasts: BoxStream<'static, DataPayload>,
     ) -> Self {
         Self {
             inner: InnerFailureDetector::new(
@@ -47,7 +47,7 @@ impl FailureDetector {
     pub fn mark_payload_as_encapsulated(
         &mut self,
         id: MessageIdentifier,
-        payload: BlendPayload,
+        payload: DataPayload,
         epoch: Epoch,
     ) {
         assert!(
@@ -127,7 +127,7 @@ mod tests {
     use crate::{
         core::delivery::FailureDetector,
         delivery::test_utils::{DEADLINE, ROUND, proposal, transaction, until},
-        message::BlendPayload,
+        message::DataPayload,
     };
 
     /// Rounds a message spends waiting on the proofs that back it, before it is
@@ -139,7 +139,7 @@ mod tests {
     fn new_failure_monitor() -> (
         FailureDetector,
         Instant,
-        mpsc::UnboundedSender<BlendPayload>,
+        mpsc::UnboundedSender<DataPayload>,
     ) {
         let (channel, broadcasts) = mpsc::unbounded_channel();
         let detection = FailureDetector::new(

--- a/services/blend/src/core/dispatcher/libp2p.rs
+++ b/services/blend/src/core/dispatcher/libp2p.rs
@@ -28,7 +28,7 @@ use tokio::sync::oneshot;
 use tokio_stream::wrappers::{BroadcastStream, errors::BroadcastStreamRecvError};
 
 use super::PayloadDispatcher;
-use crate::message::BlendPayload;
+use crate::message::DataPayload;
 
 const LOG_TARGET: &str = blend::service::CORE;
 
@@ -120,7 +120,7 @@ where
 
 async fn observe_block_proposals<Tx>(
     chain_network_relay: ChainNetworkRelay<Tx>,
-) -> BoxStream<'static, BlendPayload>
+) -> BoxStream<'static, DataPayload>
 where
     Tx: Send + 'static,
 {
@@ -143,7 +143,7 @@ where
             // bytes and comparing them is all the sender has to do. One that does
             // not fit a payload is one Blend cannot have carried, so it is not a
             // delivery this node is waiting on.
-            ready(BlendPayload::try_from_proposal(&proposal).ok())
+            ready(DataPayload::try_from_proposal(&proposal).ok())
         })
         .boxed()
 }
@@ -190,7 +190,7 @@ async fn submit_transaction<Item, Key>(
 
 async fn observe_transactions<Item, Key>(
     mempool_relay: MempoolRelay<Item, Key>,
-) -> BoxStream<'static, BlendPayload>
+) -> BoxStream<'static, DataPayload>
 where
     Item: Serialize + Clone + Send + 'static,
     Key: PrefixedKey<Prefix: Send> + Send + 'static,
@@ -214,7 +214,7 @@ where
             // bytes and comparing them is all the sender has to do. If it cannot fit into
             // the maximum size Blend allows, it means the tx was not sent with Blend in the
             // first place.
-            ready(BlendPayload::try_from_transaction(&transaction).ok())
+            ready(DataPayload::try_from_transaction(&transaction).ok())
         })
         .boxed()
 }
@@ -271,9 +271,9 @@ where
         }
     }
 
-    async fn dispatch(&self, payload: BlendPayload) {
+    async fn dispatch(&self, payload: DataPayload) {
         match payload {
-            BlendPayload::BlockProposal(proposal) => {
+            DataPayload::BlockProposal(proposal) => {
                 broadcast_block_proposal(
                     &self.network_relay,
                     self.settings.topic.clone(),
@@ -281,13 +281,13 @@ where
                 )
                 .await;
             }
-            BlendPayload::Transaction(transaction) => {
+            DataPayload::Transaction(transaction) => {
                 submit_transaction(&self.mempool_relay, transaction).await;
             }
         }
     }
 
-    async fn observe_broadcasts(&self) -> BoxStream<'static, BlendPayload> {
+    async fn observe_broadcasts(&self) -> BoxStream<'static, DataPayload> {
         let proposals_stream =
             stream::once(observe_block_proposals(self.chain_network_relay.clone())).flatten();
         let transactions_stream =

--- a/services/blend/src/core/dispatcher/mod.rs
+++ b/services/blend/src/core/dispatcher/mod.rs
@@ -5,7 +5,7 @@ use lb_network_service::{NetworkService, backends::NetworkBackend};
 use overwatch::services::{ServiceData, relay::OutboundRelay};
 use serde::{Serialize, de::DeserializeOwned};
 
-use crate::message::BlendPayload;
+use crate::message::DataPayload;
 
 pub mod libp2p;
 
@@ -38,8 +38,8 @@ pub trait PayloadDispatcher<RuntimeServiceId> {
     ) -> Self;
 
     /// Deliver a decapsulated payload to the local service that owns it.
-    async fn dispatch(&self, payload: BlendPayload);
+    async fn dispatch(&self, payload: DataPayload);
 
     /// Return a stream of payloads appearing on the broadcasting channel.
-    async fn observe_broadcasts(&self) -> BoxStream<'static, BlendPayload>;
+    async fn observe_broadcasts(&self) -> BoxStream<'static, DataPayload>;
 }

--- a/services/blend/src/core/mod.rs
+++ b/services/blend/src/core/mod.rs
@@ -106,7 +106,7 @@ use crate::{
     epoch_info::{PolEpochInfo, PolInfoProvider as PolInfoProviderTrait},
     kms::PreloadKmsService,
     membership::{self, ZkInfo, chain::BlendEpochState},
-    message::{BlendPayload, ProcessedMessage, ServiceMessage},
+    message::{DataPayload, DataPayloadType, ProcessedMessage, ServiceMessage},
     pending::{
         EncapsulationResult, LocalEncapsulation, MessageKind, NextLocalMessage, PendingProposals,
         PendingTransactions, next_local_message, resolve_encapsulation,
@@ -1231,14 +1231,14 @@ where
     NetworkSettings: Clone,
 {
     match message {
-        ServiceMessage::Blend(BlendPayload::Transaction(transaction)) => {
+        ServiceMessage::Blend(DataPayload::Transaction(transaction)) => {
             queue_transaction_for_encapsulation(
                 transaction,
                 pending_transactions,
                 recovery_checkpoint,
             )
         }
-        ServiceMessage::Blend(BlendPayload::BlockProposal(proposal)) => {
+        ServiceMessage::Blend(DataPayload::BlockProposal(proposal)) => {
             let copies = NonZeroU64::new(blend_config.data_replication_factor.strict_add(1))
                 .expect("A block proposal is always sent at least once.");
             pending_proposals.queue(proposal, copies);
@@ -1299,7 +1299,7 @@ where
                 let (proposals, crypto_processor, scheduler) = current_epoch.scheduling_borrows();
                 match kind {
                     MessageKind::Proposal => {
-                        let payload = BlendPayload::BlockProposal(
+                        let payload = DataPayload::BlockProposal(
                             proposals
                                 .head()
                                 .expect("A proposal copy was encapsulated, so one is queued.")
@@ -1566,7 +1566,7 @@ where
     BackendSettings: Clone + Send + Sync,
     ProofsVerifier: ProofsVerifierTrait,
 {
-    let payload = BlendPayload::Transaction(
+    let payload = DataPayload::Transaction(
         pending_transactions
             .head()
             .expect("A transaction was encapsulated, so one is queued.")
@@ -1979,7 +1979,7 @@ fn schedule_local_encapsulated_message<
     CorePoQGenerator,
 >(
     wrapped_message: &EncapsulatedMessageWithVerifiedPublicHeader,
-    payload: BlendPayload,
+    payload: DataPayload,
     failure_detector: Option<&mut FailureDetector>,
     cryptographic_processor: &CurrentEpochCryptographicProcessor<
         NodeId,
@@ -2012,6 +2012,8 @@ where
         .receiver()
         .decapsulate_message_recursive(wrapped_message.clone());
 
+    let payload_type = payload.payload_type();
+
     let Ok(multi_layer_decapsulation_output) = self_decapsulation_output else {
         // The outermost layer of the data message is not for us, hence we treat this as
         // a regular data message that should be released at the next round.
@@ -2019,7 +2021,15 @@ where
         if let Some(failure_detector) = failure_detector {
             failure_detector.mark_payload_as_encapsulated(wrapped_message.id(), payload, epoch);
         }
-        scheduler.queue_data_message(wrapped_message.clone());
+        match payload_type {
+            DataPayloadType::BlockProposal => {
+                scheduler.queue_data_message_and_skip_cover_message(wrapped_message.clone());
+            }
+            DataPayloadType::Transaction => {
+                scheduler
+                    .queue_data_message_without_skipping_cover_message(wrapped_message.clone());
+            }
+        }
         assert_eq!(
             state_updater.add_unsent_data_message(wrapped_message.clone()),
             Ok(()),
@@ -2038,10 +2048,10 @@ where
         DecapsulatedMessageType::Completed(fully_decapsulated_message) => {
             let data_message = match fully_decapsulated_message.into_components() {
                 (PayloadType::BlockProposal, encoded_block_proposal) => {
-                    BlendPayload::BlockProposal(encoded_block_proposal)
+                    DataPayload::BlockProposal(encoded_block_proposal)
                 }
                 (PayloadType::Transaction, encoded_transaction) => {
-                    BlendPayload::Transaction(encoded_transaction)
+                    DataPayload::Transaction(encoded_transaction)
                 }
                 (PayloadType::Cover, _) => {
                     panic!(
@@ -2314,10 +2324,10 @@ where
         DecapsulatedMessageType::Completed(fully_decapsulated_message) => {
             let data_message = match fully_decapsulated_message.into_components() {
                 (PayloadType::BlockProposal, encoded_block_proposal) => {
-                    BlendPayload::BlockProposal(encoded_block_proposal)
+                    DataPayload::BlockProposal(encoded_block_proposal)
                 }
                 (PayloadType::Transaction, encoded_transaction) => {
-                    BlendPayload::Transaction(encoded_transaction)
+                    DataPayload::Transaction(encoded_transaction)
                 }
                 (PayloadType::Cover, _) => {
                     tracing::trace!(target: LOG_TARGET, "Discarding received cover message.");

--- a/services/blend/src/core/mod.rs
+++ b/services/blend/src/core/mod.rs
@@ -2031,7 +2031,7 @@ where
             }
         }
         assert_eq!(
-            state_updater.add_unsent_data_message(wrapped_message.clone()),
+            state_updater.add_unsent_data_message(wrapped_message.clone(), payload_type),
             Ok(()),
             "There should not be another copy of the same locally-generated encapsulated data message: {wrapped_message:?}."
         );

--- a/services/blend/src/core/scheduler.rs
+++ b/services/blend/src/core/scheduler.rs
@@ -5,6 +5,8 @@ use lb_blend::scheduling::{
     message_scheduler::{ProcessedMessageScheduler as _, Settings, epoch_info::EpochInfo},
 };
 
+use crate::message::DataPayloadType;
+
 /// A wrapper around a [`MessageScheduler`] that allows creation with a set of
 /// initial messages.
 pub struct SchedulerWrapper<Rng, ProcessedMessage, DataMessage> {
@@ -27,11 +29,18 @@ where
     ) -> Self
     where
         ProcessedMessages: Iterator<Item = ProcessedMessage>,
-        DataMessages: Iterator<Item = DataMessage>,
+        DataMessages: Iterator<Item = (DataMessage, DataPayloadType)>,
     {
         let mut scheduler = EpochMessageScheduler::new(epoch_info, rng, settings);
         processed_messages.for_each(|m| scheduler.schedule_processed_message(m));
-        data_messages.for_each(|m| scheduler.queue_data_message_and_skip_cover_message(m));
+        data_messages.for_each(|(message, payload_type)| match payload_type {
+            DataPayloadType::BlockProposal => {
+                scheduler.queue_data_message_and_skip_cover_message(message);
+            }
+            DataPayloadType::Transaction => {
+                scheduler.queue_data_message_without_skipping_cover_message(message);
+            }
+        });
         Self { scheduler }
     }
 }

--- a/services/blend/src/core/scheduler.rs
+++ b/services/blend/src/core/scheduler.rs
@@ -31,7 +31,7 @@ where
     {
         let mut scheduler = EpochMessageScheduler::new(epoch_info, rng, settings);
         processed_messages.for_each(|m| scheduler.schedule_processed_message(m));
-        data_messages.for_each(|m| scheduler.queue_data_message(m));
+        data_messages.for_each(|m| scheduler.queue_data_message_and_skip_cover_message(m));
         Self { scheduler }
     }
 }

--- a/services/blend/src/core/service_components.rs
+++ b/services/blend/src/core/service_components.rs
@@ -3,7 +3,7 @@ use tokio::sync::oneshot;
 
 use crate::{
     core::{BlendService, backends::BlendBackend, dispatcher::PayloadDispatcher},
-    message::{BlendPayload, NetworkInfo, ServiceMessage},
+    message::{DataPayload, NetworkInfo, ServiceMessage},
 };
 
 /// Helper trait to help the Blend proxy service rely on the concrete types of
@@ -105,7 +105,7 @@ pub trait MessageComponents<NodeId> {
 }
 
 impl<NodeId> MessageComponents<NodeId> for ServiceMessage<NodeId> {
-    type Payload = BlendPayload;
+    type Payload = DataPayload;
 
     fn into_payload(self) -> Self::Payload {
         match self {

--- a/services/blend/src/core/state.rs
+++ b/services/blend/src/core/state.rs
@@ -1,5 +1,5 @@
 mod serde {
-    use std::collections::{HashSet, VecDeque};
+    use std::collections::{HashMap, HashSet, VecDeque};
 
     use lb_blend::message::{
         encap::validated::EncapsulatedMessageWithVerifiedPublicHeader,
@@ -11,7 +11,7 @@ mod serde {
 
     use crate::{
         core::state::{error, recovery_state::RecoveryServiceState, service::ServiceState},
-        message::ProcessedMessage,
+        message::{DataPayloadType, ProcessedMessage},
     };
 
     #[derive(Clone, Serialize, Deserialize)]
@@ -22,7 +22,7 @@ mod serde {
         last_seen_epoch: Epoch,
         spent_core_quota: Quota,
         unsent_processed_messages: HashSet<ProcessedMessage>,
-        unsent_data_messages: HashSet<EncapsulatedMessageWithVerifiedPublicHeader>,
+        unsent_data_messages: HashMap<EncapsulatedMessageWithVerifiedPublicHeader, DataPayloadType>,
         pending_transactions: VecDeque<Vec<u8>>,
         current_epoch_token_collector: EpochBlendingTokenCollector,
         old_epoch_token_collector: Option<OldEpochBlendingTokenCollector>,
@@ -84,7 +84,7 @@ mod serde {
 pub use self::service::ServiceState;
 mod service {
     use core::fmt::{self, Debug, Formatter};
-    use std::collections::{HashSet, VecDeque};
+    use std::collections::{HashMap, HashSet, VecDeque};
 
     use lb_blend::message::{
         encap::validated::EncapsulatedMessageWithVerifiedPublicHeader,
@@ -95,7 +95,7 @@ mod service {
 
     use crate::{
         core::state::{error, recovery_state::RecoveryServiceState, state_updater::StateUpdater},
-        message::ProcessedMessage,
+        message::{DataPayloadType, ProcessedMessage},
     };
 
     /// Recovery state for Blend core service.
@@ -106,7 +106,7 @@ mod service {
         /// tracked.
         spent_core_quota: Quota,
         unsent_processed_messages: HashSet<ProcessedMessage>,
-        unsent_data_messages: HashSet<EncapsulatedMessageWithVerifiedPublicHeader>,
+        unsent_data_messages: HashMap<EncapsulatedMessageWithVerifiedPublicHeader, DataPayloadType>,
         /// Transactions handed over for blending that are still waiting for a
         /// `PoW` solution to back their layer proofs.
         pending_transactions: VecDeque<Vec<u8>>,
@@ -163,7 +163,10 @@ mod service {
             last_seen_epoch: Epoch,
             spent_core_quota: Quota,
             unsent_processed_messages: HashSet<ProcessedMessage>,
-            unsent_data_messages: HashSet<EncapsulatedMessageWithVerifiedPublicHeader>,
+            unsent_data_messages: HashMap<
+                EncapsulatedMessageWithVerifiedPublicHeader,
+                DataPayloadType,
+            >,
             pending_transactions: VecDeque<Vec<u8>>,
             current_epoch_token_collector: EpochBlendingTokenCollector,
             old_epoch_token_collector: Option<OldEpochBlendingTokenCollector>,
@@ -228,7 +231,7 @@ mod service {
                 epoch,
                 Quota::ZERO,
                 HashSet::new(),
-                HashSet::new(),
+                HashMap::new(),
                 pending_transactions,
                 current_epoch_token_collector,
                 old_epoch_token_collector,
@@ -309,7 +312,7 @@ mod service {
             Epoch,
             Quota,
             HashSet<ProcessedMessage>,
-            HashSet<EncapsulatedMessageWithVerifiedPublicHeader>,
+            HashMap<EncapsulatedMessageWithVerifiedPublicHeader, DataPayloadType>,
             VecDeque<Vec<u8>>,
             EpochBlendingTokenCollector,
             Option<OldEpochBlendingTokenCollector>,
@@ -359,8 +362,13 @@ mod service {
         pub(super) fn add_unsent_data_message(
             &mut self,
             message: EncapsulatedMessageWithVerifiedPublicHeader,
+            payload_type: DataPayloadType,
         ) -> Result<(), ()> {
-            if self.unsent_data_messages.insert(message) {
+            if self
+                .unsent_data_messages
+                .insert(message, payload_type)
+                .is_none()
+            {
                 Ok(())
             } else {
                 Err(())
@@ -371,7 +379,7 @@ mod service {
             &mut self,
             message: &EncapsulatedMessageWithVerifiedPublicHeader,
         ) -> Result<(), ()> {
-            if self.unsent_data_messages.remove(message) {
+            if self.unsent_data_messages.remove(message).is_some() {
                 Ok(())
             } else {
                 Err(())
@@ -380,7 +388,7 @@ mod service {
 
         pub const fn unsent_data_messages(
             &self,
-        ) -> &HashSet<EncapsulatedMessageWithVerifiedPublicHeader> {
+        ) -> &HashMap<EncapsulatedMessageWithVerifiedPublicHeader, DataPayloadType> {
             &self.unsent_data_messages
         }
 
@@ -417,7 +425,7 @@ mod state_updater {
 
     use crate::{
         core::state::{error, service::ServiceState},
-        message::ProcessedMessage,
+        message::{DataPayloadType, ProcessedMessage},
     };
 
     /// A state updater which gathers changes to the underlying [`ServiceState`]
@@ -500,14 +508,20 @@ mod state_updater {
         /// unsent, meaning that it has been scheduled for release but
         /// not yet released.
         ///
+        /// `payload_type` is stored alongside the message because the payload
+        /// it carries is encrypted, so a message restored from the recovery
+        /// state could otherwise not be told apart from a block proposal, and
+        /// the two types must be acted on differently.
+        ///
         /// It returns `Ok` if the message was not already present, `Err`
         /// otherwise.
         pub fn add_unsent_data_message(
             &mut self,
             message: EncapsulatedMessageWithVerifiedPublicHeader,
+            payload_type: DataPayloadType,
         ) -> Result<(), ()> {
             self.changed = true;
-            self.inner.add_unsent_data_message(message)
+            self.inner.add_unsent_data_message(message, payload_type)
         }
 
         /// Mark a new [`EncapsulatedMessageWithVerifiedPublicHeader`] as sent,

--- a/services/blend/src/core/tests/mod.rs
+++ b/services/blend/src/core/tests/mod.rs
@@ -52,7 +52,7 @@ use crate::{
     epoch::{CoreEpochInfo, CoreEpochPublicInfo},
     epoch_info::PolEpochInfo,
     membership::{MembershipInfo, ZkInfo, chain::BlendEpochState},
-    message::{BlendPayload, ServiceMessage},
+    message::{DataPayload, ServiceMessage},
     pending::{NextLocalMessage, PendingTransactions, next_local_message},
     test_utils::{
         crypto::{
@@ -2265,7 +2265,7 @@ async fn a_proposal_the_network_never_delivers_is_broadcast_in_the_clear() {
         spawn_core_watching_the_broadcasting_channel().await;
 
     inbound_message_sender
-        .send(ServiceMessage::Blend(BlendPayload::BlockProposal(
+        .send(ServiceMessage::Blend(DataPayload::BlockProposal(
             proposal.clone(),
         )))
         .await
@@ -2275,7 +2275,7 @@ async fn a_proposal_the_network_never_delivers_is_broadcast_in_the_clear() {
         .await
         .expect("the deadline should have expired by now")
         .expect("the service should still be running");
-    assert_eq!(broadcast, BlendPayload::BlockProposal(proposal));
+    assert_eq!(broadcast, DataPayload::BlockProposal(proposal));
 }
 
 /// Seeing the proposal come out of the Blend network is what cancels the direct
@@ -2287,7 +2287,7 @@ async fn a_proposal_the_network_delivers_is_never_broadcast_in_the_clear() {
         spawn_core_watching_the_broadcasting_channel().await;
 
     inbound_message_sender
-        .send(ServiceMessage::Blend(BlendPayload::BlockProposal(
+        .send(ServiceMessage::Blend(DataPayload::BlockProposal(
             proposal.clone(),
         )))
         .await
@@ -2298,7 +2298,7 @@ async fn a_proposal_the_network_delivers_is_never_broadcast_in_the_clear() {
     sleep(deadline / 2).await;
     broadcasting_channel
         .carrying
-        .send(BlendPayload::BlockProposal(proposal))
+        .send(DataPayload::BlockProposal(proposal))
         .expect("the service is subscribed");
 
     assert!(
@@ -2413,7 +2413,7 @@ async fn a_proposal_arriving_before_the_pol_info_is_still_sent() {
     // The gate is shut, so the leadership branch has nothing to give: this is the
     // window the proposal used to die in.
     inbound_message_sender
-        .send(ServiceMessage::Blend(BlendPayload::BlockProposal(
+        .send(ServiceMessage::Blend(DataPayload::BlockProposal(
             b"proposal".to_vec(),
         )))
         .await
@@ -2552,7 +2552,7 @@ async fn the_previous_epoch_keeps_releasing_under_its_own_epoch() {
 
     // Queued under epoch 0, and released on a round that has not come yet.
     inbound_message_sender
-        .send(ServiceMessage::Blend(BlendPayload::Transaction(
+        .send(ServiceMessage::Blend(DataPayload::Transaction(
             b"transaction".to_vec(),
         )))
         .await
@@ -2696,14 +2696,14 @@ async fn a_message_that_can_never_be_sent_does_not_block_the_rest() {
     // One byte over what a payload can hold, so encapsulating it fails the same
     // way however long it waits.
     inbound_message_sender
-        .send(ServiceMessage::Blend(BlendPayload::BlockProposal(vec![
+        .send(ServiceMessage::Blend(DataPayload::BlockProposal(vec![
             0;
             MAX_PAYLOAD_BODY_SIZE + 1
         ])))
         .await
         .unwrap();
     inbound_message_sender
-        .send(ServiceMessage::Blend(BlendPayload::Transaction(
+        .send(ServiceMessage::Blend(DataPayload::Transaction(
             b"transaction".to_vec(),
         )))
         .await
@@ -2826,13 +2826,13 @@ async fn a_transaction_awaiting_a_pow_solution_does_not_stall_the_event_loop() {
     // The transaction goes in first, so if the loop blocked on mining, the
     // proposal queued behind it could never get out.
     inbound_message_sender
-        .send(ServiceMessage::Blend(BlendPayload::Transaction(
+        .send(ServiceMessage::Blend(DataPayload::Transaction(
             b"transaction".to_vec(),
         )))
         .await
         .unwrap();
     inbound_message_sender
-        .send(ServiceMessage::Blend(BlendPayload::BlockProposal(
+        .send(ServiceMessage::Blend(DataPayload::BlockProposal(
             b"proposal".to_vec(),
         )))
         .await

--- a/services/blend/src/core/tests/utils.rs
+++ b/services/blend/src/core/tests/utils.rs
@@ -65,7 +65,7 @@ use crate::{
         tests::RuntimeServiceId,
     },
     epoch::CoreEpochPublicInfo,
-    message::{BlendPayload, NetworkInfo},
+    message::{DataPayload, NetworkInfo},
     settings::TimingSettings,
     test_utils,
     test_utils::mocks::{TestChainNetworkService, TestMempoolService},
@@ -332,11 +332,11 @@ where
         Self
     }
 
-    async fn dispatch(&self, _payload: BlendPayload) {
+    async fn dispatch(&self, _payload: DataPayload) {
         note_outgoing_message();
     }
 
-    async fn observe_broadcasts(&self) -> BoxStream<'static, BlendPayload> {
+    async fn observe_broadcasts(&self) -> BoxStream<'static, DataPayload> {
         stream::empty().boxed()
     }
 }

--- a/services/blend/src/delivery/failure_detection.rs
+++ b/services/blend/src/delivery/failure_detection.rs
@@ -18,7 +18,7 @@ use tokio_stream::wrappers::IntervalStream;
 
 use crate::{
     LOG_TARGET, core::dispatcher::PayloadDispatcher, delivery::broadcast_undelivered_messages,
-    message::BlendPayload,
+    message::DataPayload,
 };
 
 struct BlendedPayloadDetails {
@@ -30,9 +30,9 @@ pub struct FailureDetector {
     maximum_blending_delay: NonZeroU64,
     rounds_clock: IntervalStream,
     current_round: Round,
-    payload_broadcasts: Fuse<BoxStream<'static, BlendPayload>>,
+    payload_broadcasts: Fuse<BoxStream<'static, DataPayload>>,
     /// Messages sent out via Blend, up to the round their deadline passes.
-    unacknowledged_blended_payloads: HashMap<BlendPayload, BlendedPayloadDetails>,
+    unacknowledged_blended_payloads: HashMap<DataPayload, BlendedPayloadDetails>,
 }
 
 impl FailureDetector {
@@ -40,7 +40,7 @@ impl FailureDetector {
     pub fn new(
         maximum_blending_delay: NonZeroU64,
         round_duration: Duration,
-        payload_broadcasts: BoxStream<'static, BlendPayload>,
+        payload_broadcasts: BoxStream<'static, DataPayload>,
     ) -> Self {
         let clock = {
             let mut clock = interval(round_duration);
@@ -56,7 +56,7 @@ impl FailureDetector {
         }
     }
 
-    pub fn mark_payload_as_blended(&mut self, payload: BlendPayload) {
+    pub fn mark_payload_as_blended(&mut self, payload: DataPayload) {
         let released_at = self.current_round;
         self.unacknowledged_blended_payloads
             .entry(payload)
@@ -70,13 +70,13 @@ impl FailureDetector {
             });
     }
 
-    fn mark_payload_as_delivered(&mut self, payload: &BlendPayload) {
+    fn mark_payload_as_delivered(&mut self, payload: &DataPayload) {
         if let Some(blended) = self.unacknowledged_blended_payloads.get_mut(payload) {
             blended.delivered = true;
         }
     }
 
-    fn take_expired_payloads(&mut self, now: Round) -> Vec<BlendPayload> {
+    fn take_expired_payloads(&mut self, now: Round) -> Vec<DataPayload> {
         let (expired, still_waiting): (HashMap<_, _>, HashMap<_, _>) =
             take(&mut self.unacknowledged_blended_payloads)
                 .into_iter()
@@ -137,7 +137,7 @@ impl FailureDetector {
 }
 
 impl Stream for FailureDetector {
-    type Item = Vec<BlendPayload>;
+    type Item = Vec<DataPayload>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         loop {
@@ -189,7 +189,7 @@ mod tests {
             FailureDetector,
             test_utils::{DEADLINE, ROUND, proposal, transaction, until},
         },
-        message::BlendPayload,
+        message::DataPayload,
         test_utils::dispatcher::TestPayloadDispatcher,
     };
 
@@ -198,7 +198,7 @@ mod tests {
     fn watching() -> (
         FailureDetector,
         Instant,
-        mpsc::UnboundedSender<BlendPayload>,
+        mpsc::UnboundedSender<DataPayload>,
     ) {
         let (channel, broadcasts) = mpsc::unbounded_channel();
         let detection = FailureDetector::new(
@@ -275,14 +275,14 @@ mod tests {
     #[tokio::test(start_paused = true)]
     async fn a_transaction_does_not_answer_for_a_proposal_of_the_same_bytes() {
         let (mut detection, start, channel) = watching();
-        detection.mark_payload_as_blended(BlendPayload::BlockProposal(b"same".into()));
+        detection.mark_payload_as_blended(DataPayload::BlockProposal(b"same".into()));
         channel
-            .send(BlendPayload::Transaction(b"same".into()))
+            .send(DataPayload::Transaction(b"same".into()))
             .expect("the watch is listening");
 
         assert_eq!(
             until(&mut detection, start, DEADLINE.get() + 2).await,
-            vec![BlendPayload::BlockProposal(b"same".into())],
+            vec![DataPayload::BlockProposal(b"same".into())],
             "what a payload is, is part of what identifies it"
         );
     }

--- a/services/blend/src/delivery/failure_detection.rs
+++ b/services/blend/src/delivery/failure_detection.rs
@@ -195,11 +195,7 @@ mod tests {
 
     /// An edge sender, the instant its round clock started, and the handle that
     /// puts payloads on the broadcasting channel it watches.
-    fn watching() -> (
-        FailureDetector,
-        Instant,
-        mpsc::UnboundedSender<DataPayload>,
-    ) {
+    fn watching() -> (FailureDetector, Instant, mpsc::UnboundedSender<DataPayload>) {
         let (channel, broadcasts) = mpsc::unbounded_channel();
         let detection = FailureDetector::new(
             DEADLINE,

--- a/services/blend/src/delivery/mod.rs
+++ b/services/blend/src/delivery/mod.rs
@@ -1,7 +1,7 @@
 use futures::{Stream, StreamExt as _, future::join_all};
 
 pub use self::failure_detection::FailureDetector;
-use crate::{LOG_TARGET, core::dispatcher::PayloadDispatcher, message::BlendPayload, metrics};
+use crate::{LOG_TARGET, core::dispatcher::PayloadDispatcher, message::DataPayload, metrics};
 
 mod failure_detection;
 
@@ -16,9 +16,9 @@ pub mod test_utils;
 /// rather than firing.
 pub async fn next_undelivered_messages<Detection>(
     failure_detection: Option<&mut Detection>,
-) -> Option<Vec<BlendPayload>>
+) -> Option<Vec<DataPayload>>
 where
-    Detection: Stream<Item = Vec<BlendPayload>> + Unpin + Send,
+    Detection: Stream<Item = Vec<DataPayload>> + Unpin + Send,
 {
     match failure_detection {
         Some(failure_detection) => failure_detection.next().await,
@@ -33,7 +33,7 @@ pub async fn broadcast_undelivered_messages<Dispatcher, UndeliveredPayloads, Run
     payload_dispatcher: &Dispatcher,
 ) where
     Dispatcher: PayloadDispatcher<RuntimeServiceId> + Sync,
-    UndeliveredPayloads: ExactSizeIterator<Item = BlendPayload> + Send,
+    UndeliveredPayloads: ExactSizeIterator<Item = DataPayload> + Send,
 {
     // TODO: Once we switch to a well-defined API for blending payloads, we can and
     // should show the relevant details for each payload that failed. E.g., for
@@ -44,7 +44,7 @@ pub async fn broadcast_undelivered_messages<Dispatcher, UndeliveredPayloads, Run
         undelivered.len()
     );
     join_all(undelivered.into_iter().map(|payload| {
-        metrics::payload_bypassed_blend(payload.payload_type());
+        metrics::data_payload_bypassed_blend(payload.payload_type());
         payload_dispatcher.dispatch(payload)
     }))
     .await;

--- a/services/blend/src/delivery/test_utils.rs
+++ b/services/blend/src/delivery/test_utils.rs
@@ -3,19 +3,19 @@ use core::{num::NonZeroU64, time::Duration};
 use futures::{Stream, StreamExt as _};
 use tokio::time::Instant;
 
-use crate::message::BlendPayload;
+use crate::message::DataPayload;
 
 pub const ROUND: Duration = Duration::from_secs(1);
 pub const DEADLINE: NonZeroU64 = NonZeroU64::new(6).unwrap();
 
 #[must_use]
-pub fn proposal() -> BlendPayload {
-    BlendPayload::BlockProposal(b"proposal".to_vec())
+pub fn proposal() -> DataPayload {
+    DataPayload::BlockProposal(b"proposal".to_vec())
 }
 
 #[must_use]
-pub fn transaction() -> BlendPayload {
-    BlendPayload::Transaction(b"transaction".to_vec())
+pub fn transaction() -> DataPayload {
+    DataPayload::Transaction(b"transaction".to_vec())
 }
 
 /// Turns the clock until `round`, collecting whatever expired on the way.
@@ -25,9 +25,9 @@ pub async fn until<Detection>(
     detection: &mut Detection,
     start: Instant,
     round: u64,
-) -> Vec<BlendPayload>
+) -> Vec<DataPayload>
 where
-    Detection: Stream<Item = Vec<BlendPayload>> + Unpin,
+    Detection: Stream<Item = Vec<DataPayload>> + Unpin,
 {
     let stop = start + ROUND * u32::try_from(round).expect("The tests turn few rounds.");
     let mut expired = Vec::new();

--- a/services/blend/src/edge/mod.rs
+++ b/services/blend/src/edge/mod.rs
@@ -49,7 +49,7 @@ use crate::{
     epoch_info::{PolEpochInfo, PolInfoProvider as PolInfoProviderTrait},
     kms::PreloadKmsService,
     membership::{self, chain::BlendEpochState, node_id},
-    message::{BlendPayload, NetworkInfo, ServiceMessage},
+    message::{DataPayload, NetworkInfo, ServiceMessage},
     pending::{EncapsulationResult, LocalEncapsulation, MessageKind, PendingTransactions},
 };
 
@@ -415,10 +415,10 @@ where
             }
             Some(message) = inbound_relay.next() => {
                 match message {
-                    ServiceMessage::Blend(BlendPayload::Transaction(transaction)) => {
+                    ServiceMessage::Blend(DataPayload::Transaction(transaction)) => {
                         pending_transactions.queue(transaction);
                     }
-                    ServiceMessage::Blend(BlendPayload::BlockProposal(proposal)) => {
+                    ServiceMessage::Blend(DataPayload::BlockProposal(proposal)) => {
                         let proposal_copies = NonZeroU64::new(settings.data_replication_factor.checked_add(1).expect("Data replication factor should not overflow when incremented.")).expect("Number of block proposal copies cannot be zero by definition.");
                         current_epoch.queue_proposal(proposal, proposal_copies);
                     }
@@ -442,8 +442,8 @@ where
                     EncapsulationResult::Complete(encapsulation) => {
                         let LocalEncapsulation { message, kind } = *encapsulation;
                         let payload = match kind {
-                            MessageKind::Proposal => current_epoch.proposals().head().map(|proposal| BlendPayload::BlockProposal(proposal.to_vec())),
-                            MessageKind::Transaction => pending_transactions.head().map(|transaction| BlendPayload::Transaction(transaction.to_vec())),
+                            MessageKind::Proposal => current_epoch.proposals().head().map(|proposal| DataPayload::BlockProposal(proposal.to_vec())),
+                            MessageKind::Transaction => pending_transactions.head().map(|transaction| DataPayload::Transaction(transaction.to_vec())),
                         }
                         .expect("A message was encapsulated, so the payload it carries is queued.");
                         current_epoch.send(message).await;

--- a/services/blend/src/edge/tests/mod.rs
+++ b/services/blend/src/edge/tests/mod.rs
@@ -26,7 +26,7 @@ use crate::{
     },
     epoch_info::PolEpochInfo,
     membership::chain::BlendEpochState,
-    message::{BlendPayload, ServiceMessage},
+    message::{DataPayload, ServiceMessage},
     pending::{NextLocalMessage, PendingTransactions, next_local_message},
     test_utils::{
         epoch::{GatedPolStreamProvider, PolGate},
@@ -57,7 +57,7 @@ async fn run_with_epoch_transition() {
 
     // A message should be forwarded to the core node 0.
     msg_sender
-        .send(BlendPayload::BlockProposal(vec![0]).into())
+        .send(DataPayload::BlockProposal(vec![0]).into())
         .await
         .expect("channel opened");
     assert_eq!(
@@ -75,7 +75,7 @@ async fn run_with_epoch_transition() {
 
     // A message should be forwarded to the core node 1.
     msg_sender
-        .send(BlendPayload::BlockProposal(vec![0]).into())
+        .send(DataPayload::BlockProposal(vec![0]).into())
         .await
         .expect("channel opened");
     assert_eq!(
@@ -104,7 +104,7 @@ async fn a_proposal_the_network_never_delivers_is_broadcast_in_the_clear() {
     } = spawn_run(local_node, 1, Some(membership(&[core_node], local_node))).await;
 
     msg_sender
-        .send(BlendPayload::BlockProposal(proposal.clone()).into())
+        .send(DataPayload::BlockProposal(proposal.clone()).into())
         .await
         .expect("channel opened");
     // It goes into the Blend network first: the direct broadcast is the last
@@ -125,7 +125,7 @@ async fn a_proposal_the_network_never_delivers_is_broadcast_in_the_clear() {
     .await
     .expect("the deadline must expire within the deadline")
     .expect("channel opened");
-    assert_eq!(broadcast, BlendPayload::BlockProposal(proposal));
+    assert_eq!(broadcast, DataPayload::BlockProposal(proposal));
 }
 
 /// [`run`] leaves a proposal alone once it has seen it on the broadcasting
@@ -143,7 +143,7 @@ async fn a_proposal_the_network_delivers_is_never_broadcast_in_the_clear() {
     } = spawn_run(local_node, 1, Some(membership(&[core_node], local_node))).await;
 
     msg_sender
-        .send(BlendPayload::BlockProposal(proposal.clone()).into())
+        .send(DataPayload::BlockProposal(proposal.clone()).into())
         .await
         .expect("channel opened");
     assert_eq!(
@@ -154,7 +154,7 @@ async fn a_proposal_the_network_delivers_is_never_broadcast_in_the_clear() {
     // Some exit node broadcast it, which is all the sender ever learns.
     broadcasting_channel
         .carrying
-        .send(BlendPayload::BlockProposal(proposal))
+        .send(DataPayload::BlockProposal(proposal))
         .expect("the service is subscribed");
 
     assert!(
@@ -187,7 +187,7 @@ async fn a_node_that_does_not_bypass_never_broadcasts_in_the_clear() {
     .await;
 
     msg_sender
-        .send(BlendPayload::BlockProposal(vec![7; 8]).into())
+        .send(DataPayload::BlockProposal(vec![7; 8]).into())
         .await
         .expect("channel opened");
     assert_eq!(
@@ -221,7 +221,7 @@ async fn a_transaction_the_network_never_delivers_is_broadcast_in_the_clear() {
     } = spawn_run(local_node, 1, Some(membership(&[core_node], local_node))).await;
 
     msg_sender
-        .send(BlendPayload::Transaction(transaction.clone()).into())
+        .send(DataPayload::Transaction(transaction.clone()).into())
         .await
         .expect("channel opened");
     assert_eq!(
@@ -236,7 +236,7 @@ async fn a_transaction_the_network_never_delivers_is_broadcast_in_the_clear() {
     .await
     .expect("the deadline must expire within the deadline")
     .expect("channel opened");
-    assert_eq!(broadcast, BlendPayload::Transaction(transaction));
+    assert_eq!(broadcast, DataPayload::Transaction(transaction));
 }
 
 /// [`run`] blends a transaction, drawing its layer proofs from the `PoW` branch
@@ -264,7 +264,7 @@ async fn run_blends_a_transaction() {
     .await;
 
     msg_sender
-        .send(BlendPayload::Transaction(vec![0]).into())
+        .send(DataPayload::Transaction(vec![0]).into())
         .await
         .expect("channel opened");
     assert_eq!(
@@ -529,7 +529,7 @@ async fn a_proposal_arriving_before_the_pol_info_is_still_blended() {
     // The gate is shut, so there is no handler yet: this is the window the
     // proposal used to die in.
     msg_sender
-        .send(ServiceMessage::Blend(BlendPayload::BlockProposal(
+        .send(ServiceMessage::Blend(DataPayload::BlockProposal(
             b"proposal".to_vec(),
         )))
         .await
@@ -578,14 +578,14 @@ async fn a_message_that_can_never_be_sent_does_not_block_the_rest() {
     // One byte over what a payload can hold, so encapsulating it fails the same
     // way however long it waits.
     msg_sender
-        .send(ServiceMessage::Blend(BlendPayload::BlockProposal(vec![
+        .send(ServiceMessage::Blend(DataPayload::BlockProposal(vec![
             0;
             MAX_PAYLOAD_BODY_SIZE + 1
         ])))
         .await
         .unwrap();
     msg_sender
-        .send(ServiceMessage::Blend(BlendPayload::Transaction(
+        .send(ServiceMessage::Blend(DataPayload::Transaction(
             b"transaction".to_vec(),
         )))
         .await

--- a/services/blend/src/instance.rs
+++ b/services/blend/src/instance.rs
@@ -20,7 +20,7 @@ use crate::{
         },
     },
     membership::MembershipInfo,
-    message::BlendPayload,
+    message::DataPayload,
     modes::{self, BroadcastMode, CoreMode, EdgeMode},
 };
 
@@ -50,7 +50,7 @@ impl<CoreService, EdgeService, RuntimeServiceId>
     Instance<CoreService, EdgeService, RuntimeServiceId>
 where
     CoreService: ServiceData<
-            Message: MessageComponents<CoreService::NodeId, Payload: Into<BlendPayload>>
+            Message: MessageComponents<CoreService::NodeId, Payload: Into<DataPayload>>
                          + Send
                          + Sync
                          + 'static,

--- a/services/blend/src/lib.rs
+++ b/services/blend/src/lib.rs
@@ -49,7 +49,7 @@ use crate::{
         chain::BlendEpochState,
         node_id::{self, TryFrom as _},
     },
-    message::{BlendPayload, ProxyServiceMessage},
+    message::{DataPayload, ProxyServiceMessage},
     settings::Settings,
 };
 
@@ -107,7 +107,7 @@ impl<CoreService, EdgeService, SdpService, RuntimeServiceId> ServiceCore<Runtime
     for BlendService<CoreService, EdgeService, SdpService, RuntimeServiceId>
 where
     CoreService: ServiceData<
-            Message: MessageComponents<CoreService::NodeId, Payload: Into<BlendPayload>>
+            Message: MessageComponents<CoreService::NodeId, Payload: Into<DataPayload>>
                          + Send
                          + Sync
                          + 'static,

--- a/services/blend/src/message.rs
+++ b/services/blend/src/message.rs
@@ -87,7 +87,7 @@ pub enum DataPayload {
     Transaction(Vec<u8>),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub enum DataPayloadType {
     BlockProposal,
     Transaction,

--- a/services/blend/src/message.rs
+++ b/services/blend/src/message.rs
@@ -1,9 +1,7 @@
 use core::fmt::{self, Debug, Formatter};
 
 pub use lb_blend::message::MAX_PAYLOAD_BODY_SIZE;
-use lb_blend::message::{
-    PayloadType, encap::validated::EncapsulatedMessageWithVerifiedPublicHeader,
-};
+use lb_blend::message::encap::validated::EncapsulatedMessageWithVerifiedPublicHeader;
 use lb_codec::BinaryEncode;
 use lb_core::{
     codec::SerializeOp,
@@ -49,7 +47,7 @@ impl<InnerMessage> From<InnerMessage> for ProxyServiceMessage<InnerMessage> {
 pub enum ServiceMessage<NodeId> {
     /// To send a payload through the blend network, for the exit node to
     /// hand over to whichever local service owns that kind of payload.
-    Blend(BlendPayload),
+    Blend(DataPayload),
     /// Request the current blend network info (connected peers).
     GetNetworkInfo {
         reply: oneshot::Sender<Option<NetworkInfo<NodeId>>>,
@@ -75,8 +73,8 @@ impl<NodeId> Debug for ServiceMessage<NodeId> {
     }
 }
 
-impl<NodeId> From<BlendPayload> for ServiceMessage<NodeId> {
-    fn from(value: BlendPayload) -> Self {
+impl<NodeId> From<DataPayload> for ServiceMessage<NodeId> {
+    fn from(value: DataPayload) -> Self {
         Self::Blend(value)
     }
 }
@@ -84,12 +82,27 @@ impl<NodeId> From<BlendPayload> for ServiceMessage<NodeId> {
 /// The plaintext body of a Blend data message, tagged with what it carries.
 // TODO: Replace with strong types for each message type Blend supports.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
-pub enum BlendPayload {
+pub enum DataPayload {
     BlockProposal(Vec<u8>),
     Transaction(Vec<u8>),
 }
 
-impl BlendPayload {
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum DataPayloadType {
+    BlockProposal,
+    Transaction,
+}
+
+impl AsRef<str> for DataPayloadType {
+    fn as_ref(&self) -> &str {
+        match self {
+            Self::BlockProposal => "block_proposal",
+            Self::Transaction => "transaction",
+        }
+    }
+}
+
+impl DataPayload {
     /// Encodes a transaction for blending, refusing one that could never fit.
     // TODO: This will go once we move away from `Vec<u8>` and into strong types
     // for each message type Blend supports. Then we can also implement `TryFrom`
@@ -128,10 +141,10 @@ impl BlendPayload {
 
     /// The wire discriminant this payload travels under.
     #[must_use]
-    pub const fn payload_type(&self) -> PayloadType {
+    pub const fn payload_type(&self) -> DataPayloadType {
         match self {
-            Self::BlockProposal(_) => PayloadType::BlockProposal,
-            Self::Transaction(_) => PayloadType::Transaction,
+            Self::BlockProposal(_) => DataPayloadType::BlockProposal,
+            Self::Transaction(_) => DataPayloadType::Transaction,
         }
     }
 
@@ -171,12 +184,12 @@ pub enum ProposalNotBlendable {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub enum ProcessedMessage {
-    Decapsulated(BlendPayload),
+    Decapsulated(DataPayload),
     Encapsulated(Box<EncapsulatedMessageWithVerifiedPublicHeader>),
 }
 
-impl From<BlendPayload> for ProcessedMessage {
-    fn from(value: BlendPayload) -> Self {
+impl From<DataPayload> for ProcessedMessage {
+    fn from(value: DataPayload) -> Self {
         Self::Decapsulated(value)
     }
 }

--- a/services/blend/src/metrics.rs
+++ b/services/blend/src/metrics.rs
@@ -1,5 +1,5 @@
 mod imp {
-    use lb_blend::message::PayloadType;
+    use crate::message::DataPayloadType;
 
     const ACTION_PUBLISH: &str = "publish";
     const ACTION_FORWARD: &str = "forward";
@@ -79,9 +79,9 @@ mod imp {
         lb_tracing::increase_counter_u64!(blend_core_peers_blocked_total, 1, reason = reason);
     }
 
-    /// Reports a payload the Blend network failed to deliver within the
+    /// Reports a data payload the Blend network failed to deliver within the
     /// delivery deadline, and that this node therefore broadcast in the clear.
-    pub fn payload_bypassed_blend(payload_type: PayloadType) {
+    pub fn data_payload_bypassed_blend(payload_type: DataPayloadType) {
         lb_tracing::increase_counter_u64!(
             blend_payloads_bypassed_total,
             1,

--- a/services/blend/src/modes/broadcast.rs
+++ b/services/blend/src/modes/broadcast.rs
@@ -13,7 +13,7 @@ use overwatch::{
 
 use crate::{
     core::{dispatcher::PayloadDispatcher, service_components::MessageComponents},
-    message::{BlendPayload, NetworkInfo},
+    message::{DataPayload, NetworkInfo},
     modes::Error,
 };
 
@@ -72,7 +72,7 @@ where
 {
     pub async fn handle_inbound_message<Message>(&self, message: Message) -> Result<(), Error>
     where
-        Message: MessageComponents<NodeId, Payload: Into<BlendPayload>> + Send + Sync + 'static,
+        Message: MessageComponents<NodeId, Payload: Into<DataPayload>> + Send + Sync + 'static,
     {
         match message.try_into_network_info_request() {
             Ok(reply) => {
@@ -286,7 +286,7 @@ pub mod tests {
             }
         }
 
-        async fn dispatch(&self, payload: BlendPayload) {
+        async fn dispatch(&self, payload: DataPayload) {
             debug!("Dispatching payload: {payload:?}");
             let message = payload.body().to_vec();
             self.relay
@@ -299,7 +299,7 @@ pub mod tests {
                 .unwrap();
         }
 
-        async fn observe_broadcasts(&self) -> BoxStream<'static, BlendPayload> {
+        async fn observe_broadcasts(&self) -> BoxStream<'static, DataPayload> {
             stream::empty().boxed()
         }
     }
@@ -308,10 +308,10 @@ pub mod tests {
     pub struct TestMessage(Vec<u8>);
 
     impl<NodeId> MessageComponents<NodeId> for TestMessage {
-        type Payload = BlendPayload;
+        type Payload = DataPayload;
 
         fn into_payload(self) -> Self::Payload {
-            BlendPayload::BlockProposal(self.0)
+            DataPayload::BlockProposal(self.0)
         }
 
         fn try_into_pending_transactions_request(

--- a/services/blend/src/test_utils/dispatcher.rs
+++ b/services/blend/src/test_utils/dispatcher.rs
@@ -10,7 +10,7 @@ use tokio_stream::wrappers::{BroadcastStream, errors::BroadcastStreamRecvError};
 
 use crate::{
     core::dispatcher::PayloadDispatcher,
-    message::BlendPayload,
+    message::DataPayload,
     test_utils::mocks::{TestChainNetworkService, TestMempoolService},
 };
 
@@ -20,15 +20,15 @@ const CHANNEL_SIZE: usize = 32;
 /// control: what the node hands over is reported on one channel, and what the
 /// broadcasting channel is carrying is fed in on the other.
 pub struct TestPayloadDispatcher {
-    dispatched: mpsc::UnboundedSender<BlendPayload>,
-    broadcasting_channel: broadcast::Sender<BlendPayload>,
+    dispatched: mpsc::UnboundedSender<DataPayload>,
+    broadcasting_channel: broadcast::Sender<DataPayload>,
 }
 
 /// What a test holds on to: the payloads the node dispatched, and the handle it
 /// puts payloads on the broadcasting channel with.
 pub struct TestBroadcastingChannel {
-    pub dispatched: mpsc::UnboundedReceiver<BlendPayload>,
-    pub carrying: broadcast::Sender<BlendPayload>,
+    pub dispatched: mpsc::UnboundedReceiver<DataPayload>,
+    pub carrying: broadcast::Sender<DataPayload>,
 }
 
 impl TestPayloadDispatcher {
@@ -70,14 +70,14 @@ where
         Self::new().0
     }
 
-    async fn dispatch(&self, payload: BlendPayload) {
+    async fn dispatch(&self, payload: DataPayload) {
         drop(self.dispatched.send(payload));
     }
 
-    async fn observe_broadcasts(&self) -> BoxStream<'static, BlendPayload> {
+    async fn observe_broadcasts(&self) -> BoxStream<'static, DataPayload> {
         BroadcastStream::new(self.broadcasting_channel.subscribe())
             .filter_map(
-                async |payload: Result<BlendPayload, BroadcastStreamRecvError>| payload.ok(),
+                async |payload: Result<DataPayload, BroadcastStreamRecvError>| payload.ok(),
             )
             .boxed()
     }

--- a/services/blend/src/test_utils/dispatcher.rs
+++ b/services/blend/src/test_utils/dispatcher.rs
@@ -76,9 +76,7 @@ where
 
     async fn observe_broadcasts(&self) -> BoxStream<'static, DataPayload> {
         BroadcastStream::new(self.broadcasting_channel.subscribe())
-            .filter_map(
-                async |payload: Result<DataPayload, BroadcastStreamRecvError>| payload.ok(),
-            )
+            .filter_map(async |payload: Result<DataPayload, BroadcastStreamRecvError>| payload.ok())
             .boxed()
     }
 }

--- a/services/chain/chain-leader/src/blend.rs
+++ b/services/chain/chain-leader/src/blend.rs
@@ -8,7 +8,7 @@
 
 use std::marker::PhantomData;
 
-use lb_blend_service::message::{BlendPayload, ProxyServiceMessage, ServiceMessage};
+use lb_blend_service::message::{DataPayload, ProxyServiceMessage, ServiceMessage};
 use lb_codec::BinaryEncode as _;
 use lb_core::block::Proposal;
 use lb_log_targets::chain;
@@ -51,7 +51,7 @@ where
         if let Err((e, _)) = self
             .relay
             .send(
-                ServiceMessage::Blend(BlendPayload::BlockProposal(proposal.encode_to_vec())).into(),
+                ServiceMessage::Blend(DataPayload::BlockProposal(proposal.encode_to_vec())).into(),
             )
             .await
         {

--- a/services/pow/src/service.rs
+++ b/services/pow/src/service.rs
@@ -12,7 +12,7 @@ use std::{
 use futures::{Stream, StreamExt as _};
 use lb_blend_service::{
     api::{ApiError as BlendApiError, BlendServiceApi, BlendServiceData},
-    message::{BlendPayload, MAX_PAYLOAD_BODY_SIZE, TransactionNotBlendable},
+    message::{DataPayload, MAX_PAYLOAD_BODY_SIZE, TransactionNotBlendable},
 };
 use lb_chain_service::{
     ProcessedBlockEvent, Slot,
@@ -1510,7 +1510,7 @@ where
     BlendService::NodeId: Send,
     RuntimeServiceId: Sync,
 {
-    let payload = BlendPayload::try_from_transaction(&signed_tx)?;
+    let payload = DataPayload::try_from_transaction(&signed_tx)?;
     blend_api.publish(payload).await?;
     Ok(())
 }


### PR DESCRIPTION
## 1. What does this PR implement?

This PR fixes a previous misconception baked into the Blend code: because block proposals and transactions are both called data messages, we treated them both almost the same everywhere. Nevertheless, while block proposals are meant to interact with the cover release schedule to maintain indistinguishability, transactions are not. This PR hence fixes that. Among all the designs considered, this sounded the most simple to me, because `DataMessage` is a generic in the underlying machinery so there is no other way of accounting for one without skipping a cover message if not by manually saying so via the API.

## 2. Does the code have enough context to be clearly understood?

Yes.

## 3. Who are the specification authors and who is accountable for this PR?

@madxor spec @ntn-x2 impl

## 4. Is the specification accurate and complete?

Yes.

## 5. Does the implementation introduce changes in the specification?

No. It fixes a minor inconsistency.