### PR TITLE
fix(blend): bound spammy-peer blocks to epochs and own the blocklist in the blend behaviour

### DIFF
--- a/blend/network/src/core/with_core/behaviour/mod.rs
+++ b/blend/network/src/core/with_core/behaviour/mod.rs
@@ -57,6 +57,32 @@ mod tests;
 
 const LOG_TARGET: &str = blend::network::core::core::BEHAVIOUR;
 
+/// Longest a spammy peer stays blocked, in epochs. A peer's first spammy
+/// verdict blocks it until the next epoch; every further verdict adds an
+/// epoch, up to this cap. The membership, and the `PoQ` public inputs the
+/// verdict may have been based on, are rebuilt every epoch, so a block that
+/// outlives the epoch it was issued in outlives its evidence.
+const MAX_BLOCK_DURATION_IN_EPOCHS: u32 = 4;
+
+/// The reason a connection with a blocked peer is denied.
+#[derive(Debug)]
+pub struct BlockedPeer {
+    peer_id: PeerId,
+    until_epoch: Epoch,
+}
+
+impl core::fmt::Display for BlockedPeer {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(
+            f,
+            "peer {:?} is blocked for spamming until epoch {:?}",
+            self.peer_id, self.until_epoch
+        )
+    }
+}
+
+impl core::error::Error for BlockedPeer {}
+
 #[derive(Debug)]
 pub struct Config {
     /// The [minimum, maximum] peering degree of this node.
@@ -143,6 +169,15 @@ pub struct Behaviour<ObservationWindowClockProvider, ProofsVerifier> {
     /// States for processing messages from the old epoch
     /// before the transition period has passed.
     old_epoch: Option<OldEpoch<ProofsVerifier>>,
+    /// Peers caught spamming on a current-epoch connection, with the epoch at
+    /// which they may connect again. No new connection is upgraded with a
+    /// blocked peer in either direction; connections it already holds (an
+    /// old-epoch one draining during the transition period) are unaffected.
+    blocked_peers: HashMap<PeerId, Epoch>,
+    /// Number of spammy verdicts issued against each peer, which sets how many
+    /// epochs its next block lasts. Entries are dropped at the epoch
+    /// transition for peers that are neither blocked nor members any more.
+    spam_strikes: HashMap<PeerId, u32>,
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Copy)]
@@ -230,6 +265,16 @@ pub enum Event {
     /// A connection with a peer has dropped. The last state that was negotiated
     /// with the peer is also returned.
     PeerDisconnected(PeerId, NegotiatedPeerState),
+    /// A peer was caught spamming on its current-epoch connection and no new
+    /// connection will be upgraded with it before `until_epoch`.
+    PeerBlocked {
+        peer_id: PeerId,
+        reason: SpamReason,
+        until_epoch: Epoch,
+    },
+    /// A peer's block has expired at an epoch transition and it may connect
+    /// again.
+    PeerUnblocked(PeerId),
     /// An outbound connection request was successfully negotiated with the
     /// remote peer.
     OutboundConnectionUpgradeSucceeded(PeerId),
@@ -279,6 +324,8 @@ impl<ObservationWindowClockProvider, ProofsVerifier>
             minimum_network_size: config.minimum_network_size,
             num_blend_layers: config.num_blend_layers,
             old_epoch: None,
+            blocked_peers: HashMap::new(),
+            spam_strikes: HashMap::new(),
         }
     }
 
@@ -302,6 +349,7 @@ impl<ObservationWindowClockProvider, ProofsVerifier>
         let current_epoch_proofs_verifier =
             mem::replace(&mut self.proofs_verifier, Arc::new(new_proofs_verifier));
 
+        self.lift_expired_blocks();
         self.stop_old_epoch();
 
         self.old_epoch = Some(OldEpoch::new(
@@ -331,6 +379,67 @@ impl<ObservationWindowClockProvider, ProofsVerifier>
                 self.try_wake();
             }
         }
+    }
+
+    /// Unblocks the peers whose block has run its course at the current epoch,
+    /// and forgets the strikes of peers that are neither blocked nor members.
+    fn lift_expired_blocks(&mut self) {
+        let current_epoch = self.current_epoch_info.1;
+        let expired_blocks: Vec<PeerId> = self
+            .blocked_peers
+            .iter()
+            .filter(|(_, until_epoch)| **until_epoch <= current_epoch)
+            .map(|(peer_id, _)| *peer_id)
+            .collect();
+        for peer_id in expired_blocks {
+            self.blocked_peers.remove(&peer_id);
+            tracing::debug!(target: LOG_TARGET, "Unblocking peer {peer_id:?}: its block expired at epoch {current_epoch:?}.");
+            self.events
+                .push_back(ToSwarm::GenerateEvent(Event::PeerUnblocked(peer_id)));
+        }
+        let blocked_peers = &self.blocked_peers;
+        let membership = &self.current_epoch_info.0;
+        self.spam_strikes.retain(|peer_id, _| {
+            blocked_peers.contains_key(peer_id) || membership.contains(peer_id)
+        });
+        self.try_wake();
+    }
+
+    /// Blocks a peer caught spamming on its current-epoch connection: its
+    /// first strike blocks it until the next epoch, every further strike adds
+    /// an epoch, up to [`MAX_BLOCK_DURATION_IN_EPOCHS`].
+    fn block_peer(&mut self, peer_id: PeerId, reason: SpamReason) {
+        let strikes = self.spam_strikes.entry(peer_id).or_insert(0);
+        *strikes = strikes.saturating_add(1);
+        let until_epoch: Epoch = u32::from(self.current_epoch_info.1)
+            .saturating_add((*strikes).min(MAX_BLOCK_DURATION_IN_EPOCHS))
+            .into();
+        tracing::debug!(target: LOG_TARGET, "Blocking spammy peer {peer_id:?} for reason {reason:?} until epoch {until_epoch:?} (strike {strikes}).");
+        self.blocked_peers.insert(peer_id, until_epoch);
+        self.events
+            .push_back(ToSwarm::GenerateEvent(Event::PeerBlocked {
+                peer_id,
+                reason,
+                until_epoch,
+            }));
+        self.try_wake();
+    }
+
+    /// Whether no new connection may be upgraded with the peer because it was
+    /// caught spamming.
+    #[must_use]
+    pub fn is_blocked(&self, peer_id: &PeerId) -> bool {
+        self.blocked_peers.contains_key(peer_id)
+    }
+
+    /// The peers currently blocked for spamming.
+    pub fn blocked_peers(&self) -> impl Iterator<Item = &PeerId> {
+        self.blocked_peers.keys()
+    }
+
+    #[must_use]
+    pub fn num_blocked_peers(&self) -> usize {
+        self.blocked_peers.len()
     }
 
     #[must_use]
@@ -726,6 +835,12 @@ impl<ObservationWindowClockProvider, ProofsVerifier>
 
     /// Mark the connection with the sender of a malformed message as malicious
     /// and instruct its connection handler to drop the substream.
+    ///
+    /// Only the offending connection is closed. If it is the peer's
+    /// current-epoch connection, the peer is also blocked from opening or
+    /// receiving new connections until its block expires; an old-epoch
+    /// connection with the same peer keeps draining during the transition
+    /// period.
     fn close_spammy_connection(
         &mut self,
         (peer_id, connection_id): (PeerId, ConnectionId),
@@ -744,10 +859,15 @@ impl<ObservationWindowClockProvider, ProofsVerifier>
         (peer_id, connection_id): (PeerId, ConnectionId),
         reason: SpamReason,
     ) {
-        self.update_state_for_negotiated_peer(
+        // A verdict counts once per connection: a second failure on the same
+        // connection before it is torn down must not add a strike.
+        if let Some(previous_state) = self.update_state_for_negotiated_peer(
             (peer_id, connection_id),
             NegotiatedPeerState::Spammy(reason),
-        );
+        ) && !previous_state.is_spammy()
+        {
+            self.block_peer(peer_id, reason);
+        }
     }
 
     /// Update the state of an already negotiated peer if exists,
@@ -1080,6 +1200,18 @@ where
         _: &Multiaddr,
         remote_addr: &Multiaddr,
     ) -> Result<THandler<Self>, ConnectionDenied> {
+        // A peer caught spamming in this or a recent epoch gets no new
+        // connection. Denying (rather than a dummy handler) closes this
+        // connection only: the peer's old-epoch connection, if any, is not
+        // touched.
+        if let Some(until_epoch) = self.blocked_peers.get(&peer_id) {
+            tracing::debug!(target: LOG_TARGET, "Denying inbound connection {connection_id:?} with peer {peer_id:?} with addr {remote_addr:?} blocked until epoch {until_epoch:?}.");
+            return Err(ConnectionDenied::new(BlockedPeer {
+                peer_id,
+                until_epoch: *until_epoch,
+            }));
+        }
+
         // If the new peer makes the set of established connections too large, do not
         // try to upgrade the connection.
         if self.negotiated_peers.len() >= *self.peering_degree.end() {
@@ -1130,6 +1262,19 @@ where
         _: Endpoint,
         _: PortUse,
     ) -> Result<THandler<Self>, ConnectionDenied> {
+        // Reached only by a dial that was in flight when the verdict landed:
+        // `handle_pending_outbound_connection` refuses later dials before the
+        // transport handshake. The denial surfaces as `DialError::Denied`, an
+        // unrecoverable error, so the swarm picks another peer instead of
+        // retrying this one.
+        if let Some(until_epoch) = self.blocked_peers.get(&peer_id) {
+            tracing::debug!(target: LOG_TARGET, "Denying outbound connection {connection_id:?} with peer {peer_id:?} with addr {remote_addr:?} blocked until epoch {until_epoch:?}.");
+            return Err(ConnectionDenied::new(BlockedPeer {
+                peer_id,
+                until_epoch: *until_epoch,
+            }));
+        }
+
         // If the new peer makes the set of established connections too large, do not
         // try to upgrade the connection.
         if self.negotiated_peers.len() >= *self.peering_degree.end() {
@@ -1165,6 +1310,27 @@ where
             tracing::debug!(target: LOG_TARGET, "Denying outbound connection {connection_id:?} with edge peer {peer_id:?} with addr {remote_addr:?}.");
             Either::Right(DummyConnectionHandler)
         })
+    }
+
+    /// Refuses to dial a blocked peer at all, so the node does not pay a
+    /// transport handshake for a connection it would deny once established.
+    fn handle_pending_outbound_connection(
+        &mut self,
+        connection_id: ConnectionId,
+        maybe_peer: Option<PeerId>,
+        _: &[Multiaddr],
+        _: Endpoint,
+    ) -> Result<Vec<Multiaddr>, ConnectionDenied> {
+        if let Some(peer_id) = maybe_peer
+            && let Some(until_epoch) = self.blocked_peers.get(&peer_id)
+        {
+            tracing::debug!(target: LOG_TARGET, "Refusing to dial peer {peer_id:?} on connection {connection_id:?}: blocked until epoch {until_epoch:?}.");
+            return Err(ConnectionDenied::new(BlockedPeer {
+                peer_id,
+                until_epoch: *until_epoch,
+            }));
+        }
+        Ok(vec![])
     }
 
     /// Informs the behaviour about an event from the [`Swarm`].

--- a/blend/network/src/core/with_core/behaviour/tests/blocklist.rs
+++ b/blend/network/src/core/with_core/behaviour/tests/blocklist.rs
@@ -1,0 +1,367 @@
+//! The list of peers blocked for spamming, which the behaviour owns: what a
+//! block denies, what it leaves alone, and how long it lasts.
+
+use core::time::Duration;
+
+use futures::StreamExt as _;
+use lb_blend_membership::Membership;
+use lb_blend_message::serialize_encapsulated_message_with_verified_public_header;
+use lb_cryptarchia_engine::Epoch;
+use lb_libp2p::SwarmEvent;
+use libp2p::swarm::dial_opts::{DialOpts, PeerCondition};
+use libp2p_swarm_test::SwarmExt as _;
+use test_log::test;
+use tokio::{select, time::sleep};
+
+use crate::core::{
+    tests::utils::{TestEncapsulatedMessageWithEpoch, TestProofsVerifier, TestSwarm},
+    with_core::behaviour::{
+        Event, MAX_BLOCK_DURATION_IN_EPOCHS, SpamReason,
+        tests::utils::{
+            BehaviourBuilder, SwarmExt as _, build_memberships, new_nodes_with_empty_address,
+        },
+    },
+};
+
+/// A first strike blocks until the next epoch, each further strike adds an
+/// epoch up to the cap, an expired block is lifted at the epoch transition, and
+/// strikes are forgotten once the peer is neither blocked nor a member.
+#[test(tokio::test)]
+async fn block_duration_escalates_per_strike_and_expires_with_epochs() {
+    let (mut identities, nodes) = new_nodes_with_empty_address(2);
+    let local_identity = identities.next().unwrap();
+    let remote_peer = nodes[1].id;
+    // The behaviour starts at epoch 0.
+    let mut behaviour = BehaviourBuilder::new(&local_identity)
+        .with_membership(&nodes)
+        .build();
+    let membership = Membership::new_without_local(&nodes);
+
+    behaviour.block_peer(remote_peer, SpamReason::InvalidProofOfQuota);
+    assert_eq!(behaviour.blocked_peers.get(&remote_peer), Some(&1.into()));
+    assert!(behaviour.is_blocked(&remote_peer));
+
+    // Lifted at epoch 1, but the strike is remembered while the peer is a member.
+    behaviour.start_new_epoch(
+        (membership.clone(), 1.into()),
+        TestProofsVerifier::accepting(),
+    );
+    assert!(!behaviour.is_blocked(&remote_peer));
+    assert_eq!(behaviour.spam_strikes.get(&remote_peer), Some(&1));
+
+    // Second strike: two epochs, so still blocked at epoch 2 and lifted at 3.
+    behaviour.block_peer(remote_peer, SpamReason::DuplicateMessage);
+    assert_eq!(behaviour.blocked_peers.get(&remote_peer), Some(&3.into()));
+    behaviour.start_new_epoch(
+        (membership.clone(), 2.into()),
+        TestProofsVerifier::accepting(),
+    );
+    assert!(behaviour.is_blocked(&remote_peer));
+    behaviour.start_new_epoch((membership, 3.into()), TestProofsVerifier::accepting());
+    assert!(!behaviour.is_blocked(&remote_peer));
+
+    // The escalation is capped.
+    for _ in 0..(MAX_BLOCK_DURATION_IN_EPOCHS + 2) {
+        behaviour.block_peer(remote_peer, SpamReason::UndeserializableMessage);
+    }
+    assert_eq!(
+        behaviour.blocked_peers.get(&remote_peer),
+        Some(&(3 + MAX_BLOCK_DURATION_IN_EPOCHS).into())
+    );
+
+    // A peer that leaves the membership while blocked stays blocked until its
+    // block expires, and its strikes are forgotten once it is neither.
+    let empty_membership = Membership::new_without_local(&[]);
+    behaviour.start_new_epoch(
+        (empty_membership.clone(), 4.into()),
+        TestProofsVerifier::accepting(),
+    );
+    assert!(behaviour.is_blocked(&remote_peer));
+    assert!(behaviour.spam_strikes.contains_key(&remote_peer));
+    behaviour.start_new_epoch(
+        (empty_membership, (3 + MAX_BLOCK_DURATION_IN_EPOCHS).into()),
+        TestProofsVerifier::accepting(),
+    );
+    assert!(!behaviour.is_blocked(&remote_peer));
+    assert!(!behaviour.spam_strikes.contains_key(&remote_peer));
+    assert_eq!(behaviour.num_blocked_peers(), 0);
+}
+
+/// A peer caught spamming is blocked when the verdict is issued, its new
+/// connections are denied in the same epoch, and it connects again once its
+/// block has expired at the next epoch.
+#[expect(clippy::too_many_lines, reason = "Test function.")]
+#[test(tokio::test)]
+async fn blocked_peer_is_denied_until_its_block_expires() {
+    let (mut identities, nodes) = new_nodes_with_empty_address(2);
+    let mut dialing_swarm = TestSwarm::new(&identities.next().unwrap(), |id| {
+        BehaviourBuilder::new(id).with_membership(&nodes).build()
+    });
+    let mut listening_swarm = TestSwarm::new(&identities.next().unwrap(), |id| {
+        BehaviourBuilder::new(id).with_membership(&nodes).build()
+    });
+    let dialing_peer_id = *dialing_swarm.local_peer_id();
+    let listening_peer_id = *listening_swarm.local_peer_id();
+
+    listening_swarm.listen().with_memory_addr_external().await;
+    dialing_swarm
+        .connect_and_wait_for_upgrade(&mut listening_swarm)
+        .await;
+
+    // Garbage over the current-epoch connection: a spammy verdict.
+    dialing_swarm
+        .behaviour_mut()
+        .force_send_serialized_message_to_current_epoch_peer(b"garbage".to_vec(), listening_peer_id)
+        .unwrap();
+
+    let mut blocked_event = false;
+    let mut connection_closed = false;
+    loop {
+        select! {
+            () = sleep(Duration::from_secs(10)) => { break; }
+            _ = dialing_swarm.select_next_some() => {}
+            event = listening_swarm.select_next_some() => {
+                match event {
+                    SwarmEvent::Behaviour(Event::PeerBlocked { peer_id, reason, until_epoch }) => {
+                        assert_eq!(peer_id, dialing_peer_id);
+                        assert_eq!(reason, SpamReason::UndeserializableMessage);
+                        // Behaviours start at epoch 0: a first strike lasts one epoch.
+                        assert_eq!(until_epoch, Epoch::from(1));
+                        blocked_event = true;
+                    }
+                    SwarmEvent::ConnectionClosed { peer_id, .. } if peer_id == dialing_peer_id => {
+                        connection_closed = true;
+                    }
+                    _ => {}
+                }
+            }
+        }
+        if blocked_event && connection_closed {
+            break;
+        }
+    }
+    assert!(blocked_event, "a spammy verdict must block the peer");
+    assert!(connection_closed, "the spammy connection must be closed");
+    assert!(listening_swarm.behaviour().is_blocked(&dialing_peer_id));
+    assert_eq!(listening_swarm.behaviour().num_blocked_peers(), 1);
+
+    // The blocked peer dials again: the connection is denied before any
+    // upgrade, and the dialer sees it closed.
+    let listening_address = listening_swarm
+        .external_addresses()
+        .next()
+        .cloned()
+        .expect("listening swarm must have an external address");
+    dialing_swarm
+        .dial(
+            DialOpts::peer_id(listening_peer_id)
+                .addresses(vec![listening_address.clone()])
+                .condition(PeerCondition::Always)
+                .build(),
+        )
+        .unwrap();
+
+    let mut denied = false;
+    let mut closed_on_dialer = false;
+    loop {
+        select! {
+            () = sleep(Duration::from_secs(10)) => { break; }
+            event = dialing_swarm.select_next_some() => {
+                if let SwarmEvent::ConnectionClosed { peer_id, .. } = event && peer_id == listening_peer_id {
+                    closed_on_dialer = true;
+                }
+            }
+            event = listening_swarm.select_next_some() => {
+                match event {
+                    SwarmEvent::IncomingConnectionError { .. } => {
+                        denied = true;
+                    }
+                    SwarmEvent::Behaviour(Event::InboundConnectionUpgradeSucceeded(peer_id)) => {
+                        panic!("connection with blocked peer {peer_id:?} must not be upgraded");
+                    }
+                    _ => {}
+                }
+            }
+        }
+        if denied && closed_on_dialer {
+            break;
+        }
+    }
+    assert!(
+        denied,
+        "the listening swarm must deny the blocked peer's connection"
+    );
+    assert!(
+        closed_on_dialer,
+        "the blocked peer must see its connection closed"
+    );
+    assert!(listening_swarm.behaviour().negotiated_peers.is_empty());
+
+    // The next epoch lifts the block, and the peer connects again.
+    let memberships = build_memberships(&[&dialing_swarm, &listening_swarm]);
+    listening_swarm.behaviour_mut().start_new_epoch(
+        (memberships[1].clone(), 1.into()),
+        TestProofsVerifier::accepting(),
+    );
+    assert!(!listening_swarm.behaviour().is_blocked(&dialing_peer_id));
+
+    let mut unblocked_event = false;
+    loop {
+        select! {
+            () = sleep(Duration::from_secs(5)) => { break; }
+            _ = dialing_swarm.select_next_some() => {}
+            event = listening_swarm.select_next_some() => {
+                if let SwarmEvent::Behaviour(Event::PeerUnblocked(peer_id)) = event {
+                    assert_eq!(peer_id, dialing_peer_id);
+                    unblocked_event = true;
+                    break;
+                }
+            }
+        }
+    }
+    assert!(
+        unblocked_event,
+        "an expired block must be reported to the swarm"
+    );
+
+    tokio::time::timeout(
+        Duration::from_secs(10),
+        dialing_swarm.connect_and_wait_for_upgrade(&mut listening_swarm),
+    )
+    .await
+    .expect("a peer whose block expired must be able to connect again");
+    assert!(
+        listening_swarm
+            .behaviour()
+            .negotiated_peers
+            .contains_key(&dialing_peer_id)
+    );
+}
+
+/// During the transition period a node holds two connections with the same
+/// peer. A spammy verdict on the new-epoch one closes that connection only:
+/// the old-epoch connection keeps carrying, and the node keeps processing, the
+/// previous epoch's messages until the transition period ends.
+#[expect(clippy::too_many_lines, reason = "Test function.")]
+#[test(tokio::test)]
+async fn verdict_on_new_epoch_connection_leaves_old_epoch_connection_open() {
+    let (mut identities, nodes) = new_nodes_with_empty_address(2);
+    let mut dialing_swarm = TestSwarm::new(&identities.next().unwrap(), |id| {
+        BehaviourBuilder::new(id).with_membership(&nodes).build()
+    });
+    let mut listening_swarm = TestSwarm::new(&identities.next().unwrap(), |id| {
+        BehaviourBuilder::new(id).with_membership(&nodes).build()
+    });
+    let dialing_peer_id = *dialing_swarm.local_peer_id();
+    let listening_peer_id = *listening_swarm.local_peer_id();
+
+    listening_swarm.listen().with_memory_addr_external().await;
+    dialing_swarm
+        .connect_and_wait_for_upgrade(&mut listening_swarm)
+        .await;
+    let old_epoch_connection = listening_swarm
+        .behaviour()
+        .negotiated_peers
+        .get(&dialing_peer_id)
+        .unwrap()
+        .connection_id;
+
+    // Both sides move to epoch 1; the connection above becomes old-epoch on
+    // both, and a new one is opened for the new epoch.
+    let memberships = build_memberships(&[&dialing_swarm, &listening_swarm]);
+    dialing_swarm.behaviour_mut().start_new_epoch(
+        (memberships[0].clone(), 1.into()),
+        TestProofsVerifier::accepting(),
+    );
+    listening_swarm.behaviour_mut().start_new_epoch(
+        (memberships[1].clone(), 1.into()),
+        TestProofsVerifier::accepting(),
+    );
+    dialing_swarm
+        .connect_and_wait_for_upgrade(&mut listening_swarm)
+        .await;
+    let new_epoch_connection = listening_swarm
+        .behaviour()
+        .negotiated_peers
+        .get(&dialing_peer_id)
+        .unwrap()
+        .connection_id;
+    assert_ne!(old_epoch_connection, new_epoch_connection);
+    assert!(
+        listening_swarm
+            .behaviour()
+            .old_epoch_peer_ids()
+            .unwrap()
+            .any(|peer_id| *peer_id == dialing_peer_id)
+    );
+
+    // Garbage over the new-epoch connection: the peer is blocked and that
+    // connection is closed.
+    dialing_swarm
+        .behaviour_mut()
+        .force_send_serialized_message_to_current_epoch_peer(b"garbage".to_vec(), listening_peer_id)
+        .unwrap();
+
+    let mut new_epoch_connection_closed = false;
+    loop {
+        select! {
+            () = sleep(Duration::from_secs(10)) => { break; }
+            _ = dialing_swarm.select_next_some() => {}
+            event = listening_swarm.select_next_some() => {
+                if let SwarmEvent::ConnectionClosed { peer_id, connection_id, .. } = event && peer_id == dialing_peer_id {
+                    assert_eq!(connection_id, new_epoch_connection, "only the offending connection may be closed");
+                    new_epoch_connection_closed = true;
+                    break;
+                }
+            }
+        }
+    }
+    assert!(new_epoch_connection_closed);
+    assert!(listening_swarm.behaviour().is_blocked(&dialing_peer_id));
+    assert!(
+        listening_swarm
+            .behaviour()
+            .old_epoch_peer_ids()
+            .unwrap()
+            .any(|peer_id| *peer_id == dialing_peer_id),
+        "the old-epoch connection must survive the verdict"
+    );
+
+    // An old-epoch message from the blocked peer is still delivered over the
+    // old-epoch connection.
+    let old_epoch_message = TestEncapsulatedMessageWithEpoch::new(0.into(), b"last-epoch");
+    dialing_swarm
+        .behaviour_mut()
+        .force_send_serialized_message_to_peer_at_epoch(
+            serialize_encapsulated_message_with_verified_public_header(&old_epoch_message),
+            listening_peer_id,
+            0.into(),
+        )
+        .unwrap();
+
+    let mut old_epoch_message_delivered = false;
+    loop {
+        select! {
+            () = sleep(Duration::from_secs(10)) => { break; }
+            _ = dialing_swarm.select_next_some() => {}
+            event = listening_swarm.select_next_some() => {
+                match event {
+                    SwarmEvent::Behaviour(Event::Message { sender, epoch, .. }) => {
+                        assert_eq!(sender, dialing_peer_id);
+                        assert_eq!(epoch, Epoch::from(0));
+                        old_epoch_message_delivered = true;
+                        break;
+                    }
+                    SwarmEvent::ConnectionClosed { peer_id, connection_id, .. } if peer_id == dialing_peer_id => {
+                        panic!("old-epoch connection {connection_id:?} must not be closed by a verdict on another connection");
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+    assert!(
+        old_epoch_message_delivered,
+        "messages of the previous epoch must keep flowing over the old-epoch connection"
+    );
+}

--- a/blend/network/src/core/with_core/behaviour/tests/mod.rs
+++ b/blend/network/src/core/with_core/behaviour/tests/mod.rs
@@ -1,3 +1,4 @@
+mod blocklist;
 mod bootstrapping;
 mod connection_maintenance;
 mod epoch;

--- a/blend/network/src/core/with_core/behaviour/tests/utils.rs
+++ b/blend/network/src/core/with_core/behaviour/tests/utils.rs
@@ -175,6 +175,8 @@ impl BehaviourBuilder {
             message_cache: MessageCache::new(),
             proofs_verifier: Arc::new(self.proofs_verifier),
             pending_poq_verifications: PendingPoQVerifications::new(),
+            blocked_peers: HashMap::new(),
+            spam_strikes: HashMap::new(),
         }
     }
 }

--- a/libp2p/src/dial_error_ext.rs
+++ b/libp2p/src/dial_error_ext.rs
@@ -14,7 +14,10 @@ impl DialErrorExt for DialError {
             // The address handed resolves back to this node.
             | Self::LocalPeerId { .. }
             // There is no address to dial for this peer.
-            | Self::NoAddresses => false,
+            | Self::NoAddresses
+            // A behaviour refused the connection (the peer is blocked). Nothing
+            // we retry changes that verdict; a new epoch may.
+            | Self::Denied { .. } => false,
 
             // Per-address transport failures. Permanent only when every address
             // failed because we cannot speak its protocol at all; a timeout,
@@ -27,9 +30,7 @@ impl DialErrorExt for DialError {
             }
 
             // Local, transient conditions.
-            Self::Denied { .. }
-            | Self::Aborted
-            | Self::DialPeerConditionFalse(_) => true,
+            Self::Aborted | Self::DialPeerConditionFalse(_) => true,
         }
     }
 }

--- a/services/blend/src/core/backends/libp2p/behaviour.rs
+++ b/services/blend/src/core/backends/libp2p/behaviour.rs
@@ -1,16 +1,20 @@
 use lb_blend::scheduling::membership::Membership;
 use lb_chain_service::Epoch;
 use lb_libp2p::NetworkBehaviour;
-use libp2p::{PeerId, allow_block_list::BlockedPeers};
+use libp2p::PeerId;
 
 use crate::core::{
     backends::libp2p::Libp2pBlendBackendSettings, settings::RunningBlendConfig as BlendConfig,
 };
 
+/// The blend behaviour owns the list of peers blocked for spamming (see
+/// `lb_blend::network::core::with_core::behaviour::Behaviour::is_blocked`), so
+/// no `allow_block_list` behaviour is composed here: a verdict closes only the
+/// offending connection, and the block's lifetime is bound to epochs by the
+/// component that issues the verdicts.
 #[derive(NetworkBehaviour)]
 pub struct BlendBehaviour<ObservationWindowProvider, ProofsVerifier> {
     pub blend: lb_blend::network::core::NetworkBehaviour<ObservationWindowProvider, ProofsVerifier>,
-    pub blocked_peers: libp2p::allow_block_list::Behaviour<BlockedPeers>,
 }
 
 impl<ObservationWindowProvider, ProofsVerifier>
@@ -57,7 +61,6 @@ where
                 config.peer_id(),
                 config.backend.protocol_name.clone().into_inner(),
             ),
-            blocked_peers: libp2p::allow_block_list::Behaviour::default(),
         }
     }
 }

--- a/services/blend/src/core/backends/libp2p/swarm.rs
+++ b/services/blend/src/core/backends/libp2p/swarm.rs
@@ -19,7 +19,7 @@ use lb_blend::{
         with_core::{
             behaviour::{
                 ConnectionUpgradeFailureReason, Event as CoreToCoreEvent, IntervalStreamProvider,
-                NegotiatedPeerState,
+                NegotiatedPeerState, SpamReason,
             },
             error::SendError,
         },
@@ -238,14 +238,16 @@ where
             return;
         }
 
-        let negotiated_peers = self.behaviour().blend.with_core().negotiated_peers().keys();
+        let core_behaviour = self.behaviour().blend.with_core();
+        let negotiated_peers = core_behaviour.negotiated_peers().keys();
+        let num_blocked_peers = core_behaviour.num_blocked_peers();
 
         // We need to clone else we would not be able to call `self.dial` below, which
         // requires access to `&mut self`.
         let current_membership = self.current_epoch_info.membership.clone();
 
         let exclude_peers: HashSet<PeerId> = negotiated_peers
-            .chain(self.swarm.behaviour().blocked_peers.blocked_peers())
+            .chain(core_behaviour.blocked_peers())
             .chain(self.ongoing_dials.keys())
             .chain(self.unrecoverable_peers.iter())
             .chain(except.iter())
@@ -260,6 +262,21 @@ where
             .peekable();
 
         let no_more_peers_to_dial = peers_to_dial.peek().is_none();
+
+        // A node whose blocklist has swallowed its membership would otherwise
+        // look idle: it needs connections, and finds nobody to dial.
+        if no_more_peers_to_dial && num_blocked_peers > 0 {
+            tracing::warn!(
+                target: LOG_TARGET,
+                diagnostic = BLEND_REACHABILITY,
+                event = "blend_no_dialable_peers",
+                epoch = u32::from(self.current_epoch_info.epoch),
+                membership_size = current_membership.size(),
+                blocked_peers = num_blocked_peers,
+                needed_connections = amount,
+                "No member is dialable: every member is negotiated, being dialed, unreachable, or blocked for spamming."
+            );
+        }
 
         // When no membership peer is eligible to be dialed but we still have peers
         // we gave up on earlier in this dial cycle (`except`), we want to clear
@@ -424,14 +441,24 @@ where
         self.dial_random_peers_except(connections_to_establish, except);
     }
 
+    /// A spammy peer was already blocked by the behaviour when the verdict was
+    /// issued (`Event::PeerBlocked`); here only its connection slot is
+    /// refilled.
     fn handle_disconnected_peer(&mut self, peer_id: PeerId, peer_state: NegotiatedPeerState) {
         tracing::trace!(target: LOG_TARGET, "Peer {peer_id} disconnected with state {peer_state:?}.");
-        if let NegotiatedPeerState::Spammy(reason) = peer_state {
-            tracing::debug!(target: LOG_TARGET, "Blocking spammy peer {peer_id} for reason {reason:?}.");
-            self.swarm.behaviour_mut().blocked_peers.block_peer(peer_id);
-            metrics::core_peer_blocked(reason.as_str());
-        }
         self.check_and_dial_new_peers_except(&HashSet::from([peer_id]));
+    }
+
+    fn handle_blocked_peer(&self, peer_id: PeerId, reason: SpamReason, until_epoch: Epoch) {
+        tracing::debug!(target: LOG_TARGET, "Peer {peer_id} blocked for reason {reason:?} until epoch {until_epoch:?}.");
+        metrics::core_peer_blocked(reason.as_str());
+        metrics::core_peers_blocked(self.num_blocked_peers());
+    }
+
+    fn handle_unblocked_peer(&self, peer_id: PeerId) {
+        tracing::debug!(target: LOG_TARGET, "Peer {peer_id} unblocked: its block expired.");
+        metrics::core_peer_unblocked();
+        metrics::core_peers_blocked(self.num_blocked_peers());
     }
 
     fn collect_network_info(&self) -> NetworkInfo<PeerId> {
@@ -478,6 +505,16 @@ where
                 peer_state,
             ) => {
                 self.handle_disconnected_peer(peer_id, peer_state);
+            }
+            lb_blend::network::core::with_core::behaviour::Event::PeerBlocked {
+                peer_id,
+                reason,
+                until_epoch,
+            } => {
+                self.handle_blocked_peer(peer_id, reason, until_epoch);
+            }
+            lb_blend::network::core::with_core::behaviour::Event::PeerUnblocked(peer_id) => {
+                self.handle_unblocked_peer(peer_id);
             }
             lb_blend::network::core::with_core::behaviour::Event::OutboundConnectionUpgradeFailed { peer, reason } => {
                 match reason {
@@ -635,6 +672,8 @@ where
                 self.pending_retries.clear();
                 self.unrecoverable_peers.clear();
                 self.pending_full_membership_retry = None;
+                // Expired blocks are lifted by the behaviour in `start_new_epoch`,
+                // so the peers concerned are dialable again right here.
                 self.check_and_dial_new_peers();
             }
             BlendSwarmMessage::CompleteEpochTransition => {
@@ -942,6 +981,10 @@ where
 
     fn num_healthy_peers(&self) -> usize {
         self.swarm.behaviour().blend.with_core().num_healthy_peers()
+    }
+
+    fn num_blocked_peers(&self) -> usize {
+        self.swarm.behaviour().blend.with_core().num_blocked_peers()
     }
 
     fn available_connection_slots(&self) -> usize {

--- a/services/blend/src/core/backends/libp2p/tests/network_maintenance.rs
+++ b/services/blend/src/core/backends/libp2p/tests/network_maintenance.rs
@@ -5,12 +5,22 @@ use lb_blend::{
 };
 use libp2p::core::Endpoint;
 use test_log::test;
-use tokio::{select, time::sleep};
+use tokio::{
+    select,
+    time::{sleep, timeout},
+};
 
 use crate::{
-    core::backends::libp2p::{
-        core_swarm_test_utils::{new_nodes_with_empty_address, update_nodes},
-        tests::utils::{BlendBehaviourBuilder, SwarmBuilder, SwarmExt as _, TestSwarm},
+    core::backends::{
+        BackendEpochInfo,
+        libp2p::{
+            core_swarm_test_utils::{new_nodes_with_empty_address, update_nodes},
+            swarm::BlendSwarmMessage,
+            tests::utils::{
+                BlendBehaviourBuilder, InnerSwarm, SwarmBuilder, SwarmExt as _, TestProofsVerifier,
+                TestSwarm, build_membership,
+            },
+        },
     },
     test_utils::TestEncapsulatedMessage,
 };
@@ -194,9 +204,9 @@ async fn on_malicious_peer() {
     assert!(
         listening_swarm
             .behaviour()
-            .blocked_peers
-            .blocked_peers()
-            .contains(malicious_swarm.local_peer_id())
+            .blend
+            .with_core()
+            .is_blocked(malicious_swarm.local_peer_id())
     );
 
     // We check that the malicious peer has no entry in the set of negotiated peers.
@@ -223,4 +233,207 @@ async fn on_malicious_peer() {
         NegotiatedPeerState::Healthy
     );
     assert_eq!(second_swarm_connection_details.role(), Endpoint::Listener);
+}
+
+/// Polls both swarms until `condition` holds on the first one or `duration`
+/// elapses, returning whether it held.
+async fn poll_both_until(
+    first: &mut InnerSwarm,
+    second: &mut InnerSwarm,
+    duration: Duration,
+    condition: impl Fn(&InnerSwarm) -> bool + Send + Sync,
+) -> bool {
+    timeout(duration, async {
+        // Checked before every poll rather than after the first swarm's
+        // events only: the condition may already hold, or become true while
+        // the other swarm is the one making progress.
+        while !condition(first) {
+            select! {
+                () = first.poll_next() => {}
+                () = second.poll_next() => {}
+            }
+        }
+    })
+    .await
+    .is_ok()
+}
+
+/// Two core nodes. The listening one rejects every `PoQ`, which is what a
+/// node does to the messages of a peer whose proofs were generated for a
+/// different epoch than the one the connection was accepted under. The dialing
+/// one connects and sends a single message, and ends up blocked.
+async fn block_dialing_peer_for_invalid_poq() -> (
+    InnerSwarm,
+    InnerSwarm,
+    tokio::sync::mpsc::Sender<BlendSwarmMessage<TestProofsVerifier>>,
+    Vec<Node<libp2p::PeerId>>,
+) {
+    let (mut identities, mut nodes) = new_nodes_with_empty_address(2);
+
+    let TestSwarm {
+        swarm: mut dialing_swarm,
+        ..
+    } = SwarmBuilder::new(identities.next().unwrap(), &nodes)
+        .build(|id, membership| BlendBehaviourBuilder::new(id, membership).build());
+    let (dialing_node, _) = dialing_swarm.listen_and_return_membership_entry(None).await;
+    update_nodes(&mut nodes, &dialing_node.id, dialing_node.address.clone());
+
+    let TestSwarm {
+        swarm: mut listening_swarm,
+        swarm_message_sender,
+        ..
+    } = SwarmBuilder::new(identities.next().unwrap(), &nodes).build(|id, membership| {
+        BlendBehaviourBuilder::new(id, membership)
+            .with_rejecting_proofs_verifier()
+            .build()
+    });
+    let (listening_node, _) = listening_swarm
+        .listen_and_return_membership_entry(None)
+        .await;
+    update_nodes(
+        &mut nodes,
+        &listening_node.id,
+        listening_node.address.clone(),
+    );
+
+    dialing_swarm.dial_peer_at_addr(listening_node.id, listening_node.address.clone());
+    assert!(
+        poll_both_until(
+            &mut listening_swarm,
+            &mut dialing_swarm,
+            Duration::from_secs(5),
+            |swarm| {
+                swarm
+                    .behaviour()
+                    .blend
+                    .with_core()
+                    .negotiated_peers()
+                    .contains_key(&dialing_node.id)
+            }
+        )
+        .await,
+        "connection was not negotiated by the listening swarm"
+    );
+    // The handler events are asynchronous, so the dialing side may learn of
+    // the negotiation a little later than the listening side.
+    assert!(
+        poll_both_until(
+            &mut dialing_swarm,
+            &mut listening_swarm,
+            Duration::from_secs(5),
+            |swarm| {
+                swarm
+                    .behaviour()
+                    .blend
+                    .with_core()
+                    .negotiated_peers()
+                    .contains_key(&listening_node.id)
+            }
+        )
+        .await,
+        "connection was not negotiated by the dialing swarm"
+    );
+
+    dialing_swarm
+        .behaviour_mut()
+        .blend
+        .with_core_mut()
+        .force_send_message_to_current_epoch_peer(
+            &TestEncapsulatedMessage::new(b"proof-for-another-epoch"),
+            listening_node.id,
+        )
+        .unwrap();
+
+    // The block is issued with the verdict, before the connection is torn
+    // down, so wait for both.
+    assert!(
+        poll_both_until(
+            &mut listening_swarm,
+            &mut dialing_swarm,
+            Duration::from_secs(10),
+            |swarm| {
+                let core_behaviour = swarm.behaviour().blend.with_core();
+                core_behaviour.is_blocked(&dialing_node.id)
+                    && !core_behaviour
+                        .negotiated_peers()
+                        .contains_key(&dialing_node.id)
+            }
+        )
+        .await,
+        "a peer whose PoQ fails verification must be blocked and disconnected"
+    );
+
+    (listening_swarm, dialing_swarm, swarm_message_sender, nodes)
+}
+
+#[test(tokio::test)]
+async fn peer_with_invalid_poq_is_blocked() {
+    let (listening_swarm, dialing_swarm, _sender, _nodes) =
+        block_dialing_peer_for_invalid_poq().await;
+    assert!(
+        listening_swarm
+            .behaviour()
+            .blend
+            .with_core()
+            .is_blocked(dialing_swarm.local_peer_id())
+    );
+    // The spammy connection was closed, and nothing else is negotiated.
+    assert_eq!(
+        listening_swarm
+            .behaviour()
+            .blend
+            .with_core()
+            .num_negotiated_peers(),
+        0
+    );
+}
+
+/// A block must not outlive the epoch it was issued in: the next epoch
+/// rebuilds the membership and brings new `PoQ` public inputs, under which the
+/// rejected peer's messages may well verify. Here the new epoch's verifier
+/// accepts everything and the blocked peer is the only other member, so the
+/// listening swarm must unblock it and negotiate with it again.
+#[test(tokio::test)]
+async fn blocked_peer_is_dialable_again_in_next_epoch() {
+    let (mut listening_swarm, mut dialing_swarm, swarm_message_sender, nodes) =
+        block_dialing_peer_for_invalid_poq().await;
+    let dialing_peer_id = *dialing_swarm.local_peer_id();
+    let listening_peer_id = *listening_swarm.local_peer_id();
+
+    swarm_message_sender
+        .send(BlendSwarmMessage::StartNewEpoch(BackendEpochInfo {
+            membership: build_membership(&nodes, Some(listening_peer_id)),
+            epoch: 2.into(),
+            proofs_verifier: TestProofsVerifier::default(),
+        }))
+        .await
+        .unwrap();
+
+    let renegotiated = poll_both_until(
+        &mut listening_swarm,
+        &mut dialing_swarm,
+        Duration::from_secs(5),
+        |swarm| {
+            swarm
+                .behaviour()
+                .blend
+                .with_core()
+                .negotiated_peers()
+                .contains_key(&dialing_peer_id)
+        },
+    )
+    .await;
+
+    assert!(
+        !listening_swarm
+            .behaviour()
+            .blend
+            .with_core()
+            .is_blocked(&dialing_peer_id),
+        "a peer blocked in epoch 1 is still blocked in epoch 2"
+    );
+    assert!(
+        renegotiated,
+        "the listening swarm did not reconnect to the peer it blocked in the previous epoch"
+    );
 }

--- a/services/blend/src/core/backends/libp2p/tests/redials.rs
+++ b/services/blend/src/core/backends/libp2p/tests/redials.rs
@@ -325,7 +325,7 @@ async fn core_epoch_rotation_clears_pending_retries() {
     let new_epoch_info = BackendEpochInfo {
         membership: Membership::new_without_local(&[]),
         epoch: 2.into(),
-        proofs_verifier: TestProofsVerifier,
+        proofs_verifier: TestProofsVerifier::default(),
     };
     swarm_message_sender
         .send(BlendSwarmMessage::StartNewEpoch(new_epoch_info))
@@ -403,7 +403,7 @@ async fn core_does_not_give_up_below_minimum_peering_degree() {
         .send(BlendSwarmMessage::StartNewEpoch(BackendEpochInfo {
             membership: new_membership,
             epoch: 2.into(),
-            proofs_verifier: TestProofsVerifier,
+            proofs_verifier: TestProofsVerifier::default(),
         }))
         .await
         .unwrap();

--- a/services/blend/src/core/backends/libp2p/tests/utils.rs
+++ b/services/blend/src/core/backends/libp2p/tests/utils.rs
@@ -22,9 +22,7 @@ use lb_blend::{
 use lb_chain_service::Epoch;
 use lb_key_management_system_service::keys::UnsecuredEd25519Key;
 use lb_libp2p::{Protocol, SwarmEvent};
-use libp2p::{
-    Multiaddr, PeerId, Swarm, allow_block_list, core::transport::ListenerId, identity::Keypair,
-};
+use libp2p::{Multiaddr, PeerId, Swarm, core::transport::ListenerId, identity::Keypair};
 use libp2p_swarm_test::SwarmExt as _;
 use rand::SeedableRng as _;
 use rand_chacha::ChaCha20Rng;
@@ -46,18 +44,21 @@ use crate::{
 };
 
 /// A `PoQ` verifier for the swarm tests, which accepts every proof it is
-/// handed.
+/// handed unless `reject_all` is set.
 ///
-/// What a node does with a *failed* verification is decided by the behaviour,
-/// so it is tested there rather than here.
-#[derive(Debug, Clone, Copy)]
-pub struct TestProofsVerifier;
+/// Rejecting every proof is what a verifier does to messages whose proofs
+/// were generated against another epoch's public inputs, which is how the
+/// swarm's reaction to a failed verification (blocking the sender) is tested.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct TestProofsVerifier {
+    pub reject_all: bool,
+}
 
 impl ProofsVerifier for TestProofsVerifier {
     type Error = ();
 
     fn new(_public_inputs: PoQVerificationInputsMinusSigningKey) -> Self {
-        Self
+        Self::default()
     }
 
     fn verify_proof_of_quota(
@@ -65,6 +66,9 @@ impl ProofsVerifier for TestProofsVerifier {
         proof: ProofOfQuota,
         _signing_key: &lb_key_management_system_service::keys::Ed25519PublicKey,
     ) -> Result<VerifiedProofOfQuota, Self::Error> {
+        if self.reject_all {
+            return Err(());
+        }
         Ok(VerifiedProofOfQuota::from_proof_of_quota_unchecked(proof))
     }
 
@@ -141,7 +145,7 @@ impl SwarmBuilder {
         let public_info = BackendEpochInfo {
             membership: build_membership(membership, Some(identity.public().into())),
             epoch: 1.into(),
-            proofs_verifier: TestProofsVerifier,
+            proofs_verifier: TestProofsVerifier::default(),
         };
         Self {
             identity,
@@ -213,7 +217,7 @@ impl BlendBehaviourBuilder {
             membership,
             observation_window: None,
             peering_degree: None,
-            proofs_verifier: TestProofsVerifier,
+            proofs_verifier: TestProofsVerifier::default(),
         }
     }
 
@@ -228,6 +232,13 @@ impl BlendBehaviourBuilder {
 
     pub fn with_peering_degree(mut self, peering_degree: RangeInclusive<usize>) -> Self {
         self.peering_degree = Some(peering_degree);
+        self
+    }
+
+    /// Every `PoQ` this behaviour verifies fails, as if the sender's proofs
+    /// were generated for a different epoch.
+    pub fn with_rejecting_proofs_verifier(mut self) -> Self {
+        self.proofs_verifier = TestProofsVerifier { reject_all: true };
         self
     }
 
@@ -261,7 +272,6 @@ impl BlendBehaviourBuilder {
                 self.peer_id,
                 PROTOCOL_NAME,
             ),
-            blocked_peers: allow_block_list::Behaviour::default(),
         }
     }
 }

--- a/services/blend/src/metrics.rs
+++ b/services/blend/src/metrics.rs
@@ -71,6 +71,17 @@ mod imp {
         lb_tracing::increase_counter_u64!(blend_core_peers_blocked_total, 1, reason = reason);
     }
 
+    /// Reports a core peer whose block expired at an epoch transition.
+    pub fn core_peer_unblocked() {
+        lb_tracing::increase_counter_u64!(blend_core_peers_unblocked_total, 1);
+    }
+
+    /// Number of core peers currently blocked for spamming. A value close to
+    /// the membership size means the node has nobody left to dial.
+    pub fn core_peers_blocked(count: usize) {
+        lb_tracing::metric_observable_gauge_u64_set!(blend_core_peers_blocked, count as u64);
+    }
+
     /// Reports a data payload the Blend network failed to deliver within the
     /// delivery deadline, and that this node therefore broadcast in the clear.
     pub fn data_payload_bypassed_blend(payload_type: DataPayloadType) {


### PR DESCRIPTION
## Problem

A core peer caught spamming is blocked for the life of the process (`services/blend/src/core/backends/libp2p/swarm.rs`, `handle_disconnected_peer` → `allow_block_list::block_peer`; nothing ever calls `unblock_peer`, and `StartNewEpoch` clears every other per-epoch set but not the blocklist). `block_peer` also closes `CloseConnection::All`, so the old-epoch connection to the same peer, which the transition period requires us to keep serving, is torn down too.

The only verdict live today, `InvalidProofOfQuota`, is triggered by honest peers whenever two nodes cross an epoch boundary a little apart and one dials the other in between (a proof generated under the new epoch's public inputs fails under the old verifier, and vice versa). Every block is permanent, so the blocklist grows until a node has nobody left to dial. Full analysis in the audit reports for issues #101 and #117 of `logos-blockchain-agent-message-board`.

A second, smaller problem with the current ordering: the block is only issued on `PeerDisconnected(Spammy)`, and if `StartNewEpoch` is processed between the verdict and the actual `ConnectionClosed`, the connection has moved to `OldEpoch`, the close is swallowed, no event is emitted, and the peer is never blocked (and is re-dialed immediately).

## Change

The blend core behaviour (`blend/network`) now owns the blocklist:

- **Epoch-bounded lifetime.** A spammy verdict on a current-epoch connection blocks the peer until the next epoch; every further strike adds an epoch, capped at `MAX_BLOCK_DURATION_IN_EPOCHS = 4`. `start_new_epoch` lifts expired blocks and forgets the strikes of peers that are neither blocked nor members, so both maps stay bounded by the membership size.
- **Block at verdict time, enforced in the behaviour.** `set_connection_to_spammy` blocks the peer when it actually marks the peer's current-epoch connection (once per connection). A blocked peer is denied in `handle_pending_outbound_connection` (no transport handshake for our own dials) and in `handle_established_{inbound,outbound}_connection` with `ConnectionDenied`. Only the offending connection is closed; an old-epoch connection with the same peer keeps draining.
- **Events.** `Event::PeerBlocked { peer_id, reason, until_epoch }` and `Event::PeerUnblocked(peer_id)`; the swarm uses them for logging and metrics only.
- **Service side.** `allow_block_list` is no longer composed into `BlendBehaviour`; the dial filter reads the behaviour's blocklist; new `blend_core_peers_unblocked_total` counter and `blend_core_peers_blocked` gauge next to the existing `blend_core_peers_blocked_total{reason}`; a `warn` (`blend_reachability` / `blend_no_dialable_peers`) when no member is dialable while peers are blocked.
- **`DialError::Denied` is unrecoverable** (`libp2p/src/dial_error_ext.rs`): a dial in flight when the verdict lands, or a backoff retry against a now-blocked peer, is abandoned and replaced instead of retried up to `max_dial_attempts_per_peer` times.

`ConnectionDenied` rather than a `DummyConnectionHandler` (as used for edge peers) because a dummy handler on an outbound connection never produces `OutboundConnectionUpgradeFailed`, leaving the swarm's `ongoing_dials` entry dangling for the epoch; `Denied` surfaces as `OutgoingConnectionError` and is handled.

## Tests

New in `blend/network/src/core/with_core/behaviour/tests/blocklist.rs`:
- `block_duration_escalates_per_strike_and_expires_with_epochs`
- `blocked_peer_is_denied_until_its_block_expires` (verdict → `PeerBlocked` → re-dial denied → next epoch `PeerUnblocked` → reconnects)
- `verdict_on_new_epoch_connection_leaves_old_epoch_connection_open` (two connections during a transition; only the new-epoch one is closed, an old-epoch message is still delivered)

New in `services/blend/src/core/backends/libp2p/tests/network_maintenance.rs`: `peer_with_invalid_poq_is_blocked`, `blocked_peer_is_dialable_again_in_next_epoch` (the latter fails on `master`). `TestProofsVerifier` gained a `reject_all` mode for these.

- `cargo test -p logos-blockchain-blend-network --lib with_core::behaviour::tests`: 41 passed, 3 ignored
- `cargo test -p logos-blockchain-blend-service --lib backends::libp2p::tests`: 20 passed, 2 ignored
- `cargo test -p logos-blockchain-libp2p`: 65 passed
- clippy (`--tests`) clean on the three crates; `cargo +nightly-2026-07-05 fmt --check` clean

## Spec

`blend-protocol.md` §Connectivity Maintenance defines the blacklist without a lifetime, without a rule for a blacklist covering the membership, and without saying whether a verdict closes the other connection to the same neighbour during the transition period; an issue is filed in logos-lips for that. This PR picks "until the next epoch, escalating per strike" as the lifetime, which is the smallest change consistent with the spec rebuilding membership, connections and proof public inputs every epoch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01To3n4ZvMar9dM7gVMKGWEr
