### PR TITLE
fix: Make git and the flake's rev available to build scripts in nix builds

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -98,17 +98,17 @@
         ]
       },
       "locked": {
-        "lastModified": 1787281715,
-        "narHash": "sha256-5yIL5XL31hCZBPWDdUOvUy4cYAl27XZrke7JELhHlnI=",
+        "lastModified": 1788505699,
+        "narHash": "sha256-PSPDCdbEBEbSDCWcqv5GkbyD2ACQ9Diz6vmEbWdy4dM=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "89abdfd661ea493cde2f73d7b1332cb34150aa43",
+        "rev": "9eccf73c5b810052f08aa77ae0548c383259f17f",
         "type": "github"
       },
       "original": {
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "89abdfd661ea493cde2f73d7b1332cb34150aa43",
+        "rev": "9eccf73c5b810052f08aa77ae0548c383259f17f",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -24,6 +24,7 @@
 
   outputs =
     {
+      self,
       nixpkgs,
       rust-overlay,
       crane,
@@ -87,7 +88,15 @@
               pkgs.pkg-config
               pkgs.clang
               pkgs.llvmPackages.libclang.lib
+              pkgs.git
             ];
+            # The source is a git-less snapshot; give `git rev-parse HEAD` the flake's rev.
+            preBuild = pkgs.lib.optionalString (self ? rev) ''
+              if [ ! -e .git ]; then
+                git init -q
+                echo ${self.rev} > .git/HEAD
+              fi
+            '';
             LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
             LBC_ROOT_DIR = logos-blockchain-circuits.packages.${system}.default;
             RAPIDSNARK_LIB_DIR = rust-rapidsnark.packages.${system}.rapidsnark;


### PR DESCRIPTION
## 1. What does this PR implement?

The base [PR](https://github.com/logos-blockchain/logos-blockchain/pull/3498) fixes commit hash issue in docker, but we had the same issue with the nix builds, change passes git commit to the flake sandbox in order to keep build.rs unmodified.

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

N/A

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

N/A

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
