### PR TITLE
feat(logos-sql): report write status changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5447,6 +5447,7 @@ dependencies = [
  "bincode",
  "blake2",
  "clap",
+ "futures-util",
  "hex",
  "logos-blockchain-codec",
  "logos-blockchain-groth16",
@@ -5460,6 +5461,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-stream",
  "tracing",
 ]
 

--- a/logos_sql/Cargo.toml
+++ b/logos_sql/Cargo.toml
@@ -16,6 +16,7 @@ workspace = true
 [dependencies]
 bincode                          = { workspace = true }
 blake2                           = { workspace = true }
+futures-util                     = { workspace = true }
 lb-codec                         = { workspace = true }
 lb-key-management-system-service = { workspace = true }
 lb-log-targets                   = { workspace = true }
@@ -26,6 +27,7 @@ reqwest                          = { workspace = true }
 rusqlite                         = { features = ["backup", "bundled", "functions", "hooks"], workspace = true }
 thiserror                        = { workspace = true }
 tokio                            = { features = ["macros", "rt", "sync", "time"], workspace = true }
+tokio-stream                     = { features = ["sync"], workspace = true }
 tracing                          = { workspace = true }
 
 [dev-dependencies]

--- a/logos_sql/src/applier.rs
+++ b/logos_sql/src/applier.rs
@@ -12,6 +12,7 @@ use crate::{
     db::{Databases, PendingPublish, SuffixWrite},
     error::Error,
     protocol::{self, ChannelInscription, TxId},
+    status::WriteStatusChange,
 };
 
 const TARGET: &str = lb_log_targets::logos_sql::APPLIER;
@@ -78,24 +79,38 @@ struct SqlChanges {
 /// adopted writes apply only to live state. A branch change reconstructs live
 /// state from finalized history and the retained canonical suffix.
 ///
+/// Retain `notifications` across retries and publish them only after success:
+/// status changes can commit before a rebuild or checkpoint save fails.
+///
 /// # Errors
 ///
 /// Returns an error if SQL cannot be applied, a channel payload cannot be
 /// decoded, or the checkpoint cannot be persisted.
-pub fn on_event(db: &mut Databases, event: &Event, channel_id: ChannelId) -> Result<(), Error> {
+pub fn on_event(
+    db: &mut Databases,
+    event: &Event,
+    channel_id: ChannelId,
+    notifications: &mut Vec<WriteStatusChange>,
+) -> Result<(), Error> {
     match event {
         Event::BlocksProcessed {
             checkpoint,
             channel_update,
             finalized,
-        } => process_blocks(db, checkpoint, channel_update, finalized, channel_id)?,
+        } => process_blocks(
+            db,
+            checkpoint,
+            channel_update,
+            finalized,
+            channel_id,
+            notifications,
+        ),
         Event::Ready => {
             tracing::info!(target: TARGET, "sequencer ready");
+            Ok(())
         }
-        Event::MempoolPending(_) | Event::TurnNotification { .. } => {}
+        Event::MempoolPending(_) | Event::TurnNotification { .. } => Ok(()),
     }
-
-    Ok(())
 }
 
 /// Applies one block event before advancing its checkpoint.
@@ -108,6 +123,7 @@ fn process_blocks(
     channel_update: &ChannelUpdate,
     finalized: &[FinalizedTx],
     channel_id: ChannelId,
+    notifications: &mut Vec<WriteStatusChange>,
 ) -> Result<(), Error> {
     let changes = SqlChanges::from_block(channel_update, finalized, channel_id);
 
@@ -122,11 +138,13 @@ fn process_blocks(
     let plan = changes.application_plan(db)?;
 
     match plan {
-        ApplicationPlan::ApplyChanges => changes.apply(db)?,
-        ApplicationPlan::Rebuild(cause) => changes.rebuild(db, &cause)?,
+        ApplicationPlan::ApplyChanges => notifications.extend(changes.apply(db)?),
+        ApplicationPlan::Rebuild(cause) => changes.rebuild(db, &cause, notifications)?,
     }
 
-    db.persist_checkpoint(checkpoint)
+    db.persist_checkpoint(checkpoint)?;
+
+    Ok(())
 }
 
 impl SqlChanges {
@@ -191,13 +209,13 @@ impl SqlChanges {
             // `LIVE.db`, which removes its pending-write record. If both records
             // still exist, the process stopped between those two steps and the
             // rebuild must resume.
-            if db.is_write_displaced(pending.tx_id)? {
+            if db.pending_write_rebuild_was_interrupted(pending.tx_id)? {
                 return Ok(ApplicationPlan::Rebuild(
                     RebuildCause::PendingWriteInvalidated(pending),
                 ));
             }
 
-            if self.changes_pending_base(db)? {
+            if self.changes_history_before_pending_write(db)? {
                 return Ok(ApplicationPlan::Rebuild(
                     RebuildCause::PendingWriteInvalidated(pending),
                 ));
@@ -218,7 +236,7 @@ impl SqlChanges {
     /// already retained in the live suffix only moves the finalized
     /// boundary and does not invalidate the pending write's execution
     /// order.
-    fn changes_pending_base(&self, db: &Databases) -> Result<bool, Error> {
+    fn changes_history_before_pending_write(&self, db: &Databases) -> Result<bool, Error> {
         if !self.adopted.is_empty() || !self.orphaned.is_empty() {
             return Ok(true);
         }
@@ -234,7 +252,7 @@ impl SqlChanges {
 
     /// Applies an event whose existing `LIVE.db` effects remain correctly
     /// ordered.
-    fn apply(&self, db: &mut Databases) -> Result<(), Error> {
+    fn apply(&self, db: &mut Databases) -> Result<Vec<WriteStatusChange>, Error> {
         Self::apply_inscriptions(db, &self.finalized, ApplyTarget::LibAndLive)?;
         Self::apply_inscriptions(db, &self.adopted, ApplyTarget::Live)?;
         self.apply_history_delta(db)
@@ -245,17 +263,28 @@ impl SqlChanges {
     /// The displacement, when applicable, and suffix are persisted before
     /// replacing `LIVE.db` so an interrupted rebuild can be recognized and
     /// safely repeated.
-    fn rebuild(&self, db: &mut Databases, cause: &RebuildCause) -> Result<(), Error> {
+    fn rebuild(
+        &self,
+        db: &mut Databases,
+        cause: &RebuildCause,
+        notifications: &mut Vec<WriteStatusChange>,
+    ) -> Result<(), Error> {
         match cause {
             RebuildCause::PendingWriteInvalidated(pending) => {
-                db.record_unpublished_displacement(pending)?;
+                let change = db.record_pending_write_displacement(pending)?;
+
+                if !notifications.contains(&change) {
+                    notifications.push(change);
+                }
             }
             RebuildCause::ChannelFork => {}
         }
 
         Self::apply_inscriptions(db, &self.finalized, ApplyTarget::Lib)?;
-        self.apply_history_delta(db)?;
-        rebuild_live_from_suffix(db)
+        notifications.extend(self.apply_history_delta(db)?);
+        rebuild_live_from_suffix(db)?;
+
+        Ok(())
     }
 
     fn apply_inscriptions(
@@ -270,9 +299,8 @@ impl SqlChanges {
         Ok(())
     }
 
-    /// Applies this event to the replayable suffix and local displacement
-    /// outcomes.
-    fn apply_history_delta(&self, db: &mut Databases) -> Result<(), Error> {
+    /// Applies this event to the replayable suffix and local write statuses.
+    fn apply_history_delta(&self, db: &mut Databases) -> Result<Vec<WriteStatusChange>, Error> {
         let finalized = self
             .finalized
             .iter()
@@ -437,13 +465,22 @@ mod tests {
     use rusqlite::types::Value;
     use tempfile::TempDir;
 
-    use super::on_event;
+    fn on_event(
+        db: &mut Databases,
+        event: &Event,
+        channel_id: ChannelId,
+    ) -> Result<Vec<WriteStatusChange>, crate::Error> {
+        let mut changes = Vec::new();
+        super::on_event(db, event, channel_id, &mut changes)?;
+        Ok(changes)
+    }
     use crate::{
         db::{Databases, SuffixWrite},
         protocol::{
             CapturedFunctionCalls, ChannelInscription, EncodedWrite, PAYLOAD_MARKER, Statement,
             Transaction, TxId,
         },
+        status::{WriteStatus, WriteStatusChange},
     };
 
     const CHANNEL_ID: [u8; 32] = [9; 32];
@@ -540,6 +577,13 @@ mod tests {
             .expect("database should open for reading")
             .query_row("PRAGMA journal_mode", [], |row| row.get(0))
             .expect("journal mode should be readable")
+    }
+
+    fn assert_status(db: &Databases, tx_id: TxId, expected: Option<WriteStatus>) {
+        assert_eq!(
+            db.write_status(tx_id).expect("write status should load"),
+            expected
+        );
     }
 
     fn text_values(path: &std::path::Path, table: &str) -> Vec<String> {
@@ -734,7 +778,8 @@ mod tests {
         let lib_path = db.lib_path().to_owned();
 
         let create = transaction("CREATE TABLE items(value INTEGER NOT NULL)", Vec::new());
-        db.commit_local_write(TxId::generate(), &create)
+        let create_tx_id = db
+            .commit_local_write(TxId::generate(), &create)
             .expect("schema write should commit");
         let create_pending = db
             .pending_publish()
@@ -773,11 +818,7 @@ mod tests {
                 .tx_id,
             insert_tx_id
         );
-        assert!(
-            db.displaced_writes()
-                .expect("displaced writes should load")
-                .is_empty()
-        );
+        assert_status(&db, create_tx_id, Some(WriteStatus::Finalized));
     }
 
     #[test]
@@ -971,14 +1012,13 @@ mod tests {
     }
 
     #[test]
-    fn orphaned_local_write_rebuilds_live_and_reports_displacement() {
+    fn active_reader_keeps_its_snapshot_during_live_rebuild() {
         let dir = TempDir::new().expect("temporary directory should be created");
         let mut db = Databases::open(dir.path()).expect("databases should open");
         let live_path = db.live_path().to_owned();
 
         let local = transaction("CREATE TABLE local_write(value INTEGER)", Vec::new());
-        let local_tx_id = db
-            .commit_local_write(TxId::generate(), &local)
+        db.commit_local_write(TxId::generate(), &local)
             .expect("local write should commit");
         let local_pending = db
             .pending_publish()
@@ -1025,11 +1065,6 @@ mod tests {
         assert!(!table_exists(&live_path, "local_write"));
         assert!(table_exists(&live_path, "adopted_too_early"));
         assert_eq!(journal_mode(&live_path), "wal");
-        assert_eq!(
-            db.displaced_writes().expect("displaced writes should load"),
-            vec![local_tx_id]
-        );
-
         let local_still_visible: bool = reader
             .query_row(
                 "SELECT EXISTS(
@@ -1059,27 +1094,80 @@ mod tests {
             .expect("reader should observe rebuilt state after its snapshot");
 
         assert!(adopted_visible);
+    }
 
-        let restore_original = blocks_processed(
-            checkpoint(3, 3),
-            vec![ChannelUpdateTx::Inscription(inscription(&local_payload, 1))],
-            vec![ChannelUpdateTx::Inscription(inscription(
-                &adopted.payload,
-                2,
-            ))],
+    #[test]
+    fn local_write_reports_orphaned_adopted_and_finalized() {
+        let dir = TempDir::new().expect("temporary directory should be created");
+        let mut db = Databases::open(dir.path()).expect("databases should open");
+        let live_path = db.live_path().to_owned();
+
+        let local = transaction("CREATE TABLE local_write(value INTEGER)", Vec::new());
+        let local_tx_id = db
+            .commit_local_write(TxId::generate(), &local)
+            .expect("local write should commit");
+        let pending = db
+            .pending_publish()
+            .expect("pending write should load")
+            .expect("pending write should exist");
+        let payload = pending.payload.clone();
+
+        db.complete_publish(&checkpoint(1, 1), MsgId::from([1; 32]), &pending)
+            .expect("local publish should be complete");
+
+        let orphan = blocks_processed(
+            checkpoint(2, 2),
+            Vec::new(),
+            vec![ChannelUpdateTx::Inscription(inscription(&payload, 1))],
             Vec::new(),
         );
 
-        on_event(&mut db, &restore_original, ChannelId::from(CHANNEL_ID))
-            .expect("restored branch should rebuild live state");
+        let changes = on_event(&mut db, &orphan, ChannelId::from(CHANNEL_ID))
+            .expect("local write should be orphaned");
+
+        assert!(!table_exists(&live_path, "local_write"));
+        assert_status(&db, local_tx_id, Some(WriteStatus::Displaced));
+        assert_eq!(
+            changes,
+            [WriteStatusChange::new(local_tx_id, WriteStatus::Displaced)]
+        );
+
+        drop(db);
+        let mut db = Databases::open(dir.path()).expect("databases should reopen");
+
+        let restore = blocks_processed(
+            checkpoint(3, 3),
+            vec![ChannelUpdateTx::Inscription(inscription(&payload, 1))],
+            Vec::new(),
+            Vec::new(),
+        );
+
+        let changes = on_event(&mut db, &restore, ChannelId::from(CHANNEL_ID))
+            .expect("original channel position should return");
 
         assert!(table_exists(&live_path, "local_write"));
-        assert!(!table_exists(&live_path, "adopted_too_early"));
-        assert!(
-            db.displaced_writes()
-                .expect("displaced writes should load")
-                .is_empty(),
-            "restoring the original channel position clears displacement"
+        assert_status(&db, local_tx_id, Some(WriteStatus::Live));
+        assert_eq!(
+            changes,
+            [WriteStatusChange::new(local_tx_id, WriteStatus::Live)]
+        );
+
+        let finalize = blocks_processed(
+            checkpoint(4, 4),
+            Vec::new(),
+            Vec::new(),
+            vec![finalized(&payload, 1)],
+        );
+
+        let changes = on_event(&mut db, &finalize, ChannelId::from(CHANNEL_ID))
+            .expect("local write should finalize");
+
+        assert!(table_exists(&live_path, "local_write"));
+        assert!(table_exists(db.lib_path(), "local_write"));
+        assert_status(&db, local_tx_id, Some(WriteStatus::Finalized));
+        assert_eq!(
+            changes,
+            [WriteStatusChange::new(local_tx_id, WriteStatus::Finalized)]
         );
     }
 
@@ -1137,12 +1225,7 @@ mod tests {
             .expect("replayed branch update should be idempotent");
 
         assert_eq!(text_values(&live_path, "items"), vec!["new"]);
-        assert!(
-            db.displaced_writes()
-                .expect("displaced writes should load")
-                .is_empty(),
-            "foreign orphaned writes are not application outcomes"
-        );
+        assert_status(&db, old_branch.tx_id, None);
     }
 
     #[test]
@@ -1180,10 +1263,7 @@ mod tests {
                 .expect("pending publication should load")
                 .is_none()
         );
-        assert_eq!(
-            db.displaced_writes().expect("displaced writes should load"),
-            vec![local_tx_id]
-        );
+        assert_status(&db, local_tx_id, Some(WriteStatus::Displaced));
     }
 
     #[test]
@@ -1227,10 +1307,7 @@ mod tests {
 
         assert!(!table_exists(&live_path, "previous_write"));
         assert!(!table_exists(&live_path, "local_write"));
-        assert_eq!(
-            db.displaced_writes().expect("displaced writes should load"),
-            vec![local_tx_id]
-        );
+        assert_status(&db, local_tx_id, Some(WriteStatus::Displaced));
     }
 
     #[test]
@@ -1256,7 +1333,7 @@ mod tests {
 
         // Simulate a crash after the control-state transaction commits but
         // before the replacement LIVE database is installed.
-        db.record_unpublished_displacement(&pending)
+        db.record_pending_write_displacement(&pending)
             .expect("displacement should be recorded");
         db.apply_history_delta(
             &[],
@@ -1291,10 +1368,7 @@ mod tests {
                 .expect("pending publication should load")
                 .is_none()
         );
-        assert_eq!(
-            db.displaced_writes().expect("displaced writes should load"),
-            vec![local_tx_id]
-        );
+        assert_status(&db, local_tx_id, Some(WriteStatus::Displaced));
     }
 
     #[test]
@@ -1320,7 +1394,7 @@ mod tests {
 
         // Simulate a crash after the control-state transaction commits but
         // before the replacement LIVE database is installed.
-        db.record_unpublished_displacement(&pending)
+        db.record_pending_write_displacement(&pending)
             .expect("displacement should be recorded");
         db.apply_history_delta(
             &[],
@@ -1359,10 +1433,7 @@ mod tests {
                 .expect("pending publication should load")
                 .is_none()
         );
-        assert_eq!(
-            db.displaced_writes().expect("displaced writes should load"),
-            vec![local_tx_id]
-        );
+        assert_status(&db, local_tx_id, Some(WriteStatus::Displaced));
     }
 
     #[test]
@@ -1393,9 +1464,6 @@ mod tests {
         assert!(!table_exists(&live_path, "local_write"));
         assert!(table_exists(&live_path, "finalized_write"));
         assert!(table_exists(db.lib_path(), "finalized_write"));
-        assert_eq!(
-            db.displaced_writes().expect("displaced writes should load"),
-            vec![local_tx_id]
-        );
+        assert_status(&db, local_tx_id, Some(WriteStatus::Displaced));
     }
 }

--- a/logos_sql/src/db.rs
+++ b/logos_sql/src/db.rs
@@ -14,12 +14,14 @@ use rusqlite::{
     backup::Backup,
     hooks::{AuthAction, AuthContext, Authorization},
     params, params_from_iter,
+    types::{FromSql, FromSqlError, FromSqlResult, ToSql, ToSqlOutput, ValueRef},
 };
 
 use crate::{
     error::Error,
     functions::FunctionOverrides,
     protocol::{ChannelInscription, EncodedWrite, Transaction, TxId},
+    status::{WriteStatus, WriteStatusChange},
 };
 
 const DATABASE_BUSY_TIMEOUT: Duration = Duration::from_secs(5);
@@ -30,6 +32,9 @@ const REBUILD_DATABASE_FILE: &str = "LIVE.rebuild.db";
 const BACKUP_PAGES_PER_STEP: i32 = 128;
 const BACKUP_RETRY_DELAY: Duration = Duration::from_millis(10);
 const RESERVED_OBJECT_PREFIX: &str = "__logos_sql_";
+const LIVE_STATUS: &str = "live";
+const DISPLACED_STATUS: &str = "displaced";
+const FINALIZED_STATUS: &str = "finalized";
 
 // Present in both state databases so replicated SQL observes the same schema.
 // Only LIVE.db stores a row, committed atomically with the local write.
@@ -50,8 +55,7 @@ const APPLIED_WRITE_SCHEMA: &str = "
     ) STRICT;
 ";
 
-// Stores participant-local progress and rejected channel writes independently
-// of replicated database state.
+// Stores participant-local state independently of the replicated databases.
 const CONTROL_SCHEMA: &str = "
     CREATE TABLE IF NOT EXISTS __logos_sql_state (
         singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
@@ -74,7 +78,12 @@ const CONTROL_SCHEMA: &str = "
 
     CREATE TABLE IF NOT EXISTS __logos_sql_displaced_writes (
         tx_id BLOB PRIMARY KEY CHECK (length(tx_id) = 32),
-        this_msg BLOB UNIQUE CHECK (this_msg IS NULL OR length(this_msg) = 32)
+        this_msg BLOB NOT NULL UNIQUE CHECK (length(this_msg) = 32)
+    ) STRICT;
+
+    CREATE TABLE IF NOT EXISTS __logos_sql_write_statuses (
+        tx_id BLOB PRIMARY KEY CHECK (length(tx_id) = 32),
+        status TEXT NOT NULL CHECK (status IN ('live', 'displaced', 'finalized'))
     ) STRICT;
 ";
 
@@ -140,10 +149,24 @@ const SELECT_LOCAL_SUFFIX_WRITE: &str = "
     WHERE this_msg = ?1 AND local = 1
 ";
 
+const SELECT_LOCAL_SUFFIX_WRITE_BY_TX: &str = "
+    SELECT EXISTS(
+        SELECT 1
+        FROM __logos_sql_live_suffix
+        WHERE tx_id = ?1 AND local = 1
+    )
+";
+
 const SELECT_SUFFIX_WRITE_EXISTS: &str = "
     SELECT EXISTS(
         SELECT 1 FROM __logos_sql_live_suffix WHERE this_msg = ?1
     )
+";
+
+const UPSERT_WRITE_STATUS: &str = "
+    INSERT INTO __logos_sql_write_statuses (tx_id, status)
+    VALUES (?1, ?2)
+    ON CONFLICT (tx_id) DO UPDATE SET status = excluded.status
 ";
 
 const INSERT_DISPLACED_WRITE: &str = "
@@ -152,26 +175,33 @@ const INSERT_DISPLACED_WRITE: &str = "
     ON CONFLICT (tx_id) DO UPDATE SET this_msg = excluded.this_msg
 ";
 
-const INSERT_UNPUBLISHED_DISPLACED_WRITE: &str = "
-    INSERT INTO __logos_sql_displaced_writes (tx_id, this_msg)
-    VALUES (?1, NULL)
-    ON CONFLICT (tx_id) DO NOTHING
-";
-
 const DELETE_DISPLACED_WRITE: &str = "
     DELETE FROM __logos_sql_displaced_writes
     WHERE this_msg = ?1
 ";
 
-const SELECT_DISPLACED_WRITES: &str = "
-    SELECT tx_id
-    FROM __logos_sql_displaced_writes
-    ORDER BY rowid
+const DELETE_DISPLACED_WRITE_BY_TX: &str = "
+    DELETE FROM __logos_sql_displaced_writes
+    WHERE tx_id = ?1
 ";
 
-const SELECT_DISPLACED_WRITE_EXISTS: &str = "
+const SELECT_WRITE_STATUS: &str = "
+    SELECT status
+    FROM __logos_sql_write_statuses
+    WHERE tx_id = ?1
+";
+
+const SELECT_DISPLACED_WRITE_AT_POSITION: &str = "
+    SELECT tx_id
+    FROM __logos_sql_displaced_writes
+    WHERE this_msg = ?1
+";
+
+const SELECT_DISPLACED_WRITE_BY_TX: &str = "
     SELECT EXISTS(
-        SELECT 1 FROM __logos_sql_displaced_writes WHERE tx_id = ?1
+        SELECT 1
+        FROM __logos_sql_displaced_writes
+        WHERE tx_id = ?1
     )
 ";
 
@@ -376,58 +406,41 @@ impl Databases {
     }
 
     /// Applies one channel event to retained unfinalized history and local
-    /// write outcomes.
+    /// write statuses.
     ///
-    /// Finalized writes leave the suffix and clear any provisional
-    /// displacement. Orphaned local writes become displaced, while restoring
-    /// their original channel position clears that outcome again. The whole
-    /// delta commits together so replay after a crash cannot observe only one
-    /// side of a branch change.
+    /// Removes finalized and orphaned writes from the live suffix, adds
+    /// adopted writes, and updates local write statuses. These changes commit
+    /// in one transaction so a crash cannot leave a partially recorded update.
     pub(crate) fn apply_history_delta(
         &mut self,
         finalized: &[MsgId],
         orphaned: &[MsgId],
         adopted: &[SuffixWrite],
-    ) -> Result<(), Error> {
+    ) -> Result<Vec<WriteStatusChange>, Error> {
         let transaction = self.control.transaction()?;
+        let mut changes = Vec::new();
 
         for this_msg in finalized {
-            transaction.execute(DELETE_DISPLACED_WRITE, [this_msg.as_ref()])?;
-            transaction.execute(DELETE_SUFFIX_WRITE, [this_msg.as_ref()])?;
+            if let Some(change) = finalize_write(&transaction, this_msg)? {
+                changes.push(change);
+            }
         }
 
         for this_msg in orphaned {
-            let local_tx_id = transaction
-                .query_row(SELECT_LOCAL_SUFFIX_WRITE, [this_msg.as_ref()], |row| {
-                    row.get::<_, Vec<u8>>(0)
-                })
-                .optional()?;
-
-            if let Some(tx_id) = local_tx_id {
-                transaction.execute(INSERT_DISPLACED_WRITE, params![tx_id, this_msg.as_ref()])?;
+            if let Some(change) = orphan_write(&transaction, this_msg)? {
+                changes.push(change);
             }
-
-            transaction.execute(DELETE_SUFFIX_WRITE, [this_msg.as_ref()])?;
         }
 
         for write in adopted {
-            let restored_local =
-                transaction.execute(DELETE_DISPLACED_WRITE, [write.this_msg.as_ref()])? != 0;
-
-            transaction.execute(
-                INSERT_SUFFIX_WRITE,
-                params![
-                    write.this_msg.as_ref(),
-                    write.tx_id.as_ref(),
-                    write.payload,
-                    write.local || restored_local
-                ],
-            )?;
+            if let Some(change) = adopt_write(&transaction, write)? {
+                changes.push(change);
+            }
         }
 
         transaction.commit()?;
 
-        Ok(())
+        Ok(changes)
     }
 
     pub(crate) fn live_suffix(&self) -> Result<Vec<SuffixWrite>, Error> {
@@ -462,19 +475,47 @@ impl Databases {
             .map_err(Error::from)
     }
 
-    pub(crate) fn displaced_writes(&self) -> Result<Vec<TxId>, Error> {
-        let mut statement = self.control.prepare(SELECT_DISPLACED_WRITES)?;
-        let rows = statement.query_map([], |row| row.get::<_, Vec<u8>>(0))?;
+    pub(crate) fn write_status(&self, tx_id: TxId) -> Result<Option<WriteStatus>, Error> {
+        let stored = self
+            .control
+            .query_row(SELECT_WRITE_STATUS, [tx_id.as_ref()], |row| {
+                row.get::<_, WriteStatus>(0)
+            })
+            .optional()
+            .map_err(|error| match error {
+                rusqlite::Error::FromSqlConversionFailure(..)
+                | rusqlite::Error::InvalidColumnType(..) => {
+                    Error::InvalidLocalState("stored write status is invalid")
+                }
+                error => Error::from(error),
+            })?;
 
-        rows.map(|row| decode_tx_id(row?)).collect()
+        if let Some(status) = stored {
+            return Ok(Some(status));
+        }
+
+        if self
+            .pending_publish()?
+            .is_some_and(|pending| pending.tx_id == tx_id)
+        {
+            return Ok(Some(WriteStatus::Live));
+        }
+
+        let live: bool =
+            self.control
+                .query_row(SELECT_LOCAL_SUFFIX_WRITE_BY_TX, [tx_id.as_ref()], |row| {
+                    row.get(0)
+                })?;
+
+        Ok(live.then_some(WriteStatus::Live))
     }
 
-    pub(crate) fn is_write_displaced(&self, tx_id: TxId) -> Result<bool, Error> {
-        self.control
-            .query_row(SELECT_DISPLACED_WRITE_EXISTS, [tx_id.as_ref()], |row| {
-                row.get(0)
-            })
-            .map_err(Error::from)
+    /// Reports whether recovery must finish removing a pending local write.
+    ///
+    /// A rebuild saves the displaced status before replacing `LIVE.db`.
+    /// If the pending record still exists, the rebuild has not finished.
+    pub(crate) fn pending_write_rebuild_was_interrupted(&self, tx_id: TxId) -> Result<bool, Error> {
+        Ok(self.write_status(tx_id)? == Some(WriteStatus::Displaced))
     }
 
     /// Records a local write whose base changed before `ZoneSDK` accepted it.
@@ -482,14 +523,15 @@ impl Databases {
     /// The pending record remains in `LIVE.db` until the rebuild replaces the
     /// database. If recovery is interrupted, that record makes the same event
     /// request another rebuild.
-    pub(crate) fn record_unpublished_displacement(
-        &self,
+    pub(crate) fn record_pending_write_displacement(
+        &mut self,
         pending: &PendingPublish,
-    ) -> Result<(), Error> {
-        self.control
-            .execute(INSERT_UNPUBLISHED_DISPLACED_WRITE, [pending.tx_id.as_ref()])?;
+    ) -> Result<WriteStatusChange, Error> {
+        let transaction = self.control.transaction()?;
+        let change = set_write_status(&transaction, pending.tx_id, WriteStatus::Displaced)?;
+        transaction.commit()?;
 
-        Ok(())
+        Ok(change)
     }
 
     /// Creates a replacement live database from the finalized image.
@@ -525,7 +567,7 @@ impl Databases {
     /// Records a channel write that every replica must skip.
     ///
     /// Keeping the rejection in participant-local state allows replay to
-    /// advance past invalid input and preserves the outcome for later
+    /// advance past invalid input and preserves the reason for later
     /// application reporting. `tx_id` is absent when the payload could not be
     /// decoded.
     pub(crate) fn record_rejected_write(
@@ -662,6 +704,165 @@ impl Databases {
         configure_connection(&conn)?;
 
         Ok(conn)
+    }
+}
+
+/// Removes a write's suffix and displacement records; marks it finalized if
+/// local.
+fn finalize_write(
+    transaction: &rusqlite::Transaction<'_>,
+    this_msg: &MsgId,
+) -> Result<Option<WriteStatusChange>, Error> {
+    let mut local_tx_id = transaction
+        .query_row(SELECT_LOCAL_SUFFIX_WRITE, [this_msg.as_ref()], |row| {
+            row.get::<_, Vec<u8>>(0)
+        })
+        .optional()?;
+
+    if local_tx_id.is_none() {
+        local_tx_id = transaction
+            .query_row(
+                SELECT_DISPLACED_WRITE_AT_POSITION,
+                [this_msg.as_ref()],
+                |row| row.get::<_, Vec<u8>>(0),
+            )
+            .optional()?;
+    }
+
+    let change = local_tx_id
+        .map(decode_tx_id)
+        .transpose()?
+        .map(|tx_id| set_write_status(transaction, tx_id, WriteStatus::Finalized))
+        .transpose()?;
+
+    transaction.execute(DELETE_DISPLACED_WRITE, [this_msg.as_ref()])?;
+    transaction.execute(DELETE_SUFFIX_WRITE, [this_msg.as_ref()])?;
+
+    Ok(change)
+}
+
+/// Removes a write from the live suffix and marks it displaced if local.
+fn orphan_write(
+    transaction: &rusqlite::Transaction<'_>,
+    this_msg: &MsgId,
+) -> Result<Option<WriteStatusChange>, Error> {
+    let local_tx_id = transaction
+        .query_row(SELECT_LOCAL_SUFFIX_WRITE, [this_msg.as_ref()], |row| {
+            row.get::<_, Vec<u8>>(0)
+        })
+        .optional()?;
+
+    let change = if let Some(tx_id) = local_tx_id {
+        let tx_id = decode_tx_id(tx_id)?;
+
+        transaction.execute(
+            INSERT_DISPLACED_WRITE,
+            params![tx_id.as_ref(), this_msg.as_ref()],
+        )?;
+
+        Some(set_write_status(
+            transaction,
+            tx_id,
+            WriteStatus::Displaced,
+        )?)
+    } else {
+        None
+    };
+
+    transaction.execute(DELETE_SUFFIX_WRITE, [this_msg.as_ref()])?;
+
+    Ok(change)
+}
+
+/// Adds a write to the live suffix; marks a displaced local write live again.
+fn adopt_write(
+    transaction: &rusqlite::Transaction<'_>,
+    write: &SuffixWrite,
+) -> Result<Option<WriteStatusChange>, Error> {
+    let restored_tx_id = transaction
+        .query_row(
+            SELECT_DISPLACED_WRITE_AT_POSITION,
+            [write.this_msg.as_ref()],
+            |row| row.get::<_, Vec<u8>>(0),
+        )
+        .optional()?;
+
+    if let Some(tx_id) = restored_tx_id
+        && decode_tx_id(tx_id)? != write.tx_id
+    {
+        return Err(Error::InvalidLocalState(
+            "stored displaced write does not match its channel payload",
+        ));
+    }
+
+    let restored_local = transaction.query_row(
+        SELECT_DISPLACED_WRITE_BY_TX,
+        [write.tx_id.as_ref()],
+        |row| row.get::<_, bool>(0),
+    )?;
+
+    let change = if restored_local {
+        let change = Some(set_write_status(
+            transaction,
+            write.tx_id,
+            WriteStatus::Live,
+        )?);
+        transaction.execute(DELETE_DISPLACED_WRITE_BY_TX, [write.tx_id.as_ref()])?;
+
+        change
+    } else {
+        None
+    };
+
+    transaction.execute(
+        INSERT_SUFFIX_WRITE,
+        params![
+            write.this_msg.as_ref(),
+            write.tx_id.as_ref(),
+            write.payload,
+            write.local || restored_local
+        ],
+    )?;
+
+    Ok(change)
+}
+
+fn set_write_status(
+    transaction: &rusqlite::Transaction<'_>,
+    tx_id: TxId,
+    status: WriteStatus,
+) -> Result<WriteStatusChange, Error> {
+    transaction.execute(UPSERT_WRITE_STATUS, params![tx_id.as_ref(), status])?;
+
+    Ok(WriteStatusChange::new(tx_id, status))
+}
+
+impl ToSql for WriteStatus {
+    fn to_sql(&self) -> rusqlite::Result<ToSqlOutput<'_>> {
+        let status = match self {
+            Self::Live => LIVE_STATUS,
+            Self::Displaced => DISPLACED_STATUS,
+            Self::Finalized => FINALIZED_STATUS,
+        };
+
+        Ok(status.into())
+    }
+}
+
+impl FromSql for WriteStatus {
+    fn column_result(value: ValueRef<'_>) -> FromSqlResult<Self> {
+        match value.as_str()? {
+            LIVE_STATUS => Ok(Self::Live),
+            DISPLACED_STATUS => Ok(Self::Displaced),
+            FINALIZED_STATUS => Ok(Self::Finalized),
+            _ => Err(FromSqlError::Other(
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "stored write status is invalid",
+                )
+                .into(),
+            )),
+        }
     }
 }
 
@@ -971,6 +1172,7 @@ mod tests {
             CapturedFunction, CapturedFunctionCall, CapturedFunctionCalls, ChannelInscription,
             Statement, Transaction, TxId,
         },
+        status::WriteStatus,
     };
 
     fn checkpoint(byte: u8, slot: u64) -> SequencerCheckpoint {
@@ -1090,7 +1292,68 @@ mod tests {
     }
 
     #[test]
-    fn finalization_clears_a_provisional_displacement() {
+    fn republished_write_returns_to_live_status_at_its_new_position() {
+        let dir = TempDir::new().expect("temporary directory should be created");
+        let mut db = Databases::open(dir.path()).expect("databases should open");
+        let tx_id = db
+            .commit_local_write(
+                TxId::generate(),
+                &transaction("CREATE TABLE local_write(value INTEGER)"),
+            )
+            .expect("local write should commit");
+        let pending = db
+            .pending_publish()
+            .expect("pending write should load")
+            .expect("pending write should exist");
+        let original_position = MsgId::from([7; 32]);
+
+        db.complete_publish(&checkpoint(1, 1), original_position, &pending)
+            .expect("publish should be complete");
+        db.apply_history_delta(&[], &[original_position], &[])
+            .expect("local write should be orphaned");
+
+        db.apply_history_delta(
+            &[],
+            &[],
+            &[super::SuffixWrite {
+                this_msg: MsgId::from([8; 32]),
+                tx_id,
+                payload: pending.payload,
+                local: false,
+            }],
+        )
+        .expect("different channel position should be retained as a foreign write");
+
+        assert_eq!(
+            db.write_status(tx_id).expect("write status should load"),
+            Some(WriteStatus::Live)
+        );
+    }
+
+    #[test]
+    fn invalid_stored_write_status_returns_invalid_local_state() {
+        let dir = TempDir::new().expect("temporary directory should be created");
+        let db = Databases::open(dir.path()).expect("databases should open");
+        let tx_id = TxId::generate();
+
+        db.control
+            .execute_batch("PRAGMA ignore_check_constraints = ON")
+            .expect("constraint checks should be disabled to simulate corruption");
+        db.control
+            .execute(
+                "INSERT INTO __logos_sql_write_statuses (tx_id, status) VALUES (?1, 'invalid')",
+                [tx_id.as_ref()],
+            )
+            .expect("invalid stored status should be inserted");
+
+        assert!(matches!(
+            db.write_status(tx_id),
+            Err(Error::InvalidLocalState("stored write status is invalid"))
+        ));
+    }
+
+    #[test]
+    fn latest_write_status_survives_restart() {
         let dir = TempDir::new().expect("temporary directory should be created");
         let mut db = Databases::open(dir.path()).expect("databases should open");
         let tx_id = db
@@ -1108,20 +1371,27 @@ mod tests {
         db.complete_publish(&checkpoint(1, 1), this_msg, &pending)
             .expect("publish should be complete");
         db.apply_history_delta(&[], &[this_msg], &[])
-            .expect("local write should be orphaned");
+            .expect("local write should be displaced");
 
         assert_eq!(
-            db.displaced_writes().expect("displaced writes should load"),
-            vec![tx_id]
+            db.write_status(tx_id).expect("write status should load"),
+            Some(WriteStatus::Displaced)
         );
 
         db.apply_history_delta(&[this_msg], &[], &[])
-            .expect("finalized suffix should be removed");
+            .expect("local write should finalize");
 
-        assert!(
-            db.displaced_writes()
-                .expect("displaced writes should load")
-                .is_empty()
+        assert_eq!(
+            db.write_status(tx_id).expect("write status should load"),
+            Some(WriteStatus::Finalized)
+        );
+
+        drop(db);
+        let db = Databases::open(dir.path()).expect("databases should reopen");
+
+        assert_eq!(
+            db.write_status(tx_id).expect("write status should reload"),
+            Some(WriteStatus::Finalized)
         );
     }
 
@@ -1145,6 +1415,10 @@ mod tests {
             .expect("row should be readable");
 
         assert_eq!(count, 1);
+        assert_eq!(
+            db.write_status(tx_id).expect("write status should load"),
+            Some(WriteStatus::Live)
+        );
         assert_eq!(
             db.pending_publish()
                 .expect("pending publication should load")

--- a/logos_sql/src/lib.rs
+++ b/logos_sql/src/lib.rs
@@ -13,9 +13,11 @@ mod logos_sql;
 mod protocol;
 mod runtime;
 mod sql;
+mod status;
 
 pub use error::Error;
 pub use logos_sql::{LogosSql, LogosSqlConfig};
 pub use protocol::TxId;
 pub use rusqlite::types::ToSql;
 pub use sql::TransactionBuilder;
+pub use status::{WriteStatus, WriteStatusChange, WriteStatusChanges, WriteStatusChangesError};

--- a/logos_sql/src/logos_sql.rs
+++ b/logos_sql/src/logos_sql.rs
@@ -12,7 +12,14 @@ use lb_zone_sdk::{
 use reqwest::Url;
 use rusqlite::Connection;
 
-use crate::{db::Databases, error::Error, protocol::TxId, runtime, sql::TransactionBuilder};
+use crate::{
+    db::Databases,
+    error::Error,
+    protocol::TxId,
+    runtime,
+    sql::TransactionBuilder,
+    status::{WriteStatus, WriteStatusChanges},
+};
 
 /// Configuration for one `λSQL` database.
 pub struct LogosSqlConfig {
@@ -123,28 +130,47 @@ impl LogosSql {
             .await
     }
 
-    /// Returns local writes whose channel position was removed by a conflict
-    /// or reorganization.
+    /// Returns the current status of a local write.
     ///
-    /// Logos SQL does not execute these writes again. The returned set is
-    /// durable across restarts but provisional: a later reorganization that
-    /// restores the original channel position removes its `TxId` from the
-    /// set. This API does not yet report when a displacement becomes final.
-    /// Repeated calls return the same IDs until such a restoration because
-    /// the current API has no application acknowledgement operation.
-    /// An application that retries before finality must therefore make the
-    /// replacement safe if the original write returns.
+    /// `None` means this participant has no record of `tx_id`. A displaced
+    /// write can become live again if a channel reorganization restores it.
+    /// Once a write is [`WriteStatus::Finalized`], its status cannot change.
     ///
     /// # Errors
     ///
-    /// Returns an error when the runtime is no longer available or its local
-    /// outcome state cannot be read.
-    pub async fn displaced_writes(&self) -> Result<Vec<TxId>, Error> {
+    /// Returns an error if the runtime has stopped or local status cannot be
+    /// read.
+    pub async fn write_status(&self, tx_id: TxId) -> Result<Option<WriteStatus>, Error> {
         self.runtime
             .as_ref()
             .ok_or(Error::RuntimeStopped)?
-            .displaced_writes()
+            .write_status(tx_id)
             .await
+    }
+
+    /// Subscribes to future status changes for local writes.
+    ///
+    /// Notifications are kept in memory and are lost on restart. If the
+    /// application reads too slowly, older notifications are dropped and the
+    /// stream reports `Lagged`. Call [`Self::write_status`] for each write you
+    /// are tracking to get its latest saved status.
+    ///
+    /// Subscribe before querying current statuses so changes that happen
+    /// during those queries are included in the stream.
+    ///
+    /// Logos SQL does not retry or republish displaced writes.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the runtime is no longer available.
+    pub fn write_status_changes(&self) -> Result<WriteStatusChanges, Error> {
+        let receiver = self
+            .runtime
+            .as_ref()
+            .ok_or(Error::RuntimeStopped)?
+            .subscribe_write_status_changes();
+
+        Ok(WriteStatusChanges::new(receiver))
     }
 
     /// Opens a read-only connection to the replicated database.

--- a/logos_sql/src/runtime.rs
+++ b/logos_sql/src/runtime.rs
@@ -8,7 +8,7 @@ use lb_zone_sdk::{
     sequencer::{Event, SequencerCheckpoint, ZoneSequencer, channel_inscriptions},
 };
 use tokio::{
-    sync::{mpsc, oneshot},
+    sync::{broadcast, mpsc, oneshot},
     task::JoinHandle,
 };
 
@@ -17,9 +17,11 @@ use crate::{
     db::{Databases, PendingPublish},
     error::Error,
     protocol::{Transaction, TxId},
+    status::{WriteStatus, WriteStatusChange},
 };
 
 const COMMAND_CHANNEL_CAPACITY: usize = 16;
+const STATUS_CHANNEL_CAPACITY: usize = 256;
 const PUBLISH_RETRY_INTERVAL: Duration = Duration::from_secs(5);
 const TARGET: &str = lb_log_targets::logos_sql::RUNTIME;
 
@@ -30,8 +32,9 @@ enum Command {
         transaction: Transaction,
         response_tx: oneshot::Sender<Result<TxId, Error>>,
     },
-    DisplacedWrites {
-        response_tx: oneshot::Sender<Result<Vec<TxId>, Error>>,
+    WriteStatus {
+        tx_id: TxId,
+        response_tx: oneshot::Sender<Result<Option<WriteStatus>, Error>>,
     },
     Shutdown,
 }
@@ -39,6 +42,7 @@ enum Command {
 /// Control surface for the owning runtime task.
 pub struct RuntimeHandle {
     command_tx: mpsc::Sender<Command>,
+    status_rx: broadcast::Receiver<WriteStatusChange>,
     ready_rx: oneshot::Receiver<()>,
     task: JoinHandle<Result<(), Error>>,
 }
@@ -51,6 +55,7 @@ pub fn spawn(
     restored_checkpoint: Option<SequencerCheckpoint>,
 ) -> RuntimeHandle {
     let (command_tx, command_rx) = mpsc::channel(COMMAND_CHANNEL_CAPACITY);
+    let (status_tx, status_rx) = broadcast::channel(STATUS_CHANNEL_CAPACITY);
     let (ready_tx, ready_rx) = oneshot::channel();
 
     let runtime = Runtime {
@@ -58,6 +63,7 @@ pub fn spawn(
         db,
         channel_id,
         command_rx,
+        status_tx,
         sequencer_ready: false,
         ready_checkpoint_pending: false,
         ready_tx: Some(ready_tx),
@@ -68,6 +74,7 @@ pub fn spawn(
 
     RuntimeHandle {
         command_tx,
+        status_rx,
         ready_rx,
         task,
     }
@@ -108,14 +115,18 @@ impl RuntimeHandle {
         response_rx.await.map_err(|_| Error::RuntimeStopped)?
     }
 
-    pub(crate) async fn displaced_writes(&self) -> Result<Vec<TxId>, Error> {
+    pub(crate) async fn write_status(&self, tx_id: TxId) -> Result<Option<WriteStatus>, Error> {
         let (response_tx, response_rx) = oneshot::channel();
         self.command_tx
-            .send(Command::DisplacedWrites { response_tx })
+            .send(Command::WriteStatus { tx_id, response_tx })
             .await
             .map_err(|_| Error::RuntimeStopped)?;
 
         response_rx.await.map_err(|_| Error::RuntimeStopped)?
+    }
+
+    pub(crate) fn subscribe_write_status_changes(&self) -> broadcast::Receiver<WriteStatusChange> {
+        self.status_rx.resubscribe()
     }
 
     pub(crate) async fn shutdown(self) -> Result<(), Error> {
@@ -146,6 +157,7 @@ struct Runtime {
     db: Databases,
     channel_id: ChannelId,
     command_rx: mpsc::Receiver<Command>,
+    status_tx: broadcast::Sender<WriteStatusChange>,
     sequencer_ready: bool,
     ready_checkpoint_pending: bool,
     ready_tx: Option<oneshot::Sender<()>>,
@@ -157,6 +169,8 @@ struct Runtime {
 struct PendingEvent {
     event: Event,
     error: Error,
+    // Retain committed status changes until the whole event finishes applying.
+    notifications: Vec<WriteStatusChange>,
 }
 
 impl Runtime {
@@ -205,8 +219,13 @@ impl Runtime {
 
                 true
             }
-            Command::DisplacedWrites { response_tx } => {
-                drop(response_tx.send(self.db.displaced_writes()));
+            Command::WriteStatus { tx_id, response_tx } => {
+                let result = if self.event_pending_retry.is_some() {
+                    Err(Error::RuntimeHalted)
+                } else {
+                    self.db.write_status(tx_id)
+                };
+                drop(response_tx.send(result));
 
                 true
             }
@@ -224,6 +243,7 @@ impl Runtime {
         }
 
         self.db.commit_local_write(tx_id, &transaction)?;
+        self.notify_status_change(WriteStatusChange::new(tx_id, WriteStatus::Live));
 
         tracing::trace!(
             target: TARGET,
@@ -245,8 +265,12 @@ impl Runtime {
     }
 
     async fn handle_event(&mut self, event: Event) {
-        match applier::on_event(&mut self.db, &event, self.channel_id) {
+        let mut notifications = Vec::new();
+        let result = applier::on_event(&mut self.db, &event, self.channel_id, &mut notifications);
+
+        match result {
             Ok(()) => {
+                self.notify_status_changes(notifications);
                 self.record_applied_event(&event);
 
                 if self.can_publish()
@@ -261,7 +285,11 @@ impl Runtime {
             }
             Err(error) => {
                 tracing::error!(target: TARGET, %error, "applier halted");
-                self.event_pending_retry = Some(PendingEvent { event, error });
+                self.event_pending_retry = Some(PendingEvent {
+                    event,
+                    error,
+                    notifications,
+                });
             }
         }
     }
@@ -282,17 +310,26 @@ impl Runtime {
 
     async fn retry_event(&mut self, pending: PendingEvent) -> Result<(), Error> {
         let event = pending.event;
+        let mut notifications = pending.notifications;
 
-        if let Err(error) = applier::on_event(&mut self.db, &event, self.channel_id) {
-            if !is_retryable_apply_error(&error) {
-                return Err(error);
+        match applier::on_event(&mut self.db, &event, self.channel_id, &mut notifications) {
+            Ok(()) => {}
+            Err(error) => {
+                if !is_retryable_apply_error(&error) {
+                    return Err(error);
+                }
+
+                tracing::debug!(target: TARGET, %error, "applier retry failed");
+                self.event_pending_retry = Some(PendingEvent {
+                    event,
+                    error,
+                    notifications,
+                });
+                return Ok(());
             }
-
-            tracing::debug!(target: TARGET, %error, "applier retry failed");
-            self.event_pending_retry = Some(PendingEvent { event, error });
-            return Ok(());
         }
 
+        self.notify_status_changes(notifications);
         self.record_applied_event(&event);
 
         if self.can_publish()
@@ -302,6 +339,16 @@ impl Runtime {
         }
 
         Ok(())
+    }
+
+    fn notify_status_changes(&self, changes: Vec<WriteStatusChange>) {
+        for change in changes {
+            self.notify_status_change(change);
+        }
+    }
+
+    fn notify_status_change(&self, change: WriteStatusChange) {
+        drop(self.status_tx.send(change));
     }
 
     fn record_applied_event(&mut self, event: &Event) {
@@ -440,18 +487,132 @@ const fn is_retryable_apply_error(error: &Error) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use futures_util::{FutureExt as _, StreamExt as _};
     use lb_key_management_system_service::keys::Ed25519Key;
     use lb_zone_sdk::{
         CommonHttpClient,
         adapter::NodeHttpClient,
-        node_types::{ChannelId, HeaderId, MsgId, Slot},
-        sequencer::{ChannelUpdate, Event, FundingConfig, SequencerCheckpoint, ZoneSequencer},
+        node_types::{ChannelId, HeaderId, MsgId, Slot, TxHash},
+        sequencer::{
+            ChannelUpdate, ChannelUpdateTx, Event, FundingConfig, InscriptionInfo,
+            SequencerCheckpoint, ZoneSequencer,
+        },
     };
     use tempfile::TempDir;
-    use tokio::sync::{mpsc, oneshot};
+    use tokio::sync::{broadcast, mpsc, oneshot};
 
-    use super::{COMMAND_CHANNEL_CAPACITY, PendingEvent, PublishState, Runtime};
-    use crate::{db::Databases, error::Error};
+    use super::{COMMAND_CHANNEL_CAPACITY, Command, PendingEvent, PublishState, Runtime};
+    use crate::{
+        db::Databases,
+        error::Error,
+        sql::TransactionBuilder,
+        status::{WriteStatus, WriteStatusChange, WriteStatusChanges, WriteStatusChangesError},
+    };
+
+    #[tokio::test]
+    async fn status_stream_closes_when_runtime_stops_with_handle_alive() {
+        let (_dir, runtime, ready_rx) = runtime();
+        let (command_tx, _) = mpsc::channel(COMMAND_CHANNEL_CAPACITY);
+        let handle = super::RuntimeHandle {
+            command_tx,
+            status_rx: runtime.status_tx.subscribe(),
+            ready_rx,
+            task: tokio::spawn(async { Ok(()) }),
+        };
+        let mut stream = WriteStatusChanges::new(handle.subscribe_write_status_changes());
+
+        drop(runtime);
+
+        assert_eq!(stream.next().now_or_never(), Some(None));
+        handle.shutdown().await.expect("task should stop");
+    }
+
+    #[tokio::test]
+    async fn status_notification_survives_a_failed_checkpoint_save() {
+        let (dir, mut runtime, _ready_rx) = runtime();
+        let mut notifications = runtime.status_tx.subscribe();
+        let (tx_id, transaction) =
+            TransactionBuilder::new("CREATE TABLE local_write(value INTEGER)")
+                .finish()
+                .expect("transaction should be valid");
+        runtime
+            .db
+            .commit_local_write(tx_id, &transaction)
+            .expect("write should commit");
+        let pending = runtime
+            .db
+            .pending_publish()
+            .expect("pending write should load")
+            .unwrap();
+        let inscription = InscriptionInfo {
+            tx_hash: TxHash::from([2; 32]),
+            parent_msg: MsgId::root(),
+            this_msg: MsgId::from([2; 32]),
+            payload: pending
+                .payload
+                .clone()
+                .try_into()
+                .expect("payload should fit"),
+            signer: None,
+        };
+        let mut event = blocks_processed();
+        let Event::BlocksProcessed {
+            checkpoint,
+            channel_update,
+            ..
+        } = &mut event
+        else {
+            unreachable!()
+        };
+        runtime
+            .db
+            .complete_publish(checkpoint, inscription.this_msg, &pending)
+            .expect("publication should be recorded");
+        channel_update
+            .orphaned
+            .push(ChannelUpdateTx::Inscription(inscription));
+
+        let control = rusqlite::Connection::open(dir.path().join("control.db"))
+            .expect("control database should open");
+        control
+            .execute_batch(
+                "CREATE TRIGGER fail_checkpoint BEFORE UPDATE OF checkpoint ON __logos_sql_state
+             BEGIN SELECT RAISE(FAIL, 'test checkpoint failure'); END;",
+            )
+            .expect("failure should be installed");
+
+        runtime.handle_event(event).await;
+
+        assert!(runtime.event_pending_retry.is_some());
+        assert_eq!(
+            runtime.db.write_status(tx_id).unwrap(),
+            Some(WriteStatus::Displaced)
+        );
+        assert!(matches!(
+            notifications.try_recv(),
+            Err(broadcast::error::TryRecvError::Empty)
+        ));
+
+        control
+            .execute_batch("DROP TRIGGER fail_checkpoint")
+            .expect("failure should be removed");
+        runtime
+            .retry_pending_work()
+            .await
+            .expect("event should recover");
+
+        assert!(runtime.event_pending_retry.is_none());
+        assert_eq!(
+            notifications
+                .try_recv()
+                .expect("notification should arrive"),
+            WriteStatusChange::new(tx_id, WriteStatus::Displaced)
+        );
+        assert!(matches!(
+            notifications.try_recv(),
+            Err(broadcast::error::TryRecvError::Empty)
+        ));
+    }
 
     #[tokio::test]
     async fn ready_waits_for_its_block_checkpoint_before_enabling_writes() {
@@ -481,6 +642,7 @@ mod tests {
         runtime.event_pending_retry = Some(PendingEvent {
             event: blocks_processed(),
             error: Error::InvalidLocalState("test applier failure"),
+            notifications: Vec::new(),
         });
 
         let error = runtime
@@ -491,6 +653,104 @@ mod tests {
             error,
             Error::InvalidLocalState("test applier failure")
         ));
+    }
+
+    #[tokio::test]
+    async fn missed_status_notifications_can_be_recovered_by_querying() {
+        let (_dir, mut runtime, _ready_rx) = runtime();
+        let (status_tx, receiver) = broadcast::channel(1);
+        runtime.status_tx = status_tx;
+        let mut changes = WriteStatusChanges::new(receiver);
+
+        let (tx_id, transaction) =
+            TransactionBuilder::new("CREATE TABLE local_write(value INTEGER)")
+                .finish()
+                .expect("transaction should be valid");
+
+        runtime
+            .db
+            .commit_local_write(tx_id, &transaction)
+            .expect("local write should commit");
+
+        let pending = runtime
+            .db
+            .pending_publish()
+            .expect("pending write should load")
+            .expect("pending write should exist");
+
+        let inscription = InscriptionInfo {
+            tx_hash: TxHash::from([2; 32]),
+            parent_msg: MsgId::root(),
+            this_msg: MsgId::from([2; 32]),
+            payload: pending
+                .payload
+                .clone()
+                .try_into()
+                .expect("payload should fit"),
+            signer: None,
+        };
+
+        let mut orphan = blocks_processed();
+        let Event::BlocksProcessed {
+            checkpoint,
+            channel_update,
+            ..
+        } = &mut orphan
+        else {
+            unreachable!()
+        };
+
+        runtime
+            .db
+            .complete_publish(checkpoint, inscription.this_msg, &pending)
+            .expect("publication should be recorded");
+
+        channel_update
+            .orphaned
+            .push(ChannelUpdateTx::Inscription(inscription.clone()));
+
+        runtime.handle_event(orphan).await;
+
+        assert!(runtime.event_pending_retry.is_none());
+        assert_eq!(
+            runtime.db.write_status(tx_id).expect("status should load"),
+            Some(WriteStatus::Displaced)
+        );
+
+        let mut adopted = blocks_processed();
+        let Event::BlocksProcessed { channel_update, .. } = &mut adopted else {
+            unreachable!()
+        };
+
+        channel_update
+            .adopted
+            .push(ChannelUpdateTx::Inscription(inscription));
+
+        runtime.handle_event(adopted).await;
+
+        assert!(runtime.event_pending_retry.is_none());
+        assert_eq!(
+            changes.next().now_or_never(),
+            Some(Some(Err(WriteStatusChangesError::Lagged(1))))
+        );
+
+        let (response_tx, response_rx) = oneshot::channel();
+
+        runtime
+            .handle_command(Command::WriteStatus { tx_id, response_tx })
+            .await;
+
+        assert_eq!(
+            response_rx
+                .await
+                .expect("status response should arrive")
+                .expect("status should load"),
+            Some(WriteStatus::Live)
+        );
+        assert_eq!(
+            changes.next().now_or_never(),
+            Some(Some(Ok(WriteStatusChange::new(tx_id, WriteStatus::Live))))
+        );
     }
 
     fn runtime() -> (TempDir, Runtime, oneshot::Receiver<()>) {
@@ -516,12 +776,14 @@ mod tests {
             None,
         );
         let (_command_tx, command_rx) = mpsc::channel(COMMAND_CHANNEL_CAPACITY);
+        let (status_tx, _) = broadcast::channel(16);
         let (ready_tx, ready_rx) = oneshot::channel();
         let runtime = Runtime {
             sequencer,
             db,
             channel_id,
             command_rx,
+            status_tx,
             sequencer_ready: false,
             ready_checkpoint_pending: false,
             ready_tx: Some(ready_tx),

--- a/logos_sql/src/status.rs
+++ b/logos_sql/src/status.rs
@@ -1,0 +1,83 @@
+//! Local write statuses and notifications of status changes.
+
+use std::{
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use futures_util::Stream;
+use tokio::sync::broadcast;
+use tokio_stream::wrappers::{BroadcastStream, errors::BroadcastStreamRecvError};
+
+use crate::TxId;
+
+/// The current status of a local write.
+///
+/// A displaced write can become live again if a channel reorganization restores
+/// it. Once a write is [`Self::Finalized`], its status cannot change.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum WriteStatus {
+    /// The write's SQL changes are present in `LIVE.db`.
+    Live,
+    /// The write's SQL changes have been removed from `LIVE.db`.
+    Displaced,
+    /// The write is part of finalized channel history.
+    Finalized,
+}
+
+/// A notification that a local write's status changed.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct WriteStatusChange {
+    /// The transaction ID returned when the write was submitted.
+    pub tx_id: TxId,
+    /// Current status after the change.
+    pub status: WriteStatus,
+}
+
+impl WriteStatusChange {
+    pub(crate) const fn new(tx_id: TxId, status: WriteStatus) -> Self {
+        Self { tx_id, status }
+    }
+}
+
+/// Error reported when the application reads status notifications too slowly.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]
+pub enum WriteStatusChangesError {
+    /// The number of notifications dropped before the application read them.
+    #[error("missed {0} write status changes; query the current status")]
+    Lagged(u64),
+}
+
+/// A stream of status changes for local writes.
+///
+/// Notifications are kept in memory and are lost on restart. Reading too
+/// slowly drops older notifications and produces
+/// [`Lagged`](WriteStatusChangesError::Lagged).
+/// Call [`LogosSql::write_status`](crate::LogosSql::write_status) for each
+/// write you are tracking to get its latest saved status.
+pub struct WriteStatusChanges {
+    inner: BroadcastStream<WriteStatusChange>,
+}
+
+impl WriteStatusChanges {
+    pub(crate) fn new(receiver: broadcast::Receiver<WriteStatusChange>) -> Self {
+        Self {
+            inner: BroadcastStream::new(receiver),
+        }
+    }
+}
+
+impl Stream for WriteStatusChanges {
+    type Item = Result<WriteStatusChange, WriteStatusChangesError>;
+
+    fn poll_next(mut self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        match Pin::new(&mut self.inner).poll_next(context) {
+            Poll::Ready(Some(Err(BroadcastStreamRecvError::Lagged(missed)))) => {
+                Poll::Ready(Some(Err(WriteStatusChangesError::Lagged(missed))))
+            }
+            Poll::Ready(Some(Ok(change))) => Poll::Ready(Some(Ok(change))),
+            Poll::Ready(None) => Poll::Ready(None),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}

--- a/tests/src/cucumber/logos_sql.rs
+++ b/tests/src/cucumber/logos_sql.rs
@@ -3,7 +3,7 @@ use std::{
     fmt,
 };
 
-use logos_sql::{LogosSql, TxId};
+use logos_sql::{LogosSql, TxId, WriteStatus};
 
 use crate::cucumber::error::{StepError, StepResult};
 
@@ -75,8 +75,16 @@ impl LogosSqlState {
     pub async fn displaced_writes(&self) -> Result<HashSet<TxId>, StepError> {
         let mut displaced = HashSet::new();
 
-        for instance in self.instances.values() {
-            displaced.extend(instance.displaced_writes().await?);
+        for tx_id in self.writes.values().copied() {
+            for instance in self.instances.values() {
+                match instance.write_status(tx_id).await? {
+                    Some(WriteStatus::Displaced) => {
+                        displaced.insert(tx_id);
+                        break;
+                    }
+                    Some(WriteStatus::Live | WriteStatus::Finalized) | None => {}
+                }
+            }
         }
 
         Ok(displaced)


### PR DESCRIPTION
## 1. What does this PR implement?

This PR adds write status queries and notifications so applications can respond when their writes are displaced, restored, or finalized.

- `write_status(tx_id)` returns the latest saved status.
- `write_status_changes()` provides live notifications.

Apps can use these to update their UI or decide how to handle conflicts.

## 2. Does the code have enough context to be clearly understood?
Yes

## 3. Who are the specification authors and who is accountable for this PR?
@andrussal 

## 4. Is the specification accurate and complete?
N/A

## 5. Does the implementation introduce changes in the specification?
N/A

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
