### PR TITLE
perf(ledger): run the cheap SDPActive checks before the proof-of-quota pairing

### DIFF
--- a/blend/message/src/crypto/proofs.rs
+++ b/blend/message/src/crypto/proofs.rs
@@ -30,7 +30,7 @@ pub struct PoQVerificationInputsMinusSigningKey {
     pub pow: PowInputs,
 }
 
-#[cfg(test)]
+#[cfg(any(test, feature = "unsafe-test-functions"))]
 impl Default for PoQVerificationInputsMinusSigningKey {
     fn default() -> Self {
         use lb_blend_proofs::quota::Quota;

--- a/blend/message/src/encap/mod.rs
+++ b/blend/message/src/encap/mod.rs
@@ -10,8 +10,16 @@ pub mod decapsulated;
 pub mod encapsulated;
 pub mod validated;
 
+#[cfg(any(test, feature = "unsafe-test-functions"))]
+mod scripted_verifier;
 #[cfg(test)]
 mod tests;
+
+#[cfg(any(test, feature = "unsafe-test-functions"))]
+pub use scripted_verifier::{
+    ProofOfQuotaScript, ProofOfSelectionScript, Rejected, ScriptedProofsVerifier,
+    VerificationCounts,
+};
 
 /// An epoch-bound `PoQ` verifier.
 pub trait ProofsVerifier {

--- a/blend/message/src/encap/scripted_verifier.rs
+++ b/blend/message/src/encap/scripted_verifier.rs
@@ -1,0 +1,181 @@
+//! A scriptable [`ProofsVerifier`] for tests.
+
+use core::cell::RefCell;
+use std::rc::Rc;
+
+use lb_blend_proofs::{
+    quota::{ProofOfQuota, VerifiedProofOfQuota},
+    selection::{ProofOfSelection, VerifiedProofOfSelection, inputs::VerifyInputs},
+};
+use lb_key_management_system_keys::keys::Ed25519PublicKey;
+
+use crate::{crypto::proofs::PoQVerificationInputsMinusSigningKey, encap::ProofsVerifier};
+
+/// Decides whether a proof of quota is accepted, given the public inputs the
+/// verifier was created with, the proof, and the signing key.
+pub type ProofOfQuotaScript =
+    Rc<dyn Fn(&PoQVerificationInputsMinusSigningKey, &ProofOfQuota, &Ed25519PublicKey) -> bool>;
+
+/// Decides whether a proof of selection is accepted, given the public inputs
+/// the verifier was created with, the proof, and the verification inputs.
+pub type ProofOfSelectionScript =
+    Rc<dyn Fn(&PoQVerificationInputsMinusSigningKey, &ProofOfSelection, &VerifyInputs) -> bool>;
+
+/// How many times each verification method has been called on the current
+/// thread since the script was last set or the counts last reset.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct VerificationCounts {
+    pub proof_of_quota: usize,
+    pub proof_of_selection: usize,
+}
+
+/// The error a [`ScriptedProofsVerifier`] returns for a proof its script
+/// rejects.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[error("proof rejected by the test script")]
+pub struct Rejected;
+
+struct Script {
+    proof_of_quota: ProofOfQuotaScript,
+    proof_of_selection: ProofOfSelectionScript,
+    counts: VerificationCounts,
+}
+
+impl Script {
+    fn new(accept_proof_of_quota: bool, accept_proof_of_selection: bool) -> Self {
+        Self {
+            proof_of_quota: Rc::new(move |_, _, _| accept_proof_of_quota),
+            proof_of_selection: Rc::new(move |_, _, _| accept_proof_of_selection),
+            counts: VerificationCounts::default(),
+        }
+    }
+}
+
+thread_local! {
+    static SCRIPT: RefCell<Script> = RefCell::new(Script::new(true, true));
+}
+
+/// A [`ProofsVerifier`] whose outcomes are scripted per thread and whose calls
+/// are counted, replacing the one-off always-accept, always-reject and
+/// reject-one-kind doubles.
+///
+/// The script lives in a thread-local: every `#[test]` runs on its own thread,
+/// so a script set at the start of a test is private to that test, and a fresh
+/// thread accepts every proof until told otherwise. A `#[tokio::test]` on a
+/// current-thread runtime behaves the same; on a multi-thread runtime the
+/// worker threads see the default script.
+///
+/// An instance holds the public inputs it was created with through
+/// [`ProofsVerifier::new`] and hands them to the script, so a script can
+/// depend on the epoch the verifier belongs to. Tests that need an instance
+/// by value use [`Default`], which carries the default public inputs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ScriptedProofsVerifier {
+    public_inputs: PoQVerificationInputsMinusSigningKey,
+}
+
+impl Default for ScriptedProofsVerifier {
+    fn default() -> Self {
+        Self::new(PoQVerificationInputsMinusSigningKey::default())
+    }
+}
+
+impl ScriptedProofsVerifier {
+    /// Accepts every proof (the default), and resets the counts.
+    pub fn accept_all() {
+        Self::set_script(Script::new(true, true));
+    }
+
+    /// Rejects every proof, and resets the counts.
+    pub fn reject_all() {
+        Self::set_script(Script::new(false, false));
+    }
+
+    /// Rejects every proof of quota and accepts every proof of selection, and
+    /// resets the counts.
+    pub fn reject_proofs_of_quota() {
+        Self::set_script(Script::new(false, true));
+    }
+
+    /// Accepts every proof of quota and rejects every proof of selection, and
+    /// resets the counts.
+    pub fn reject_proofs_of_selection() {
+        Self::set_script(Script::new(true, false));
+    }
+
+    /// Decides proofs of quota with `script`, leaving the proof-of-selection
+    /// script and the counts as they are.
+    pub fn script_proof_of_quota(
+        script: impl Fn(&PoQVerificationInputsMinusSigningKey, &ProofOfQuota, &Ed25519PublicKey) -> bool
+        + 'static,
+    ) {
+        SCRIPT.with_borrow_mut(|current| current.proof_of_quota = Rc::new(script));
+    }
+
+    /// Decides proofs of selection with `script`, leaving the proof-of-quota
+    /// script and the counts as they are.
+    pub fn script_proof_of_selection(
+        script: impl Fn(&PoQVerificationInputsMinusSigningKey, &ProofOfSelection, &VerifyInputs) -> bool
+        + 'static,
+    ) {
+        SCRIPT.with_borrow_mut(|current| current.proof_of_selection = Rc::new(script));
+    }
+
+    /// The number of verification calls made on this thread since the script
+    /// was last set or the counts last reset.
+    #[must_use]
+    pub fn verification_counts() -> VerificationCounts {
+        SCRIPT.with_borrow(|current| current.counts)
+    }
+
+    /// Sets both counts back to zero without touching the script.
+    pub fn reset_verification_counts() {
+        SCRIPT.with_borrow_mut(|current| current.counts = VerificationCounts::default());
+    }
+
+    /// The public inputs this instance was created with.
+    #[must_use]
+    pub const fn public_inputs(&self) -> &PoQVerificationInputsMinusSigningKey {
+        &self.public_inputs
+    }
+
+    fn set_script(script: Script) {
+        SCRIPT.with_borrow_mut(|current| *current = script);
+    }
+}
+
+impl ProofsVerifier for ScriptedProofsVerifier {
+    type Error = Rejected;
+
+    fn new(public_inputs: PoQVerificationInputsMinusSigningKey) -> Self {
+        Self { public_inputs }
+    }
+
+    fn verify_proof_of_quota(
+        &self,
+        proof: ProofOfQuota,
+        signing_key: &Ed25519PublicKey,
+    ) -> Result<VerifiedProofOfQuota, Self::Error> {
+        let accepted = SCRIPT.with_borrow_mut(|current| {
+            current.counts.proof_of_quota += 1;
+            (current.proof_of_quota)(&self.public_inputs, &proof, signing_key)
+        });
+        accepted
+            .then(|| VerifiedProofOfQuota::from_proof_of_quota_unchecked(proof))
+            .ok_or(Rejected)
+    }
+
+    fn verify_proof_of_selection(
+        &self,
+        proof: ProofOfSelection,
+        inputs: &VerifyInputs,
+    ) -> Result<VerifiedProofOfSelection, Self::Error> {
+        let accepted = SCRIPT.with_borrow_mut(|current| {
+            current.counts.proof_of_selection += 1;
+            (current.proof_of_selection)(&self.public_inputs, &proof, inputs)
+        });
+        accepted
+            .then(|| VerifiedProofOfSelection::from_proof_of_selection_unchecked(proof))
+            .ok_or(Rejected)
+    }
+}

--- a/blend/message/src/encap/tests.rs
+++ b/blend/message/src/encap/tests.rs
@@ -1,20 +1,15 @@
-use core::convert::Infallible;
-
-use lb_blend_proofs::{
-    quota::{ProofOfQuota, VerifiedProofOfQuota},
-    selection::{ProofOfSelection, VerifiedProofOfSelection, inputs::VerifyInputs},
-};
+use lb_blend_proofs::{quota::VerifiedProofOfQuota, selection::VerifiedProofOfSelection};
 use lb_codec::{BinaryDecode as _, BinaryEncode as _};
 use lb_core::codec::{DeserializeOp as _, SerializeOp as _};
 use lb_key_management_system_keys::keys::{
-    Ed25519PublicKey, Ed25519Signature, UnsecuredEd25519Key, X25519PrivateKey,
+    Ed25519Signature, UnsecuredEd25519Key, X25519PrivateKey,
 };
 
 use crate::{
     Error, PaddedPayloadBody, PayloadType,
-    crypto::{key_ext::Ed25519SecretKeyExt as _, proofs::PoQVerificationInputsMinusSigningKey},
+    crypto::key_ext::Ed25519SecretKeyExt as _,
     encap::{
-        ProofsVerifier,
+        ScriptedProofsVerifier,
         decapsulated::DecapsulationOutput,
         encapsulated::{EncapsulatedMessage, EncapsulatedPart},
         validated::{
@@ -26,92 +21,11 @@ use crate::{
     message::{payload::MAX_PAYLOAD_BODY_SIZE, public_header::VerifiedPublicHeader},
 };
 
-struct NeverFailingProofsVerifier;
-
-impl ProofsVerifier for NeverFailingProofsVerifier {
-    type Error = Infallible;
-
-    fn new(_public_inputs: PoQVerificationInputsMinusSigningKey) -> Self {
-        Self
-    }
-
-    fn verify_proof_of_quota(
-        &self,
-        proof: ProofOfQuota,
-        _signing_key: &Ed25519PublicKey,
-    ) -> Result<VerifiedProofOfQuota, Self::Error> {
-        Ok(VerifiedProofOfQuota::from_proof_of_quota_unchecked(proof))
-    }
-
-    fn verify_proof_of_selection(
-        &self,
-        proof: ProofOfSelection,
-        _inputs: &VerifyInputs,
-    ) -> Result<VerifiedProofOfSelection, Self::Error> {
-        Ok(VerifiedProofOfSelection::from_proof_of_selection_unchecked(
-            proof,
-        ))
-    }
-}
-
-struct AlwaysFailingProofOfQuotaVerifier;
-
-impl ProofsVerifier for AlwaysFailingProofOfQuotaVerifier {
-    type Error = ();
-
-    fn new(_public_inputs: PoQVerificationInputsMinusSigningKey) -> Self {
-        Self
-    }
-
-    fn verify_proof_of_quota(
-        &self,
-        _proof: ProofOfQuota,
-        _signing_key: &Ed25519PublicKey,
-    ) -> Result<VerifiedProofOfQuota, Self::Error> {
-        Err(())
-    }
-
-    fn verify_proof_of_selection(
-        &self,
-        proof: ProofOfSelection,
-        _inputs: &VerifyInputs,
-    ) -> Result<VerifiedProofOfSelection, Self::Error> {
-        Ok(VerifiedProofOfSelection::from_proof_of_selection_unchecked(
-            proof,
-        ))
-    }
-}
-
-struct AlwaysFailingProofOfSelectionVerifier;
-
-impl ProofsVerifier for AlwaysFailingProofOfSelectionVerifier {
-    type Error = ();
-
-    fn new(_public_inputs: PoQVerificationInputsMinusSigningKey) -> Self {
-        Self
-    }
-
-    fn verify_proof_of_quota(
-        &self,
-        proof: ProofOfQuota,
-        _signing_key: &Ed25519PublicKey,
-    ) -> Result<VerifiedProofOfQuota, Self::Error> {
-        Ok(VerifiedProofOfQuota::from_proof_of_quota_unchecked(proof))
-    }
-
-    fn verify_proof_of_selection(
-        &self,
-        _proof: ProofOfSelection,
-        _inputs: &VerifyInputs,
-    ) -> Result<VerifiedProofOfSelection, Self::Error> {
-        Err(())
-    }
-}
-
 #[test]
 fn encapsulate_and_decapsulate() {
     const PAYLOAD_BODY: &[u8] = b"hello";
-    let verifier = NeverFailingProofsVerifier;
+    ScriptedProofsVerifier::accept_all();
+    let verifier = ScriptedProofsVerifier::default();
 
     let (inputs, blend_node_enc_keys) = generate_inputs(2);
     let msg = EncapsulatedMessage::from(
@@ -199,7 +113,8 @@ fn payload_too_long() {
 #[test]
 fn invalid_public_header_signature() {
     const PAYLOAD_BODY: &[u8] = b"hello";
-    let verifier = NeverFailingProofsVerifier;
+    ScriptedProofsVerifier::accept_all();
+    let verifier = ScriptedProofsVerifier::default();
 
     let msg_with_invalid_signature = {
         let (inputs, _) = generate_inputs(2);
@@ -228,7 +143,8 @@ fn invalid_public_header_proof_of_quota() {
     use lb_blend_proofs::quota::Error as PoQError;
 
     const PAYLOAD_BODY: &[u8] = b"hello";
-    let verifier = AlwaysFailingProofOfQuotaVerifier;
+    ScriptedProofsVerifier::reject_proofs_of_quota();
+    let verifier = ScriptedProofsVerifier::default();
 
     let (inputs, _) = generate_inputs(2);
     let msg = EncapsulatedMessage::from(
@@ -254,7 +170,8 @@ fn invalid_blend_header_proof_of_selection() {
     use lb_blend_proofs::selection::Error as PoSelError;
 
     const PAYLOAD_BODY: &[u8] = b"hello";
-    let verifier = AlwaysFailingProofOfSelectionVerifier;
+    ScriptedProofsVerifier::reject_proofs_of_selection();
+    let verifier = ScriptedProofsVerifier::default();
 
     let (inputs, blend_node_enc_keys) = generate_inputs(2);
     let msg = EncapsulatedMessage::from(
@@ -295,14 +212,15 @@ fn serde_encapsulated_and_verified() {
         EncapsulatedMessage::from_bytes(&serialized_encapsulated_message).unwrap();
     assert_eq!(deserialized_as_unverified, msg.into());
     deserialized_as_unverified
-        .verify_public_header(&NeverFailingProofsVerifier)
+        .verify_public_header(&ScriptedProofsVerifier::default())
         .unwrap();
 }
 
 #[test]
 fn encapsulate_and_decapsulate_via_two_step_verification() {
     const PAYLOAD_BODY: &[u8] = b"hello";
-    let verifier = NeverFailingProofsVerifier;
+    ScriptedProofsVerifier::accept_all();
+    let verifier = ScriptedProofsVerifier::default();
 
     let (inputs, blend_node_enc_keys) = generate_inputs(2);
     let msg = EncapsulatedMessage::from(
@@ -392,7 +310,8 @@ fn encapsulate_and_decapsulate_fewer_layers_than_maximum() {
     // reconstruct invariant that the per-layer signatures depend on.
     const PAYLOAD_BODY: &[u8] = b"hello";
     const MAX_LAYERS: usize = 4;
-    let verifier = NeverFailingProofsVerifier;
+    ScriptedProofsVerifier::accept_all();
+    let verifier = ScriptedProofsVerifier::default();
 
     for used_layers in 1..=MAX_LAYERS {
         let (inputs, blend_node_enc_keys) = generate_inputs(used_layers);
@@ -478,7 +397,8 @@ fn payload_body_round_trips_through_encapsulation() {
     // Random padding must not disturb the body itself: what comes out of a full
     // decapsulation is exactly what went in, with no padding bleeding into it.
     const BODY: &[u8] = b"hello";
-    let verifier = NeverFailingProofsVerifier;
+    ScriptedProofsVerifier::accept_all();
+    let verifier = ScriptedProofsVerifier::default();
 
     let (inputs, blend_node_enc_keys) = generate_inputs(1);
     let DecapsulationOutput::Completed {
@@ -545,7 +465,7 @@ fn decapsulate_empty_private_headers_returns_error() {
         // Dummy private key
         &[0; _].into(),
         &RequiredProofOfSelectionVerificationInputs::default(),
-        &NeverFailingProofsVerifier,
+        &ScriptedProofsVerifier::default(),
     );
     assert!(matches!(result, Err(Error::EmptyEncapsulationInputs)));
 }

--- a/blend/message/src/reward/activity.rs
+++ b/blend/message/src/reward/activity.rs
@@ -1,5 +1,5 @@
 use educe::Educe;
-use lb_blend_proofs::selection::inputs::VerifyInputs;
+use lb_blend_proofs::selection::{VerifiedProofOfSelection, inputs::VerifyInputs};
 use lb_cryptarchia_engine::Epoch;
 use serde::Serialize;
 use tracing::debug;
@@ -8,9 +8,20 @@ use crate::{
     encap::ProofsVerifier as ProofsVerifierTrait,
     reward::{
         LOG_TARGET,
+        epoch::{BlendingTokenEvaluation, EpochRandomness},
         token::{BlendingToken, HammingDistance},
     },
 };
+
+/// Why an activity proof was rejected.
+#[derive(Debug)]
+pub enum VerifyError<E> {
+    /// The proof of selection or the proof of quota did not verify.
+    Proof(E),
+    /// The token's Hamming distance to the next epoch randomness exceeds the
+    /// activity threshold.
+    HammingDistanceTooLarge,
+}
 
 /// An activity proof for an epoch, made of the blending token
 /// that has the smallest Hamming distance satisfying the activity threshold.
@@ -38,30 +49,100 @@ impl ActivityProof {
         &self.token
     }
 
-    pub fn verify_and_build<ProofsVerifier>(
+    /// Runs the cheap half of the verification: the proof of selection (a
+    /// `ChaCha20` draw and one Poseidon2 compression) and the activity
+    /// threshold on the not-yet-verified token (one serialisation and two
+    /// Blake2b hashes).
+    ///
+    /// Neither check needs the proof of quota to have been verified: the
+    /// proof of selection binds to the key nullifier carried by the proof of
+    /// quota bytes, and the Hamming distance is a function of the token bytes
+    /// only. Callers run this before [`Self::verify_quota`], whose Groth16
+    /// pairing check is three orders of magnitude more expensive, so that a
+    /// message a genuine provider can fail on never reaches the pairing.
+    pub fn verify_selection_and_evaluate<ProofsVerifier>(
         proof: &lb_core::sdp::blend::ActivityProof,
         verifier: &ProofsVerifier,
         node_index: u64,
         membership_size: u64,
+        token_evaluation: &BlendingTokenEvaluation,
+        next_epoch_randomness: EpochRandomness,
+    ) -> Result<(VerifiedProofOfSelection, HammingDistance), VerifyError<ProofsVerifier::Error>>
+    where
+        ProofsVerifier: ProofsVerifierTrait,
+    {
+        let proof_of_selection = verifier
+            .verify_proof_of_selection(
+                proof.proof_of_selection,
+                &VerifyInputs {
+                    expected_node_index: node_index,
+                    total_membership_size: membership_size,
+                    key_nullifier: proof.proof_of_quota.key_nullifier(),
+                },
+            )
+            .map_err(VerifyError::Proof)?;
+
+        let hamming_distance = token_evaluation
+            .evaluate_unverified(
+                &proof.signing_key,
+                &proof.proof_of_quota,
+                &proof.proof_of_selection,
+                next_epoch_randomness,
+            )
+            .ok_or(VerifyError::HammingDistanceTooLarge)?;
+
+        Ok((proof_of_selection, hamming_distance))
+    }
+
+    /// Runs the expensive half of the verification, the proof-of-quota
+    /// pairing check, and builds the activity proof from the verified parts.
+    ///
+    /// `proof_of_selection` is the output of
+    /// [`Self::verify_selection_and_evaluate`] for the same `proof`.
+    pub fn verify_quota<ProofsVerifier>(
+        proof: &lb_core::sdp::blend::ActivityProof,
+        verifier: &ProofsVerifier,
+        proof_of_selection: VerifiedProofOfSelection,
     ) -> Result<Self, ProofsVerifier::Error>
     where
         ProofsVerifier: ProofsVerifierTrait,
     {
         let proof_of_quota =
             verifier.verify_proof_of_quota(proof.proof_of_quota, &proof.signing_key)?;
-        let proof_of_selection = verifier.verify_proof_of_selection(
-            proof.proof_of_selection,
-            &VerifyInputs {
-                expected_node_index: node_index,
-                total_membership_size: membership_size,
-                key_nullifier: proof.proof_of_quota.key_nullifier(),
-            },
-        )?;
 
         Ok(Self::new(
             proof.epoch,
             BlendingToken::new(proof.signing_key, proof_of_quota, proof_of_selection),
         ))
+    }
+
+    /// Verifies an activity proof and evaluates its token, cheapest check
+    /// first: [`Self::verify_selection_and_evaluate`], then
+    /// [`Self::verify_quota`].
+    pub fn verify_and_build<ProofsVerifier>(
+        proof: &lb_core::sdp::blend::ActivityProof,
+        verifier: &ProofsVerifier,
+        node_index: u64,
+        membership_size: u64,
+        token_evaluation: &BlendingTokenEvaluation,
+        next_epoch_randomness: EpochRandomness,
+    ) -> Result<(Self, HammingDistance), VerifyError<ProofsVerifier::Error>>
+    where
+        ProofsVerifier: ProofsVerifierTrait,
+    {
+        let (proof_of_selection, hamming_distance) = Self::verify_selection_and_evaluate(
+            proof,
+            verifier,
+            node_index,
+            membership_size,
+            token_evaluation,
+            next_epoch_randomness,
+        )?;
+
+        let verified_proof =
+            Self::verify_quota(proof, verifier, proof_of_selection).map_err(VerifyError::Proof)?;
+
+        Ok((verified_proof, hamming_distance))
     }
 }
 

--- a/blend/message/src/reward/epoch.rs
+++ b/blend/message/src/reward/epoch.rs
@@ -1,15 +1,22 @@
 use core::fmt::{self, Debug, Formatter};
 use std::ops::Add as _;
 
-use lb_blend_proofs::quota::Quota;
+use lb_blend_proofs::{
+    quota::{ProofOfQuota, Quota},
+    selection::ProofOfSelection,
+};
 use lb_core::crypto::ZkHash;
 use lb_cryptarchia_engine::Epoch;
 use lb_groth16::{Fr, FrBytes, fr_to_bytes};
+use lb_key_management_system_keys::keys::Ed25519PublicKey;
 use lb_log_targets::{blend, diagnostic::BLEND_REACHABILITY};
 use lb_utils::math::{F64Ge1, NonNegativeF64};
 use serde::{Deserialize, Serialize};
 
-use crate::reward::{BlendingToken, activity, token::HammingDistance};
+use crate::reward::{
+    BlendingToken, activity,
+    token::{self, HammingDistance},
+};
 
 const LOG_TARGET: &str = blend::message::REWARD;
 
@@ -87,6 +94,30 @@ impl BlendingTokenEvaluation {
         evaluation
             .satisfies_activity_threshold
             .then_some(evaluation.distance)
+    }
+
+    /// Like [`Self::evaluate`], but for a token whose proofs have not been
+    /// verified yet.
+    ///
+    /// The Hamming distance depends only on the token bytes, so a verifier can
+    /// reject an over-threshold token before running the proof-of-quota
+    /// pairing check.
+    #[must_use]
+    pub fn evaluate_unverified(
+        &self,
+        signing_key: &Ed25519PublicKey,
+        proof_of_quota: &ProofOfQuota,
+        proof_of_selection: &ProofOfSelection,
+        next_epoch_randomness: EpochRandomness,
+    ) -> Option<HammingDistance> {
+        let distance = token::unverified_hamming_distance(
+            signing_key,
+            proof_of_quota,
+            proof_of_selection,
+            self.token_count_byte_len,
+            next_epoch_randomness,
+        );
+        (distance <= self.activity_threshold).then_some(distance)
     }
 
     /// Evaluates a token once and retains both the distance and the threshold

--- a/blend/message/src/reward/mod.rs
+++ b/blend/message/src/reward/mod.rs
@@ -4,7 +4,7 @@ mod token;
 
 use std::collections::HashSet;
 
-pub use activity::ActivityProof;
+pub use activity::{ActivityProof, VerifyError};
 pub use epoch::EpochInfo;
 use lb_cryptarchia_engine::Epoch;
 use lb_log_targets::{blend, diagnostic::BLEND_REACHABILITY};

--- a/blend/message/src/reward/token.rs
+++ b/blend/message/src/reward/token.rs
@@ -2,7 +2,10 @@ use blake2::{
     Blake2bVar,
     digest::{Update as _, VariableOutput as _},
 };
-use lb_blend_proofs::{quota::VerifiedProofOfQuota, selection::VerifiedProofOfSelection};
+use lb_blend_proofs::{
+    quota::{ProofOfQuota, VerifiedProofOfQuota},
+    selection::{ProofOfSelection, VerifiedProofOfSelection},
+};
 use lb_core::codec::SerializeOp as _;
 use lb_key_management_system_keys::keys::Ed25519PublicKey;
 use serde::{Deserialize, Serialize};
@@ -39,16 +42,13 @@ impl BlendingToken {
         token_count_byte_len: u64,
         next_epoch_randomness: EpochRandomness,
     ) -> HammingDistance {
-        let token = self
-            .to_bytes()
-            .expect("BlendingToken should be serializable");
-        let token_hash = hash(&token, token_count_byte_len as usize);
-        let epoch_randomness_hash = hash(
-            &next_epoch_randomness.as_bytes(),
-            token_count_byte_len as usize,
-        );
-
-        HammingDistance::new(&token_hash, &epoch_randomness_hash)
+        unverified_hamming_distance(
+            &self.signing_key,
+            self.proof_of_quota.as_ref(),
+            self.proof_of_selection.as_ref(),
+            token_count_byte_len,
+            next_epoch_randomness,
+        )
     }
 
     #[must_use]
@@ -63,6 +63,50 @@ impl BlendingToken {
     pub(crate) const fn proof_of_selection(&self) -> &VerifiedProofOfSelection {
         &self.proof_of_selection
     }
+}
+
+/// The serialised form of a blending token, borrowed from its parts.
+///
+/// [`VerifiedProofOfQuota`] and [`VerifiedProofOfSelection`] are newtypes over
+/// their unverified counterparts, so this serialises to exactly the bytes a
+/// [`BlendingToken`] serialises to (pinned by
+/// `test_unverified_token_bytes_match_blending_token`) without requiring the
+/// proofs to have been verified. The ledger uses it to evaluate the activity
+/// threshold before paying for the proof-of-quota pairing check.
+#[derive(Serialize)]
+struct UnverifiedTokenRef<'a> {
+    signing_key: &'a Ed25519PublicKey,
+    proof_of_quota: &'a ProofOfQuota,
+    proof_of_selection: &'a ProofOfSelection,
+}
+
+/// Computes the Hamming distance between the blending token made of the given
+/// (not yet verified) parts and the next epoch randomness.
+///
+/// The distance is a function of the token bytes only, so it is the same
+/// whether or not the proofs have been verified.
+#[must_use]
+pub fn unverified_hamming_distance(
+    signing_key: &Ed25519PublicKey,
+    proof_of_quota: &ProofOfQuota,
+    proof_of_selection: &ProofOfSelection,
+    token_count_byte_len: u64,
+    next_epoch_randomness: EpochRandomness,
+) -> HammingDistance {
+    let token = UnverifiedTokenRef {
+        signing_key,
+        proof_of_quota,
+        proof_of_selection,
+    }
+    .to_bytes()
+    .expect("BlendingToken should be serializable");
+    let token_hash = hash(&token, token_count_byte_len as usize);
+    let epoch_randomness_hash = hash(
+        &next_epoch_randomness.as_bytes(),
+        token_count_byte_len as usize,
+    );
+
+    HammingDistance::new(&token_hash, &epoch_randomness_hash)
 }
 
 /// Compute blake-2b hash of `input`, producing `output_size` bytes.
@@ -160,6 +204,30 @@ mod tests {
     fn test_blending_token_hamming_distance() {
         let token = blending_token(1, 1, 2);
         assert_eq!(token.hamming_distance(1, Fr::ONE.into()), 5.into());
+    }
+
+    /// The unverified view must serialise to the same bytes as the token,
+    /// otherwise the ledger's pre-pairing threshold check would evaluate a
+    /// different token than the prover selected.
+    #[test]
+    fn test_unverified_token_bytes_match_blending_token() {
+        let token = blending_token(1, 2, 3);
+        let unverified = UnverifiedTokenRef {
+            signing_key: &token.signing_key,
+            proof_of_quota: token.proof_of_quota.as_ref(),
+            proof_of_selection: token.proof_of_selection.as_ref(),
+        };
+        assert_eq!(token.to_bytes().unwrap(), unverified.to_bytes().unwrap());
+        assert_eq!(
+            token.hamming_distance(1, Fr::ONE.into()),
+            unverified_hamming_distance(
+                &token.signing_key,
+                token.proof_of_quota.as_ref(),
+                token.proof_of_selection.as_ref(),
+                1,
+                Fr::ONE.into(),
+            )
+        );
     }
 
     fn blending_token(

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -35,11 +35,12 @@ thiserror                     = { workspace = true }
 tracing                       = { workspace = true }
 
 [dev-dependencies]
-divan      = { workspace = true }
-lb-core    = { features = ["test-utils", "unsafe-test-functions"], workspace = true }
-lb-zksign  = { workspace = true }
-rand       = { features = ["std", "std_rng"], workspace = true }
-serde_json = { features = ["alloc"], workspace = true }
+divan            = { workspace = true }
+lb-blend-message = { features = ["unsafe-test-functions"], workspace = true }
+lb-core          = { features = ["test-utils", "unsafe-test-functions"], workspace = true }
+lb-zksign        = { workspace = true }
+rand             = { features = ["std", "std_rng"], workspace = true }
+serde_json       = { features = ["alloc"], workspace = true }
 
 [[bench]]
 harness = false

--- a/ledger/src/mantle/sdp/rewards/blend/mod.rs
+++ b/ledger/src/mantle/sdp/rewards/blend/mod.rs
@@ -92,6 +92,12 @@ where
 
                 let ActivityMetadata::Blend(proof) = metadata;
 
+                // Cheapest check first: a provider that already has an accepted
+                // message for the target epoch is rejected before any proof is
+                // verified.
+                target_epoch_tracker
+                    .ensure_not_submitted(&provider_id, target_epoch_state.epoch())?;
+
                 let (zk_id, hamming_distance) = target_epoch_state.verify_proof(
                     &provider_id,
                     proof,
@@ -299,12 +305,12 @@ impl RewardsParameters {
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::HashMap, convert::Infallible};
+    use std::collections::HashMap;
 
-    use lb_blend_message::crypto::proofs::PoQVerificationInputsMinusSigningKey;
+    use lb_blend_message::encap::{ScriptedProofsVerifier, VerificationCounts};
     use lb_blend_proofs::{
         quota::{ProofOfQuota, VerifiedProofOfQuota},
-        selection::{ProofOfSelection, VerifiedProofOfSelection, inputs::VerifyInputs},
+        selection::{ProofOfSelection, VerifiedProofOfSelection},
     };
     use lb_core::{
         crypto::ZkHash,
@@ -362,7 +368,7 @@ mod tests {
         );
 
         // Create a reward tracker based on epoch0
-        let rewards_tracker = Rewards::<AlwaysSuccessProofsVerifier>::new(&params, &epoch0);
+        let rewards_tracker = Rewards::<ScriptedProofsVerifier>::new(&params, &epoch0);
         assert!(matches!(
             rewards_tracker,
             Rewards::WithoutTargetEpoch { .. } // No target epoch yet since epoch 0 is the 1st
@@ -393,7 +399,7 @@ mod tests {
             Fr::ZERO,
         );
         let epoch1 = new_epoch_state_with_same_snapshot(1, 1, &epoch0);
-        let (rewards_tracker, _) = Rewards::<AlwaysSuccessProofsVerifier>::new(&params, &epoch0)
+        let (rewards_tracker, _) = Rewards::<ScriptedProofsVerifier>::new(&params, &epoch0)
             .update_epoch(&epoch0, &epoch1, &config, &params);
 
         // Update epoch from 1 to 2 without any activity proofs submitted.
@@ -424,7 +430,7 @@ mod tests {
             Fr::ZERO,
         );
         let epoch1 = new_epoch_state_with_same_snapshot(1, 1, &epoch0);
-        let (rewards_tracker, _) = Rewards::<AlwaysSuccessProofsVerifier>::new(&params, &epoch0)
+        let (rewards_tracker, _) = Rewards::<ScriptedProofsVerifier>::new(&params, &epoch0)
             .add_income(1000)
             .update_epoch(&epoch0, &epoch1, &config, &params);
 
@@ -524,7 +530,7 @@ mod tests {
         let epoch0 =
             create_epoch_state(&[provider1], ServiceType::BlendNetwork, 0.into(), Fr::ZERO);
         let epoch1 = new_epoch_state_with_same_snapshot(1, 1, &epoch0);
-        let (rewards_tracker, _) = Rewards::<AlwaysSuccessProofsVerifier>::new(&params, &epoch0)
+        let (rewards_tracker, _) = Rewards::<ScriptedProofsVerifier>::new(&params, &epoch0)
             .update_epoch(&epoch0, &epoch1, &config, &params);
 
         // provider1 submits an activity proof.
@@ -576,7 +582,7 @@ mod tests {
         let epoch0 =
             create_epoch_state(&[provider1], ServiceType::BlendNetwork, 0.into(), Fr::ZERO);
         let epoch1 = new_epoch_state_with_same_snapshot(1, 1, &epoch0);
-        let (rewards_tracker, _) = Rewards::<AlwaysSuccessProofsVerifier>::new(&params, &epoch0)
+        let (rewards_tracker, _) = Rewards::<ScriptedProofsVerifier>::new(&params, &epoch0)
             .update_epoch(&epoch0, &epoch1, &config, &params);
 
         // provider1 submits an activity proof with invalid epoch.
@@ -619,7 +625,7 @@ mod tests {
         let epoch0 =
             create_epoch_state(&[provider1], ServiceType::BlendNetwork, 0.into(), Fr::ZERO);
         let epoch1 = new_epoch_state_with_same_snapshot(1, 1, &epoch0);
-        let (rewards_tracker, _) = Rewards::<AlwaysSuccessProofsVerifier>::new(&params, &epoch0)
+        let (rewards_tracker, _) = Rewards::<ScriptedProofsVerifier>::new(&params, &epoch0)
             .update_epoch(&epoch0, &epoch1, &config, &params);
 
         // `unknown` was never declared, so target_epoch_state.providers
@@ -653,7 +659,7 @@ mod tests {
         let epoch0 =
             create_epoch_state(&[provider1], ServiceType::BlendNetwork, 0.into(), Fr::ZERO);
         let epoch1 = new_epoch_state_with_same_snapshot(1, 1, &epoch0);
-        let (rewards_tracker, _) = Rewards::<AlwaysSuccessProofsVerifier>::new(&params, &epoch0)
+        let (rewards_tracker, _) = Rewards::<ScriptedProofsVerifier>::new(&params, &epoch0)
             .update_epoch(&epoch0, &epoch1, &config, &params);
         assert!(matches!(
             rewards_tracker,
@@ -708,7 +714,7 @@ mod tests {
         // Accumulate income during epoch 0 (funds future target epoch 0).
         let epoch0_income: Value = 1000;
         let rewards_tracker =
-            Rewards::<AlwaysSuccessProofsVerifier>::new(&params, &epoch0).add_income(epoch0_income);
+            Rewards::<ScriptedProofsVerifier>::new(&params, &epoch0).add_income(epoch0_income);
 
         // Transition 0 → 1 with shrunk snapshot:
         // - WithoutTargetEpoch → WithTargetEpoch (for epoch 0)
@@ -778,7 +784,7 @@ mod tests {
             create_epoch_state(&[provider1], ServiceType::BlendNetwork, 0.into(), Fr::ZERO);
 
         // Create rewards tracker
-        let rewards_tracker = Rewards::<AlwaysSuccessProofsVerifier>::new(&params, &epoch0);
+        let rewards_tracker = Rewards::<ScriptedProofsVerifier>::new(&params, &epoch0);
 
         // Transition 0 → 1 with grown snapshot:
         // - WithoutTargetEpoch → WithoutTargetEpoch (for epoch 0)
@@ -851,7 +857,7 @@ mod tests {
             Fr::ZERO,
         );
         drop(
-            Rewards::<AlwaysSuccessProofsVerifier>::new(&params, &epoch0)
+            Rewards::<ScriptedProofsVerifier>::new(&params, &epoch0)
                 .update_epoch(&epoch0, &epoch0, &config, &params),
         );
     }
@@ -871,7 +877,7 @@ mod tests {
             Fr::ZERO,
         );
         let epoch1 = new_epoch_state_with_same_snapshot(1, 1, &epoch0);
-        let (rewards_tracker, _) = Rewards::<AlwaysSuccessProofsVerifier>::new(&params, &epoch0)
+        let (rewards_tracker, _) = Rewards::<ScriptedProofsVerifier>::new(&params, &epoch0)
             .update_epoch(&epoch0, &epoch1, &config, &params);
         // Now try to "go back" from epoch 1 to epoch 0.
         drop(rewards_tracker.update_epoch(&epoch1, &epoch0, &config, &params));
@@ -893,7 +899,7 @@ mod tests {
         let epoch0 =
             create_epoch_state(&[provider1], ServiceType::BlendNetwork, 0.into(), Fr::ZERO);
         let epoch1 = new_epoch_state_with_same_snapshot(1, 1, &epoch0);
-        let (rewards_tracker, _) = Rewards::<AlwaysSuccessProofsVerifier>::new(&params, &epoch0)
+        let (rewards_tracker, _) = Rewards::<ScriptedProofsVerifier>::new(&params, &epoch0)
             .add_income(epoch0_income)
             .update_epoch(&epoch0, &epoch1, &config, &params);
 
@@ -955,7 +961,7 @@ mod tests {
             ZkHash::from(9999),
         );
         let epoch1 = new_epoch_state_with_same_snapshot(1, 1, &epoch0);
-        let (rewards_tracker, _) = Rewards::<AlwaysSuccessProofsVerifier>::new(&params, &epoch0)
+        let (rewards_tracker, _) = Rewards::<ScriptedProofsVerifier>::new(&params, &epoch0)
             .update_epoch(&epoch0, &epoch1, &config, &params);
 
         // provider1 submits an activity proof that is larger than activity threshold.
@@ -990,7 +996,8 @@ mod tests {
         let epoch0 =
             create_epoch_state(&[provider1], ServiceType::BlendNetwork, 0.into(), Fr::ZERO);
         let epoch1 = new_epoch_state_with_same_snapshot(1, 1, &epoch0);
-        let (rewards_tracker, _) = Rewards::<AlwaysFailureProofsVerifier>::new(&params, &epoch0)
+        ScriptedProofsVerifier::reject_all();
+        let (rewards_tracker, _) = Rewards::<ScriptedProofsVerifier>::new(&params, &epoch0)
             .update_epoch(&epoch0, &epoch1, &config, &params);
 
         // provider1 submits an activity proof, but PoQ/PoSel verification fails.
@@ -1030,11 +1037,19 @@ mod tests {
             Fr::ZERO,
         );
         let epoch1 = new_epoch_state_with_same_snapshot(1, 1, &epoch0);
-        let (rewards_tracker, _) = Rewards::<ZeroNonceFailureProofsVerifier>::new(&params, &epoch0)
+        // The verifier rejects every proof while the epoch nonce it was created
+        // with is zero.
+        ScriptedProofsVerifier::script_proof_of_quota(|inputs, _, _| {
+            inputs.leader.pol_epoch_nonce != Fr::ZERO
+        });
+        ScriptedProofsVerifier::script_proof_of_selection(|inputs, _, _| {
+            inputs.leader.pol_epoch_nonce != Fr::ZERO
+        });
+        let (rewards_tracker, _) = Rewards::<ScriptedProofsVerifier>::new(&params, &epoch0)
             .update_epoch(&epoch0, &epoch1, &config, &params);
 
-        // provider submits an activity proof, but rejected due to
-        // ZeroNonceFailureProofsVerifier
+        // provider submits an activity proof, but it is rejected because the
+        // verifier was created with a zero epoch nonce.
         let err = rewards_tracker
             .update_active(
                 provider,
@@ -1069,97 +1084,157 @@ mod tests {
             .unwrap();
     }
 
-    #[derive(Debug, Clone, PartialEq)]
-    struct AlwaysSuccessProofsVerifier;
-
-    impl ProofsVerifierTrait for AlwaysSuccessProofsVerifier {
-        type Error = Infallible;
-
-        fn new(_public_inputs: PoQVerificationInputsMinusSigningKey) -> Self {
-            Self
-        }
-
-        fn verify_proof_of_quota(
-            &self,
-            proof: ProofOfQuota,
-            _signing_key: &Ed25519PublicKey,
-        ) -> Result<VerifiedProofOfQuota, Self::Error> {
-            Ok(VerifiedProofOfQuota::from_bytes_unchecked((&proof).into()))
-        }
-
-        fn verify_proof_of_selection(
-            &self,
-            proof: ProofOfSelection,
-            _inputs: &VerifyInputs,
-        ) -> Result<VerifiedProofOfSelection, Self::Error> {
-            Ok(VerifiedProofOfSelection::from_bytes_unchecked(
-                (&proof).into(),
-            ))
-        }
+    fn activity_proof(epoch: u32, byte: u8) -> ActivityMetadata {
+        ActivityMetadata::Blend(Box::new(blend::ActivityProof {
+            epoch: epoch.into(),
+            proof_of_quota: new_proof_of_quota_unchecked(byte),
+            signing_key: new_signing_key(1),
+            proof_of_selection: new_proof_of_selection_unchecked(byte),
+        }))
     }
 
-    #[derive(Debug, Clone, PartialEq)]
-    struct AlwaysFailureProofsVerifier;
+    /// A duplicate message is rejected on the map lookup alone: neither the
+    /// proof of selection nor the proof of quota is verified for it.
+    #[test]
+    fn test_duplicate_active_message_rejected_before_any_verification() {
+        ScriptedProofsVerifier::accept_all();
+        let provider1 = create_provider_id(1);
+        let config = create_service_parameters();
+        let params = create_blend_rewards_params(86_400, 1);
+        let epoch0 =
+            create_epoch_state(&[provider1], ServiceType::BlendNetwork, 0.into(), Fr::ZERO);
+        let epoch1 = new_epoch_state_with_same_snapshot(1, 1, &epoch0);
+        let (rewards_tracker, _) = Rewards::<ScriptedProofsVerifier>::new(&params, &epoch0)
+            .update_epoch(&epoch0, &epoch1, &config, &params);
 
-    impl ProofsVerifierTrait for AlwaysFailureProofsVerifier {
-        type Error = ();
+        let rewards_tracker = rewards_tracker
+            .update_active(provider1, &activity_proof(0, 1), &params)
+            .unwrap();
+        let counts_after_first_message = VerificationCounts {
+            proof_of_quota: 1,
+            proof_of_selection: 1,
+        };
+        assert_eq!(
+            ScriptedProofsVerifier::verification_counts(),
+            counts_after_first_message
+        );
 
-        fn new(_public_inputs: PoQVerificationInputsMinusSigningKey) -> Self {
-            Self
-        }
-
-        fn verify_proof_of_quota(
-            &self,
-            _proof: ProofOfQuota,
-            _signing_key: &Ed25519PublicKey,
-        ) -> Result<VerifiedProofOfQuota, Self::Error> {
-            Err(())
-        }
-
-        fn verify_proof_of_selection(
-            &self,
-            _proof: ProofOfSelection,
-            _inputs: &VerifyInputs,
-        ) -> Result<VerifiedProofOfSelection, Self::Error> {
-            Err(())
-        }
+        let err = rewards_tracker
+            .update_active(provider1, &activity_proof(0, 2), &params)
+            .unwrap_err();
+        assert_eq!(
+            err,
+            Error::DuplicateActiveMessage {
+                epoch: 0.into(),
+                provider_id: Box::new(provider1)
+            }
+        );
+        assert_eq!(
+            ScriptedProofsVerifier::verification_counts(),
+            counts_after_first_message
+        );
     }
 
-    #[derive(Debug, Clone, PartialEq)]
-    struct ZeroNonceFailureProofsVerifier(bool);
+    /// Every duplicate after the first accepted message costs one map lookup
+    /// and no proof verification, however many there are. This is the cost a
+    /// block builder pays per proposal when the pool holds `n` re-sent or
+    /// replayed messages from the same provider.
+    #[test]
+    fn test_many_duplicate_active_messages_cost_no_verification() {
+        const DUPLICATES: usize = 10_000;
 
-    impl ProofsVerifierTrait for ZeroNonceFailureProofsVerifier {
-        type Error = ();
+        ScriptedProofsVerifier::accept_all();
+        let provider1 = create_provider_id(1);
+        let config = create_service_parameters();
+        let params = create_blend_rewards_params(86_400, 1);
+        let epoch0 =
+            create_epoch_state(&[provider1], ServiceType::BlendNetwork, 0.into(), Fr::ZERO);
+        let epoch1 = new_epoch_state_with_same_snapshot(1, 1, &epoch0);
+        let (rewards_tracker, _) = Rewards::<ScriptedProofsVerifier>::new(&params, &epoch0)
+            .update_epoch(&epoch0, &epoch1, &config, &params);
 
-        fn new(public_inputs: PoQVerificationInputsMinusSigningKey) -> Self {
-            // Fail only if pol_epoch_nonce is ZERO
-            Self(public_inputs.leader.pol_epoch_nonce != Fr::ZERO)
+        let rewards_tracker = rewards_tracker
+            .update_active(provider1, &activity_proof(0, 1), &params)
+            .unwrap();
+        ScriptedProofsVerifier::reset_verification_counts();
+
+        for byte in (0..DUPLICATES).map(|i| (i % usize::from(u8::MAX)) as u8) {
+            let err = rewards_tracker
+                .update_active(provider1, &activity_proof(0, byte), &params)
+                .unwrap_err();
+            assert!(matches!(err, Error::DuplicateActiveMessage { .. }));
         }
+        assert_eq!(
+            ScriptedProofsVerifier::verification_counts(),
+            VerificationCounts::default()
+        );
+    }
 
-        fn verify_proof_of_quota(
-            &self,
-            proof: ProofOfQuota,
-            _signing_key: &Ed25519PublicKey,
-        ) -> Result<VerifiedProofOfQuota, Self::Error> {
-            if self.0 {
-                Ok(VerifiedProofOfQuota::from_bytes_unchecked((&proof).into()))
-            } else {
-                Err(())
+    /// A mis-selected message fails the proof of selection and never reaches
+    /// the proof-of-quota pairing check.
+    #[test]
+    fn test_mis_selected_active_message_rejected_before_proof_of_quota() {
+        ScriptedProofsVerifier::reject_proofs_of_selection();
+        let provider1 = create_provider_id(1);
+        let config = create_service_parameters();
+        let params = create_blend_rewards_params(86_400, 1);
+        let epoch0 =
+            create_epoch_state(&[provider1], ServiceType::BlendNetwork, 0.into(), Fr::ZERO);
+        let epoch1 = new_epoch_state_with_same_snapshot(1, 1, &epoch0);
+        let (rewards_tracker, _) = Rewards::<ScriptedProofsVerifier>::new(&params, &epoch0)
+            .update_epoch(&epoch0, &epoch1, &config, &params);
+
+        let err = rewards_tracker
+            .update_active(provider1, &activity_proof(0, 1), &params)
+            .unwrap_err();
+        assert_eq!(err, Error::InvalidProof);
+        assert_eq!(
+            ScriptedProofsVerifier::verification_counts(),
+            VerificationCounts {
+                proof_of_quota: 0,
+                proof_of_selection: 1,
             }
-        }
+        );
+    }
 
-        fn verify_proof_of_selection(
-            &self,
-            proof: ProofOfSelection,
-            _inputs: &VerifyInputs,
-        ) -> Result<VerifiedProofOfSelection, Self::Error> {
-            if self.0 {
-                Ok(VerifiedProofOfSelection::from_bytes_unchecked(
-                    (&proof).into(),
-                ))
-            } else {
-                Err(())
+    /// A token above the activity threshold is rejected before the
+    /// proof-of-quota pairing check. Same fixture as
+    /// `test_blend_proof_distance_larger_than_activity_threshold`.
+    #[test]
+    fn test_over_threshold_active_message_rejected_before_proof_of_quota() {
+        ScriptedProofsVerifier::accept_all();
+        let provider1 = create_provider_id(1);
+        let config = create_service_parameters();
+        let params = create_blend_rewards_params(10, 1);
+        let epoch0 = create_epoch_state(
+            &[provider1],
+            ServiceType::BlendNetwork,
+            0.into(),
+            ZkHash::from(9999),
+        );
+        let epoch1 = new_epoch_state_with_same_snapshot(1, 1, &epoch0);
+        let (rewards_tracker, _) = Rewards::<ScriptedProofsVerifier>::new(&params, &epoch0)
+            .update_epoch(&epoch0, &epoch1, &config, &params);
+
+        let err = rewards_tracker
+            .update_active(
+                provider1,
+                &ActivityMetadata::Blend(Box::new(blend::ActivityProof {
+                    epoch: 0.into(),
+                    proof_of_quota: new_proof_of_quota_unchecked(4),
+                    signing_key: new_signing_key(4),
+                    proof_of_selection: new_proof_of_selection_unchecked(4),
+                })),
+                &params,
+            )
+            .unwrap_err();
+        assert_eq!(err, Error::HammingDistanceTooLarge);
+        assert_eq!(
+            ScriptedProofsVerifier::verification_counts(),
+            VerificationCounts {
+                proof_of_quota: 0,
+                proof_of_selection: 1,
             }
-        }
+        );
     }
 }

--- a/ledger/src/mantle/sdp/rewards/blend/target_epoch.rs
+++ b/ledger/src/mantle/sdp/rewards/blend/target_epoch.rs
@@ -2,7 +2,7 @@ use std::{cmp::Ordering, collections::HashMap, iter::once};
 
 use lb_blend_message::{
     encap::ProofsVerifier as ProofsVerifierTrait,
-    reward::{BlendingTokenEvaluation, HammingDistance},
+    reward::{BlendingTokenEvaluation, HammingDistance, VerifyError},
 };
 use lb_core::{
     mantle::{Utxo, Value},
@@ -100,26 +100,29 @@ where
             .get(provider_id)
             .ok_or_else(|| Error::UnknownProvider(Box::new(*provider_id)))?;
 
-        let verified_proof = lb_blend_message::reward::ActivityProof::verify_and_build(
-            proof,
-            &self.proof_verifier,
-            index,
-            num_providers,
-        )
-        .map_err(|_| Error::InvalidProof)?;
+        // Proof of selection, then activity threshold, then the proof-of-quota
+        // pairing check, so that a message a genuine provider can fail on is
+        // rejected before the expensive step.
+        let (verified_proof, hamming_distance) =
+            lb_blend_message::reward::ActivityProof::verify_and_build(
+                proof,
+                &self.proof_verifier,
+                index,
+                num_providers,
+                &self.token_evaluation,
+                current_epoch_state.epoch_randomness(),
+            )
+            .map_err(|error| match error {
+                VerifyError::Proof(_) => Error::InvalidProof,
+                VerifyError::HammingDistanceTooLarge => Error::HammingDistanceTooLarge,
+            })?;
 
         tracing::trace!(
             target: LOG_TARGET,
-            "Verifying activity proof {:?} with epoch randomness: {:?}",
+            "Verified activity proof {:?} with epoch randomness: {:?}",
             verified_proof.token().signing_key(),
             current_epoch_state.epoch_randomness()
         );
-        let Some(hamming_distance) = self.token_evaluation.evaluate(
-            verified_proof.token(),
-            current_epoch_state.epoch_randomness(),
-        ) else {
-            return Err(Error::HammingDistanceTooLarge);
-        };
 
         Ok((zk_id, hamming_distance))
     }
@@ -149,6 +152,27 @@ impl TargetEpochTracker {
         }
     }
 
+    /// Rejects a second activity message from `provider_id` for the target
+    /// epoch.
+    ///
+    /// This is the cheapest check on the activity path (one map lookup) and
+    /// the one a genuine provider is most likely to fail, so callers run it
+    /// before any proof verification. [`Self::insert`] runs it again, so the
+    /// invariant does not depend on the caller.
+    pub fn ensure_not_submitted(
+        &self,
+        provider_id: &ProviderId,
+        epoch: Epoch,
+    ) -> Result<(), Error> {
+        if self.submitted_proofs.contains_key(provider_id) {
+            return Err(Error::DuplicateActiveMessage {
+                epoch,
+                provider_id: Box::new(*provider_id),
+            });
+        }
+        Ok(())
+    }
+
     pub fn insert(
         &self,
         provider_id: ProviderId,
@@ -156,12 +180,7 @@ impl TargetEpochTracker {
         zk_id: ZkPublicKey,
         hamming_distance: HammingDistance,
     ) -> Result<Self, Error> {
-        if self.submitted_proofs.contains_key(&provider_id) {
-            return Err(Error::DuplicateActiveMessage {
-                epoch,
-                provider_id: Box::new(provider_id),
-            });
-        }
+        self.ensure_not_submitted(&provider_id, epoch)?;
 
         debug!(
             target: LOG_TARGET,


### PR DESCRIPTION
## Summary

`SDPActive` execution verified the Blend proof of quota (a Groth16 pairing check, about 1-6 ms) before the three checks a message from a genuine provider can fail on: the one-message-per-provider duplicate check, the proof of selection, and the activity threshold. Each of those costs a map lookup or a few hashes. A block builder trial-executes the whole pool on every proposal, so `n` re-sent, replayed or mis-selected messages cost it `n` pairings per proposal until they age out.

This PR runs the checks cheapest first, without changing what is accepted, what state is touched, or any encoding:

- **duplicate** (`TargetEpochTracker::ensure_not_submitted`, one map lookup) in `Rewards::update_active`, before any proof is looked at; `insert` keeps its own check so the invariant does not depend on the caller;
- **proof of selection** then **activity threshold**, computed on the not-yet-verified token, in the new `ActivityProof::verify_selection_and_evaluate`;
- **proof of quota** last, in the new `ActivityProof::verify_quota`.

`ActivityProof::verify_and_build` is kept as the composition of the two halves and is what the ledger calls. The split is the seam for deferring the pairing into the block's ZK batch (the `SDP_ACTIVE` gas follow-up): `verify_quota` is the only thing that would move.

The threshold on the unverified token goes through `UnverifiedTokenRef`, a borrowed serde view of `(signing_key, ProofOfQuota, ProofOfSelection)`. `VerifiedProofOfQuota` and `VerifiedProofOfSelection` are newtypes and bincode serialises newtypes transparently, so its bytes equal `BlendingToken::to_bytes()`; `test_unverified_token_bytes_match_blending_token` pins that, and `BlendingToken::hamming_distance` now delegates to the same function so prover and ledger cannot drift.

Behaviour change visible to a client: a message that is both a duplicate and invalid now reports `DuplicateActiveMessage` instead of `InvalidProof`. Both are rejections; errors are not part of the state.

## Test doubles

The ledger had three near-identical `ProofsVerifier` doubles and the ordering tests need a fourth that counts calls; `blend/message` had three more. They are replaced by one `ScriptedProofsVerifier` in `lb_blend_message::encap`, behind the existing `unsafe-test-functions` feature: a per-thread script decides each outcome (`accept_all`, `reject_all`, `reject_proofs_of_quota`, `reject_proofs_of_selection`, or a closure that sees the verifier's public inputs), and every call is counted. The five doubles in `blend/network`, `blend/provers` and `services/blend` are left for a follow-up; they carry their own semantics (a remaining-layers countdown, epoch-derived expected proofs) and live in async test suites.

## Tests

New, in `ledger/src/mantle/sdp/rewards/blend/mod.rs`:

- `test_duplicate_active_message_rejected_before_any_verification`: after the first accepted message the counts are (1 PoQ, 1 PoSel); a duplicate is rejected and the counts do not move.
- `test_many_duplicate_active_messages_cost_no_verification`: 10 000 duplicates after one accepted message, zero verifier calls. This is the cost the builder's trial execution pays per proposal for a pool of duplicates.
- `test_mis_selected_active_message_rejected_before_proof_of_quota`: `InvalidProof` with counts (0, 1).
- `test_over_threshold_active_message_rejected_before_proof_of_quota`: `HammingDistanceTooLarge` with counts (0, 1).

`cargo test -p logos-blockchain-ledger --lib`: 166 passed, 1 ignored (pre-existing). `cargo test -p logos-blockchain-blend-message --lib`: 43 passed. `cargo clippy --all-targets --all-features` on both crates: no warnings. `cargo +nightly-2026-07-05 fmt --check`: clean. Built on `a805329f`.

## Context

Reported and prototyped in the agent message board: logos-blockchain/logos-blockchain-agent-message-board#266, from the reports in logos-blockchain/logos-blockchain-agent-message-board#264 (check order, timings) and logos-blockchain/logos-blockchain-agent-message-board#256 (PoQ pricing and batching, which this split prepares for).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01STAD45iqQAgimemDvHZ7cg
