### PR TITLE
chore: cargo-deny

### DIFF
--- a/.cargo-deny.toml
+++ b/.cargo-deny.toml
@@ -8,7 +8,6 @@ exclude-dev  = false
 ignore = [
   { id = "RUSTSEC-2024-0388", reason = "`derivative` is unmaintained. No workspace crate depends on it directly. Pulled in via `ark-groth16` -> `ark-crypto-primitives`, which requires it non-optionally in both 0.5 and 0.6, so no arkworks upgrade can drop it. Re-evaluate this entry on future arkworks releases." },
   { id = "RUSTSEC-2024-0436", reason = "`paste` is unmaintained. No workspace crate depends on it directly. Pulled in via `ark-ff` 0.5 (removed in 0.6, which needs jellyfish/`jf-poseidon2` on arkworks 0.6 first) and via `netlink-packet-core` 0.8 behind libp2p's `if-watch` (removed in 0.9, but `if-watch` 3.2.2 still requires ^0.8.1). Re-evaluate this entry in the future and drop it once/if both are gone." },
-  { id = "RUSTSEC-2025-0055", reason = "`tracing-subscriber` v0.2.25 pulled in by ark-relations v0.4.0 - will be addressed before mainnet" },
   { id = "RUSTSEC-2025-0141", reason = "`bincode` is unmaintained but continuing to use it." },
   { id = "RUSTSEC-2026-0118", reason = "`hickory-proto` can enter an unbounded DNSSEC NSEC3 validation loop and exhaust memory; pulled in through libp2p." },
   { id = "RUSTSEC-2026-0119", reason = "`hickory-proto` DNS message compression can cause CPU exhaustion during encoding; pulled in through libp2p." },

--- a/.cargo-deny.toml
+++ b/.cargo-deny.toml
@@ -5,15 +5,16 @@ all-features = true
 exclude-dev  = false
 
 [advisories]
+# When adding a new line, please consider to which group the advisory belongs, and whether the issue can be fixed by upgrading some dependencies.
 ignore = [
   # Unmaintained deps. To review periodically to check if they can be removed with an upgrade.
   { id = "RUSTSEC-2024-0388", reason = "`derivative` is unmaintained. No workspace crate depends on it directly. Pulled in via `ark-groth16` -> `ark-crypto-primitives`, which requires it non-optionally in both 0.5 and 0.6, so no arkworks upgrade can drop it. Re-evaluate this entry on future arkworks releases." },
   { id = "RUSTSEC-2024-0436", reason = "`paste` is unmaintained. No workspace crate depends on it directly. Pulled in via `ark-ff` 0.5 (removed in 0.6, which needs jellyfish/`jf-poseidon2` on arkworks 0.6 first) and via `netlink-packet-core` 0.8 behind libp2p's `if-watch` (removed in 0.9, but `if-watch` 3.2.2 still requires ^0.8.1). Re-evaluate this entry in the future and drop it once/if both are gone." },
-  # Vulnerable deps, affecting out production code. To review periodically to check if they can be removed with an upgrade.
+  # Vulnerable deps, affecting our production code. To review periodically to check if they can be removed with an upgrade.
   { id = "RUSTSEC-2026-0119", reason = "`hickory-proto` O(n^2) name compression during DNS message *encoding* (no feature gate, so the code is present). We use it only as a stub resolver behind `libp2p` `.with_dns()`, encoding small outbound queries rather than many-record responses, so exposure is low. Fixed in `hickory-proto` 0.26.1+, but `libp2p-dns` 0.44.0 (latest) still requires `hickory-resolver` ^0.25.2, so the upgrade is blocked upstream." },
-
   # Unmaintained deps. Acknowledged but a replacement has not been decided yet.
   { id = "RUSTSEC-2025-0141", reason = "`bincode` is unmaintained but continuing to use it." },
+
   # Vulnerable deps, not affecting our production code.
   { id = "RUSTSEC-2026-0118", reason = "`hickory-proto` unbounded NSEC3 closest-encloser loop. NOT APPLICABLE to our build: the advisory requires the `dnssec-ring` or `dnssec-aws-lc-rs` feature, and the only features we enable on `hickory-proto` 0.25.2 are `std`, `tokio` and `futures-io`, so the vulnerable validator is not compiled in. Kept only because cargo-deny matches on crate version, not enabled features. Reached solely via `libp2p` -> `libp2p-dns` -> `hickory-resolver`." },
   { id = "RUSTSEC-2026-0194", reason = "`quick-xml` < 0.41 quadratic duplicate-attribute scan when parsing untrusted XML. Reached only through the optional `profiling` feature (`lb-http-api-common` -> `pprof` 0.15 -> `inferno` 0.11 -> `quick-xml` 0.26); `pprof` is absent from default node builds and no CI or release build enables it. `inferno` uses `quick-xml` to WRITE flamegraph SVG from our own profiler output - we never feed it untrusted XML, and the affected APIs are parser-side. `inferno` 0.12.8 already uses the patched `quick-xml` ^0.41, but `pprof` 0.15.0 (latest) pins `inferno` ^0.11, so this is blocked upstream. The patched `quick-xml` 0.41.0 is already in the graph via `junit-report`; only the 0.26 copy is affected." },
@@ -29,9 +30,8 @@ allow-wildcard-paths = false
 multiple-versions    = "allow"
 
 [bans.std-replacements]
-level        = "deny"
-rust-version = "1.0"
-scope        = "workspace"
+level = "deny"
+scope = "workspace"
 
 [bans.workspace-dependencies]
 duplicates = "deny"
@@ -54,7 +54,6 @@ allow = [
   "Unicode-3.0",
   "Zlib",
 ]
-confidence-threshold = 0.93
 private = { ignore = false }
 unused-allowed-license = "deny"
 unused-license-exception = "deny"

--- a/.cargo-deny.toml
+++ b/.cargo-deny.toml
@@ -1,9 +1,8 @@
 # Config file reference can be found at https://embarkstudios.github.io/cargo-deny/checks/cfg.html.
 
 [graph]
-all-features        = true
-exclude-dev         = true
-no-default-features = true
+all-features = true
+exclude-dev  = false
 
 [advisories]
 ignore = [
@@ -17,12 +16,23 @@ ignore = [
   { id = "RUSTSEC-2026-0194", reason = "`quick-xml` v0.26 is pulled in by pprof (via inferno) and will not parse untrusted XML." },
   { id = "RUSTSEC-2026-0195", reason = "`quick-xml` v0.26 is pulled in by pprof (via inferno) and will not parse untrusted XML." },
 ]
+unmaintained = "all"
+unsound = "all"
 unused-ignored-advisory = "deny"
 yanked = "deny"
 
 [bans]
 allow-wildcard-paths = false
 multiple-versions    = "allow"
+
+[bans.std-replacements]
+level        = "deny"
+rust-version = "1.0"
+scope        = "workspace"
+
+[bans.workspace-dependencies]
+duplicates = "deny"
+unused     = "deny"
 
 [licenses]
 allow = [
@@ -41,8 +51,10 @@ allow = [
   "Unicode-3.0",
   "Zlib",
 ]
+confidence-threshold = 0.93
 private = { ignore = false }
 unused-allowed-license = "deny"
+unused-license-exception = "deny"
 
 [sources]
 allow-git = [
@@ -52,8 +64,11 @@ allow-git = [
   "https://github.com/logos-blockchain/logos-blockchain-rust-rapidsnark.git",
   "https://github.com/logos-blockchain/logos-blockchain-testing.git",
 ]
+required-git-spec = "tag"
 unknown-git = "deny"
 unknown-registry = "deny"
+unused-allowed-org = "deny"
+unused-allowed-source = "deny"
 
 [sources.allow-org]
 github = ["logos-co"]

--- a/.cargo-deny.toml
+++ b/.cargo-deny.toml
@@ -6,14 +6,18 @@ exclude-dev  = false
 
 [advisories]
 ignore = [
+  # Unmaintained deps. To review periodically to check if they can be removed with an upgrade.
   { id = "RUSTSEC-2024-0388", reason = "`derivative` is unmaintained. No workspace crate depends on it directly. Pulled in via `ark-groth16` -> `ark-crypto-primitives`, which requires it non-optionally in both 0.5 and 0.6, so no arkworks upgrade can drop it. Re-evaluate this entry on future arkworks releases." },
   { id = "RUSTSEC-2024-0436", reason = "`paste` is unmaintained. No workspace crate depends on it directly. Pulled in via `ark-ff` 0.5 (removed in 0.6, which needs jellyfish/`jf-poseidon2` on arkworks 0.6 first) and via `netlink-packet-core` 0.8 behind libp2p's `if-watch` (removed in 0.9, but `if-watch` 3.2.2 still requires ^0.8.1). Re-evaluate this entry in the future and drop it once/if both are gone." },
+  # Vulnerable deps, affecting out production code. To review periodically to check if they can be removed with an upgrade.
+  { id = "RUSTSEC-2026-0119", reason = "`hickory-proto` O(n^2) name compression during DNS message *encoding* (no feature gate, so the code is present). We use it only as a stub resolver behind `libp2p` `.with_dns()`, encoding small outbound queries rather than many-record responses, so exposure is low. Fixed in `hickory-proto` 0.26.1+, but `libp2p-dns` 0.44.0 (latest) still requires `hickory-resolver` ^0.25.2, so the upgrade is blocked upstream." },
+
+  # Unmaintained deps. Acknowledged but a replacement has not been decided yet.
   { id = "RUSTSEC-2025-0141", reason = "`bincode` is unmaintained but continuing to use it." },
-  { id = "RUSTSEC-2026-0118", reason = "`hickory-proto` can enter an unbounded DNSSEC NSEC3 validation loop and exhaust memory; pulled in through libp2p." },
-  { id = "RUSTSEC-2026-0119", reason = "`hickory-proto` DNS message compression can cause CPU exhaustion during encoding; pulled in through libp2p." },
-  { id = "RUSTSEC-2026-0173", reason = "`proc-macro-error2` is unmaintained." },
-  { id = "RUSTSEC-2026-0194", reason = "`quick-xml` v0.26 is pulled in by pprof (via inferno) and will not parse untrusted XML." },
-  { id = "RUSTSEC-2026-0195", reason = "`quick-xml` v0.26 is pulled in by pprof (via inferno) and will not parse untrusted XML." },
+  # Vulnerable deps, not affecting our production code.
+  { id = "RUSTSEC-2026-0118", reason = "`hickory-proto` unbounded NSEC3 closest-encloser loop. NOT APPLICABLE to our build: the advisory requires the `dnssec-ring` or `dnssec-aws-lc-rs` feature, and the only features we enable on `hickory-proto` 0.25.2 are `std`, `tokio` and `futures-io`, so the vulnerable validator is not compiled in. Kept only because cargo-deny matches on crate version, not enabled features. Reached solely via `libp2p` -> `libp2p-dns` -> `hickory-resolver`." },
+  { id = "RUSTSEC-2026-0194", reason = "`quick-xml` < 0.41 quadratic duplicate-attribute scan when parsing untrusted XML. Reached only through the optional `profiling` feature (`lb-http-api-common` -> `pprof` 0.15 -> `inferno` 0.11 -> `quick-xml` 0.26); `pprof` is absent from default node builds and no CI or release build enables it. `inferno` uses `quick-xml` to WRITE flamegraph SVG from our own profiler output - we never feed it untrusted XML, and the affected APIs are parser-side. `inferno` 0.12.8 already uses the patched `quick-xml` ^0.41, but `pprof` 0.15.0 (latest) pins `inferno` ^0.11, so this is blocked upstream. The patched `quick-xml` 0.41.0 is already in the graph via `junit-report`; only the 0.26 copy is affected." },
+  { id = "RUSTSEC-2026-0195", reason = "`quick-xml` < 0.41 unbounded `NsReader` namespace-declaration allocation when parsing untrusted XML. Reached only through the optional `profiling` feature (`lb-http-api-common` -> `pprof` 0.15 -> `inferno` 0.11 -> `quick-xml` 0.26); `pprof` is absent from default node builds and no CI or release build enables it. `inferno` uses `quick-xml` to WRITE flamegraph SVG from our own profiler output - we never feed it untrusted XML, and the affected APIs are parser-side. `inferno` 0.12.8 already uses the patched `quick-xml` ^0.41, but `pprof` 0.15.0 (latest) pins `inferno` ^0.11, so this is blocked upstream. The patched `quick-xml` 0.41.0 is already in the graph via `junit-report`; only the 0.26 copy is affected." },
 ]
 unmaintained = "all"
 unsound = "all"

--- a/.cargo-deny.toml
+++ b/.cargo-deny.toml
@@ -6,8 +6,8 @@ exclude-dev  = false
 
 [advisories]
 ignore = [
-  { id = "RUSTSEC-2024-0388", reason = "`derivative` is unmaintained; consider using an alternative. Use `cargo tree -p derivative -i > tmp.txt` to check the dependency tree." },
-  { id = "RUSTSEC-2024-0436", reason = "`paste` has a security vulnerability; consider using an alternative. Use `cargo tree -p paste -i > tmp.txt` to check the dependency tree." },
+  { id = "RUSTSEC-2024-0388", reason = "`derivative` is unmaintained. No workspace crate depends on it directly. Pulled in via `ark-groth16` -> `ark-crypto-primitives`, which requires it non-optionally in both 0.5 and 0.6, so no arkworks upgrade can drop it. Re-evaluate this entry on future arkworks releases." },
+  { id = "RUSTSEC-2024-0436", reason = "`paste` is unmaintained. No workspace crate depends on it directly. Pulled in via `ark-ff` 0.5 (removed in 0.6, which needs jellyfish/`jf-poseidon2` on arkworks 0.6 first) and via `netlink-packet-core` 0.8 behind libp2p's `if-watch` (removed in 0.9, but `if-watch` 3.2.2 still requires ^0.8.1). Re-evaluate this entry in the future and drop it once/if both are gone." },
   { id = "RUSTSEC-2025-0055", reason = "`tracing-subscriber` v0.2.25 pulled in by ark-relations v0.4.0 - will be addressed before mainnet" },
   { id = "RUSTSEC-2025-0141", reason = "`bincode` is unmaintained but continuing to use it." },
   { id = "RUSTSEC-2026-0118", reason = "`hickory-proto` can enter an unbounded DNSSEC NSEC3 validation loop and exhaust memory; pulled in through libp2p." },

--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -54,10 +54,10 @@ jobs:
       # Thus, results may differ from local runs.
       # To avoid this, we install and run `cargo-deny` manually.
       - name: Install cargo-deny
-        run: cargo install cargo-deny --locked --version 0.19.0
+        run: cargo install cargo-deny --locked --version 0.20.2
 
       - name: Run cargo-deny
-        run: CARGO_BUILD_WARNINGS=deny cargo-deny --locked --all-features check --hide-inclusion-graph -c .cargo-deny.toml --show-stats
+        run: CARGO_BUILD_WARNINGS=deny cargo-deny --locked --config .cargo-deny.toml check --hide-inclusion-graph --show-stats
 
   workspace-deps:
     name: Check for correctly declared dependencies in the workspace

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
           ["--all", "--all-targets", "--all-features", "--", "-D", "warnings"]
         pass_filenames: false
   - repo: https://github.com/EmbarkStudios/cargo-deny
-    rev: 09faadcea2d0d1742492e6872b743d1e4d151a27 # 0.19.0
+    rev: bca0dde53651ee946720e4540b5ce2610bec8f06 # 0.20.2
     hooks:
       - id: cargo-deny
         args:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,7 +204,7 @@ dependencies = [
  "ark-poly",
  "ark-serialize",
  "ark-std",
- "educe",
+ "educe 0.6.0",
  "fnv",
  "hashbrown 0.15.5",
  "itertools 0.13.0",
@@ -226,7 +226,7 @@ dependencies = [
  "ark-std",
  "arrayvec",
  "digest",
- "educe",
+ "educe 0.6.0",
  "itertools 0.13.0",
  "num-bigint",
  "num-traits",
@@ -282,7 +282,7 @@ dependencies = [
  "ark-ff",
  "ark-serialize",
  "ark-std",
- "educe",
+ "educe 0.6.0",
  "fnv",
  "hashbrown 0.15.5",
 ]
@@ -1886,6 +1886,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "educe"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e451fac8dd8dece16234604bf1efce6e90fddd8ab6ad4d66eec0eca5160959dd"
+dependencies = [
+ "enum-ordinalize",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.5",
+]
+
+[[package]]
 name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1930,22 +1942,22 @@ dependencies = [
 
 [[package]]
 name = "enum-ordinalize"
-version = "4.3.2"
+version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a1091a7bb1f8f2c4b28f1fe2cef4980ca2d410a3d727d67ecc3178c9b0800f0"
+checksum = "89dd01549b09589510cf0647475075d12071456586d70f5c75c98ae2a5537677"
 dependencies = [
  "enum-ordinalize-derive",
 ]
 
 [[package]]
 name = "enum-ordinalize-derive"
-version = "4.3.2"
+version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ca9601fb2d62598ee17836250842873a413586e5d7ed88b356e38ddbb0ec631"
+checksum = "a65863d15a4ce2888bd2f0f543cc963d3879c3a022c8ee43f6141d479a3ac815"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -3385,7 +3397,7 @@ dependencies = [
  "async-broadcast",
  "async-stream",
  "backon",
- "educe",
+ "educe 0.6.0",
  "futures",
  "hashbrown 0.16.1",
  "hostname 0.4.2",
@@ -4061,8 +4073,8 @@ version = "0.0.0"
 dependencies = [
  "bincode",
  "blake2",
- "derivative",
  "divan",
+ "educe 0.7.6",
  "hex",
  "itertools 0.14.0",
  "logos-blockchain-blend-crypto",
@@ -4141,7 +4153,7 @@ name = "logos-blockchain-blend-provers"
 version = "0.0.0"
 dependencies = [
  "async-trait",
- "derivative",
+ "educe 0.7.6",
  "futures",
  "hex",
  "libp2p",
@@ -4261,7 +4273,7 @@ name = "logos-blockchain-chain-broadcast-service"
 version = "0.0.0"
 dependencies = [
  "async-trait",
- "derivative",
+ "educe 0.7.6",
  "logos-blockchain-core",
  "logos-blockchain-log-targets",
  "overwatch",
@@ -4342,7 +4354,7 @@ version = "0.0.0"
 dependencies = [
  "async-trait",
  "bytes",
- "derivative",
+ "educe 0.7.6",
  "futures",
  "logos-blockchain-chain-broadcast-service",
  "logos-blockchain-core",
@@ -4747,8 +4759,8 @@ dependencies = [
 name = "logos-blockchain-ledger"
 version = "0.0.0"
 dependencies = [
- "derivative",
  "divan",
+ "educe 0.7.6",
  "logos-blockchain-blend-crypto",
  "logos-blockchain-blend-message",
  "logos-blockchain-blend-proofs",
@@ -5123,9 +5135,9 @@ dependencies = [
  "axum 0.7.9",
  "bincode",
  "cucumber",
- "derivative",
  "divan",
  "ed25519",
+ "educe 0.7.6",
  "futures",
  "futures-util",
  "hex",
@@ -8038,6 +8050,17 @@ name = "syn"
 version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12df2e0110f65b775f769bb17ef989067a1d931b2eb822bd4346631eeada89f9"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1986,11 +1986,10 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.4.1"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]
@@ -5279,7 +5278,6 @@ dependencies = [
  "logos-blockchain-storage-service",
  "logos-blockchain-tracing",
  "logos-blockchain-tracing-service",
- "logos-blockchain-tx-service",
  "logos-blockchain-utils",
  "overwatch",
  "overwatch-derive",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1489,36 +1489,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
-dependencies = [
- "darling_core 0.20.11",
- "darling_macro 0.20.11",
-]
-
-[[package]]
-name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core 0.23.0",
- "darling_macro 0.23.0",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn 2.0.118",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -1536,22 +1512,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
-dependencies = [
- "darling_core 0.20.11",
- "quote",
- "syn 2.0.118",
-]
-
-[[package]]
-name = "darling_macro"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core 0.23.0",
+ "darling_core",
  "quote",
  "syn 2.0.118",
 ]
@@ -1579,7 +1544,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 2.0.118",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -6599,6 +6564,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error-attr3"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e564d14133360e1ae169ffde5da25881b5fa47261665b8e5713c212c27799da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "proc-macro-error2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6608,6 +6583,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "proc-macro-error3"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f0d4471b3436c22106b21913b1dda531558918ae9b7ec55d58aa84b43552233"
+dependencies = [
+ "proc-macro-error-attr3",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -7728,7 +7715,7 @@ version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
- "darling 0.23.0",
+ "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -9214,13 +9201,12 @@ dependencies = [
 
 [[package]]
 name = "validator_derive"
-version = "0.20.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7df16e474ef958526d1205f6dda359fdfab79d9aa6d54bafcb92dcd07673dca"
+checksum = "240e4b81c20a1d6d50d1d7265c658dfbd204e8b9ac4d80f3c931f39462196335"
 dependencies = [
- "darling 0.20.11",
- "once_cell",
- "proc-macro-error2",
+ "darling",
+ "proc-macro-error3",
  "proc-macro2",
  "quote",
  "syn 2.0.118",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -296,7 +296,6 @@ dependencies = [
  "ark-ff",
  "ark-std",
  "tracing",
- "tracing-subscriber 0.2.25",
 ]
 
 [[package]]
@@ -1180,7 +1179,7 @@ dependencies = [
  "tonic",
  "tracing",
  "tracing-core",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -4644,6 +4643,7 @@ dependencies = [
  "ark-ec",
  "ark-ff",
  "ark-groth16",
+ "ark-relations",
  "ark-serialize",
  "bincode",
  "generic-array 1.4.3",
@@ -4811,7 +4811,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber",
  "zerocopy",
 ]
 
@@ -4878,7 +4878,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber",
  "utoipa",
 ]
 
@@ -5183,7 +5183,7 @@ dependencies = [
  "time",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -5254,7 +5254,7 @@ dependencies = [
  "tracing-gelf",
  "tracing-loki",
  "tracing-opentelemetry",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber",
  "url",
 ]
 
@@ -5273,7 +5273,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-appender",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -6152,7 +6152,7 @@ dependencies = [
  "opentelemetry",
  "tracing",
  "tracing-core",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -8235,7 +8235,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b9c218384242b5c89b68303ab6f6fc53a312d923f0c14dc6bb860c6aeee40f1"
 dependencies = [
  "test-log-macros",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -8824,7 +8824,7 @@ dependencies = [
  "symlink",
  "thiserror 2.0.18",
  "time",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -8874,7 +8874,7 @@ dependencies = [
  "tokio-util",
  "tracing-core",
  "tracing-futures",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -8904,7 +8904,7 @@ dependencies = [
  "tracing-core",
  "tracing-log",
  "tracing-serde",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber",
  "url",
 ]
 
@@ -8919,7 +8919,7 @@ dependencies = [
  "smallvec",
  "tracing",
  "tracing-core",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber",
  "web-time",
 ]
 
@@ -8930,15 +8930,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
 dependencies = [
  "serde",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-subscriber"
-version = "0.2.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71"
-dependencies = [
  "tracing-core",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -184,6 +184,7 @@ ark-bn254                          = { default-features = false, version = "0.5"
 ark-ec                             = { default-features = false, version = "0.5" }
 ark-ff                             = { default-features = false, version = "0.5" }
 ark-groth16                        = { default-features = false, version = "0.5" }
+ark-relations                      = { default-features = false, version = "0.5" }
 ark-serialize                      = { default-features = false, version = "0.5" }
 astro-float                        = { default-features = false, version = "0.9" }
 async-ctrlc                        = { default-features = false, version = "1.2" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -202,11 +202,11 @@ color-eyre                         = { default-features = false, version = "0.6.
 console-subscriber                 = { default-features = false, version = "0.5" }
 const-hex                          = { default-features = false, version = "1" }
 cucumber                           = { default-features = false, version = "=0.23.0" }
-derivative                         = { default-features = false, version = "2" }
 dhat                               = { default-features = false, version = "0.3.3" }
 divan                              = { default-features = false, version = "0.1" }
 ed25519                            = { default-features = false, version = "2.2.3" }
 ed25519-dalek                      = { default-features = false, version = "2" }
+educe                              = { default-features = false, version = "0.7.6" }
 either                             = { default-features = false, version = "1.15.0" }
 flate2                             = { default-features = false, version = "1.1.9" }
 fork_stream                        = { default-features = false, version = "0.1.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -197,7 +197,6 @@ boon                               = { default-features = false, version = "0.6"
 bytes                              = { default-features = false, version = "1.3" }
 cbindgen                           = { default-features = false, version = "0.29" }
 chrono                             = { default-features = false, version = "0.4" }
-cipher                             = { default-features = false, version = "0.4" }
 clap                               = { default-features = false, version = "4" }
 color-eyre                         = { default-features = false, version = "0.6.0" }
 console-subscriber                 = { default-features = false, version = "0.5" }
@@ -253,7 +252,6 @@ rand                               = { default-features = false, version = "0.8"
 rand_chacha                        = { default-features = false, version = "0.3" }
 rand_core                          = { default-features = false, version = "0.6.4" }
 rayon                              = { default-features = false, version = "1.12" }
-redb                               = { default-features = false, version = "2.2" }
 reqwest                            = { default-features = false, version = "0.12" }
 rocksdb                            = { default-features = false, version = "0.24" }
 rpds                               = { default-features = false, version = "1" }

--- a/blend/message/Cargo.toml
+++ b/blend/message/Cargo.toml
@@ -14,7 +14,7 @@ workspace = true
 
 [dependencies]
 blake2                        = { workspace = true }
-derivative                    = { workspace = true }
+educe                         = { features = ["Debug"], workspace = true }
 hex                           = { workspace = true }
 itertools                     = { workspace = true }
 lb-blend-crypto               = { workspace = true }

--- a/blend/message/src/encap/encapsulated.rs
+++ b/blend/message/src/encap/encapsulated.rs
@@ -1,6 +1,6 @@
 use core::num::NonZeroU64;
 
-use derivative::Derivative;
+use educe::Educe;
 use itertools::Itertools as _;
 use lb_blend_crypto::{ZkHash, cipher::Cipher, pseudo_random_sized_bytes, random_sized_bytes};
 use lb_blend_proofs::{
@@ -39,13 +39,13 @@ const LOG_TARGET: &str = blend::message::ROOT;
 pub type MessageIdentifier = ZkHash;
 
 /// An unverified encapsulated message that is received from a peer.
-#[derive(Derivative, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
-#[derivative(Debug)]
+#[derive(Educe, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[educe(Debug)]
 pub struct EncapsulatedMessage {
     /// A public header that is not encapsulated.
     public_header: PublicHeader,
     /// Encapsulated parts
-    #[derivative(Debug = "ignore")] // too long
+    #[educe(Debug(ignore))] // too long
     encapsulated_part: EncapsulatedPart,
 }
 

--- a/blend/message/src/encap/validated.rs
+++ b/blend/message/src/encap/validated.rs
@@ -1,4 +1,4 @@
-use derivative::Derivative;
+use educe::Educe;
 use lb_blend_crypto::random_sized_bytes;
 use lb_blend_proofs::{
     quota::{self, VerifiedProofOfQuota},
@@ -23,12 +23,12 @@ use crate::{
     reward::BlendingToken,
 };
 
-#[derive(Derivative, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
-#[derivative(Debug)]
+#[derive(Educe, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
+#[educe(Debug)]
 /// An encapsulated message whose public header signature has been verified.
 pub struct EncapsulatedMessageWithVerifiedSignature {
     public_header_with_verified_signature: PublicHeaderWithVerifiedSignature,
-    #[derivative(Debug = "ignore")] // too long
+    #[educe(Debug(ignore))] // too long
     encapsulated_part: EncapsulatedPart,
 }
 
@@ -130,11 +130,11 @@ pub struct RequiredProofOfSelectionVerificationInputs {
 }
 
 /// An encapsulated message whose public header has been verified.
-#[derive(Derivative, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
-#[derivative(Debug)]
+#[derive(Educe, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
+#[educe(Debug)]
 pub struct EncapsulatedMessageWithVerifiedPublicHeader {
     validated_public_header: VerifiedPublicHeader,
-    #[derivative(Debug = "ignore")] // too long
+    #[educe(Debug(ignore))] // too long
     encapsulated_part: EncapsulatedPart,
 }
 

--- a/blend/message/src/reward/activity.rs
+++ b/blend/message/src/reward/activity.rs
@@ -1,4 +1,4 @@
-use derivative::Derivative;
+use educe::Educe;
 use lb_blend_proofs::selection::inputs::VerifyInputs;
 use lb_cryptarchia_engine::Epoch;
 use serde::Serialize;
@@ -14,11 +14,11 @@ use crate::{
 
 /// An activity proof for an epoch, made of the blending token
 /// that has the smallest Hamming distance satisfying the activity threshold.
-#[derive(Derivative, Serialize)]
-#[derivative(Debug)]
+#[derive(Educe, Serialize)]
+#[educe(Debug)]
 pub struct ActivityProof {
     epoch: Epoch,
-    #[derivative(Debug = "ignore")]
+    #[educe(Debug(ignore))]
     token: BlendingToken,
 }
 

--- a/blend/provers/Cargo.toml
+++ b/blend/provers/Cargo.toml
@@ -14,7 +14,7 @@ workspace = true
 
 [dependencies]
 async-trait                   = { workspace = true }
-derivative                    = { workspace = true }
+educe                         = { features = ["Debug"], workspace = true }
 futures                       = { workspace = true }
 hex                           = { workspace = true }
 lb-blend-membership           = { workspace = true }

--- a/blend/provers/src/crypto/mod.rs
+++ b/blend/provers/src/crypto/mod.rs
@@ -1,6 +1,6 @@
 use std::{num::NonZeroU64, sync::Arc};
 
-use derivative::Derivative;
+use educe::Educe;
 pub use lb_blend_message::encap::validated::EncapsulatedMessageWithVerifiedPublicHeader;
 use lb_blend_proofs::quota::Quota;
 use lb_key_management_system_keys::keys::X25519PrivateKey;
@@ -18,12 +18,12 @@ pub use self::leader::send::EpochCryptographicProcessor as LeaderSenderOnlyEpoch
 #[cfg(test)]
 mod test_utils;
 
-#[derive(Clone, Derivative)]
-#[derivative(Debug)]
+#[derive(Clone, Educe)]
+#[educe(Debug)]
 pub struct EpochCryptographicProcessorSettings {
     /// The non-ephemeral encryption key (NEK) derived from the secret key
     /// corresponding to the public key registered in the membership (SDP).
-    #[derivative(Debug = "ignore")]
+    #[educe(Debug(ignore))]
     pub non_ephemeral_encryption_key: X25519PrivateKey,
     /// `ß_c`: number of blending operations for each locally generated message.
     pub num_blend_layers: NonZeroU64,

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -13,7 +13,7 @@ version     = { workspace = true }
 workspace = true
 
 [dependencies]
-derivative                    = { workspace = true }
+educe                         = { features = ["Clone", "PartialEq"], workspace = true }
 lb-blend-crypto               = { workspace = true }
 lb-blend-message              = { workspace = true }
 lb-blend-proofs               = { workspace = true }

--- a/ledger/src/cryptarchia/mod.rs
+++ b/ledger/src/cryptarchia/mod.rs
@@ -5,7 +5,7 @@ mod test;
 
 use std::sync::{Arc, LazyLock};
 
-use derivative::Derivative;
+use educe::Educe;
 use lb_core::{
     crypto::{ZkDigest, ZkHasher},
     events::TxEvent,
@@ -205,8 +205,8 @@ impl EpochState {
 ///
 /// NOTE: Most collection fields in this struct should use `rpds`
 /// since we keep a copy of this state for each block.
-#[derive(Derivative, serde::Serialize, serde::Deserialize)]
-#[derivative(Clone, PartialEq)]
+#[derive(Educe, serde::Serialize, serde::Deserialize)]
+#[educe(Clone, PartialEq)]
 pub struct LedgerState {
     // All available Unspent Transaction Outputs (UTXOs) at the current slot
     // TODO: move UTXOs in the mantle ledger. There is no reason to keep them here
@@ -224,10 +224,10 @@ pub struct LedgerState {
     // rolling snapshot of the state for the next epoch, used for epoch transitions
     pub next_epoch_state: EpochState,
     pub epoch_state: EpochState,
-    #[derivative(PartialEq = "ignore")]
+    #[educe(PartialEq(ignore))]
     block_density: BlockDensity,
     // Using an Arc wrapper here as this can be completely shared among instances of LedgerState
-    #[derivative(PartialEq = "ignore")]
+    #[educe(PartialEq(ignore))]
     stake_inference: Arc<StakeInference>,
     // rolling fee window of 120 blocks, used to derive block rewards
     #[serde(with = "serde_arrays")]

--- a/services/chain/broadcast-service/Cargo.toml
+++ b/services/chain/broadcast-service/Cargo.toml
@@ -14,7 +14,7 @@ workspace = true
 
 [dependencies]
 async-trait    = { workspace = true }
-derivative     = { workspace = true }
+educe          = { features = ["Debug"], workspace = true }
 lb-core        = { workspace = true }
 lb-log-targets = { workspace = true }
 overwatch      = { workspace = true }

--- a/services/chain/broadcast-service/src/lib.rs
+++ b/services/chain/broadcast-service/src/lib.rs
@@ -2,7 +2,7 @@ use core::fmt::Debug;
 use std::fmt::Display;
 
 use async_trait::async_trait;
-use derivative::Derivative;
+use educe::Educe;
 use lb_core::header::HeaderId;
 use lb_log_targets::chain;
 use overwatch::{
@@ -25,8 +25,8 @@ pub struct BlockInfo {
     pub header_id: HeaderId,
 }
 
-#[derive(Derivative)]
-#[derivative(Debug)]
+#[derive(Educe)]
+#[educe(Debug)]
 pub enum BlockBroadcastMsg {
     BroadcastFinalizedBlock(BlockInfo),
     SubscribeToFinalizedBlocks {

--- a/services/chain/chain-service/Cargo.toml
+++ b/services/chain/chain-service/Cargo.toml
@@ -15,7 +15,7 @@ workspace = true
 [dependencies]
 async-trait                = { workspace = true }
 bytes                      = { workspace = true }
-derivative                 = { workspace = true }
+educe                      = { features = ["Debug"], workspace = true }
 futures                    = { workspace = true }
 lb-chain-broadcast-service = { workspace = true }
 lb-core                    = { workspace = true }

--- a/services/chain/chain-service/src/lib.rs
+++ b/services/chain/chain-service/src/lib.rs
@@ -20,7 +20,7 @@ use std::{
 };
 
 use bytes::Bytes;
-use derivative::Derivative;
+use educe::Educe;
 use futures::{Stream, TryStreamExt as _};
 use lb_chain_broadcast_service::BlockBroadcastService;
 use lb_core::{
@@ -136,8 +136,8 @@ struct RecoveryBlocks<Tx> {
     fell_back_to_lib: bool,
 }
 
-#[derive(Derivative)]
-#[derivative(Debug)]
+#[derive(Educe)]
+#[educe(Debug)]
 pub enum ConsensusMsg<Tx> {
     /// Read-only queries and subscriptions.
     /// These are served in every service phase.
@@ -164,8 +164,8 @@ impl<Tx> From<Query> for ConsensusMsg<Tx> {
 }
 
 /// Read-only queries and subscriptions, served in every service phase.
-#[derive(Derivative)]
-#[derivative(Debug)]
+#[derive(Educe)]
+#[educe(Debug)]
 pub enum Query {
     Info {
         reply_channel: oneshot::Sender<ChainServiceInfo>,
@@ -179,7 +179,7 @@ pub enum Query {
     GetHeaders {
         from_descendant: Option<HeaderId>,
         to_ancestor: Option<HeaderId>,
-        #[derivative(Debug = "ignore")]
+        #[educe(Debug(ignore))]
         reply_channel: oneshot::Sender<HeaderIdStream>,
     },
     GetLedgerState {

--- a/services/tx-service/Cargo.toml
+++ b/services/tx-service/Cargo.toml
@@ -41,12 +41,17 @@ utoipa             = { features = ["macros"], optional = true, workspace = true 
 
 [dev-dependencies]
 lb-tracing-service = { workspace = true }
-lb-tx-service      = { features = ["rocksdb-backend"], workspace = true }
 overwatch-derive   = { workspace = true }
 tempfile           = { workspace = true }
 
 [features]
-default         = []
+# `rocksdb-backend` is default-on so this crate's own integration tests
+# (`tests/mock.rs`) compile against the RocksDB adapter. This replaces a self
+# dev-dependency, which made `cargo-deny` unable to include dev-dependencies in
+# its graph (`krates` panics on the resulting cycle). Workspace consumers are
+# unaffected: `[workspace.dependencies]` sets `default-features = false` and
+# members may not override it, so each still opts in explicitly.
+default         = ["rocksdb-backend"]
 rocksdb-backend = ["lb-storage-service/rocksdb-backend"]
 
 # enable to help generate OpenAPI

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -24,8 +24,8 @@ lb-utxotree = { workspace = true }
 axum                             = { features = ["http1", "json", "tokio"], workspace = true }
 bincode                          = { workspace = true }
 cucumber                         = { features = ["macros", "output-junit"], workspace = true }
-derivative                       = { workspace = true }
 ed25519                          = { workspace = true }
+educe                            = { features = ["Default"], workspace = true }
 futures                          = { workspace = true }
 futures-util                     = { workspace = true }
 hex                              = { workspace = true }

--- a/tests/src/cucumber/world.rs
+++ b/tests/src/cucumber/world.rs
@@ -10,7 +10,7 @@ use std::{
 };
 
 use cucumber::World;
-use derivative::Derivative;
+use educe::Educe;
 use lb_core::{
     codec::DeserializeOp as _,
     header::HeaderId,
@@ -951,8 +951,8 @@ pub struct ScenarioLifecycle {
 }
 
 /// Chain and genesis parameters captured at cluster build time.
-#[derive(Derivative)]
-#[derivative(Default)]
+#[derive(Educe)]
+#[educe(Default)]
 pub struct ChainParameters {
     /// Manual: List of genesis block UTXOs allocated in the genesis
     /// configuration.
@@ -964,7 +964,7 @@ pub struct ChainParameters {
     pub genesis_tokens: Vec<GenesisTokens>,
     /// Effective epoch length, populated from the first launched node's
     /// deployment config.
-    #[derivative(Default(value = "DEFAULT_SLOTS_PER_EPOCH"))]
+    #[educe(Default(expression = DEFAULT_SLOTS_PER_EPOCH))]
     pub slots_per_epoch: NonZero<u64>,
 }
 

--- a/zk/groth16/Cargo.toml
+++ b/zk/groth16/Cargo.toml
@@ -13,7 +13,8 @@ version     = { workspace = true }
 ark-bn254     = { features = ["curve"], workspace = true }
 ark-ec        = { workspace = true }
 ark-ff        = { workspace = true }
-ark-groth16   = { features = ["std"], workspace = true }
+ark-groth16   = { workspace = true }
+ark-relations = { workspace = true }
 ark-serialize = { workspace = true }
 generic-array = { features = ["serde"], workspace = true }
 hex           = { features = ["alloc"], workspace = true }

--- a/zk/groth16/src/lib.rs
+++ b/zk/groth16/src/lib.rs
@@ -20,7 +20,7 @@ use ark_ff::{BigInteger as _, PrimeField as _};
 pub use circuit_integer::{CircuitInteger, CircuitIntegerOutOfRange};
 pub use modulus_shift::{ModulusShift, ModulusShiftOutOfRange};
 use num_bigint::BigUint;
-pub use verifier::{groth16_batch_verify, groth16_verify};
+pub use verifier::{VerificationError, groth16_batch_verify, groth16_verify};
 
 pub const GROTH16_SAFE_BYTES_SIZE: usize = 31;
 

--- a/zk/groth16/src/verifier.rs
+++ b/zk/groth16/src/verifier.rs
@@ -1,19 +1,40 @@
-use std::{error::Error, ops::Mul as _};
+use core::fmt::{Display, Formatter};
+use std::{error::Error, fmt, ops::Mul as _};
 
 use ark_ec::{CurveGroup as _, VariableBaseMSM as _, pairing::Pairing};
 use ark_ff::{UniformRand as _, Zero as _};
 use ark_groth16::{Groth16, r1cs_to_qap::LibsnarkReduction};
+use ark_relations::r1cs::SynthesisError;
 use rand::thread_rng;
 
 use crate::{proof::Proof, verification_key::PreparedVerificationKey};
+
+/// Error returned when Groth16 verification cannot be carried out.
+///
+/// Wraps `ark_relations`' `SynthesisError`. That type only implements
+/// [`std::error::Error`] when `ark-relations/std` is on, and we deliberately
+/// keep it off: it is an optional dependency that drags in `tracing-subscriber`
+/// 0.2 (RUSTSEC-2025-0055). Wrapping it here lets callers keep treating the
+/// failure as a `std` error without pulling that in.
+#[derive(Debug)]
+pub struct VerificationError(SynthesisError);
+
+impl Display for VerificationError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl Error for VerificationError {}
 
 pub fn groth16_verify<E: Pairing>(
     vk: &PreparedVerificationKey<E>,
     proof: &Proof<E>,
     public_inputs: &[E::ScalarField],
-) -> Result<bool, impl Error + use<E>> {
+) -> Result<bool, VerificationError> {
     let proof: ark_groth16::Proof<E> = proof.into();
     Groth16::<E, LibsnarkReduction>::verify_proof(vk.as_ref(), &proof, public_inputs)
+        .map_err(VerificationError)
 }
 
 pub fn groth16_batch_verify<E: Pairing>(


### PR DESCRIPTION
## 1. What does this PR implement?

This PR:

1. Updates the `cargo-deny` binary to the latest `0.20.2` version, in CI as well as in the pre-commit hook.
2. Address the `RUSTSEC-2025-0055` by not enabling the `std` feature on the `ark-relations` dependency, but rather implement a simple error type for zk proof verification result, and `RUSTSEC-2026-0173` by simply upgrading the `validator` crate to the latest version.
3. Replaces workspace dependencies on the `derivative` crate, which is unmaintained. The entry cannot be removed from our cargo-deny config because it is pulled by other dependencies.
4. Harden the cargo-deny configuration by checking also dev-dependencies (useful especially with build-time ones), and making explicit "deny"s in case the defaults change in the future.
5. Improve the description of the remaining entries, and organized them by category, to make it easier to understand why they are there, and when they could be removed.

I plan to open another PR in the future (lower priority) that introduces a monthly workflow to go over the remaining cargo-deny entries and check whether they can be addressed. Goal would be to have an empty list, in the end. The same workflow will probably also check whether we can update any of our CI tools, like cargo-deny or taplo, to get any new features/fixes they introduce.

## 2. Does the code have enough context to be clearly understood?

Yes.

## 3. Who are the specification authors and who is accountable for this PR?

@ntn-x2 

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

No.