### PR TITLE
chore(template): Update instructions to point to close releases module repository

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-candidate.md
+++ b/.github/ISSUE_TEMPLATE/release-candidate.md
@@ -67,10 +67,10 @@ Most of the template content is the same or very similar to what is in `release.
 - [ ] Re-generate the `flake.lock` file using the command `nix flake lock`
 - [ ] Commit the changes and tag them with `X.Y.Z-rc.N`
 - [ ] Push the commit and the tag
-- [ ] Enter the [logos-modules-release] repository locally. If you just cloned the repository, run `git submodule update --init --recursive`
+- [ ] Enter the [blockchain-modules-release] repository locally. If you just cloned the repository, run `git submodule update --init --recursive`
 - [ ] Branch out from the latest `master` commit with a release branch named `blockchain-module-X.Y.Z-rc.N`
 - [ ] Navigate to the `submodules/logos-blockchain-module` directory and checkout the `X.Y.Z-rc.N` tag
-- [ ] Commit the changes to the [logos-modules-release] repository
+- [ ] Commit the changes to the [blockchain-modules-release] repository
 - [ ] Manually trigger the [logos-blockchain-module-workflow] workflow with the `Force build` option selected from the `blockchain-module-X.Y.Z-rc.N` branch
 - [ ] Post the link to the workflow run to this issue for easier review
 - [ ] Wait for the workflow to complete before moving on to the next step
@@ -114,5 +114,5 @@ Most of the template content is the same or very similar to what is in `release.
 [github-release-candidate-section]: #release-candidate-publication
 [node-docker-build-workflow]: https://github.com/logos-blockchain/logos-blockchain/actions/workflows/publish-node-image.yml
 [logos-blockchain-module]: https://github.com/logos-blockchain/logos-blockchain-module
-[logos-modules-release]: https://github.com/logos-co/logos-modules-release
+[blockchain-modules-release]: https://github.com/logos-blockchain/blockchain-modules-release
 [logos-blockchain-module-workflow]: https://github.com/logos-co/logos-modules-release/actions/workflows/release-logos-blockchain-module.yml


### PR DESCRIPTION
## 1. What does this PR implement?

Update RC instructions to release on blockchain modules releases instead of overall logos repository.

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@danielSanchezQ @bacv 

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

N/A

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
